### PR TITLE
perf(core): read a band selection's ends without mapping every key

### DIFF
--- a/.changeset/band-span-ends.md
+++ b/.changeset/band-span-ends.md
@@ -7,14 +7,16 @@
 Migration: none — internal
 
 `SemanticViewport.resolve` reports the first and last selected values on a band
-axis. It got them by mapping the whole key list first, and the map allocated a
-short-lived array per key — so reading two values from an N-key selection cost
-about N allocations.
+axis. It got them by mapping the whole key list through a `flatMap` used as a
+filter, allocating a short-lived array per key to read two values. It now scans
+inward from each end.
 
-Scan inward from each end instead. Allocations drop from N to none, and a
-selection whose outermost keys are on the axis now stops after two lookups
-rather than N. Worst case, where few keys land on the axis, still walks the
-list once.
+Scope honestly: this is an allocation cleanup on a cold path, not a hot-path
+win. The only in-tree caller is the precise-bounds editor's apply handler, which
+calls `project` on the same selection a few lines later — and that still walks
+every key, doing more per key than the loop removed here. What this buys is
+simpler code and no per-key garbage; `SemanticViewportPanel` is exported, so
+external callers get it too.
 
-N is caller-supplied and in-tree comes from the interval brush, bounded by the
-number of categories on the axis.
+Behaviour is unchanged: a key the axis does not carry is skipped exactly as the
+map step dropped it, one match is both ends, and no match is still undefined.

--- a/.changeset/band-span-ends.md
+++ b/.changeset/band-span-ends.md
@@ -1,0 +1,20 @@
+---
+"@ggsvelte/core": patch
+---
+
+# Read a band selection's ends without mapping every key
+
+Migration: none — internal
+
+`SemanticViewport.resolve` reports the first and last selected values on a band
+axis. It got them by mapping the whole key list first, and the map allocated a
+short-lived array per key — so reading two values from an N-key selection cost
+about N allocations.
+
+Scan inward from each end instead. Allocations drop from N to none, and a
+selection whose outermost keys are on the axis now stops after two lookups
+rather than N. Worst case, where few keys land on the axis, still walks the
+list once.
+
+N is caller-supplied and in-tree comes from the interval brush, bounded by the
+number of categories on the axis.

--- a/packages/core/src/semantic-viewport.ts
+++ b/packages/core/src/semantic-viewport.ts
@@ -153,14 +153,36 @@ function bandValueIndex(scale: PositionScale): ReadonlyMap<string, CellValue> {
   return valuesByKey;
 }
 
-function bandValuesForKeys(
+/**
+ * First and last selected keys that land on the axis.
+ *
+ * `resolve` reports only the two ends, so scan inward from each rather than
+ * mapping the whole selection: the key list is caller-supplied and as long as
+ * the axis has categories, and mapping it allocated an array per key to read
+ * two values. A key the axis does not carry is skipped, exactly as the map
+ * step dropped it.
+ */
+function bandSpanForKeys(
   valuesByKey: ReadonlyMap<string, CellValue>,
   keys: readonly string[],
-): readonly CellValue[] {
-  return keys.flatMap((key) => {
-    const value = valuesByKey.get(key);
-    return value === undefined ? [] : [value];
-  });
+): readonly [CellValue, CellValue] | undefined {
+  let firstIndex = -1;
+  let first: CellValue | undefined;
+  for (let i = 0; i < keys.length; i++) {
+    const value = valuesByKey.get(keys[i]!);
+    if (value !== undefined) {
+      first = value;
+      firstIndex = i;
+      break;
+    }
+  }
+  if (firstIndex === -1) return undefined;
+  for (let i = keys.length - 1; i > firstIndex; i--) {
+    const value = valuesByKey.get(keys[i]!);
+    if (value !== undefined) return [first!, value];
+  }
+  // Only one key landed on the axis; it is both ends.
+  return [first!, first!];
 }
 
 function projectedSpan(
@@ -304,8 +326,7 @@ function createPanel(
         if (axis === undefined) return undefined;
         if (axis.kind === "continuous") return axis.domain;
         if (scale.type !== "band") return undefined;
-        const values = bandValuesForKeys(bandValuesByKey, axis.keys);
-        return values.length === 0 ? undefined : [values[0]!, values.at(-1)!];
+        return bandSpanForKeys(bandValuesByKey, axis.keys);
       };
       const x = resolveAxis(scales.x, selection.x, xBandValuesByKey);
       const y = resolveAxis(scales.y, selection.y, yBandValuesByKey);

--- a/packages/core/tests/semantic-viewport.test.ts
+++ b/packages/core/tests/semantic-viewport.test.ts
@@ -631,4 +631,65 @@ describe("RenderModel semantic viewport", () => {
       model.viewport.locate(250, 250, { left: 100, top: 100, width: 100, height: 100 }),
     ).toEqual({ x: 150, y: 150 });
   });
+
+  it("resolves a band selection without materializing every key", () => {
+    // resolve() reports the first and last selected values. It used to map the
+    // whole key list to get them, allocating an array per key to read two.
+    const categories = Array.from({ length: 400 }, (_, i) => `c${i}`);
+    const model = runPipeline(
+      gg(
+        categories.map((category, i) => ({ category, y: i })),
+        aes({ x: "category", y: "y" }),
+      )
+        .geomPoint()
+        .spec(),
+      { width: 400, height: 300 },
+    );
+    const scenePanel = model.scene.panels[0]!;
+    const panel = model.viewport.panel(scenePanel.id)!;
+
+    let reads = 0;
+    const keys = new Proxy(
+      categories.map((category) => encodeKey(category)),
+      {
+        get(target, prop) {
+          if (typeof prop === "string" && /^\d+$/.test(prop)) reads += 1;
+          return Reflect.get(target, prop) as unknown;
+        },
+      },
+    );
+    expect(panel.resolve({ x: { kind: "band", keys } }).x).toEqual(["c0", "c399"]);
+    expect(reads).toBeGreaterThan(0);
+    // Two ends, found by scanning inward from each. Mapping the whole list
+    // reads all 400.
+    expect(reads).toBeLessThan(10);
+    model.dispose();
+  });
+
+  it("still finds the ends when the outermost keys are not on the axis", () => {
+    const model = runPipeline(
+      gg(
+        [
+          { category: "a", y: 1 },
+          { category: "b", y: 2 },
+          { category: "c", y: 3 },
+        ],
+        aes({ x: "category", y: "y" }),
+      )
+        .geomPoint()
+        .spec(),
+      { width: 400, height: 300 },
+    );
+    const scenePanel = model.scene.panels[0]!;
+    const panel = model.viewport.panel(scenePanel.id)!;
+
+    // Unknown keys bracket the real ones and must be skipped from both sides.
+    const keys = ["ghost-1", encodeKey("a"), encodeKey("c"), "ghost-2"];
+    expect(panel.resolve({ x: { kind: "band", keys } }).x).toEqual(["a", "c"]);
+    // Every key unknown: no span at all.
+    expect(panel.resolve({ x: { kind: "band", keys: ["ghost-1", "ghost-2"] } }).x).toBeUndefined();
+    // A single known key is both ends.
+    expect(panel.resolve({ x: { kind: "band", keys: [encodeKey("b")] } }).x).toEqual(["b", "b"]);
+    model.dispose();
+  });
 });

--- a/packages/core/tests/semantic-viewport.test.ts
+++ b/packages/core/tests/semantic-viewport.test.ts
@@ -659,10 +659,9 @@ describe("RenderModel semantic viewport", () => {
       },
     );
     expect(panel.resolve({ x: { kind: "band", keys } }).x).toEqual(["c0", "c399"]);
-    expect(reads).toBeGreaterThan(0);
-    // Two ends, found by scanning inward from each. Mapping the whole list
-    // reads all 400.
-    expect(reads).toBeLessThan(10);
+    // Exactly two, and independent of the key count: a bound relative to the
+    // fixture size would go green if the fixture ever shrank.
+    expect(reads).toBe(2);
     model.dispose();
   });
 
@@ -688,8 +687,40 @@ describe("RenderModel semantic viewport", () => {
     expect(panel.resolve({ x: { kind: "band", keys } }).x).toEqual(["a", "c"]);
     // Every key unknown: no span at all.
     expect(panel.resolve({ x: { kind: "band", keys: ["ghost-1", "ghost-2"] } }).x).toBeUndefined();
-    // A single known key is both ends.
+    // A single known key is both ends, whether or not unknowns bracket it —
+    // the second reaches the same return only after the backward scan runs.
     expect(panel.resolve({ x: { kind: "band", keys: [encodeKey("b")] } }).x).toEqual(["b", "b"]);
+    expect(
+      panel.resolve({ x: { kind: "band", keys: ["ghost-1", encodeKey("b"), "ghost-2"] } }).x,
+    ).toEqual(["b", "b"]);
+    // No keys at all: nothing to span.
+    expect(panel.resolve({ x: { kind: "band", keys: [] } }).x).toBeUndefined();
+    // A key repeated is still just that value at both ends.
+    expect(
+      panel.resolve({ x: { kind: "band", keys: [encodeKey("b"), encodeKey("b")] } }).x,
+    ).toEqual(["b", "b"]);
+  });
+
+  it("spans a band y axis the same way", () => {
+    const model = runPipeline(
+      gg(
+        [
+          { x: 1, category: "a" },
+          { x: 2, category: "b" },
+          { x: 3, category: "c" },
+        ],
+        aes({ x: "x", y: "category" }),
+      )
+        .geomPoint()
+        .spec(),
+      { width: 400, height: 300 },
+    );
+    const scenePanel = model.scene.panels[0]!;
+    const panel = model.viewport.panel(scenePanel.id)!;
+    expect(
+      panel.resolve({ y: { kind: "band", keys: ["ghost", encodeKey("a"), encodeKey("c")] } }).y,
+    ).toEqual(["a", "c"]);
+    model.dispose();
     model.dispose();
   });
 });


### PR DESCRIPTION
## What

`SemanticViewport.resolve` reports the first and last selected values on a band axis. It got them by mapping the whole key list through a `flatMap` used as a filter — one short-lived array per key — and then took `values[0]` and `values.at(-1)`. It now scans inward from each end.

Closes #1322.

## Scope, honestly

This is an allocation cleanup on a cold path, not a hot-path win, and the PR says so rather than dressing it in complexity language.

The only in-tree caller is the precise-bounds editor's apply handler, which calls `project` on the same selection four lines later. Measured through the real pipeline with 400 categories:

| call | reads before | reads after |
|---|---|---|
| `resolve` | 400 | 2 |
| `project` | 400 | 400 |

So the call site's cost is essentially unchanged — `projectedSpan` normalizes every key and does strictly more per key than the loop removed here. I filed that as **#1332**, since it's where the per-key cost at that call site actually is.

What this buys: simpler code (a helper and a filter-shaped `flatMap` both gone), no per-key garbage, and `SemanticViewportPanel` is exported so external callers get it too.

## Behaviour

Unchanged. A reviewer ran the exact old body against the new one over **200,020 cases** — 20 hand-built adversarial inputs plus 200k randomized key lists — comparing both slots with `Object.is`. **Zero mismatches.**

Covered: empty list; all keys unknown; exactly one known; known only at the ends; known only in the middle; a single known key bracketed by unknowns; duplicate keys; the empty-string key; `__proto__`, `constructor`, `toString`, `valueOf`, `hasOwnProperty`; falsy stored values including `0`, `false`, `NaN`, `-0`, `null`; sparse arrays; and a Proxy-backed key list. `CellValue` cannot be `undefined` (`table-types.ts:11`), so `value === undefined` means "key absent" and never "value is undefined".

## Verification

- `bun test packages/core packages/spec` — 2751 pass, 0 fail
- `bun run check`, `lint`, `lint:type-aware`, `knip`, `fmt:check` — clean

The read guard asserts **exactly 2**, not a bound relative to the fixture: a threshold like `< 10` against 400 categories would silently go green if the fixture ever shrank. It fails against the old implementation at 400.

Tests also pin an empty key list, a repeated key, a single known key bracketed by unknowns on both sides (the only input that reaches the final return after the backward scan iterates), and a band y axis.

## Follow-ups

- #1332 — `projectedSpan` normalizes every selected key, which is the real per-key cost at this call site
- Still open from earlier audits: #1307, #1308, #1309, #1310, #1311, #1312, #1318, #1320, #1327, #1328, #1329
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1333" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->