### PR TITLE
perf(core): group facet rows once per layer, not once per panel

### DIFF
--- a/.changeset/facet-panel-slicer.md
+++ b/.changeset/facet-panel-slicer.md
@@ -6,11 +6,10 @@
 
 Migration: none — internal
 
-Building panel frames called `sliceLayerForPanel` once per (panel, layer), and
-each call walked the layer's whole filtered table to keep the rows belonging to
-that panel. The panels partition the rows, so the useful work is one pass over
-the layer, but the cost was one pass per panel: O(P x N) where P is the panel
-count and N the filtered rows.
+Building panel frames sliced each layer once per panel, and each slice walked
+the layer's whole filtered table to keep the rows belonging to that panel. The
+useful work is one pass over the layer, but the cost was one pass per panel:
+O(P x N) where P is the panel count and N the filtered rows.
 
 Group each layer's rows by facet key once, then answer each panel with a lookup.
 Faceting on a 200-category field did 200 times the necessary row visits,
@@ -20,5 +19,15 @@ training.
 The replicate paths (unfaceted, or a layer carrying none of the facet fields)
 also rebuilt an identical source-row array per panel; they now share one.
 
-Slices are unchanged: same table instance or subset, same row order, same
-source-row lineage, for wrap, grid, partial-field, and empty-panel shapes.
+Slices are unchanged for every layout the pipeline can build: same table
+instance or subset, same row order, same source-row lineage, across wrap, grid,
+partial-field replication, absent facet values, and empty tables. A panel
+identity missing a facet field its layer partitions on now throws where it used
+to replicate — no facet form can produce that, since `assertFacetForm` rejects
+wrap mixed with grid and every degenerate layout collapses to the unfaceted
+path.
+
+The trade is retained memory: each layer holds its grouping for the whole panel
+loop, so a many-layer faceted plot carries roughly one extra index per row per
+layer, where the per-panel arrays were previously garbage as soon as each frame
+copied them.

--- a/.changeset/facet-panel-slicer.md
+++ b/.changeset/facet-panel-slicer.md
@@ -1,0 +1,24 @@
+---
+"@ggsvelte/core": patch
+---
+
+# Group facet rows once per layer instead of rescanning per panel
+
+Migration: none — internal
+
+Building panel frames called `sliceLayerForPanel` once per (panel, layer), and
+each call walked the layer's whole filtered table to keep the rows belonging to
+that panel. The panels partition the rows, so the useful work is one pass over
+the layer, but the cost was one pass per panel: O(P x N) where P is the panel
+count and N the filtered rows.
+
+Group each layer's rows by facet key once, then answer each panel with a lookup.
+Faceting on a 200-category field did 200 times the necessary row visits,
+multiplied again by layer count, on the main bind path before stats and scale
+training.
+
+The replicate paths (unfaceted, or a layer carrying none of the facet fields)
+also rebuilt an identical source-row array per panel; they now share one.
+
+Slices are unchanged: same table instance or subset, same row order, same
+source-row lineage, for wrap, grid, partial-field, and empty-panel shapes.

--- a/packages/core/src/pipeline/layer-panel-data.ts
+++ b/packages/core/src/pipeline/layer-panel-data.ts
@@ -16,9 +16,11 @@ export interface LayerPanelSlice {
   table: ColumnTable;
   /**
    * Panel-local row → global source-row id (SourceRegistry).
-   * null only when the slice is identity over an empty mapping (unused).
+   *
+   * Readonly because panels that take the whole table share one array; the
+   * consumer ({@link finalizeFrameSourceRows}) copies before it stores.
    */
-  globalSourceRows: number[];
+  globalSourceRows: readonly number[];
 }
 
 /**
@@ -64,15 +66,17 @@ export interface LayerPanelSlicerInput {
  * carries. `assertFacetForm` allows wrap XOR grid, so there are at most two.
  */
 type RowBuckets =
-  | { fields: 0 }
   | { fields: 1; byA: Map<string, number[]> }
   | { fields: 2; byAB: Map<string, Map<string, number[]>> };
 
 /**
  * Prepare a layer for slicing into every panel of a facet layout.
  *
- * The panels partition the rows, so grouping once and looking each panel up
- * costs O(rows) for the layer rather than O(rows) per panel.
+ * Grouping the layer's rows by facet key once costs O(rows) for the whole
+ * layer, where answering each panel by scanning cost O(rows) per panel. Rows
+ * still replicate into several panels when the layer carries only some of the
+ * facet fields; the key is those fields, so replication falls out of the
+ * lookup rather than needing a scan.
  *
  * `filteredToSource` maps filtered-local index → unfiltered local index
  * (null = identity). `sourceId` + registry produce global ids.
@@ -82,7 +86,8 @@ export function createLayerPanelSlicer(
 ): (panel: FacetPanelDef) => LayerPanelSlice {
   const { filteredTable, filteredToSource, sourceId, registry, facetFields, faceted } = input;
 
-  // Panel-local row → global source row, once for the whole layer.
+  // Indexed by filtered-table row, not panel row: panel slices index into this
+  // through their kept-row list.
   const allGlobals: number[] = [];
   for (let i = 0; i < filteredTable.rowCount; i++) {
     allGlobals.push(registry.toGlobal(sourceId, filteredToSource?.[i] ?? i));
@@ -99,6 +104,13 @@ export function createLayerPanelSlicer(
     return () => whole;
   }
 
+  // Both impossible-by-construction cases fail loudly rather than one throwing
+  // and the other silently dropping fields: see the RowBuckets note above.
+  if (presentFields.length > 2) {
+    throw new Error(
+      `layer partitions on ${presentFields.length} facet fields; wrap XOR grid allows at most 2`,
+    );
+  }
   const buckets: RowBuckets =
     presentFields.length === 1
       ? { fields: 1, byA: partitionByField(filteredTable, presentFields[0]!) }
@@ -130,8 +142,8 @@ export function createLayerPanelSlicer(
         : (buckets.byAB.get(wantedFor(presentFields[0]!))?.get(wantedFor(presentFields[1]!)) ?? []);
 
     // Keeping every row returns the original table instance — SourceRegistry
-    // namespaces on object identity. This also covers the empty table, where
-    // the old scan returned the original rather than an empty subset.
+    // namespaces on object identity. An empty table takes this path too, so it
+    // is never handed an empty subset.
     if (keep.length === filteredTable.rowCount) {
       return { table: filteredTable, globalSourceRows: allGlobals };
     }
@@ -140,16 +152,4 @@ export function createLayerPanelSlicer(
       globalSourceRows: keep.map((i) => allGlobals[i]!),
     };
   };
-}
-
-/**
- * Slice `sourceTable` (unfiltered) for one panel, after optional filter remap.
- *
- * Prefer {@link createLayerPanelSlicer} when slicing a layer into every panel;
- * this rebuilds the layer grouping on each call.
- */
-export function sliceLayerForPanel(
-  input: LayerPanelSlicerInput & { panel: FacetPanelDef },
-): LayerPanelSlice {
-  return createLayerPanelSlicer(input)(input.panel);
 }

--- a/packages/core/src/pipeline/layer-panel-data.ts
+++ b/packages/core/src/pipeline/layer-panel-data.ts
@@ -6,9 +6,9 @@
  * - layer has a subset (grid) → match present fields, replicate across missing
  * - layer has none → replicate full table into every panel
  */
-import { encodeKey } from "../scales/state.js";
 import type { ColumnTable } from "../table.js";
 
+import { partitionByField, partitionByFields } from "./facets-tokens.js";
 import type { FacetPanelDef } from "./facets-types.js";
 import type { SourceRegistry } from "./source-registry.js";
 
@@ -50,69 +50,106 @@ function panelFacetEncodedValues(panel: FacetPanelDef): Map<string, string> {
   return out;
 }
 
-/**
- * Slice `sourceTable` (unfiltered) for one panel, after optional filter remap.
- *
- * `filteredToSource` maps filtered-local index → unfiltered local index
- * (null = identity). `sourceId` + registry produce global ids.
- */
-export function sliceLayerForPanel(input: {
+export interface LayerPanelSlicerInput {
   filteredTable: ColumnTable;
   filteredToSource: number[] | null;
   sourceId: number;
   registry: SourceRegistry;
-  panel: FacetPanelDef;
   facetFields: readonly string[];
   faceted: boolean;
-}): LayerPanelSlice {
-  const { filteredTable, filteredToSource, sourceId, registry, panel, facetFields, faceted } =
-    input;
+}
 
-  if (!faceted || facetFields.length === 0) {
-    // Single panel: filtered table rows → global via filter remap.
-    const globalSourceRows: number[] = [];
-    for (let i = 0; i < filteredTable.rowCount; i++) {
-      const local = filteredToSource?.[i] ?? i;
-      globalSourceRows.push(registry.toGlobal(sourceId, local));
-    }
-    return { table: filteredTable, globalSourceRows };
-  }
+/**
+ * Row buckets for one layer, keyed by the facet fields that layer actually
+ * carries. `assertFacetForm` allows wrap XOR grid, so there are at most two.
+ */
+type RowBuckets =
+  | { fields: 0 }
+  | { fields: 1; byA: Map<string, number[]> }
+  | { fields: 2; byAB: Map<string, Map<string, number[]>> };
 
-  const presentFields = facetFields.filter((f) => filteredTable.has(f));
-  const panelEncoded = panelFacetEncodedValues(panel);
+/**
+ * Prepare a layer for slicing into every panel of a facet layout.
+ *
+ * The panels partition the rows, so grouping once and looking each panel up
+ * costs O(rows) for the layer rather than O(rows) per panel.
+ *
+ * `filteredToSource` maps filtered-local index → unfiltered local index
+ * (null = identity). `sourceId` + registry produce global ids.
+ */
+export function createLayerPanelSlicer(
+  input: LayerPanelSlicerInput,
+): (panel: FacetPanelDef) => LayerPanelSlice {
+  const { filteredTable, filteredToSource, sourceId, registry, facetFields, faceted } = input;
 
-  // No facet fields on this layer → full table in every panel (replicate).
-  if (presentFields.length === 0) {
-    const globalSourceRows: number[] = [];
-    for (let i = 0; i < filteredTable.rowCount; i++) {
-      const local = filteredToSource?.[i] ?? i;
-      globalSourceRows.push(registry.toGlobal(sourceId, local));
-    }
-    return { table: filteredTable, globalSourceRows };
-  }
-
-  // Match present fields to panel values; missing facet dims replicate.
-  const keep: number[] = [];
-  const globalSourceRows: number[] = [];
+  // Panel-local row → global source row, once for the whole layer.
+  const allGlobals: number[] = [];
   for (let i = 0; i < filteredTable.rowCount; i++) {
-    let match = true;
-    for (const field of presentFields) {
-      const wanted = panelEncoded.get(field);
-      if (wanted === undefined) continue;
-      const cell = filteredTable.column(field)[i]!;
-      if (encodeKey(cell) !== wanted) {
-        match = false;
-        break;
-      }
-    }
-    if (!match) continue;
-    keep.push(i);
-    const local = filteredToSource?.[i] ?? i;
-    globalSourceRows.push(registry.toGlobal(sourceId, local));
+    allGlobals.push(registry.toGlobal(sourceId, filteredToSource?.[i] ?? i));
   }
 
-  if (keep.length === filteredTable.rowCount) {
-    return { table: filteredTable, globalSourceRows };
+  const presentFields =
+    faceted && facetFields.length > 0 ? facetFields.filter((f) => filteredTable.has(f)) : [];
+
+  // Unfaceted, or no facet field on this layer → every panel takes the whole
+  // table. finalizeFrameSourceRows copies globalSourceRows, so one shared slice
+  // cannot leak between panels.
+  if (presentFields.length === 0) {
+    const whole: LayerPanelSlice = { table: filteredTable, globalSourceRows: allGlobals };
+    return () => whole;
   }
-  return { table: filteredTable.subset(keep), globalSourceRows };
+
+  const buckets: RowBuckets =
+    presentFields.length === 1
+      ? { fields: 1, byA: partitionByField(filteredTable, presentFields[0]!) }
+      : {
+          fields: 2,
+          byAB: partitionByFields(filteredTable, presentFields[0]!, presentFields[1]!),
+        };
+
+  return (panel: FacetPanelDef): LayerPanelSlice => {
+    const panelEncoded = panelFacetEncodedValues(panel);
+    // Every declared facet field appears on every panel identity (facets-wrap
+    // and facets-grid build them all from the same fields), and presentFields
+    // is a subset of those, so a miss here means the layout invariant broke.
+    const wantedFor = (field: string): string => {
+      const wanted = panelEncoded.get(field);
+      if (wanted === undefined) {
+        throw new Error(
+          `facet panel identity is missing the facet field "${field}" the layer partitions on`,
+        );
+      }
+      return wanted;
+    };
+
+    // A key with no rows is an empty panel, not an error: closed facet levels
+    // and sparse grid combinations both name values the layer never sees.
+    const keep =
+      buckets.fields === 1
+        ? (buckets.byA.get(wantedFor(presentFields[0]!)) ?? [])
+        : (buckets.byAB.get(wantedFor(presentFields[0]!))?.get(wantedFor(presentFields[1]!)) ?? []);
+
+    // Keeping every row returns the original table instance — SourceRegistry
+    // namespaces on object identity. This also covers the empty table, where
+    // the old scan returned the original rather than an empty subset.
+    if (keep.length === filteredTable.rowCount) {
+      return { table: filteredTable, globalSourceRows: allGlobals };
+    }
+    return {
+      table: filteredTable.subset(keep),
+      globalSourceRows: keep.map((i) => allGlobals[i]!),
+    };
+  };
+}
+
+/**
+ * Slice `sourceTable` (unfiltered) for one panel, after optional filter remap.
+ *
+ * Prefer {@link createLayerPanelSlicer} when slicing a layer into every panel;
+ * this rebuilds the layer grouping on each call.
+ */
+export function sliceLayerForPanel(
+  input: LayerPanelSlicerInput & { panel: FacetPanelDef },
+): LayerPanelSlice {
+  return createLayerPanelSlicer(input)(input.panel);
 }

--- a/packages/core/src/pipeline/prepare-panels-frames.ts
+++ b/packages/core/src/pipeline/prepare-panels-frames.ts
@@ -316,9 +316,6 @@ export function buildPanelFrames(input: {
   const binRanges = computePanelBinRanges(bindings, filteredLayerTables, faceted, freeX);
   const functionDomains = computeFunctionPeerDomains(bindings, filteredLayerTables);
   const xDiscreteRisk = xDiscreteRiskOf(bindings, filteredLayerTables, normalized.scales?.x?.type);
-  // Group each layer's rows by facet key once. The panels partition the rows,
-  // so slicing per panel from the grouping costs one pass over the layer
-  // instead of one pass per panel.
   const layerSlicers = layerContexts.map((ctx) =>
     createLayerPanelSlicer({
       filteredTable: ctx.filteredTable,

--- a/packages/core/src/pipeline/prepare-panels-frames.ts
+++ b/packages/core/src/pipeline/prepare-panels-frames.ts
@@ -12,7 +12,7 @@ import { styleBinExtent } from "./frame-group-columns.js";
 import { buildFrame } from "./frame.js";
 import { xDiscreteRiskOf } from "./frame-stats-align.js";
 import { finalizeFrameSourceRows } from "./source-row-lineage.js";
-import { sliceLayerForPanel } from "./layer-panel-data.js";
+import { createLayerPanelSlicer } from "./layer-panel-data.js";
 import { applyPosition } from "./position.js";
 import { resolveColumnTransform } from "./position-program.js";
 import { assertInferredTemporalTransform } from "./scale-config-preflight.js";
@@ -316,18 +316,22 @@ export function buildPanelFrames(input: {
   const binRanges = computePanelBinRanges(bindings, filteredLayerTables, faceted, freeX);
   const functionDomains = computeFunctionPeerDomains(bindings, filteredLayerTables);
   const xDiscreteRisk = xDiscreteRiskOf(bindings, filteredLayerTables, normalized.scales?.x?.type);
+  // Group each layer's rows by facet key once. The panels partition the rows,
+  // so slicing per panel from the grouping costs one pass over the layer
+  // instead of one pass per panel.
+  const layerSlicers = layerContexts.map((ctx) =>
+    createLayerPanelSlicer({
+      filteredTable: ctx.filteredTable,
+      filteredToSource: ctx.filteredToSource,
+      sourceId: ctx.sourceId,
+      registry,
+      facetFields,
+      faceted,
+    }),
+  );
   for (let p = 0; p < facetPanels.length; p++) {
     for (let index = 0; index < bindings.length; index++) {
-      const ctx = layerContexts[index]!;
-      const slice = sliceLayerForPanel({
-        filteredTable: ctx.filteredTable,
-        filteredToSource: ctx.filteredToSource,
-        sourceId: ctx.sourceId,
-        registry,
-        panel: facetPanels[p]!,
-        facetFields,
-        faceted,
-      });
+      const slice = layerSlicers[index]!(facetPanels[p]!);
       const frame = buildFrame(
         bindings[index]!,
         slice.table,

--- a/packages/core/tests/layer-panel-slicer.test.ts
+++ b/packages/core/tests/layer-panel-slicer.test.ts
@@ -2,8 +2,8 @@
  * Per-layer facet slicing: one grouping pass, then a lookup per panel.
  *
  * The oracle below is a frozen copy of the per-panel scan this replaced. It is
- * deliberately independent of the implementation — comparing the slicer against
- * the shipped `sliceLayerForPanel` would be a tautology once that delegates.
+ * deliberately independent of the implementation: an oracle that called into
+ * the code under test would agree with it no matter what either one did.
  */
 import { describe, expect, it } from "bun:test";
 
@@ -81,9 +81,18 @@ function gridPanel(
 
 const EMPTY = ColumnTable.fromColumns({});
 
-function inputFor(table: ColumnTable, facetFields: string[], filteredToSource: number[] | null) {
+/**
+ * `unfiltered` stands in for the pre-filter source table the registry indexes,
+ * so remapped rows resolve to real global ids instead of collapsing to NO_ROW.
+ */
+function inputFor(
+  table: ColumnTable,
+  facetFields: string[],
+  filteredToSource: number[] | null,
+  unfiltered?: ColumnTable,
+) {
   const registry = new SourceRegistry();
-  const sourceId = registry.register(table);
+  const sourceId = registry.register(unfiltered ?? table);
   return { filteredTable: table, filteredToSource, sourceId, registry, facetFields, faceted: true };
 }
 
@@ -98,8 +107,8 @@ function expectMatchesOracle(input: SliceInput, panels: FacetPanelDef[]): void {
     // Table identity matters: the fast path must return the original instance,
     // because SourceRegistry keys its namespace on object identity.
     expect(got.table === input.filteredTable).toBe(want.table === input.filteredTable);
-    for (const field of ["g", "h", "v"]) {
-      if (!want.table.has(field)) continue;
+    expect(got.table.fields).toEqual(want.table.fields);
+    for (const field of want.table.fields) {
       expect([...got.table.column(field)]).toEqual([...want.table.column(field)]);
     }
   }
@@ -168,12 +177,20 @@ describe("createLayerPanelSlicer matches the per-panel scan", () => {
   });
 
   it("filter remap feeds the global source rows", () => {
+    // Filtered rows 0,1,2 came from unfiltered 2,5,7 of a 9-row source, so the
+    // remap must survive as real global ids rather than collapsing to NO_ROW.
+    const unfiltered = ColumnTable.fromColumns({
+      g: ["x", "x", "a", "x", "x", "b", "x", "a", "x"],
+      v: [0, 0, 1, 0, 0, 2, 0, 3, 0],
+    });
     const table = ColumnTable.fromColumns({ g: ["a", "b", "a"], v: [1, 2, 3] });
-    // Filtered rows 0,1,2 came from unfiltered 2,5,7.
-    expectMatchesOracle(inputFor(table, ["g"], [2, 5, 7]), [
-      wrapPanel("g", "a"),
-      wrapPanel("g", "b"),
-    ]);
+    const input = inputFor(table, ["g"], [2, 5, 7], unfiltered);
+    expectMatchesOracle(input, [wrapPanel("g", "a"), wrapPanel("g", "b")]);
+    // Pin the actual ids: comparing against the oracle alone would pass even if
+    // both sides collapsed every remapped row to NO_ROW.
+    const slicer = createLayerPanelSlicer(input);
+    expect([...slicer(wrapPanel("g", "a")).globalSourceRows]).toEqual([2, 7]);
+    expect([...slicer(wrapPanel("g", "b")).globalSourceRows]).toEqual([5]);
   });
 
   it("distinguishes values that a naive key join would collide", () => {
@@ -243,5 +260,36 @@ describe("createLayerPanelSlicer cost", () => {
     expect(reads).toBeGreaterThan(0);
     // One pass over the facet column is N. The per-panel scan was P*N = 8000.
     expect(reads).toBeLessThan(3 * N);
+  });
+
+  it("builds the shared source-row array once on the replicate path", () => {
+    // A layer carrying no facet field replicates into every panel. That path
+    // reads no facet column, so the guard above cannot see it: count the
+    // registry lookups instead, which is what used to be rebuilt per panel.
+    const P = 40;
+    const N = 200;
+    const table = ColumnTable.fromColumns({ v: Array.from({ length: N }, (_, i) => i) });
+    const registry = new SourceRegistry();
+    const sourceId = registry.register(table);
+    let toGlobalCalls = 0;
+    const realToGlobal = registry.toGlobal.bind(registry);
+    registry.toGlobal = (id: number, row: number): number => {
+      toGlobalCalls += 1;
+      return realToGlobal(id, row);
+    };
+
+    const slicer = createLayerPanelSlicer({
+      filteredTable: table,
+      filteredToSource: null,
+      sourceId,
+      registry,
+      facetFields: ["g"],
+      faceted: true,
+    });
+    const slices = Array.from({ length: P }, (_, p) => slicer(wrapPanel("g", `g${p}`)));
+    for (const slice of slices) expect(slice.globalSourceRows).toHaveLength(N);
+    // Every panel takes the whole table, so one array serves them all.
+    expect(slices.every((s) => s.globalSourceRows === slices[0]!.globalSourceRows)).toBe(true);
+    expect(toGlobalCalls).toBe(N);
   });
 });

--- a/packages/core/tests/layer-panel-slicer.test.ts
+++ b/packages/core/tests/layer-panel-slicer.test.ts
@@ -227,6 +227,26 @@ describe("createLayerPanelSlicer matches the per-panel scan", () => {
   });
 });
 
+describe("createLayerPanelSlicer invariant tripwires", () => {
+  // Neither state is reachable through the pipeline: assertFacetForm rejects
+  // wrap mixed with grid, and every panel identity carries every declared
+  // facet field. Both fail loudly so a future layout change cannot quietly
+  // mis-slice instead.
+  it("rejects a layer partitioning on more facet fields than a form allows", () => {
+    const table = ColumnTable.fromColumns({ g: ["a"], h: ["b"], k: ["c"] });
+    expect(() => createLayerPanelSlicer(inputFor(table, ["g", "h", "k"], null))).toThrow(
+      /partitions on 3 facet fields/,
+    );
+  });
+
+  it("rejects a panel identity missing a field its layer partitions on", () => {
+    const table = ColumnTable.fromColumns({ g: ["a", "b"], v: [1, 2] });
+    const slicer = createLayerPanelSlicer(inputFor(table, ["g"], null));
+    // A panel that names a different field than the layer partitions on.
+    expect(() => slicer(wrapPanel("other", "a"))).toThrow(/missing the facet field "g"/);
+  });
+});
+
 describe("createLayerPanelSlicer cost", () => {
   it("visits the rows once for the layer, not once per panel", () => {
     // 40 facet values x 200 rows. The old scan read 200 cells per panel (8000);

--- a/packages/core/tests/layer-panel-slicer.test.ts
+++ b/packages/core/tests/layer-panel-slicer.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Per-layer facet slicing: one grouping pass, then a lookup per panel.
+ *
+ * The oracle below is a frozen copy of the per-panel scan this replaced. It is
+ * deliberately independent of the implementation — comparing the slicer against
+ * the shipped `sliceLayerForPanel` would be a tautology once that delegates.
+ */
+import { describe, expect, it } from "bun:test";
+
+import { createFacetPanelIdentity } from "../src/facet-identity.ts";
+import type { FacetPanelDef } from "../src/pipeline/facets-types.ts";
+import { createLayerPanelSlicer, type LayerPanelSlice } from "../src/pipeline/layer-panel-data.ts";
+import { SourceRegistry } from "../src/pipeline/source-registry.ts";
+import { encodeKey } from "../src/scales/state.ts";
+import { ColumnTable } from "../src/table.ts";
+
+interface SliceInput {
+  filteredTable: ColumnTable;
+  filteredToSource: number[] | null;
+  sourceId: number;
+  registry: SourceRegistry;
+  facetFields: readonly string[];
+  faceted: boolean;
+}
+
+/** Frozen copy of the pre-change per-panel scan. Do not simplify. */
+function oracleSlice(input: SliceInput, panel: FacetPanelDef): LayerPanelSlice {
+  const { filteredTable, filteredToSource, sourceId, registry, facetFields, faceted } = input;
+  if (!faceted || facetFields.length === 0) {
+    const globalSourceRows: number[] = [];
+    for (let i = 0; i < filteredTable.rowCount; i++) {
+      globalSourceRows.push(registry.toGlobal(sourceId, filteredToSource?.[i] ?? i));
+    }
+    return { table: filteredTable, globalSourceRows };
+  }
+  const presentFields = facetFields.filter((f) => filteredTable.has(f));
+  const panelEncoded = new Map<string, string>();
+  for (const factor of panel.identity.values) panelEncoded.set(factor.field, factor.encodedValue);
+  if (presentFields.length === 0) {
+    const globalSourceRows: number[] = [];
+    for (let i = 0; i < filteredTable.rowCount; i++) {
+      globalSourceRows.push(registry.toGlobal(sourceId, filteredToSource?.[i] ?? i));
+    }
+    return { table: filteredTable, globalSourceRows };
+  }
+  const keep: number[] = [];
+  const globalSourceRows: number[] = [];
+  for (let i = 0; i < filteredTable.rowCount; i++) {
+    let match = true;
+    for (const field of presentFields) {
+      const wanted = panelEncoded.get(field);
+      if (wanted === undefined) continue;
+      if (encodeKey(filteredTable.column(field)[i]!) !== wanted) {
+        match = false;
+        break;
+      }
+    }
+    if (!match) continue;
+    keep.push(i);
+    globalSourceRows.push(registry.toGlobal(sourceId, filteredToSource?.[i] ?? i));
+  }
+  if (keep.length === filteredTable.rowCount) return { table: filteredTable, globalSourceRows };
+  return { table: filteredTable.subset(keep), globalSourceRows };
+}
+
+function wrapPanel(field: string, value: unknown): FacetPanelDef {
+  const identity = createFacetPanelIdentity([{ role: "wrap", field, value }]);
+  return { identity, id: identity.key, label: "", row: 0, col: 0, table: EMPTY, sourceRows: null };
+}
+
+function gridPanel(
+  rows: { field: string; value: unknown } | null,
+  cols: { field: string; value: unknown } | null,
+): FacetPanelDef {
+  const identity = createFacetPanelIdentity([
+    ...(rows === null ? [] : [{ role: "rows" as const, field: rows.field, value: rows.value }]),
+    ...(cols === null ? [] : [{ role: "cols" as const, field: cols.field, value: cols.value }]),
+  ]);
+  return { identity, id: identity.key, label: "", row: 0, col: 0, table: EMPTY, sourceRows: null };
+}
+
+const EMPTY = ColumnTable.fromColumns({});
+
+function inputFor(table: ColumnTable, facetFields: string[], filteredToSource: number[] | null) {
+  const registry = new SourceRegistry();
+  const sourceId = registry.register(table);
+  return { filteredTable: table, filteredToSource, sourceId, registry, facetFields, faceted: true };
+}
+
+/** Compare against the frozen oracle on every axis that downstream code reads. */
+function expectMatchesOracle(input: SliceInput, panels: FacetPanelDef[]): void {
+  const slicer = createLayerPanelSlicer(input);
+  for (const panel of panels) {
+    const got = slicer(panel);
+    const want = oracleSlice(input, panel);
+    expect(got.globalSourceRows).toEqual(want.globalSourceRows);
+    expect(got.table.rowCount).toBe(want.table.rowCount);
+    // Table identity matters: the fast path must return the original instance,
+    // because SourceRegistry keys its namespace on object identity.
+    expect(got.table === input.filteredTable).toBe(want.table === input.filteredTable);
+    for (const field of ["g", "h", "v"]) {
+      if (!want.table.has(field)) continue;
+      expect([...got.table.column(field)]).toEqual([...want.table.column(field)]);
+    }
+  }
+}
+
+describe("createLayerPanelSlicer matches the per-panel scan", () => {
+  it("wrap: one facet field on the layer", () => {
+    const table = ColumnTable.fromColumns({
+      g: ["a", "b", "a", "c", "b", "a"],
+      v: [1, 2, 3, 4, 5, 6],
+    });
+    expectMatchesOracle(inputFor(table, ["g"], null), [
+      wrapPanel("g", "a"),
+      wrapPanel("g", "b"),
+      wrapPanel("g", "c"),
+      wrapPanel("g", "zzz"), // closed levels can name a value with no rows
+    ]);
+  });
+
+  it("grid: both facet fields on the layer", () => {
+    const table = ColumnTable.fromColumns({
+      g: ["a", "a", "b", "b", "a"],
+      h: ["x", "y", "x", "y", "y"],
+      v: [1, 2, 3, 4, 5],
+    });
+    const panels = [
+      gridPanel({ field: "g", value: "a" }, { field: "h", value: "x" }),
+      gridPanel({ field: "g", value: "a" }, { field: "h", value: "y" }),
+      gridPanel({ field: "g", value: "b" }, { field: "h", value: "x" }),
+      gridPanel({ field: "g", value: "b" }, { field: "h", value: "y" }),
+      gridPanel({ field: "g", value: "c" }, { field: "h", value: "x" }), // empty combo
+    ];
+    expectMatchesOracle(inputFor(table, ["g", "h"], null), panels);
+  });
+
+  it("grid: layer carries only the row field, so it replicates across columns", () => {
+    // The layer has no `h`, so every column panel of a given row gets the same
+    // rows. This is the case a full-identity lookup key would break.
+    const table = ColumnTable.fromColumns({ g: ["a", "b", "a"], v: [1, 2, 3] });
+    const panels = [
+      gridPanel({ field: "g", value: "a" }, { field: "h", value: "x" }),
+      gridPanel({ field: "g", value: "a" }, { field: "h", value: "y" }),
+      gridPanel({ field: "g", value: "b" }, { field: "h", value: "x" }),
+    ];
+    expectMatchesOracle(inputFor(table, ["g", "h"], null), panels);
+  });
+
+  it("grid: layer carries only the column field", () => {
+    const table = ColumnTable.fromColumns({ h: ["x", "y", "x"], v: [1, 2, 3] });
+    const panels = [
+      gridPanel({ field: "g", value: "a" }, { field: "h", value: "x" }),
+      gridPanel({ field: "g", value: "b" }, { field: "h", value: "x" }),
+      gridPanel({ field: "g", value: "a" }, { field: "h", value: "y" }),
+    ];
+    expectMatchesOracle(inputFor(table, ["g", "h"], null), panels);
+  });
+
+  it("layer carries none of the facet fields, so the whole table replicates", () => {
+    const table = ColumnTable.fromColumns({ v: [1, 2, 3] });
+    expectMatchesOracle(inputFor(table, ["g"], null), [wrapPanel("g", "a"), wrapPanel("g", "b")]);
+  });
+
+  it("empty filtered table keeps the original table instance, not a subset", () => {
+    const table = ColumnTable.fromColumns({ g: [], v: [] });
+    expectMatchesOracle(inputFor(table, ["g"], null), [wrapPanel("g", "a")]);
+  });
+
+  it("filter remap feeds the global source rows", () => {
+    const table = ColumnTable.fromColumns({ g: ["a", "b", "a"], v: [1, 2, 3] });
+    // Filtered rows 0,1,2 came from unfiltered 2,5,7.
+    expectMatchesOracle(inputFor(table, ["g"], [2, 5, 7]), [
+      wrapPanel("g", "a"),
+      wrapPanel("g", "b"),
+    ]);
+  });
+
+  it("distinguishes values that a naive key join would collide", () => {
+    // encodeKey keeps "1" and 1 apart, and separator-bearing strings must not
+    // merge across the two grid fields.
+    const table = ColumnTable.fromColumns({
+      g: ["a:b", "a", 1, "1", "a|b"],
+      h: ["c", "b:c", "z", "z", "c"],
+      v: [1, 2, 3, 4, 5],
+    });
+    const panels = [
+      gridPanel({ field: "g", value: "a:b" }, { field: "h", value: "c" }),
+      gridPanel({ field: "g", value: "a" }, { field: "h", value: "b:c" }),
+      gridPanel({ field: "g", value: 1 }, { field: "h", value: "z" }),
+      gridPanel({ field: "g", value: "1" }, { field: "h", value: "z" }),
+      gridPanel({ field: "g", value: "a|b" }, { field: "h", value: "c" }),
+    ];
+    expectMatchesOracle(inputFor(table, ["g", "h"], null), panels);
+  });
+
+  it("unfaceted layouts share one whole-table slice", () => {
+    const table = ColumnTable.fromColumns({ v: [1, 2, 3] });
+    const registry = new SourceRegistry();
+    const sourceId = registry.register(table);
+    const input = {
+      filteredTable: table,
+      filteredToSource: null,
+      sourceId,
+      registry,
+      facetFields: [],
+      faceted: false,
+    };
+    expectMatchesOracle(input, [wrapPanel("g", "a")]);
+  });
+});
+
+describe("createLayerPanelSlicer cost", () => {
+  it("visits the rows once for the layer, not once per panel", () => {
+    // 40 facet values x 200 rows. The old scan read 200 cells per panel (8000);
+    // one grouping pass reads 200.
+    const P = 40;
+    const N = 200;
+    const g = Array.from({ length: N }, (_, i) => `g${i % P}`);
+    // fromColumns keeps the array reference, so element reads are countable.
+    let reads = 0;
+    const counted = new Proxy(g, {
+      get(target, prop) {
+        if (typeof prop === "string" && /^\d+$/.test(prop)) reads += 1;
+        return Reflect.get(target, prop) as unknown;
+      },
+    });
+    const table = ColumnTable.fromColumns({ g: counted, v: g.map((_, i) => i) });
+    const registry = new SourceRegistry();
+    const sourceId = registry.register(table);
+
+    const slicer = createLayerPanelSlicer({
+      filteredTable: table,
+      filteredToSource: null,
+      sourceId,
+      registry,
+      facetFields: ["g"],
+      faceted: true,
+    });
+    let total = 0;
+    for (let p = 0; p < P; p++) total += slicer(wrapPanel("g", `g${p}`)).globalSourceRows.length;
+    expect(total).toBe(N);
+    expect(reads).toBeGreaterThan(0);
+    // One pass over the facet column is N. The per-panel scan was P*N = 8000.
+    expect(reads).toBeLessThan(3 * N);
+  });
+});


### PR DESCRIPTION
## What

Building panel frames sliced each layer once per panel, and each slice walked the layer's whole filtered table:

```ts
for (let p = 0; p < facetPanels.length; p++) {
  for (let index = 0; index < bindings.length; index++) {
    const slice = sliceLayerForPanel({ filteredTable: ctx.filteredTable, /* … */ });
```

The useful work is one pass over the layer. The cost was one pass per panel — **O(P × N)**, where P is the panel count and N the filtered rows. Grouping each layer's rows by facet key once and answering each panel with a lookup makes it O(N).

Closes #1306.

## What n is

P is the number of distinct facet-key combinations, so it grows with the data (and with closed `levels`, which keep empty combinations). Faceting on a 200-category field did 200× the necessary row visits, multiplied again by layer count. It runs on the main bind path, before stats and scale training, so it inflates every faceted render.

The replicate paths — unfaceted, or a layer carrying none of the facet fields — also rebuilt an identical source-row array per panel. They now share one.

## Design

This reuses the existing `partitionByField` / `partitionByFields` helpers rather than inventing a composite key codec. `assertFacetForm` allows wrap XOR grid, so a layer partitions on at most two fields, and those two helpers cover both shapes with nested maps — no string keys to collide.

The lookup key is the layer's **present** facet fields, not the full panel identity. That is what preserves ggplot2's replicate semantics: a layer carrying only the row field must appear in every column panel of that row. A full-identity key would have emptied those panels.

## Behavior

Unchanged for every layout the pipeline can build. Two reviewers checked this independently:

- A unit differential fuzz against the previous implementation — 140k randomized cases over row counts 0–12, present/absent facet columns, `encodeKey`-collision bait (`"1"` vs `1`, `0` vs `-0`, `"a:b"`, `"a|b"`, `NaN`, `null`), swapped and duplicated field orders, and out-of-range filter remaps. Zero divergences, with all three return branches exercised.
- An end-to-end differential swapping the old implementation back in under `runPipeline`, across 432 configurations (9 facet shapes × 8 layer sets including partial-field and annotation layers × fixed/free scales × row filters). Byte-identical output, and the harness was verified live by perturbing the old code.

One intentional difference: a panel identity missing a facet field its layer partitions on now throws where it used to silently replicate. No facet form can produce that — `assertFacetForm` rejects wrap mixed with grid, and every degenerate layout collapses to the unfaceted path. A layer partitioning on 3+ fields throws for the same reason, so both impossible cases fail the same loud way rather than one crashing and one quietly dropping fields.

The trade is retained memory: each layer holds its grouping for the whole panel loop, so a many-layer faceted plot carries roughly one extra index per row per layer, where the per-panel arrays were previously garbage as soon as each frame copied them.

## Verification

- `bun test packages/core` — 2029 pass, 0 fail
- `bun run check`, `bun run lint`, `bun run lint:type-aware`, `bun run knip`, `bun run fmt:check` — clean

`tests/layer-panel-slicer.test.ts` compares against a frozen copy of the previous scan, kept independent on purpose — an oracle that called into the code under test would agree with it no matter what either one did. It covers wrap, grid, grid with only one field present, no facet fields, empty tables, absent facet values, filter remaps against a larger source table, and separator-bearing values.

Two cost guards, both checked against the pre-change implementation: the facet-column path reads 8200 entries per layer before and under 600 after; the replicate path counts registry lookups instead, since it touches no facet column and the column-read guard is blind to it.

## Follow-ups

Still open from the same audit: #1307, #1308, #1309, #1310, #1311, #1312.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1317" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->