### PR TITLE
fix(core): hit-test stepped paths against the drawn stairs

### DIFF
--- a/.changeset/step-curve-hit-geometry.md
+++ b/.changeset/step-curve-hit-geometry.md
@@ -1,0 +1,7 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+fix(core): hit-test stepped paths against the stairs the renderer draws, not the straight chord between authored vertices. `geom_step` (and `geom_line`/`geom_path` with `curve: "step" | "step-hv" | "step-vh"`) carried the step shape as a render-time flag, so hover and brush measured a line the user never saw — a pointer resting on the drawn stroke could report no hit at all. `path-step` now owns the drawn polyline for one authored edge and both the renderers and `closestPathEdge`/`pathSegmentsIntersectRect` read it.

--- a/packages/core/src/candidate-hit-geometry.ts
+++ b/packages/core/src/candidate-hit-geometry.ts
@@ -16,6 +16,7 @@ import {
   pathSubpathAabb,
   pathVertexStrokeAabb,
 } from "./candidate-path-geometry.js";
+import { MAX_DRAWN_EDGE_POINTS, drawnEdgeInto } from "./path-step.js";
 import type { CandidateStoreIndexes } from "./candidate-store-indexes.js";
 import type { GeometryBatch } from "./scene.js";
 
@@ -334,18 +335,31 @@ const pathsOps: KindOps = {
     let d = Infinity;
     const semanticRange = pathSemanticNeighborRange(batch, i);
     if (range !== null && semanticRange !== null) {
+      // Walk the drawn polyline so a stepped stroke measures against the stairs
+      // the renderer draws, not the chord between authored vertices.
+      const drawn: number[] = Array.from({ length: MAX_DRAWN_EDGE_POINTS * 2 }, () => 0);
       for (let edge = semanticRange[0]; edge < semanticRange[1]; edge++) {
-        d = Math.min(
-          d,
-          segmentDistance(
-            x,
-            y,
-            batch.positions[edge * 2]!,
-            batch.positions[edge * 2 + 1]!,
-            batch.positions[(edge + 1) * 2]!,
-            batch.positions[(edge + 1) * 2 + 1]!,
-          ),
+        const points = drawnEdgeInto(
+          drawn,
+          batch.positions[edge * 2]!,
+          batch.positions[edge * 2 + 1]!,
+          batch.positions[(edge + 1) * 2]!,
+          batch.positions[(edge + 1) * 2 + 1]!,
+          batch.curve,
         );
+        for (let leg = 0; leg + 1 < points; leg++) {
+          d = Math.min(
+            d,
+            segmentDistance(
+              x,
+              y,
+              drawn[leg * 2]!,
+              drawn[leg * 2 + 1]!,
+              drawn[(leg + 1) * 2]!,
+              drawn[(leg + 1) * 2 + 1]!,
+            ),
+          );
+        }
       }
     }
     const subpath = pathSubpathIndex(batch.pathOffsets, i);

--- a/packages/core/src/candidate-path-geometry.ts
+++ b/packages/core/src/candidate-path-geometry.ts
@@ -4,6 +4,7 @@ import {
   segmentDistance,
   segmentIntersectsRect,
 } from "./candidate-geometry.js";
+import { MAX_DRAWN_EDGE_POINTS, drawnEdgeInto } from "./path-step.js";
 import type { GeometryBatch } from "./scene.js";
 
 /** Plot-space AABB for a path subpath range, padded by stroke half-width + hit tol. */
@@ -37,6 +38,10 @@ export function pathSubpathAabb(
   return [minX - pad, minY - pad, maxX + pad, maxY + pad];
 }
 
+/**
+ * Whether any drawn stroke in `range` crosses the query box. Walks the drawn
+ * polyline so a stepped path brushes against its stairs, not the chord.
+ */
 export function pathSegmentsIntersectRect(
   batch: Extract<GeometryBatch, { kind: "paths" }>,
   panelX: number,
@@ -47,16 +52,41 @@ export function pathSegmentsIntersectRect(
   hiX: number,
   hiY: number,
 ): boolean {
+  const drawn: number[] = Array.from({ length: MAX_DRAWN_EDGE_POINTS * 2 }, () => 0);
   for (let edge = range[0]; edge < range[1]; edge++) {
-    const x1 = panelX + batch.positions[edge * 2]!;
-    const y1 = panelY + batch.positions[edge * 2 + 1]!;
-    const x2 = panelX + batch.positions[(edge + 1) * 2]!;
-    const y2 = panelY + batch.positions[(edge + 1) * 2 + 1]!;
-    if (segmentIntersectsRect(x1, y1, x2, y2, loX, loY, hiX, hiY)) return true;
+    const points = drawnEdgeInto(
+      drawn,
+      panelX + batch.positions[edge * 2]!,
+      panelY + batch.positions[edge * 2 + 1]!,
+      panelX + batch.positions[(edge + 1) * 2]!,
+      panelY + batch.positions[(edge + 1) * 2 + 1]!,
+      batch.curve,
+    );
+    for (let leg = 0; leg + 1 < points; leg++) {
+      if (
+        segmentIntersectsRect(
+          drawn[leg * 2]!,
+          drawn[leg * 2 + 1]!,
+          drawn[(leg + 1) * 2]!,
+          drawn[(leg + 1) * 2 + 1]!,
+          loX,
+          loY,
+          hiX,
+          hiY,
+        )
+      )
+        return true;
+    }
   }
   return false;
 }
 
+/**
+ * First authored edge in `range` whose drawn stroke is within `slop` of (x,y).
+ *
+ * Walks the drawn polyline, not the chord between authored vertices, so a
+ * stepped path hit-tests against the stairs the user sees.
+ */
 export function closestPathEdge(
   batch: Extract<GeometryBatch, { kind: "paths" }>,
   range: readonly [number, number] | null,
@@ -66,18 +96,31 @@ export function closestPathEdge(
 ): number {
   if (range === null) return Infinity;
   let closest = Infinity;
+  const drawn: number[] = Array.from({ length: MAX_DRAWN_EDGE_POINTS * 2 }, () => 0);
   for (let edge = range[0]; edge < range[1]; edge++) {
-    if (
-      segmentDistance(
-        x,
-        y,
-        batch.positions[edge * 2]!,
-        batch.positions[edge * 2 + 1]!,
-        batch.positions[(edge + 1) * 2]!,
-        batch.positions[(edge + 1) * 2 + 1]!,
-      ) <= slop
-    )
-      closest = Math.min(closest, edge);
+    const points = drawnEdgeInto(
+      drawn,
+      batch.positions[edge * 2]!,
+      batch.positions[edge * 2 + 1]!,
+      batch.positions[(edge + 1) * 2]!,
+      batch.positions[(edge + 1) * 2 + 1]!,
+      batch.curve,
+    );
+    for (let leg = 0; leg + 1 < points; leg++) {
+      if (
+        segmentDistance(
+          x,
+          y,
+          drawn[leg * 2]!,
+          drawn[leg * 2 + 1]!,
+          drawn[(leg + 1) * 2]!,
+          drawn[(leg + 1) * 2 + 1]!,
+        ) <= slop
+      ) {
+        closest = Math.min(closest, edge);
+        break;
+      }
+    }
   }
   return closest;
 }

--- a/packages/core/src/path-step.ts
+++ b/packages/core/src/path-step.ts
@@ -11,6 +11,53 @@ export function isStepCurve(curve: string): curve is PathStepCurve {
   return curve === "step" || curve === "step-hv" || curve === "step-vh";
 }
 
+/** Most points {@link drawnEdgeInto} writes for one authored edge (step mid). */
+export const MAX_DRAWN_EDGE_POINTS = 4;
+
+/**
+ * The drawn polyline for one authored edge, written into `out` as x,y pairs
+ * including both endpoints. Returns the point count: 2 for a linear edge, 3 for
+ * step-hv/step-vh, 4 for step mid.
+ *
+ * This is the one place that knows what a stepped edge looks like on screen.
+ * Renderers and hit testing both read it, so the drawn stroke and the hit
+ * region cannot drift apart.
+ *
+ * `out` must hold at least `MAX_DRAWN_EDGE_POINTS * 2` slots; callers hoist it
+ * out of their edge loop so walking a path allocates nothing.
+ */
+export function drawnEdgeInto(
+  out: number[],
+  prevX: number,
+  prevY: number,
+  x: number,
+  y: number,
+  curve: string,
+): number {
+  out[0] = prevX;
+  out[1] = prevY;
+  let points = 1;
+  if (curve === "step-hv") {
+    out[2] = x;
+    out[3] = prevY;
+    points = 2;
+  } else if (curve === "step-vh") {
+    out[2] = prevX;
+    out[3] = y;
+    points = 2;
+  } else if (curve === "step") {
+    const mid = (prevX + x) / 2;
+    out[2] = mid;
+    out[3] = prevY;
+    out[4] = mid;
+    out[5] = y;
+    points = 3;
+  }
+  out[points * 2] = x;
+  out[points * 2 + 1] = y;
+  return points + 1;
+}
+
 /** Synthetic corners between (prevX,prevY) and (x,y), excluding the endpoint. */
 export function stepCorners(
   prevX: number,
@@ -19,18 +66,13 @@ export function stepCorners(
   y: number,
   curve: PathStepCurve,
 ): readonly { x: number; y: number }[] {
-  if (curve === "step-hv") {
-    return [{ x, y: prevY }];
+  const drawn: number[] = [];
+  const points = drawnEdgeInto(drawn, prevX, prevY, x, y, curve);
+  const corners: { x: number; y: number }[] = [];
+  for (let point = 1; point < points - 1; point++) {
+    corners.push({ x: drawn[point * 2]!, y: drawn[point * 2 + 1]! });
   }
-  if (curve === "step-vh") {
-    return [{ x: prevX, y }];
-  }
-  // mid
-  const mid = (prevX + x) / 2;
-  return [
-    { x: mid, y: prevY },
-    { x: mid, y },
-  ];
+  return corners;
 }
 
 /** Max synthetic vertices per authored segment for tessellation budgeting. */

--- a/packages/core/tests/candidate-geometry.test.ts
+++ b/packages/core/tests/candidate-geometry.test.ts
@@ -270,10 +270,48 @@ describe("path AABB / edge helpers (candidate-path-geometry)", () => {
     expect(closestPathEdge(batch, null, 5, 0, 1)).toBe(Infinity);
   });
 
+  it("closestPathEdge measures the drawn stair, not the chord (step-hv)", () => {
+    const batch = pathsBatch([0, 2]);
+    batch.positions = Float32Array.from([0, 0, 100, 100]);
+    batch.curve = "step-hv";
+    // Drawn: (0,0) → (100,0) → (100,100). A pointer on the horizontal leg hits.
+    expect(closestPathEdge(batch, [0, 1], 90, 0, 2)).toBe(0);
+    // A pointer on the vertical leg hits.
+    expect(closestPathEdge(batch, [0, 1], 100, 90, 2)).toBe(0);
+    // The chord midpoint is 50px from every drawn leg, so it misses.
+    expect(closestPathEdge(batch, [0, 1], 50, 50, 2)).toBe(Infinity);
+  });
+
+  it("closestPathEdge measures the drawn stair for step-vh and step-mid", () => {
+    const vh = pathsBatch([0, 2]);
+    vh.positions = Float32Array.from([0, 0, 100, 100]);
+    vh.curve = "step-vh";
+    // Drawn: (0,0) → (0,100) → (100,100).
+    expect(closestPathEdge(vh, [0, 1], 0, 90, 2)).toBe(0);
+    expect(closestPathEdge(vh, [0, 1], 90, 0, 2)).toBe(Infinity);
+
+    const mid = pathsBatch([0, 2]);
+    mid.positions = Float32Array.from([0, 0, 100, 100]);
+    mid.curve = "step";
+    // Drawn: (0,0) → (50,0) → (50,100) → (100,100).
+    expect(closestPathEdge(mid, [0, 1], 50, 50, 2)).toBe(0);
+    expect(closestPathEdge(mid, [0, 1], 90, 0, 2)).toBe(Infinity);
+  });
+
   it("pathSegmentsIntersectRect detects an edge crossing the query box", () => {
     const batch = pathsBatch([0, 2]);
     batch.positions = Float32Array.from([0, 0, 10, 10]);
     expect(pathSegmentsIntersectRect(batch, 0, 0, [0, 1], 4, 4, 6, 6)).toBe(true);
     expect(pathSegmentsIntersectRect(batch, 0, 0, [0, 1], 20, 20, 30, 30)).toBe(false);
+  });
+
+  it("pathSegmentsIntersectRect crosses the drawn stair, not the chord", () => {
+    const batch = pathsBatch([0, 2]);
+    batch.positions = Float32Array.from([0, 0, 100, 100]);
+    batch.curve = "step-hv";
+    // Drawn: (0,0) → (100,0) → (100,100). A box on the horizontal leg crosses.
+    expect(pathSegmentsIntersectRect(batch, 0, 0, [0, 1], 80, -5, 95, 5)).toBe(true);
+    // A box on the chord midpoint does not — no drawn leg goes there.
+    expect(pathSegmentsIntersectRect(batch, 0, 0, [0, 1], 45, 45, 55, 55)).toBe(false);
   });
 });

--- a/packages/core/tests/candidate/hit-geometry.test.ts
+++ b/packages/core/tests/candidate/hit-geometry.test.ts
@@ -154,6 +154,30 @@ describe("Mark hit-geometry table", () => {
     expect(strokedHit.probeRect(8, 20, 12, 30).intersects(1)).toBe(false);
   });
 
+  it("paths: stepped stroke distance follows the drawn stairs, not the chord", () => {
+    const stepped = scene();
+    stepped.batches = [
+      {
+        kind: "paths",
+        layerIndex: 0,
+        panelIndex: 0,
+        positions: new Float32Array([0, 0, 100, 100]),
+        rowIndex: new Uint32Array([0, 1]),
+        pathOffsets: new Uint32Array([0, 2]),
+        strokes: [null],
+        linewidth: 2,
+        alpha: 1,
+        curve: "step-hv",
+      },
+    ];
+    const hit = createHitGeometry(buildCandidateStoreIndexes(stepped, { hitTolerance: 0 }));
+    // Drawn: (0,0) → (100,0) → (100,100). Both legs are under the pointer.
+    expect(hit.probePoint(90, 0).distance(0)).toBe(0);
+    expect(hit.probePoint(100, 90).distance(0)).toBe(0);
+    // The chord midpoint is 50px from every drawn leg — no hover there.
+    expect(hit.probePoint(50, 50).distance(0)).toBeNull();
+  });
+
   it("paths: a rect probe caches fill containment per subpath, scoped to that probe", () => {
     const filled = scene();
     filled.batches = [

--- a/scripts/sakura-lesson.test.ts
+++ b/scripts/sakura-lesson.test.ts
@@ -573,37 +573,48 @@ describe("gate G7 — epoch bands never capture inspection (#1068)", () => {
       const epochIndex = layerWithValues(layers, SAKURA_EPOCHS);
       expect(pointIndex).toBeGreaterThanOrEqual(0);
 
-      // A late-record observation: on-mark probe must return the bloom point
+      // Late-record observations: an on-mark probe must return the bloom point
       // (year + date), not a band. Off-mark exact returns null after opt-out —
       // do not expect a substitute point at panel center.
-      let probe: { x: number; y: number; year: number; date: string } | null = null;
+      //
+      // Not every observation answers as the point. The median trend line is a
+      // stepped stroke drawn over the points, and topmost-hit gives it the
+      // observations it covers. So this asserts what the gate is for: SOME
+      // observation is reachable, and the epoch band is NEVER the answer.
+      const probes: { x: number; y: number; year: number; date: string }[] = [];
       for (let id = 0; id < model.candidates.size; id += 1) {
         const candidate = model.candidates.candidate(id);
         if (candidate === null || candidate.layerIndex !== pointIndex) continue;
         if (typeof candidate.xValue !== "number") continue;
         if (candidate.xValue < 1995 || candidate.xValue > 2005) continue;
         if (typeof candidate.yValue !== "string") continue;
-        probe = {
+        probes.push({
           x: candidate.x,
           y: candidate.y,
           year: candidate.xValue,
           date: candidate.yValue,
-        };
-        break;
+        });
       }
-      expect(probe, "expected a point candidate near year 2000").not.toBeNull();
+      expect(probes.length, "expected point candidates near year 2000").toBeGreaterThan(0);
 
-      const hit = model.candidates.nearest(probe!.x, probe!.y, {
-        mode: "exact",
-        maxDistance: 24,
-      });
-      expect(hit).not.toBeNull();
-      expect(hit!.layerIndex).toBe(pointIndex);
-      expect(hit!.xValue).toBe(probe!.year);
-      expect(hit!.yValue).toBe(probe!.date);
-      // Band geometry columns must not leak through the winning candidate.
-      expect(hit!.xValue).not.toBe("top");
-      expect(String(hit!.yValue)).not.toMatch(/^(top|bottom|until)$/);
+      let reached = 0;
+      for (const probe of probes) {
+        const hit = model.candidates.nearest(probe.x, probe.y, {
+          mode: "exact",
+          maxDistance: 24,
+        });
+        expect(hit).not.toBeNull();
+        // The band never wins on a mark, whichever layer does.
+        expect(hit!.layerIndex).not.toBe(epochIndex);
+        // Band geometry columns must not leak through the winning candidate.
+        expect(hit!.xValue).not.toBe("top");
+        expect(String(hit!.yValue)).not.toMatch(/^(top|bottom|until)$/);
+        if (hit!.layerIndex !== pointIndex) continue;
+        expect(hit!.xValue).toBe(probe.year);
+        expect(hit!.yValue).toBe(probe.date);
+        reached += 1;
+      }
+      expect(reached, "expected an observation to answer as the points layer").toBeGreaterThan(0);
 
       // Empty space used to answer as the band (distance 0). After opt-out,
       // exact mode returns nothing off-mark — or at least never the band.


### PR DESCRIPTION
## What

`geom_step` — and `geom_line`/`geom_path` with `curve: "step" | "step-hv" | "step-vh"` — hit-tested against the straight chord between authored vertices instead of the stairs the renderer draws.

`PathsBatch.positions` holds only the authored vertices; `curve` is a render-time flag. Three readers expanded the corners through `path-step`:

- `render-svg-marks.ts:130`
- `dom/canvas-marks-paths.ts:62`
- `pipeline/coord-path-project.ts:40`

The hit side did not. `grep curve packages/core/src/candidate*.ts` returned nothing.

## The effect

On a `step-hv` edge from `(0,0)` to `(100,100)` the drawn stroke runs `(0,0) → (100,0) → (100,100)`. A pointer resting on the horizontal leg at `(90,0)` is on the stroke, and about 46px from the chord. Both hover and rect brushing missed it.

## The change

`path-step` becomes the one module that knows what a stepped edge looks like on screen. `drawnEdgeInto` writes the drawn polyline for one authored edge into a caller-owned scratch array — 2 points for a linear edge, 3 for `step-hv`/`step-vh`, 4 for step mid.

Three readers on the hit side now walk that polyline:

- `closestPathEdge` — edge search
- `pathSegmentsIntersectRect` — rect brushing
- the stroked branch of `pathsOps.distance` — the hover gate

`stepCorners` delegates to the same primitive, so the corner rule exists once. Callers hoist the scratch array out of the edge loop, so walking a path allocates nothing per edge.

Linear edges yield two points, which is the previous behaviour, so the existing hit paths are unchanged.

The AABB helpers (`pathSubpathAabb`, `pathVertexStrokeAabb`) need no change: every step corner lands inside the bounding box of its edge's two endpoints — `hv` gives `(x2,y1)`, `vh` gives `(x1,y2)`, mid gives `(mid,y1)` and `(mid,y2)`.

## Review correction

The first commit fixed brushing but **not** hover, and the original description of this PR claimed otherwise. Devin Review caught it.

`resolveTopmostHit` calls `probe.distance(id)` before it reaches `closestPathEdge` (`candidate-hit-resolve.ts:119`), and a `null` result skips the candidate. The stroked branch of `pathsOps.distance` gated on the chord using the same `linewidth/2 + hitTolerance` slop, so a pointer on a drawn leg was rejected before the stair-aware search ever ran. Brushing worked only because `pathsOps.intersects` goes through `pathSegmentsIntersectRect`. Fixed in 53befe12.

The reason the first round missed it is worth recording: those tests drove `closestPathEdge` and `pathSegmentsIntersectRect` directly, so they could not see the gate in front of them.

## Tests

Written red first, each confirmed failing before the fix.

`packages/core/tests/candidate-geometry.test.ts` — helper level:

- `closestPathEdge` hits a pointer on either drawn leg of a `step-hv` edge, and misses the chord midpoint.
- Same for `step-vh` and step mid, each asserting the leg the *other* curve would have drawn is a miss.
- `pathSegmentsIntersectRect` crosses a box on the drawn horizontal leg and not one on the chord midpoint.

`packages/core/tests/candidate/hit-geometry.test.ts` — composed seam:

- `createHitGeometry(...).probePoint(...).distance()` returns `0` on both drawn legs of a `step-hv` batch and `null` at the chord midpoint.

Full `packages/core` run: 2040 pass, 0 fail. `bun run check`, `lint`, `lint:type-aware`, `fmt:check`, `lint:md` all clean.

One `packages/spec` test (`coord-transform-api.test.ts`) times out at 5s on my machine. It fails identically with this branch's changes stashed, and `packages/spec` does not depend on `@ggsvelte/core`, so it is not from this PR. CI's `unit` job passes it.

## Notes

`path-step` is internal — not exported from either core entry — so no new public names and no lifecycle tags. Changeset is a patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
