### PR TITLE
perf(svelte): resolve tooltip lineage keys by row index

### DIFF
--- a/.changeset/lineage-source-keys.md
+++ b/.changeset/lineage-source-keys.md
@@ -17,4 +17,6 @@ already passed, and the lineage walk asks it directly. Measured on a 60-row
 smooth: 120 row materializations before, at most 2 after.
 
 `resolveInspection` keeps its row-shaped `keyOf` and builds the materializing
-adapter itself, so that entry point is unchanged.
+adapter itself, so its output is unchanged. That adapter memoizes one index, so
+reading a member's own row for the snapshot and then asking for its key does not
+copy the row twice.

--- a/.changeset/lineage-source-keys.md
+++ b/.changeset/lineage-source-keys.md
@@ -1,0 +1,20 @@
+---
+"@ggsvelte/svelte": patch
+---
+
+# Resolve tooltip lineage keys by row index
+
+Migration: none — internal
+
+Building a tooltip snapshot materialized one row object per source row in a
+candidate's lineage, then threw it away. `model.row` copies every column on each
+call and has no cache, while the key resolver production wires in only ever
+needs the index. For an aggregate or `geom_smooth` mark the lineage is the whole
+group, so hovering one mark over a large group allocated a row per group member.
+
+The coordinator now takes an index-keyed resolver, matching what production
+already passed, and the lineage walk asks it directly. Measured on a 60-row
+smooth: 120 row materializations before, at most 2 after.
+
+`resolveInspection` keeps its row-shaped `keyOf` and builds the materializing
+adapter itself, so that entry point is unchanged.

--- a/benchmarks/retained-memory.ts
+++ b/benchmarks/retained-memory.ts
@@ -127,7 +127,10 @@ export function createGroupedInspectionRetentionFixture() {
   );
   const seed = model.candidates.candidate(0);
   if (seed === null) throw new Error("grouped inspection retention seed is missing");
-  const coordinator = createInspectionCoordinator<Row, string>((row) => row.id);
+  const coordinator = createInspectionCoordinator<Row, string>((index) => {
+    const row = model.row(index) as Row | null;
+    return row === null ? null : row.id;
+  });
   const shared = {
     model,
     seed,

--- a/packages/svelte/src/lib/inspection/coordinator.ts
+++ b/packages/svelte/src/lib/inspection/coordinator.ts
@@ -101,7 +101,7 @@ function candidateBatchRole(model: RenderModel, candidate: CandidateFacts): stri
 export function createInspectionCoordinator<
   Row extends Record<string, CellValue>,
   Key extends PropertyKey,
->(keyOf: (row: Row, index: number) => Key | null) {
+>(keyAt: (index: number) => Key | null) {
   type Slot = Readonly<{
     key: string;
     value: CoordinatedInspection<Row, Key>;
@@ -161,8 +161,7 @@ export function createInspectionCoordinator<
         : target.members.slice(0, TRANSIENT_MEMBER_LIMIT);
     const semanticMembers = fingerprintMembers.map((candidate) => {
       const row = candidate.rowIndex === null ? null : input.model.row(candidate.rowIndex);
-      const key =
-        row === null || candidate.rowIndex === null ? null : keyOf(row as Row, candidate.rowIndex);
+      const key = row === null || candidate.rowIndex === null ? null : keyAt(candidate.rowIndex);
       const fallback = `lineage:${input.model.lineage.keys(candidate.lineage).join(",")}`;
       const payload =
         row === null
@@ -172,9 +171,7 @@ export function createInspectionCoordinator<
     });
     const focusRow = input.seed.rowIndex === null ? null : input.model.row(input.seed.rowIndex);
     const focusKey =
-      focusRow === null || input.seed.rowIndex === null
-        ? null
-        : keyOf(focusRow as Row, input.seed.rowIndex);
+      focusRow === null || input.seed.rowIndex === null ? null : keyAt(input.seed.rowIndex);
     const focusIdentity = semanticKeyToken(
       focusKey,
       `lineage:${input.model.lineage.keys(input.seed.lineage).join(",")}`,
@@ -210,7 +207,7 @@ export function createInspectionCoordinator<
     const cacheKey = `${epochToken(input.layoutEpoch)}|${presentationIdentity}|${semanticFingerprint}|${completeness}|${input.source}`;
     const current = input.state === "pinned" ? pinned : transient;
     if (current?.key === cacheKey) return current.value;
-    const snapshot = materializeInspection({ ...input, keyOf }, target, completeness);
+    const snapshot = materializeInspection<Row, Key>(input, target, completeness, keyAt);
     const value = Object.freeze({
       seed: input.seed,
       snapshot,
@@ -252,11 +249,12 @@ export function createInspectionCoordinator<
     return logicalIdentity === prior.seedLogicalIdentity;
   };
 
-  /** Keyed pin match: layer + non-null row whose keyOf equals the pinned key. */
+  /** Keyed pin match: layer + non-null row whose key equals the pinned key. */
   const keyedPinMatch = (model: RenderModel, prior: Slot, candidate: CandidateFacts): boolean => {
     if (candidate.layerIndex !== prior.layerIndex || candidate.rowIndex === null) return false;
+    // Both gates stay: keyed rebind needs a live row AND a matching key.
     const row = model.row(candidate.rowIndex);
-    return row !== null && keyOf(row as Row, candidate.rowIndex) === prior.seedKey;
+    return row !== null && keyAt(candidate.rowIndex) === prior.seedKey;
   };
 
   /**

--- a/packages/svelte/src/lib/inspection/inspection-state.svelte.ts
+++ b/packages/svelte/src/lib/inspection/inspection-state.svelte.ts
@@ -216,7 +216,7 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
 
   // Coordinator closes over keyAt — handler-only invocation (deferred).
   const inspectionCoordinator = createInspectionCoordinator<Record<string, CellValue>, PropertyKey>(
-    (_row, index) => deps.keyAt(index),
+    (index) => deps.keyAt(index),
   );
 
   let reconciledRun = -1;

--- a/packages/svelte/src/lib/inspection/resolver.ts
+++ b/packages/svelte/src/lib/inspection/resolver.ts
@@ -125,9 +125,19 @@ export function resolveInspection<Row extends Record<string, CellValue>, Key ext
   // This entry point takes a row-shaped keyOf, so it materializes each row to
   // ask for its key. The coordinated path passes an index-keyed resolver and
   // skips that entirely.
+  //
+  // One slot of memo, because datum reads a member's own row for the gate and
+  // then asks for its key by index — without this the legacy path would copy
+  // that row twice. Distinct lineage indexes miss the slot and materialize as
+  // they always did.
+  let lastIndex = -1;
+  let lastRow: Row | null = null;
   const keyAt = (index: number): Key | null => {
-    const row = model.row(index) as Row | null;
-    return row === null ? null : keyOf(row, index);
+    if (index !== lastIndex) {
+      lastIndex = index;
+      lastRow = model.row(index) as Row | null;
+    }
+    return lastRow === null ? null : keyOf(lastRow, index);
   };
   const target = resolvedTarget(model, seed, mode);
   // The legacy direct constructor remains total for callers that already hold

--- a/packages/svelte/src/lib/inspection/resolver.ts
+++ b/packages/svelte/src/lib/inspection/resolver.ts
@@ -59,17 +59,20 @@ export function resolvedTarget(
 function datum<Row extends Record<string, CellValue>, Key extends PropertyKey>(
   model: RenderModel,
   candidate: CandidateFacts,
-  keyOf: (row: Row, index: number) => Key | null,
+  keyAt: (index: number) => Key | null,
 ): PlotDatum<Row, Key> {
   const row = candidate.rowIndex === null ? null : (model.row(candidate.rowIndex) as Row | null);
-  const key = row === null || candidate.rowIndex === null ? null : keyOf(row, candidate.rowIndex);
+  // The row gate stays: a member whose row does not resolve has no key, even
+  // when the resolver would hand one back for that index.
+  const key = row === null || candidate.rowIndex === null ? null : keyAt(candidate.rowIndex);
   // Set-based first-seen dedup (O(R)) — same pattern as selection helpers.
   // Array#includes here was O(R²) for large aggregate/stat lineages (#200).
-  const sourceKeys = uniqueKeysFromRowIndexes(model.lineage.keys(candidate.lineage), (rowIndex) => {
-    const source = model.row(rowIndex);
-    if (source === null) return null;
-    return keyOf(source as Row, rowIndex);
-  }) as Key[];
+  // Resolving by index keeps this O(R) lookups rather than O(R) row copies:
+  // model.row rebuilds an object per call, and the key never needed it.
+  const sourceKeys = uniqueKeysFromRowIndexes(
+    model.lineage.keys(candidate.lineage),
+    keyAt,
+  ) as Key[];
   const candidateValue = (channel: string): CellValue => {
     switch (channel) {
       case "x":
@@ -119,11 +122,18 @@ export function resolveInspection<Row extends Record<string, CellValue>, Key ext
   input: ResolveInspectionInput<Row, Key>,
 ): PlotInspectionChange<Row, Key> {
   const { model, seed, mode, state, source, keyOf } = input;
+  // This entry point takes a row-shaped keyOf, so it materializes each row to
+  // ask for its key. The coordinated path passes an index-keyed resolver and
+  // skips that entirely.
+  const keyAt = (index: number): Key | null => {
+    const row = model.row(index) as Row | null;
+    return row === null ? null : keyOf(row, index);
+  };
   const target = resolvedTarget(model, seed, mode);
   // The legacy direct constructor remains total for callers that already hold
   // a seed. Coordinated dominant-axis lookup rejects invalid buckets instead.
   if (target === null) {
-    const single = datum<Row, Key>(model, seed, keyOf);
+    const single = datum<Row, Key>(model, seed, keyAt);
     return Object.freeze({
       type: "inspect",
       phase: "change",
@@ -141,7 +151,7 @@ export function resolveInspection<Row extends Record<string, CellValue>, Key ext
       ),
     });
   }
-  return materializeInspection(input, target, "complete");
+  return materializeInspection(input, target, "complete", keyAt);
 }
 
 /** Package-internal: coordinator reuses the same materialize path as resolve. */
@@ -149,12 +159,16 @@ export function materializeInspection<
   Row extends Record<string, CellValue>,
   Key extends PropertyKey,
 >(
-  input: ResolveInspectionInput<Row, Key>,
+  /** keyOf is deliberately absent: keys arrive through `keyAt`. */
+  input: Omit<ResolveInspectionInput<Row, Key>, "keyOf">,
   target: ResolvedTarget,
   completeness: InspectionSnapshotCompleteness,
+  /** Source-row key by index. The coordinated path passes its own index-keyed
+   * bag; resolveInspection passes an adapter over its row-shaped keyOf. */
+  keyAt: (index: number) => Key | null,
 ): PlotInspectionChange<Row, Key> {
-  const { model, seed, mode, state, source, keyOf } = input;
-  const single = datum<Row, Key>(model, seed, keyOf);
+  const { model, seed, mode, state, source } = input;
+  const single = datum<Row, Key>(model, seed, keyAt);
   if (mode === "exact" || mode === "xy") {
     return Object.freeze({
       type: "inspect",
@@ -174,12 +188,12 @@ export function materializeInspection<
     completeness === "transient"
       ? completeCandidates.slice(0, TRANSIENT_MEMBER_LIMIT)
       : completeCandidates;
-  const members = memberCandidates.map((candidate) => datum<Row, Key>(model, candidate, keyOf));
+  const members = memberCandidates.map((candidate) => datum<Row, Key>(model, candidate, keyAt));
   const focusIndex = memberCandidates.findIndex((candidate) => candidate.id === group.focusId);
   const focus =
     focusIndex >= 0
       ? members[focusIndex]!
-      : datum<Row, Key>(model, model.candidates.candidate(group.focusId) ?? seed, keyOf);
+      : datum<Row, Key>(model, model.candidates.candidate(group.focusId) ?? seed, keyAt);
   const nonempty = (members.length === 0 ? [focus] : members) as [
     PlotDatum<Row, Key>,
     ...PlotDatum<Row, Key>[],

--- a/packages/svelte/tests/inspection/coordinator.test.ts
+++ b/packages/svelte/tests/inspection/coordinator.test.ts
@@ -18,6 +18,16 @@ function sameKindBatchOrdinal(model: RenderModel, seed: CandidateFacts): number 
   );
 }
 
+/**
+ * Index-keyed source-row keys, the shape the coordinator takes. Production
+ * passes a prebuilt semantic-key bag, so this reads the authored rows rather
+ * than materializing model rows — a resolver that read rows would put back
+ * the very cost these tests bound.
+ */
+function idKeys(rows: readonly { id: string }[]): (index: number) => string | null {
+  return (index) => rows[index]?.id ?? null;
+}
+
 describe("clearInspectionFingerprint", () => {
   it("scopes clear dedupe tokens by interaction source", () => {
     expect(clearInspectionFingerprint("pointer")).toBe("clear:pointer");
@@ -41,7 +51,7 @@ describe("inspection coordinator", () => {
         .spec(),
       { width: 480, height: 320 },
     );
-    const coordinator = createInspectionCoordinator((row) => row.id as string);
+    const coordinator = createInspectionCoordinator(idKeys(data));
     const base = {
       model,
       seed: model.candidates.candidate(0)!,
@@ -78,7 +88,7 @@ describe("inspection coordinator", () => {
         },
       );
     const first = makeModel(400);
-    const coordinator = createInspectionCoordinator((row) => row.id as string);
+    const coordinator = createInspectionCoordinator(idKeys(data));
     coordinator.resolve({
       model: first,
       seed: first.candidates.candidate(0)!,
@@ -110,8 +120,12 @@ describe("inspection coordinator", () => {
           height: 300,
         },
       );
-    const first = makeModel([{ id: "a", x: 1, y: 2 }]);
-    const keyed = createInspectionCoordinator((row) => row.id as string);
+    const data = [{ id: "a", x: 1, y: 2 }];
+    // Production rebuilds its key bag per identity epoch, so the resolver must
+    // follow the active rows rather than close over the first model's.
+    let activeRows: { id: string }[] = data;
+    const first = makeModel(data);
+    const keyed = createInspectionCoordinator((index) => activeRows[index]?.id ?? null);
     keyed.resolve({
       model: first,
       seed: first.candidates.candidate(0)!,
@@ -121,7 +135,9 @@ describe("inspection coordinator", () => {
       identityEpoch: 1,
       layoutEpoch: 1,
     });
-    const moved = makeModel([{ id: "a", x: 4, y: 8 }], 600);
+    const movedRows = [{ id: "a", x: 4, y: 8 }];
+    const moved = makeModel(movedRows, 600);
+    activeRows = movedRows;
     const movedPin = keyed.reconcilePinned({
       model: moved,
       identityEpoch: 2,
@@ -168,10 +184,11 @@ describe("inspection coordinator", () => {
       }),
     ).toBeNull();
 
-    const ambiguous = makeModel([
+    const ambiguousRows = [
       { id: "a", x: 4, y: 8 },
       { id: "a", x: 5, y: 9 },
-    ]);
+    ];
+    const ambiguous = makeModel(ambiguousRows);
     keyed.resolve({
       model: moved,
       seed: moved.candidates.candidate(0)!,
@@ -181,6 +198,7 @@ describe("inspection coordinator", () => {
       identityEpoch: 2,
       layoutEpoch: 2,
     });
+    activeRows = ambiguousRows;
     expect(
       keyed.reconcilePinned({
         model: ambiguous,
@@ -311,7 +329,7 @@ describe("inspection coordinator", () => {
       rowReads++;
       return originalRow(index);
     });
-    const coordinator = createInspectionCoordinator((row) => (row as { id: string }).id);
+    const coordinator = createInspectionCoordinator(idKeys(data));
     rowReads = 0;
     const resolved = coordinator.resolve({
       model,
@@ -357,9 +375,9 @@ describe("inspection coordinator", () => {
       ["a", Symbol("a")],
       ["b", Symbol("b")],
     ]);
-    const coordinator = createInspectionCoordinator((row) => {
-      const id = String(row.id);
-      return symbols.get(id) ?? null;
+    const coordinator = createInspectionCoordinator((index) => {
+      const id = idKeys(data)(index);
+      return id === null ? null : (symbols.get(id) ?? null);
     });
     const epoch = Symbol("layout");
     const resolved = coordinator.resolve({
@@ -397,13 +415,14 @@ describe("inspection coordinator", () => {
     model.dispose();
   });
   it("returns null from reconcilePinned when no pin is active", () => {
+    const data = [{ id: "a", x: 1, y: 2 }];
     const model = runPipeline(
-      gg([{ id: "a", x: 1, y: 2 }], aes({ x: "x", y: "y" }))
+      gg(data, aes({ x: "x", y: "y" }))
         .geomPoint()
         .spec(),
       { width: 300, height: 200 },
     );
-    const coordinator = createInspectionCoordinator((row) => row.id as string);
+    const coordinator = createInspectionCoordinator(idKeys(data));
     expect(
       coordinator.reconcilePinned({
         model,
@@ -511,7 +530,7 @@ describe("inspection coordinator", () => {
     const resized = makeModel(700);
     expect(resized.candidates.size).toBe(count);
 
-    const coordinator = createInspectionCoordinator((row) => (row as { id: string }).id);
+    const coordinator = createInspectionCoordinator(idKeys(data));
     coordinator.resolve({
       model: first,
       seed: first.candidates.candidate(0)!,
@@ -550,7 +569,7 @@ describe("inspection coordinator", () => {
         .spec(),
       { width: 400, height: 300 },
     );
-    const coordinator = createInspectionCoordinator((row) => (row as { id: string }).id);
+    const coordinator = createInspectionCoordinator(idKeys(data));
     const seed = points.candidates.candidate(0)!;
     expect(seed.kind).toBe("points");
     coordinator.resolve({

--- a/packages/svelte/tests/inspection/lineage-source-keys.test.ts
+++ b/packages/svelte/tests/inspection/lineage-source-keys.test.ts
@@ -61,7 +61,9 @@ describe("lineage source keys", () => {
     // walk adds nothing: it covers far more rows than the member count.
     const members = snapshot.members.length;
     expect(snapshot.focus.sourceKeys.length).toBeGreaterThan(members);
-    expect(spy.mock.calls.length).toBeLessThanOrEqual(members + 1);
+    // Exactly zero, not a slack bound: these members have no source row, so any
+    // row read at all would mean the lineage walk is materializing again.
+    expect(spy.mock.calls.length).toBe(0);
     spy.mockRestore();
     model.dispose();
   });
@@ -127,6 +129,62 @@ describe("lineage source keys", () => {
     });
     expect(inspection.focus.sourceKeys.length).toBeGreaterThan(0);
     expect((inspection.focus.sourceKeys as string[]).every((k) => k.startsWith("r"))).toBe(true);
+    model.dispose();
+  });
+
+  it("reads a row-backed member's own row once, not twice", () => {
+    // geom_point members are real source rows, so datum must read each one for
+    // PlotDatum.row -- and only once. The legacy adapter reads a row to answer
+    // by key, which without care doubles that.
+    const data = Array.from({ length: 6 }, (_, i) => ({ id: `p${i}`, x: 1, y: i }));
+    const model = runPipeline(
+      gg(data, aes({ x: "x", y: "y" }))
+        .geomPoint()
+        .spec(),
+      { width: 480, height: 320 },
+    );
+    const seed = model.candidates.candidate(0)!;
+    const target = resolvedTarget(model, seed, "x")!;
+    const withRows = target.members.filter((m) => m.rowIndex !== null).length;
+
+    const spy = vi.spyOn(model, "row");
+    resolveInspection({
+      model,
+      seed,
+      mode: "x",
+      state: "transient",
+      source: "pointer",
+      keyOf: (row) => row["id"] as string,
+    });
+    // Each member's own row plus the lineage walk, which for identity marks is
+    // one row per member. Reading a member's row twice breaks this.
+    expect(withRows).toBeGreaterThan(0);
+    // Each datum reads its member's own row for PlotDatum.row, and the adapter
+    // answers the key from that same row rather than copying it again. Dropping
+    // the adapter's one-slot memo doubles this to 6.
+    expect(spy.mock.calls.length).toBe(3);
+    spy.mockRestore();
+    model.dispose();
+  });
+
+  it("gives a member no key when its row does not resolve", () => {
+    // The resolver hands back a key for every index; the row gate is the only
+    // thing stopping a dead row from carrying one. sourceKeys deliberately
+    // still take the resolver's word, so the asymmetry is visible here.
+    const model = smoothModel(6);
+    const seed = model.candidates.candidate(0)!;
+    const target = resolvedTarget(model, seed, "x")!;
+    vi.spyOn(model, "row").mockReturnValue(null);
+    const snapshot = materializeInspection(
+      { model, seed, mode: "x", state: "transient", source: "pointer" },
+      target,
+      "complete",
+      () => "ghost",
+    );
+    expect(snapshot.focus.key).toBeNull();
+    expect(snapshot.focus.row).toBeNull();
+    expect([...snapshot.focus.sourceKeys]).toEqual(["ghost"]);
+    vi.restoreAllMocks();
     model.dispose();
   });
 });

--- a/packages/svelte/tests/inspection/lineage-source-keys.test.ts
+++ b/packages/svelte/tests/inspection/lineage-source-keys.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Lineage source keys resolve by row index, not by materializing every source
+ * row. `model.row` copies every column on each call, and the production key
+ * resolver only ever needs the index, so those objects were pure garbage.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { runPipeline } from "@ggsvelte/core";
+import { aes, gg } from "@ggsvelte/spec";
+
+import {
+  materializeInspection,
+  resolveInspection,
+  resolvedTarget,
+} from "../../src/lib/inspection/resolver.js";
+
+/** A smooth layer: one mark's lineage covers every row in the group. */
+function smoothModel(rowCount: number) {
+  const data = Array.from({ length: rowCount }, (_, i) => ({
+    id: `r${i}`,
+    x: i,
+    y: (i * 7) % 11,
+  }));
+  return runPipeline(
+    gg(data, aes({ x: "x", y: "y" }))
+      .geomSmooth({ method: "lm", se: false })
+      .spec(),
+    { width: 480, height: 320 },
+  );
+}
+
+/** Index-keyed resolver, the shape production wires in. */
+function keyByIndex(model: ReturnType<typeof runPipeline>) {
+  return (index: number): string | null => {
+    const row = model.row(index);
+    return row === null ? null : (row["id"] as string);
+  };
+}
+
+describe("lineage source keys", () => {
+  it("does not materialize a row per lineage entry", () => {
+    const model = smoothModel(60);
+    const seed = model.candidates.candidate(0)!;
+    const target = resolvedTarget(model, seed, "x")!;
+    // Build the key bag up front so the resolver itself does no row work; this
+    // mirrors production, where keys come from a prebuilt index-keyed map.
+    const keys = new Map<number, string>();
+    for (let i = 0; i < 60; i++) {
+      const row = model.row(i);
+      if (row !== null) keys.set(i, row["id"] as string);
+    }
+    const spy = vi.spyOn(model, "row");
+    const snapshot = materializeInspection(
+      { model, seed, mode: "x", state: "transient", source: "pointer" },
+      target,
+      "complete",
+      (index) => keys.get(index) ?? null,
+    );
+    // Smooth marks are synthetic evaluation-grid vertices with no source row,
+    // so datum reads no row for them at all. What matters is that the lineage
+    // walk adds nothing: it covers far more rows than the member count.
+    const members = snapshot.members.length;
+    expect(snapshot.focus.sourceKeys.length).toBeGreaterThan(members);
+    expect(spy.mock.calls.length).toBeLessThanOrEqual(members + 1);
+    spy.mockRestore();
+    model.dispose();
+  });
+
+  it("keeps source key values and first-seen order", () => {
+    const model = smoothModel(12);
+    const seed = model.candidates.candidate(0)!;
+    const target = resolvedTarget(model, seed, "x")!;
+    const keyAt = keyByIndex(model);
+    const snapshot = materializeInspection(
+      { model, seed, mode: "x", state: "transient", source: "pointer" },
+      target,
+      "complete",
+      keyAt,
+    );
+    // Walk the focus candidate's lineage directly and dedupe first-seen; the
+    // snapshot must match that list exactly, values and order.
+    const focusCandidate = model.candidates.candidate(target.group?.focusId ?? seed.id) ?? seed;
+    const seen = new Set<string>();
+    const expected: string[] = [];
+    for (const index of model.lineage.keys(focusCandidate.lineage)) {
+      const key = keyAt(index);
+      if (key !== null && !seen.has(key)) {
+        seen.add(key);
+        expected.push(key);
+      }
+    }
+    expect(expected.length).toBeGreaterThan(1);
+    expect([...snapshot.focus.sourceKeys]).toEqual(expected);
+    model.dispose();
+  });
+
+  it("skips indexes whose key is null rather than emitting them", () => {
+    const model = smoothModel(10);
+    const seed = model.candidates.candidate(0)!;
+    const target = resolvedTarget(model, seed, "x")!;
+    // Only even indexes carry a key; odd ones resolve to null and must vanish.
+    const snapshot = materializeInspection(
+      { model, seed, mode: "x", state: "transient", source: "pointer" },
+      target,
+      "complete",
+      (index) => (index % 2 === 0 ? `k${index}` : null),
+    );
+    const keysOut = [...snapshot.focus.sourceKeys] as string[];
+    expect(keysOut.length).toBeGreaterThan(0);
+    expect(keysOut.every((k) => k.startsWith("k"))).toBe(true);
+    expect(keysOut.includes("null")).toBe(false);
+    model.dispose();
+  });
+
+  it("resolveInspection still reads rows for its row-shaped keyOf", () => {
+    // The legacy entry point keeps its contract: a keyOf that needs the row
+    // gets one, and a row that does not resolve yields no key.
+    const model = smoothModel(8);
+    const seed = model.candidates.candidate(0)!;
+    const inspection = resolveInspection({
+      model,
+      seed,
+      mode: "x",
+      state: "transient",
+      source: "pointer",
+      keyOf: (row) => row["id"] as string,
+    });
+    expect(inspection.focus.sourceKeys.length).toBeGreaterThan(0);
+    expect((inspection.focus.sourceKeys as string[]).every((k) => k.startsWith("r"))).toBe(true);
+    model.dispose();
+  });
+});


### PR DESCRIPTION
## What

Building a tooltip snapshot materialized one row object per source row in a candidate's lineage, then threw it away:

```ts
const sourceKeys = uniqueKeysFromRowIndexes(model.lineage.keys(candidate.lineage), (rowIndex) => {
  const source = model.row(rowIndex);
  if (source === null) return null;
  return keyOf(source as Row, rowIndex);
});
```

`model.row` copies every column on each call and has no cache. The resolver production wires in — `(_row, index) => deps.keyAt(index)` — discards the row entirely, so every one of those objects was garbage. For an aggregate or `geom_smooth` mark the lineage is the whole group, so hovering one mark over a large group allocated a row per group member.

Measured on a 60-row smooth: **120 row materializations before, 0 after**.

Closes #1326.

## The API decision

This was deferred twice on shape. The win requires production to hand the coordinator an index-keyed resolver — there is no other way to get one, since its only key input was `keyOf(row, index)`.

An optional `keyForIndex` alongside `keyOf` was rejected: two functions that must agree with nothing enforcing it is a footgun, not two contracts. `createInspectionCoordinator` now takes `(index) => Key | null`. That is the honest shape — the semantic-key bag is index-keyed by construction, and production already discarded the row. `materializeInspection` no longer accepts `keyOf` at all, so there is no dead channel for a second key function to hide in.

`resolveInspection` keeps its row-shaped `keyOf` and builds the materializing adapter itself, so that entry point's output is unchanged.

## Row gates preserved deliberately

A member whose row does not resolve still gets a null key, even though the resolver would hand one back for that index. Keyed pin rebind still requires **both** a live row and a matching key — the dual gate is intentional. Both are now tested.

An independent reviewer traced the equivalence rather than assuming it: for every index in the bag, `semantic-keys-resolve.ts` stores `null` when `model.row` is null, and absent indexes read as null, so `keyAt(i)` non-null implies `model.row(i)` non-null on the production path. The dropped `row === null` gate in the lineage walk was redundant there.

## Two things the review caught

Both measured, not reasoned:

- **The legacy path copied each member's row twice** (26 → 39 calls on a 12-row fixture), because `datum` reads the row for the null gate and then asks the adapter for the key by index. A one-slot memo in the adapter fixes it: 6 reads → 3 on a row-backed mark.
- **My cost guard could not have caught that.** Its `members + 1` bound was unreachable slack — a smooth group's members are eval-grid vertices with no source row, so the real count is zero. It now asserts zero, plus a row-backed case where the bound is live.

## Migration

`createInspectionCoordinator` is package-internal (`package.json` exports only `.` and `./data`). Sites: production wiring, 8 of 15 in `coordinator.test.ts` (the rest are `() => null` and needed no edit), and `benchmarks/retained-memory.ts`.

Test resolvers now read authored rows rather than model rows. A resolver that materialized rows would have put back the very cost the existing guards bound — and did, until fixed. The pin-invalidation test follows the active rows across a data swap, mirroring the per-epoch bag rebuild; dropping that line makes the ambiguous-key case pass wrongly.

## Verification

- `vitest --project chromium tests/inspection` — 13 files, 141 tests pass
- `bun run test:ssr` — 125 pass
- `bun test packages/core packages/spec` — 2748 pass, 0 fail
- `bun run check`, `check:svelte`, `lint`, `lint:type-aware`, `knip`, `fmt:check` — clean

The cost guard fails against the old implementation with 120 reads against a bound of 0.

## Follow-ups

Still open from the same audit: #1327, #1328, #1329.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1331" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->