### PR TITLE
fix(core): project a wide band selection without spreading the keys

### DIFF
--- a/.changeset/band-extent-arg-limit.md
+++ b/.changeset/band-extent-arg-limit.md
@@ -1,0 +1,18 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+fix: project a wide band selection without spreading the keys
+
+`SemanticViewportPanel.project()` derived a band selection's extent with
+`Math.min(...centers)` / `Math.max(...centers)`, one argument per selected key.
+`keys` is a plain `readonly string[]` on the exported selection type, so a wide
+enough band brush threw `RangeError: Maximum call stack size exceeded` instead
+of returning an extent. The ceiling is the engine's argument limit — around
+100 000 keys in V8, so a browser hits it well before Bun does.
+
+It now walks the keys once, tracking the smallest and largest center, so no
+selection size can overflow the call. Same extent as before for every selection
+that already worked, and unknown keys are still skipped.

--- a/packages/core/src/semantic-viewport.ts
+++ b/packages/core/src/semantic-viewport.ts
@@ -174,14 +174,24 @@ function projectedSpan(
   let last: number | undefined;
   if (selection.kind === "band") {
     if (scale.type !== "band") return [0, 1];
-    const centers = bandValuesForKeys(bandValuesByKey, selection.keys).flatMap((value) => {
+    // One pass over the keys, never `Math.min(...centers)`: `keys` is caller-
+    // supplied and unbounded, and spreading it passes one argument per key,
+    // which RangeErrors on a wide enough band brush (same hazard grouping.ts
+    // avoids for `Math.max(...groups)`).
+    let minCenter = Infinity;
+    let maxCenter = -Infinity;
+    for (const key of selection.keys) {
+      const value = bandValuesByKey.get(key);
+      if (value === undefined) continue;
       const center = scale.normalize(value);
-      return center === undefined ? [] : [center];
-    });
-    if (centers.length === 0) return [0, 1];
+      if (center === undefined) continue;
+      if (center < minCenter) minCenter = center;
+      if (center > maxCenter) maxCenter = center;
+    }
+    if (minCenter === Infinity) return [0, 1];
     const halfStep = scale.step / 2;
-    first = Math.max(0, Math.min(...centers) - halfStep);
-    last = Math.min(1, Math.max(...centers) + halfStep);
+    first = Math.max(0, minCenter - halfStep);
+    last = Math.min(1, maxCenter + halfStep);
   } else {
     if (scale.type === "band") return [0, 1];
     const firstValue = scale.normalize(selection.domain[0]);

--- a/packages/core/tests/semantic-viewport.test.ts
+++ b/packages/core/tests/semantic-viewport.test.ts
@@ -247,6 +247,87 @@ describe("RenderModel semantic viewport", () => {
     expect(pixels.x1).toBeCloseTo(scenePanel.x + scenePanel.width * 0.75, 10);
   });
 
+  /**
+   * The band extent must not be derived via Math.min(...centers): `keys` is a
+   * public unbounded string[], so spreading one argument per selected key
+   * RangeErrors on a wide enough band brush. Every key here is distinct, so a
+   * dedupe-then-spread "fix" fails this too. Mirrors the grouping.ts guard.
+   */
+  it("projects a wide band selection without spreading the keys", () => {
+    const categories = Array.from({ length: 500 }, (_, i) => `c${String(i)}`);
+    const model = runPipeline(
+      gg(
+        categories.map((category, i) => ({ category, y: i })),
+        aes({ x: "category", y: "y" }),
+      )
+        .geomPoint()
+        .spec(),
+      { width: 400, height: 300 },
+    );
+    const scenePanel = model.scene.panels[0]!;
+    const panel = model.viewport.panel(scenePanel.id)!;
+    const originalMin = Math.min;
+    const originalMax = Math.max;
+    const guard =
+      (name: string, original: (...args: number[]) => number) =>
+      (...args: number[]): number => {
+        if (args.length > 100) {
+          throw new Error(
+            `Math.${name} spread over ${String(args.length)} args (band extent leak)`,
+          );
+        }
+        return original(...args);
+      };
+    Math.min = guard("min", originalMin);
+    Math.max = guard("max", originalMax);
+    try {
+      const pixels = panel.project({
+        x: { kind: "band", keys: categories.map((category) => encodeKey(category)) },
+      });
+
+      expect(pixels.x0).toBeCloseTo(scenePanel.x, 10);
+      expect(pixels.x1).toBeCloseTo(scenePanel.x + scenePanel.width, 10);
+    } finally {
+      Math.min = originalMin;
+      Math.max = originalMax;
+    }
+  });
+
+  it("skips band keys outside the domain when projecting", () => {
+    const model = runPipeline(
+      gg(
+        [
+          { category: "a", y: 1 },
+          { category: "b", y: 2 },
+          { category: "c", y: 3 },
+          { category: "d", y: 4 },
+        ],
+        aes({ x: "category", y: "y" }),
+      )
+        .geomPoint()
+        .spec(),
+      { width: 400, height: 300 },
+    );
+    const scenePanel = model.scene.panels[0]!;
+    const panel = model.viewport.panel(scenePanel.id)!;
+
+    const mixed = panel.project({
+      x: { kind: "band", keys: [encodeKey("zz"), encodeKey("b"), encodeKey("c"), encodeKey("yy")] },
+    });
+    expect(mixed.x0).toBeCloseTo(scenePanel.x + scenePanel.width * 0.25, 10);
+    expect(mixed.x1).toBeCloseTo(scenePanel.x + scenePanel.width * 0.75, 10);
+
+    const unknown = panel.project({
+      x: { kind: "band", keys: [encodeKey("zz")] },
+    });
+    expect(unknown.x0).toBeCloseTo(scenePanel.x, 10);
+    expect(unknown.x1).toBeCloseTo(scenePanel.x + scenePanel.width, 10);
+
+    const empty = panel.project({ x: { kind: "band", keys: [] } });
+    expect(empty.x0).toBeCloseTo(scenePanel.x, 10);
+    expect(empty.x1).toBeCloseTo(scenePanel.x + scenePanel.width, 10);
+  });
+
   it("resolves encoded categorical identities to raw semantic endpoints", () => {
     const model = runPipeline(
       gg(


### PR DESCRIPTION
Fixes #1315.

## The bug

`projectedSpan` built a band selection's extent by spreading one argument per
selected key:

```ts
first = Math.max(0, Math.min(...centers) - halfStep);
last = Math.min(1, Math.max(...centers) + halfStep);
```

`keys` is a plain `readonly string[]` on the exported
`SemanticViewportAxisSelection`, so its length comes from the caller. Past the
engine's argument limit the call throws `RangeError: Maximum call stack size
exceeded` instead of returning an extent.

## Validation

Measured on this machine, spreading an array of N numbers into `Math.min`:

| Engine | Result |
|---|---|
| V8 (node 22) | fine at 100 000, throws at 200 000 |
| JSC (bun 1.3.14) | fine to ~636 000, throws by ~640 000 |

A browser charting library aims at Chrome first, so the real ceiling is nearer
100 000 than the 200 000 the issue quotes.

Reaching it is cheaper than the issue suggests. `bandValuesForKeys` maps keys,
not categories, and does not deduplicate, so repeated keys inflate `centers` on
their own — four categories plus 700 000 copies of one key already threw at
`semantic-viewport.ts:183`. No 700 000-category scale needed.

## The fix

Walk the keys once, tracking the smallest and largest center. No argument-count
ceiling at any size, and it drops the two intermediate arrays the old
`flatMap` pair allocated. `grouping.ts:118-121` already documents and avoids
this same hazard for `Math.max(...groups)`.

Behaviour is unchanged for every selection that worked before. Band `normalize`
returns `(i + 0.5) / n` for a valid index and `undefined` otherwise
(`scales/train-band.ts:55-60`) — never `NaN` — so the comparison loop and the
old `Math.min` agree on every input a band scale can produce. `centers.length
=== 0` becomes `minCenter === Infinity`.

## Tests

The new test guards **arity**, not the engine limit, mirroring the guard in
`grouping.test.ts:286-311`: 500 distinct keys with `Math.min`/`Math.max`
stubbed to throw above 100 arguments.

Distinct keys are the point. A duplicate-key test would be satisfied by
deduplicating and then still spreading, which leaves the real caller broken — an
interval brush over a high-cardinality band axis produces many *distinct* keys.
This test refuses that fix. It also runs in 48 ms, against 404 ms for a test
that reaches the engine limit for real.

A second test pins the two skip branches the rewrite introduces: unknown keys
mixed with known ones, an all-unknown selection, and an empty selection.

## Verification

```
bun test packages/core        2038 pass, 0 fail
bun run check                 clean
bun node_modules/.bin/oxlint packages/core   clean
```

## Not in this change

- The other `Math.min(...)` / `Math.max(...)` sites in the tree
  (`render-svg-panel-chrome.ts`, `panel-layout.ts`, `band-guide.ts`,
  `assemble-scene-build.ts`, `SceneView.svelte`). Those spread panel counts,
  placement lists, and text-line counts — bounded by layout, not by the caller.
- `resolve`'s use of `bandValuesForKeys` (`semantic-viewport.ts:297`). It runs
  on the same selection as `project`, but it takes first and last rather than
  spreading, so a huge selection costs it memory, not a `RangeError`. Different
  defect; worth its own issue if it ever bites.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1319" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->