### PR TITLE
perf(spec): resolve a shared named dataset once, not once per layer

### DIFF
--- a/.changeset/shared-dataset-evidence.md
+++ b/.changeset/shared-dataset-evidence.md
@@ -11,9 +11,10 @@ dataset paid a full pivot of `{values}` rows into columns plus type inference
 over every column — so L layers naming one dataset did that work L times on one
 unchanged table.
 
-Resolve each name once and reuse it, seeded from the plot's own dataset so a
-layer naming the plot's table shares it too. That matches the row accounting,
-which already counts a shared name once.
+Resolve each name once and reuse it, for both the pivot and the type inference,
+seeded from the plot's own dataset so a layer naming the plot's table shares it
+rather than rebuilding. That matches the row accounting, which already counts a
+shared name once.
 
 Row and byte limits are unchanged: a shared name still counts once, and inline
 layer data still gets its own table, since equal content is not the same table.

--- a/.changeset/shared-dataset-evidence.md
+++ b/.changeset/shared-dataset-evidence.md
@@ -1,0 +1,19 @@
+---
+"@ggsvelte/spec": patch
+---
+
+# Resolve a shared named dataset once, not once per layer
+
+Migration: none — internal
+
+Data-aware validation resolved each layer's data independently. A layer naming a
+dataset paid a full pivot of `{values}` rows into columns plus type inference
+over every column — so L layers naming one dataset did that work L times on one
+unchanged table.
+
+Resolve each name once and reuse it, seeded from the plot's own dataset so a
+layer naming the plot's table shares it too. That matches the row accounting,
+which already counts a shared name once.
+
+Row and byte limits are unchanged: a shared name still counts once, and inline
+layer data still gets its own table, since equal content is not the same table.

--- a/packages/spec/src/validate-data-evidence.ts
+++ b/packages/spec/src/validate-data-evidence.ts
@@ -228,25 +228,40 @@ export function resolveLayerFieldEvidence(
 
   const layers = Array.isArray(spec["layers"]) ? (spec["layers"] as unknown[]) : [];
   const layerColumns: Array<Record<string, readonly CellValue[]> | null | "runtime"> = [];
+  /** Layer index → dataset name, for the layers that reference one. */
+  const layerNames: Array<string | null> = [];
+  // Several layers commonly name one dataset. Pivoting {values} rows into
+  // columns is O(rows x columns), so resolve each name once rather than once
+  // per reference. Inline data keeps its own table: equal content is not the
+  // same table.
+  const columnsByName = new Map<string, Record<string, readonly CellValue[]>>();
   for (const layer of layers) {
     if (!isRecord(layer) || layer["data"] === undefined) {
       layerColumns.push(null); // inherit plot
+      layerNames.push(null);
       continue;
     }
     const data = layer["data"];
-    const cols = columnsFromDataRef(data, datasets);
-    if (cols === null) {
-      // Named ref not in datasets (or malformed) — runtime-only / skip.
-      layerColumns.push("runtime");
-      continue;
+    const name = isRecord(data) && typeof data["name"] === "string" ? data["name"] : null;
+    let cols = name === null ? undefined : columnsByName.get(name);
+    if (cols === undefined) {
+      const resolved = columnsFromDataRef(data, datasets);
+      if (resolved === null) {
+        // Named ref not in datasets (or malformed) — runtime-only / skip.
+        // Left unmemoized: a miss is cheap and re-resolving keeps the
+        // runtime marker distinct from a resolved table.
+        layerColumns.push("runtime");
+        layerNames.push(null);
+        continue;
+      }
+      cols = resolved;
+      if (name !== null) columnsByName.set(name, cols);
     }
     // Deduplicate limit accounting for shared named datasets.
-    const key =
-      isRecord(data) && typeof data["name"] === "string"
-        ? `name:${data["name"]}`
-        : `inline:${layerColumns.length}`;
+    const key = name === null ? `inline:${layerColumns.length}` : `name:${name}`;
     countTable(key, cols);
     layerColumns.push(cols);
+    layerNames.push(name);
   }
 
   if (plotColumns === null && layerColumns.every((c) => c === null || c === "runtime")) {
@@ -279,10 +294,24 @@ export function resolveLayerFieldEvidence(
   }
 
   const plot = plotColumns === null ? null : evidenceFromColumns(plotColumns);
-  const layerMaps: Array<FieldEvidenceMap | null> = layerColumns.map((cols) => {
+  // Type inference walks every value of every column, so it too runs once per
+  // named dataset. The plot's own table seeds it, matching the row accounting
+  // above, which already treats a name the plot and a layer share as one table.
+  const evidenceByName = new Map<string, FieldEvidenceMap>();
+  const plotData = spec["data"];
+  if (plot !== null && isRecord(plotData) && typeof plotData["name"] === "string") {
+    evidenceByName.set(plotData["name"], plot);
+  }
+  const layerMaps: Array<FieldEvidenceMap | null> = layerColumns.map((cols, index) => {
     if (cols === "runtime") return null;
     if (cols === null) return plot;
-    return evidenceFromColumns(cols);
+    const name = layerNames[index] ?? null;
+    if (name === null) return evidenceFromColumns(cols);
+    const cached = evidenceByName.get(name);
+    if (cached !== undefined) return cached;
+    const built = evidenceFromColumns(cols);
+    evidenceByName.set(name, built);
+    return built;
   });
   return { status: "ok", plot, layers: layerMaps };
 }

--- a/packages/spec/src/validate-data-evidence.ts
+++ b/packages/spec/src/validate-data-evidence.ts
@@ -41,6 +41,11 @@ export type ResolveFieldEvidenceResult =
 
 /** Plot + per-layer field evidence from one pass over inline tables / profile. */
 export type ResolveLayerFieldEvidenceResult =
+  /**
+   * `layers[i]` may be the same object as `plot` or as another layer's entry
+   * when those layers read one dataset. Treat every map as read-only; copy
+   * before writing.
+   */
   | { status: "ok"; plot: FieldEvidenceMap | null; layers: Array<FieldEvidenceMap | null> }
   | { status: "none" }
   | { status: "errors"; errors: SpecError[] };
@@ -235,6 +240,12 @@ export function resolveLayerFieldEvidence(
   // per reference. Inline data keeps its own table: equal content is not the
   // same table.
   const columnsByName = new Map<string, Record<string, readonly CellValue[]>>();
+  const plotData = spec["data"];
+  const plotName =
+    isRecord(plotData) && typeof plotData["name"] === "string" ? plotData["name"] : null;
+  // The plot's own table seeds it, so a layer naming the plot's dataset reuses
+  // that pivot instead of building a second one.
+  if (plotColumns !== null && plotName !== null) columnsByName.set(plotName, plotColumns);
   for (const layer of layers) {
     if (!isRecord(layer) || layer["data"] === undefined) {
       layerColumns.push(null); // inherit plot
@@ -298,10 +309,7 @@ export function resolveLayerFieldEvidence(
   // named dataset. The plot's own table seeds it, matching the row accounting
   // above, which already treats a name the plot and a layer share as one table.
   const evidenceByName = new Map<string, FieldEvidenceMap>();
-  const plotData = spec["data"];
-  if (plot !== null && isRecord(plotData) && typeof plotData["name"] === "string") {
-    evidenceByName.set(plotData["name"], plot);
-  }
+  if (plot !== null && plotName !== null) evidenceByName.set(plotName, plot);
   const layerMaps: Array<FieldEvidenceMap | null> = layerColumns.map((cols, index) => {
     if (cols === "runtime") return null;
     if (cols === null) return plot;

--- a/packages/spec/tests/validate-evidence-once.test.ts
+++ b/packages/spec/tests/validate-evidence-once.test.ts
@@ -174,6 +174,63 @@ describe("tier 2 — single field-evidence pass", () => {
     expect(reads).toBeLessThan(240);
   });
 
+  it("infers a shared named dataset's types once, not once per layer", () => {
+    // A {columns} ref skips the pivot, so this counts the second stage: type
+    // inference walks the column arrays themselves.
+    const x = Array.from({ length: 40 }, (_, i) => i);
+    let reads = 0;
+    const counted = new Proxy(x, {
+      get(target, prop) {
+        if (typeof prop === "string" && /^\d+$/.test(prop)) reads += 1;
+        return Reflect.get(target, prop) as unknown;
+      },
+    });
+    const layers = Array.from({ length: 6 }, () => ({
+      geom: "point",
+      data: { name: "shared" },
+      aes: { x: { field: "x" } },
+    }));
+    const resolved = evidence.resolveLayerFieldEvidence(
+      { datasets: { shared: { columns: { x: counted } } }, layers },
+      {},
+      DEFAULT_VALIDATE_LIMITS,
+    );
+    expect(resolved.status).toBe("ok");
+    expect(reads).toBeGreaterThan(0);
+    // Six layers each inferring the column cost 1040 reads before; one pass
+    // costs far less. The bound fails on the first repeat.
+    expect(reads).toBeLessThan(400);
+  });
+
+  it("shares the plot's table with a layer that names it", () => {
+    const rows = Array.from({ length: 40 }, (_, i) => ({ x: i }));
+    let reads = 0;
+    const counted = new Proxy(rows, {
+      get(target, prop) {
+        if (typeof prop === "string" && /^\d+$/.test(prop)) reads += 1;
+        return Reflect.get(target, prop) as unknown;
+      },
+    });
+    const resolved = evidence.resolveLayerFieldEvidence(
+      {
+        data: { name: "shared" },
+        datasets: { shared: { values: counted } },
+        layers: [
+          { geom: "point", data: { name: "shared" }, aes: { x: { field: "x" } } },
+          { geom: "line", data: { name: "shared" }, aes: { x: { field: "x" } } },
+        ],
+      },
+      {},
+      DEFAULT_VALIDATE_LIMITS,
+    );
+    expect(resolved.status).toBe("ok");
+    if (resolved.status !== "ok") return;
+    // The plot pivots once; naming the same dataset must not pivot again.
+    expect(reads).toBeLessThan(2 * 40 * 2);
+    expect(resolved.layers[0]).toBe(resolved.plot);
+    expect(resolved.layers[1]).toBe(resolved.plot);
+  });
+
   it("gives layers naming one dataset the same evidence content", () => {
     const spec = {
       datasets: {

--- a/packages/spec/tests/validate-evidence-once.test.ts
+++ b/packages/spec/tests/validate-evidence-once.test.ts
@@ -145,4 +145,97 @@ describe("tier 2 — single field-evidence pass", () => {
     expect(result.ok).toBe(true);
     expect(result.advisories?.some((a) => a.code === "stacked-area-negative")).toBe(true);
   });
+
+  it("resolves a shared named dataset once, not once per layer", () => {
+    // columnsFromDataRef pivots {values} rows into columns, so counting row
+    // reads shows directly whether the pivot repeats per layer.
+    const rows = Array.from({ length: 40 }, (_, i) => ({ x: i, y: i * 2 }));
+    let reads = 0;
+    const counted = new Proxy(rows, {
+      get(target, prop) {
+        if (typeof prop === "string" && /^\d+$/.test(prop)) reads += 1;
+        return Reflect.get(target, prop) as unknown;
+      },
+    });
+    const layers = Array.from({ length: 6 }, () => ({
+      geom: "point",
+      data: { name: "shared" },
+      aes: { x: { field: "x" }, y: { field: "y" } },
+    }));
+    const resolved = evidence.resolveLayerFieldEvidence(
+      { datasets: { shared: { values: counted } }, layers },
+      {},
+      DEFAULT_VALIDATE_LIMITS,
+    );
+    expect(resolved.status).toBe("ok");
+    // One pivot of 40 rows x 2 columns costs 120 reads (40 for key discovery,
+    // 40 per column). Six layers repeating it cost 720.
+    expect(reads).toBeGreaterThan(0);
+    expect(reads).toBeLessThan(240);
+  });
+
+  it("gives layers naming one dataset the same evidence content", () => {
+    const spec = {
+      datasets: {
+        shared: {
+          values: [
+            { x: 1, y: 2 },
+            { x: 3, y: 4 },
+          ],
+        },
+      },
+      layers: [
+        { geom: "point", data: { name: "shared" }, aes: { x: { field: "x" }, y: { field: "y" } } },
+        { geom: "line", data: { name: "shared" }, aes: { x: { field: "x" }, y: { field: "y" } } },
+      ],
+    };
+    const resolved = evidence.resolveLayerFieldEvidence(spec, {}, DEFAULT_VALIDATE_LIMITS);
+    expect(resolved.status).toBe("ok");
+    if (resolved.status !== "ok") return;
+    const [first, second] = resolved.layers;
+    expect(first).not.toBeNull();
+    expect([...first!.keys()].toSorted()).toEqual(["x", "y"]);
+    expect([...second!.keys()].toSorted()).toEqual(["x", "y"]);
+    expect(first!.get("x")!.type).toBe(second!.get("x")!.type);
+    expect([...first!.get("x")!.values]).toEqual([...second!.get("x")!.values]);
+  });
+
+  it("keeps distinct inline layer datasets independent", () => {
+    const resolved = evidence.resolveLayerFieldEvidence(
+      {
+        layers: [
+          { geom: "point", data: { columns: { x: [1, 2] } }, aes: { x: { field: "x" } } },
+          { geom: "point", data: { columns: { x: ["a", "b"] } }, aes: { x: { field: "x" } } },
+        ],
+      },
+      {},
+      DEFAULT_VALIDATE_LIMITS,
+    );
+    expect(resolved.status).toBe("ok");
+    if (resolved.status !== "ok") return;
+    expect([...resolved.layers[0]!.get("x")!.values]).toEqual([1, 2]);
+    expect([...resolved.layers[1]!.get("x")!.values]).toEqual(["a", "b"]);
+  });
+
+  it("still counts a shared named dataset once toward the row limit", () => {
+    const rows = Array.from({ length: 30 }, (_, i) => ({ x: i }));
+    const layer = () => ({ geom: "point", data: { name: "shared" }, aes: { x: { field: "x" } } });
+    const resolved = evidence.resolveLayerFieldEvidence(
+      { datasets: { shared: { values: rows } }, layers: [layer(), layer(), layer()] },
+      {},
+      { ...DEFAULT_VALIDATE_LIMITS, maxRows: 60 },
+    );
+    // 3 x 30 would breach 60; the name is counted once, so this stays ok.
+    expect(resolved.status).toBe("ok");
+  });
+
+  it("treats a named ref missing from datasets as runtime for every layer", () => {
+    const layer = () => ({ geom: "point", data: { name: "absent" }, aes: { x: { field: "x" } } });
+    const resolved = evidence.resolveLayerFieldEvidence(
+      { datasets: {}, layers: [layer(), layer()] },
+      {},
+      DEFAULT_VALIDATE_LIMITS,
+    );
+    expect(resolved.status).toBe("none");
+  });
 });


### PR DESCRIPTION
## What

Data-aware validation resolved each layer's data independently. A layer naming a dataset paid two full passes over it — pivoting `{values}` rows into columns, then running type inference over every column — so L layers naming one dataset did that work L times on one unchanged table.

The dedup key already existed one line away. Row accounting has always counted a shared name once (`countTable` returns early on a repeat key, and its comment says "Deduplicate limit accounting for shared named datasets"); it just was never applied to the scanning.

## What n is, honestly

R = rows and C = columns of the dataset; L = layers naming it. R is unbounded data; **L is chart configuration**, so this is repeated work linear in layer count, not a superlinear blowup in data. It is worth fixing because the repeated unit is a full pass over the user's table, and because this is the agent-facing validation path whose own header says it "must not be resource-abusable" — the limits count a shared name once while the scanning did not, so a passing `maxRows` did not bound the CPU.

Measured on the resolver, 40 rows × 2 columns:

| shape | before | after |
|---|---|---|
| 6 layers naming one dataset (pivot) | 720 row reads | 120 |
| plot names it too | 840 | 120 |
| 6 layers, `{columns}` ref (type inference) | 1040 column reads | 240 |

## Behavior

Diagnostics unchanged. An independent reviewer built a differential harness running main's implementation beside this one over **493 specs**, comparing `validate()` output and a full structural dump including Map iteration order: several layers on one name, plot named same and different, mixed named/inline, absent names, `{columns}` vs `{values}` and every cross, `__proto__`/`constructor`/`toString` as dataset names (including own `__proto__` keys from `JSON.parse`), case-differing duplicates, names colliding with the internal `inline:0` and `__plot__` accounting keys, ragged and all-null columns, the profile path, and 400 seeded fuzz specs. **Zero mismatches**, with harness sensitivity proven by perturbing the old copy.

Limits are untouched: `totalRows`/`totalBytes` were binary-searched to their exact boundaries on four shapes and match. Inline layer data is deliberately never shared — two inline tables are distinct even when their contents are equal.

Layers naming one dataset now receive the same evidence map object. That aliasing already existed for layers inheriting plot data; the result type now documents it, and no consumer writes to a map it did not create.

## Verification

- `bun test packages/spec packages/core` — 2744 pass
- `bun run check`, `bun run lint`, `bun run lint:type-aware`, `bun run knip`, `bun run fmt:check` — clean

Two cost guards, both checked against a mutant with the relevant memo deleted: one proxies the rows array to catch a repeated pivot, the other uses a `{columns}` ref so it sees the type-inference stage the first guard is blind to.

Note: `packages/spec/tests/coord-transform-api.test.ts` times out locally under load (~12s against a 5s limit). It reproduces on `main` unchanged and is unrelated to this branch.

## Follow-ups

First audit of `packages/spec`. Also filed: #1320 (timezone validation allocates per row in the temporal parse loop). The builder double-snapshot this pass re-found is already tracked as #1280.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1324" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->