### PR TITLE
perf(svelte): bucket batches by panel once per render

### DIFF
--- a/.changeset/scene-panel-batches.md
+++ b/.changeset/scene-panel-batches.md
@@ -1,0 +1,21 @@
+---
+"@ggsvelte/core": minor
+"@ggsvelte/svelte": patch
+---
+
+# Bucket batches by panel once per render
+
+Migration: none — additive
+
+`SceneView` nested a loop over batches inside its loop over panels, deciding
+membership with a per-pair `batch.panelIndex === i`. Batch count itself grows
+with panel count — the pipeline emits per layer per panel — so the product grew
+roughly with layers times panels squared.
+
+The SVG-string renderer and the canvas renderer already grouped once (issue 185) through `groupBatchesByPanel`, which was reachable only from
+`@ggsvelte/core/dom`. It is pure, so it now sits on `@ggsvelte/core` and all
+three renderers share one copy of the routing rule rather than three.
+
+Measured element reads of the batch list per render, with 24 batches: 2 panels
+48, 4 panels 96, 12 panels 288, 24 panels 576 before; 24 at every panel count
+after.

--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -12036,8 +12036,8 @@ export const DOCS_ROUTES = [
         level: 2,
       },
       {
-        id: "experimental-320",
-        title: "experimental (320)",
+        id: "experimental-321",
+        title: "experimental (321)",
         level: 3,
       },
       {

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -19903,14 +19903,14 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["@ggsvelte/core"],
   },
   {
-    id: "heading:guide-lifecycle:experimental-320",
+    id: "heading:guide-lifecycle:experimental-321",
     kind: "heading",
-    title: "experimental (320)",
+    title: "experimental (321)",
     summary:
-      "experimental (320) in Lifecycle & editions. API stability tags per export, and the defaults-edition mechanism.",
-    href: "/guide/lifecycle#experimental-320",
+      "experimental (321) in Lifecycle & editions. API stability tags per export, and the defaults-edition mechanism.",
+    href: "/guide/lifecycle#experimental-321",
     keywords: ["Lifecycle & editions", "Reference"],
-    exact: ["experimental (320)"],
+    exact: ["experimental (321)"],
   },
   {
     id: "heading:guide-lifecycle:stable-intent-2",
@@ -32746,6 +32746,15 @@ export const DOCS_SEARCH_INDEX = [
     href: "/guide/lifecycle#ggsvelte-core",
     keywords: ["@ggsvelte/core", ".", "value", "experimental"],
     exact: ["getScaleTransform"],
+  },
+  {
+    id: "api:ggsvelte-core:groupBatchesByPanel",
+    kind: "api",
+    title: "groupBatchesByPanel",
+    summary: "@ggsvelte/core · value · experimental.",
+    href: "/guide/lifecycle#ggsvelte-core",
+    keywords: ["@ggsvelte/core", ".", "value", "experimental"],
+    exact: ["groupBatchesByPanel"],
   },
   {
     id: "api:ggsvelte-core:humanizeFieldTitle",

--- a/lifecycle.json
+++ b/lifecycle.json
@@ -4830,6 +4830,10 @@
           "kind": "value",
           "lifecycle": "experimental"
         },
+        "groupBatchesByPanel": {
+          "kind": "value",
+          "lifecycle": "experimental"
+        },
         "humanizeFieldTitle": {
           "kind": "value",
           "lifecycle": "experimental"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,9 @@
 // into lifecycle.json by scripts/gen-lifecycle.ts.
 // @lifecycle-default experimental
 
+// Panel routing shared by every renderer (SVG string, canvas, Svelte scene).
+export { groupBatchesByPanel } from "./group-batches-by-panel.js";
+
 // Full grammar: register every stat frame builder and geom batch.
 import "./pipeline/frame-stats-register-all.js";
 import "./pipeline/geometry-register-all.js";

--- a/packages/svelte/src/lib/scene/SceneView.svelte
+++ b/packages/svelte/src/lib/scene/SceneView.svelte
@@ -20,6 +20,7 @@
     ScenePanel,
   } from "@ggsvelte/core";
   import {
+    groupBatchesByPanel,
     letterboxGutterRects,
     sceneLabel,
     STRIP_BAND,
@@ -140,6 +141,19 @@
   // indexOf per batch during panel loops.
   const markFocusMasks = $derived(
     resolveBatchFocusMasks(scene.batches, markBatches, focusMasks),
+  );
+  // Bucket batches by panel once. Batch count grows with panel count (the
+  // pipeline emits per layer per panel), so testing every batch against every
+  // panel cost ~O(layers x panels^2) per render. Same routing the SVG-string
+  // and canvas renderers use, so all three drop a batch with a panelIndex that
+  // is not a real bucket (NaN, fractional, out of range) identically.
+  //
+  // Batches and their original indices stay in parallel arrays rather than
+  // paired objects: a fresh wrapper per recompute would fail the keyed each's
+  // identity check and re-run every Batch's props, where the batch object
+  // itself keeps its identity across a rebucket.
+  const panelBatches = $derived(
+    groupBatchesByPanel(scene.panels.length, markBatches, true),
   );
 
   const gridBounds = $derived.by(() => {
@@ -314,16 +328,15 @@
             ? undefined
             : `url(#${uid}-clip-${i})`}
         >
-          {#each markBatches as batch, bi (bi)}
-            {#if batch.panelIndex === i}
-              <Batch
-                {batch}
-                theme={scene.theme}
-                {focusable}
-                {markLabel}
-                focusMask={markFocusMasks[bi] ?? null}
-              />
-            {/if}
+          {#each panelBatches.byPanel[i] ?? [] as batch, k (panelBatches.indices?.[i]?.[k] ?? k)}
+            <Batch
+              {batch}
+              theme={scene.theme}
+              {focusable}
+              {markLabel}
+              focusMask={markFocusMasks[panelBatches.indices?.[i]?.[k] ?? -1] ??
+                null}
+            />
           {/each}
         </g>
       {/if}

--- a/packages/svelte/tests/scene/scene-view-panel-batches.test.ts
+++ b/packages/svelte/tests/scene/scene-view-panel-batches.test.ts
@@ -1,0 +1,182 @@
+/**
+ * SceneView routes batches to panels by bucketing once, not by testing every
+ * batch against every panel. Batch count itself grows with panel count (the
+ * pipeline emits per layer per panel), so the nested form was ~O(L x P^2).
+ */
+import { fromAny } from "@total-typescript/shoehorn";
+import { describe, expect, it } from "vitest";
+
+import type { GeometryBatch, Scene } from "@ggsvelte/core";
+
+import SceneView from "../../src/lib/scene/SceneView.svelte";
+import { render } from "../helpers/render.js";
+
+function pointsBatch(panelIndex: number, layerIndex: number): GeometryBatch {
+  return fromAny<GeometryBatch>({
+    kind: "points",
+    layerIndex,
+    panelIndex,
+    positions: Float32Array.from([1, 1]),
+    rowIndex: Uint32Array.from([0]),
+    size: 2,
+    alpha: 1,
+    shape: "circle",
+    fill: "red",
+  });
+}
+
+function panel(index: number): unknown {
+  return {
+    id: `panel-${index}`,
+    x: index * 20,
+    y: 0,
+    width: 18,
+    height: 18,
+    strip: "",
+    axisX: null,
+    axisY: null,
+    grid: { x: [], y: [] },
+    clip: false,
+  };
+}
+
+function sceneWith(panelCount: number, batches: GeometryBatch[]): Scene {
+  return fromAny<Scene>({
+    width: panelCount * 20,
+    height: 20,
+    panels: Array.from({ length: panelCount }, (_, i) => panel(i)),
+    batches,
+    legends: [],
+    theme: {
+      ink: "black",
+      accent: "blue",
+      paper: "none",
+      panel: "none",
+      interactionMuted: 0.35,
+      fontFamily: "sans-serif",
+      fontSize: 12,
+      fontWeight: 400,
+      gridX: false,
+      gridY: false,
+      showPanelBorder: false,
+    },
+    axes: { x: { ticks: [], title: "" }, y: { ticks: [], title: "" } },
+    title: "",
+    subtitle: "",
+    caption: "",
+  });
+}
+
+/** Marks actually rendered under each `data-panel` group, in document order. */
+function markLayersByPanel(container: HTMLElement): number[][] {
+  return [...container.querySelectorAll("[data-panel]")].map((group) =>
+    [...group.querySelectorAll<HTMLElement>(".gg-batch")].map((node) =>
+      Number(node.dataset["layer"]),
+    ),
+  );
+}
+
+describe("SceneView panel routing", () => {
+  it("places each batch under its own panel, keeping global order within a panel", () => {
+    // Interleaved so per-panel order cannot be read off the input order alone.
+    const batches = [
+      pointsBatch(1, 0),
+      pointsBatch(0, 1),
+      pointsBatch(1, 2),
+      pointsBatch(0, 3),
+      pointsBatch(2, 4),
+    ];
+    const { container } = render(SceneView, { props: { scene: sceneWith(3, batches) } });
+    expect(markLayersByPanel(container)).toEqual([[1, 3], [0, 2], [4]]);
+  });
+
+  it("renders nothing for a batch whose panelIndex is out of range or not an index", () => {
+    const batches = [
+      pointsBatch(0, 0),
+      pointsBatch(5, 1), // beyond the panel count
+      pointsBatch(-1, 2),
+      pointsBatch(Number.NaN, 3),
+      fromAny<GeometryBatch>({ ...pointsBatch(0, 4), panelIndex: 1.5 }),
+    ];
+    const { container } = render(SceneView, { props: { scene: sceneWith(2, batches) } });
+    expect(markLayersByPanel(container)).toEqual([[0], []]);
+  });
+
+  /** Batch-list element reads taken while rendering `panelCount` panels. */
+  function readsForPanelCount(panelCount: number, batchCount: number): number {
+    const raw = Array.from({ length: batchCount }, (_, i) => pointsBatch(i % panelCount, i));
+    let reads = 0;
+    const counted = new Proxy(raw, {
+      get(target, prop) {
+        if (typeof prop === "string" && /^\d+$/.test(prop)) reads += 1;
+        return Reflect.get(target, prop) as unknown;
+      },
+    });
+    const { container } = render(SceneView, {
+      props: { scene: sceneWith(panelCount, counted) },
+    });
+    expect(container.querySelectorAll(".gg-batch")).toHaveLength(batchCount);
+    return reads;
+  }
+
+  it("reads the batch list the same number of times however many panels there are", () => {
+    // This is the property, not a magic bound: the nested form read the list
+    // once per (panel, batch) pair, so reads tracked panel count exactly
+    // (2 panels 48, 4 panels 96, 24 panels 576 for 24 batches). Bucketing
+    // walks it once, so the count must not move with panel count.
+    const few = readsForPanelCount(2, 24);
+    const many = readsForPanelCount(24, 24);
+    expect(few).toBeGreaterThan(0);
+    expect(many).toBe(few);
+    // One pass over the list, so reads track batch count rather than panels.
+    expect(few).toBeLessThanOrEqual(2 * 24);
+  });
+
+  it("reuses mark nodes when the scene object is replaced with the same batches", () => {
+    // Only the wrapper Scene changes; the batch objects survive. The keyed each
+    // holds the batch itself, so a rebucket must not remount anything.
+    const batches = [pointsBatch(0, 0), pointsBatch(1, 1), pointsBatch(0, 2)];
+    const { container, rerender } = render(SceneView, {
+      props: { scene: sceneWith(2, batches) },
+    });
+    const before = [...container.querySelectorAll(".gg-batch")];
+    expect(before).toHaveLength(3);
+
+    void rerender({ scene: sceneWith(2, batches) });
+
+    const after = [...container.querySelectorAll(".gg-batch")];
+    expect(after).toHaveLength(3);
+    expect(after.every((node, i) => node === before[i])).toBe(true);
+  });
+
+  it("aligns focus masks with the original batch index for a reordered subset", () => {
+    // The bucket carries original indices precisely so masks stay aligned when
+    // the batches prop is a reordered subset of scene.batches.
+    const a = pointsBatch(0, 0);
+    const b = pointsBatch(1, 1);
+    const c = pointsBatch(0, 2);
+    const scene = sceneWith(2, [a, b, c]);
+    const mask = (focused: boolean) =>
+      fromAny({ primitiveCount: 1, focusedCount: focused ? 1 : 0, isFocused: () => focused });
+    // Masks are given in scene order (a, b, c) and projected onto the rendered
+    // list by identity; only c is focused. Render order b,c,a puts panel 0's
+    // batches at positions 1 and 2, so the original index and the position
+    // within the panel cannot coincide.
+    const focusMasks = [mask(false), mask(false), mask(true)];
+    const { container } = render(SceneView, {
+      props: { scene, mode: "marks", batches: [b, c, a], focusMasks },
+    });
+    const rendered = [...container.querySelectorAll<HTMLElement>(".gg-batch")];
+    // Panel 0 first (c then a), then panel 1 (b).
+    expect(rendered.map((node) => Number(node.dataset["layer"]))).toEqual([2, 0, 1]);
+    // Batch stamps data-gg-focused per mark from its mask. c is focused and a
+    // is not; reading the mask by render position rather than original index
+    // reports both unfocused.
+    const focusedFlags = rendered.map((node) =>
+      [...node.querySelectorAll<HTMLElement>("[data-gg-focused]")].map(
+        (mark) => mark.dataset["ggFocused"],
+      ),
+    );
+    expect(focusedFlags).toEqual([["true"], ["false"], ["false"]]);
+  });
+});


### PR DESCRIPTION
## What

`SceneView` nested a loop over batches inside its loop over panels, deciding membership with a per-pair test:

```svelte
{#each scene.panels as panel, i (i)}
  {#each markBatches as batch, bi (bi)}
    {#if batch.panelIndex === i}
```

Batch count itself grows with panel count — the pipeline emits per layer per panel — so the product grew roughly with layers times panels squared.

Closes #1325.

## Measured

Element reads of the batch list per render, 24 batches:

| panels | 2 | 4 | 12 | 24 |
|---|---|---|---|---|
| before | 48 | 96 | 288 | 576 |
| after | 24 | 24 | 24 | 24 |

Exactly `P × B` before, one pass after.

## Sharing the routing rule rather than copying it

The SVG-string renderer and the canvas renderer already grouped once (issue 185) through `groupBatchesByPanel`, but it was reachable only from `@ggsvelte/core/dom`, and this component must stay SSR-safe. The module is pure — it imports one type — so it now sits on `@ggsvelte/core` and all three renderers share one copy of the rule that decides which batches belong to a panel, including how a `panelIndex` that is not a real bucket is dropped.

That new export is why `@ggsvelte/core` takes a minor bump.

## Two measurements shaped the implementation

Neither was obvious from reading:

- Bucketing **indices alone** left the template re-indexing the batch list on every render pass: a flat 264 reads, worse than the nested scan's 48 at two panels. That would have been a regression for the few-panel charts that dominate.
- Pairing each batch with its index in a **wrapper object** fixed the read count but broke the keyed each's identity check, so every `Batch` re-ran its props on a rebucket (76 property reads on a scene swap, against 0 before).

Parallel arrays — the shape the core helper already returns — avoid both.

## Behavior

Unchanged. An independent reviewer rendered old and new side by side in the browser harness across a 17-case edge matrix — `-0`, `NaN`, `1.5`, `-1`, out-of-range, `±Infinity`, `1e21`, boxed `Number`, `"1"`, `undefined`, zero panels, zero batches, P>B, B>P, and mixed — all identical, including within-panel order and cross-panel-move node reuse.

## Verification

- `vitest --project chromium tests/scene` — 11 files, 77 tests pass
- `bun run test:ssr` — 15 files, 125 tests pass
- `bun test packages/core packages/spec` — 2747 pass (the one failure, `coord-transform-api`, needs ~12s against a 5s limit and reproduces on `main`)
- `bun run check`, `check:svelte`, `lint`, `lint:type-aware`, `knip`, `fmt:check` — clean

The cost guard asserts the property rather than a threshold: reads must not move with panel count. It fails against the old code with 576 vs 48. Tests also pin per-panel order, the dropped set, node reuse across a scene swap, and focus-mask alignment for a reordered subset — the last with the panel's batches at non-zero positions, so reading masks by render position instead of original index fails it.

## Follow-ups

Still open from the same audit of `packages/svelte`: #1326, #1327, #1328, #1329.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1330" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->