### PR TITLE
perf(core): build a band axis index once per scale, not once per panel

### DIFF
--- a/.changeset/tall-melons-argue.md
+++ b/.changeset/tall-melons-argue.md
@@ -1,0 +1,23 @@
+---
+"@ggsvelte/core": patch
+---
+
+# Build a band axis index once per scale, not once per panel
+
+Migration: none — internal
+
+Under the default fixed facet scales every panel is handed the same trained
+`PositionScale` object, but the semantic viewport built that scale's key→value
+index separately for each one. A plot with P panels over an axis of C
+categories walked the same domain P times and kept P copies of the resulting
+map alive for as long as the render model. Both quantities grow with the data,
+so the cost was O(P×C) where O(P+C) does.
+
+The viewport now memoises the index on the scale object itself, so panels that
+share a scale share one map. Free facet scales give each panel its own scale
+object and so still get their own index; nothing writes to the map after it is
+built.
+
+Scope honestly: this is construction work, not a per-row or per-pointer term —
+it runs once when the render model is assembled. Results from `resolve`,
+`project`, and `locate` are unchanged.

--- a/packages/core/src/semantic-viewport.ts
+++ b/packages/core/src/semantic-viewport.ts
@@ -266,9 +266,10 @@ function createPanel(
   coord: PanelCoordProjector | undefined,
   flipped: boolean,
   candidates: CandidateStore,
+  indexFor: (scale: PositionScale) => ReadonlyMap<string, CellValue>,
 ): SemanticViewportPanel {
-  const xBandValuesByKey = bandValueIndex(scales.x);
-  const yBandValuesByKey = bandValueIndex(scales.y);
+  const xBandValuesByKey = indexFor(scales.x);
+  const yBandValuesByKey = indexFor(scales.y);
   return {
     id: panel.id,
     bounds: {
@@ -381,6 +382,20 @@ export type CreateSemanticViewportInput = {
 
 export function createSemanticViewport(input: CreateSemanticViewportInput): SemanticViewport {
   const { panels, scales, coordProjectors, flipped, candidates, sceneSize } = input;
+  // Under fixed facet scales every panel is handed the same scale object, so
+  // building the band index per panel walked one domain once per panel and kept
+  // a copy of it per panel. Key on the object: free scales give each panel its
+  // own scale, so they still get their own index. The map is local to this
+  // viewport and never written after it is built, so panels can share it.
+  const bandIndexByScale = new WeakMap<PositionScale, ReadonlyMap<string, CellValue>>();
+  const indexFor = (scale: PositionScale): ReadonlyMap<string, CellValue> => {
+    let index = bandIndexByScale.get(scale);
+    if (index === undefined) {
+      index = bandValueIndex(scale);
+      bandIndexByScale.set(scale, index);
+    }
+    return index;
+  };
   const viewportPanels = panels.map((panel, panelIndex) =>
     createPanel(
       panel,
@@ -388,6 +403,7 @@ export function createSemanticViewport(input: CreateSemanticViewportInput): Sema
       coordProjectors[panelIndex],
       flipped,
       candidates,
+      indexFor,
     ),
   );
   function panelAt(point: Readonly<{ x: number; y: number }>): SemanticViewportPanel | null {

--- a/packages/core/tests/semantic-viewport-band-index.test.ts
+++ b/packages/core/tests/semantic-viewport-band-index.test.ts
@@ -1,0 +1,159 @@
+/**
+ * The viewport builds a key→value index per band axis. Under the default fixed
+ * facet scales every panel receives the *same* scale object, so building that
+ * index per panel walked one domain P times and retained P copies of it.
+ */
+import { describe, expect, it } from "bun:test";
+
+import { aes, gg } from "@ggsvelte/spec";
+
+import { runPipeline } from "../src/pipeline.ts";
+import { trainBand } from "../src/scales/train-band.ts";
+import { encodeKey } from "../src/scales/state.ts";
+import { trainContinuous } from "../src/scales/train-continuous.ts";
+import type { PositionScale } from "../src/scales/train-types.ts";
+import { createSemanticViewport } from "../src/semantic-viewport.ts";
+
+const CATEGORIES = ["a", "b", "c", "d", "e", "f", "g", "h"];
+
+/** A faceted model, used only for real panels and a real candidate store. */
+function facetedModel() {
+  const data = CATEGORIES.flatMap((cat) =>
+    ["g1", "g2", "g3", "g4"].map((g) => ({ cat, g, v: cat.codePointAt(0) ?? 0 })),
+  );
+  return runPipeline(
+    gg(data, aes({ x: "cat", y: "v" }))
+      .geomCol()
+      .facet({ wrap: "g" })
+      .spec(),
+    { width: 640, height: 400 },
+  );
+}
+
+/** Same scale, but every read of a domain element is counted. */
+function counting(scale: PositionScale): { scale: PositionScale; reads: () => number } {
+  let reads = 0;
+  const rawDomain = new Proxy(scale.rawDomain as unknown[], {
+    get(target, property, receiver) {
+      if (typeof property === "string" && /^\d+$/.test(property)) reads += 1;
+      return Reflect.get(target, property, receiver) as unknown;
+    },
+  });
+  return { scale: { ...scale, rawDomain }, reads: () => reads };
+}
+
+function viewportOver(
+  model: ReturnType<typeof runPipeline>,
+  perPanel: (index: number) => Readonly<{ x: PositionScale; y: PositionScale }>,
+) {
+  const panels = model.scene.panels;
+  return createSemanticViewport({
+    panels,
+    scales: { ...perPanel(0), panels: panels.map((_, i) => perPanel(i)) },
+    coordProjectors: [],
+    flipped: false,
+    candidates: model.candidates,
+    sceneSize: { width: 640, height: 400 },
+  });
+}
+
+describe("semantic viewport band index", () => {
+  it("walks a shared band domain once, not once per panel", () => {
+    const model = facetedModel();
+    expect(model.scene.panels.length).toBeGreaterThan(1);
+    const x = counting(trainBand([CATEGORIES]));
+    const y = trainContinuous([new Float64Array([0, 100])]);
+    viewportOver(model, () => ({ x: x.scale, y }));
+    // One walk of the domain, whatever the panel count. Building per panel read
+    // 8 x 4 = 32 here and scales with both.
+    expect(x.reads()).toBe(CATEGORIES.length);
+    model.dispose();
+  });
+
+  it("keeps a per-panel domain for each panel under free scales", () => {
+    const model = facetedModel();
+    const y = trainContinuous([new Float64Array([0, 100])]);
+    // Free scales give every panel its own scale object and its own categories.
+    const perPanel = model.scene.panels.map((_, i) => trainBand([[`p${i}-only`, "shared"]]));
+    const viewport = viewportOver(model, (i) => ({ x: perPanel[i]!, y }));
+    for (let i = 0; i < model.scene.panels.length; i++) {
+      const panel = viewport.panels[i]!;
+      const span = panel.resolve({ x: { kind: "band", keys: [`p${i}-only`, "shared"] } });
+      expect(span.x).toEqual([`p${i}-only`, "shared"]);
+      // A neighbour's category must not resolve here.
+      const other = (i + 1) % model.scene.panels.length;
+      const foreign = panel.resolve({ x: { kind: "band", keys: [`p${other}-only`] } });
+      expect(foreign.x).toBeUndefined();
+    }
+    model.dispose();
+  });
+
+  it("resolves shared-scale panels identically to per-panel indexes", () => {
+    const model = facetedModel();
+    const x = trainBand([CATEGORIES]);
+    const y = trainContinuous([new Float64Array([0, 100])]);
+    const viewport = viewportOver(model, () => ({ x, y }));
+    for (const panel of viewport.panels) {
+      expect(panel.resolve({ x: { kind: "band", keys: ["b", "zzz", "f"] } }).x).toEqual(["b", "f"]);
+      expect(panel.resolve({ x: { kind: "band", keys: ["zzz"] } }).x).toBeUndefined();
+    }
+    model.dispose();
+  });
+
+  it("shares the index across both axes and through project", () => {
+    // Band on x and y, one scale object serving every panel on both axes.
+    const model = facetedModel();
+    const scale = counting(trainBand([CATEGORIES]));
+    const viewport = viewportOver(model, () => ({ x: scale.scale, y: scale.scale }));
+    expect(scale.reads()).toBe(CATEGORIES.length);
+    for (const panel of viewport.panels) {
+      const selection = {
+        x: { kind: "band" as const, keys: ["b", "f"] },
+        y: { kind: "band" as const, keys: ["c", "e"] },
+      };
+      expect(panel.resolve(selection).x).toEqual(["b", "f"]);
+      expect(panel.resolve(selection).y).toEqual(["c", "e"]);
+      // project reads the same shared map; a wrong or empty one collapses it.
+      const rect = panel.project(selection);
+      expect(rect.x1).toBeGreaterThan(rect.x0);
+      expect(rect.y1).toBeGreaterThan(rect.y0);
+    }
+    model.dispose();
+  });
+
+  it("keeps first-wins when two domain values share an encoded key", () => {
+    // encodeKey collides only for equal-epoch Dates, and trainBand dedupes them,
+    // so the colliding domain has to be built by hand. resolve reads nothing but
+    // the index, which is why this stands up despite the rest of the scale
+    // object describing the domain it was trained on.
+    const model = facetedModel();
+    const first = new Date(0);
+    const second = new Date(0);
+    const x: PositionScale = { ...trainBand([[first]]), rawDomain: [first, second] };
+    const y = trainContinuous([new Float64Array([0, 100])]);
+    const viewport = viewportOver(model, () => ({ x, y }));
+    const key = encodeKey(first);
+    for (const panel of viewport.panels) {
+      const span = panel.resolve({ x: { kind: "band", keys: [key] } }).x;
+      // Identity, not equality: the two Dates compare equal, so only `toBe`
+      // tells first-wins from last-wins.
+      expect(span?.[0]).toBe(first);
+      expect(span?.[1]).toBe(first);
+    }
+    model.dispose();
+  });
+
+  it("hands every panel the same scale object under fixed facet scales", () => {
+    // The premise the memo rests on. If training ever copies the scale per panel
+    // the memo silently degrades to one index per panel, and nothing else here
+    // would notice.
+    const model = facetedModel();
+    const perPanel = model.scales.panels;
+    expect(perPanel.length).toBeGreaterThan(1);
+    for (const panel of perPanel) {
+      expect(panel.x).toBe(model.scales.x);
+      expect(panel.y).toBe(model.scales.y);
+    }
+    model.dispose();
+  });
+});


### PR DESCRIPTION
## What

The semantic viewport builds a key→value index for each band position axis so
`resolve` and `project` can turn selected keys back into domain values. It built
that index inside `createPanel`, once per panel per axis.

Under the **default fixed facet scales** every panel is handed the *same*
trained `PositionScale` object — `packages/core/src/pipeline/train-pipeline-scales-position-free.ts:36-53`
sets `px = fixedX` / `py = fixedY` and only reassigns them under `free_x` /
`free_y`. So a plot with P panels over an axis of C categories walked the same
domain P times, calling `encodeKey` (which allocates a string) each time, and
kept P copies of the resulting map alive for as long as the render model.

- **Before:** O(P × C) time, O(P × C) retained
- **After:** O(P + C) time, O(C) retained

Both quantities grow with the data: P is one panel per distinct facet-value
combination (`facets-wrap.ts`, `facets-grid.ts` — no cap), C is the number of
distinct categories in `rawDomain`.

## How

`createSemanticViewport` keeps a `WeakMap` keyed on the scale **object** and
hands `createPanel` a resolver instead of letting it call the builder. Panels
that share a scale share one map; free facet scales hold distinct scale objects
and so still get their own index, which is the case a name-keyed or
axis-keyed cache would break.

The map is never written after it is built — the only consumers, `bandSpanForKeys`
and `projectedSpan`, read it — so sharing one instance across panels is safe. The
`WeakMap` is local to the viewport, so it does not retain scales past it.

`bandValueIndex` itself is untouched: first-wins on a duplicated encoded key and
the empty map for a non-band scale both still hold, and both now have tests.

## Scope, stated plainly

This is construction work that runs once when the render model is assembled —
not a per-row or per-pointer term. For an ordinary chart the absolute cost is
small next to geometry and layout. It is worth doing because both dimensions
scale with the data and the fix is four lines, not because it was a cliff.

## Tests

New file `packages/core/tests/semantic-viewport-band-index.test.ts` (6 tests):

- **Cost guard** — a counting `Proxy` over `rawDomain` asserts the domain is
  walked exactly C times across P panels. Against the old code it reads 32 for
  8 categories × 4 panels.
- **Free scales** — each panel resolves against its own categories, and a
  neighbour's category does not resolve. Keying the memo on `scale.type`
  instead of identity fails this.
- **Shared scales** — every panel resolves a selection identically, misses included.
- **Both axes plus `project`** — one scale object serving x and y, walked once,
  with `project` returning a non-degenerate rect from the shared map.
- **First-wins** — two distinct `Date` objects with the same epoch collide under
  `encodeKey`; the assertion is `toBe`, so it tells first-wins from last-wins.
- **The premise** — a real faceted pipeline run asserts `scales.panels[i].x ===
  scales.x`, so if training ever starts copying the scale per panel this fails
  rather than the memo silently degrading.

Every guard was mutation-tested against the pre-fix implementation and against a
memo that returns an empty map; both mutations are killed. Two weaker tests from
the first draft were deleted after review showed they passed against a
deliberately broken `bandValueIndex`.

## Verification

```
bun test packages/core packages/spec   2757 pass, 0 fail
bun run check                          OK
bun run lint                           OK
bun run lint:type-aware                OK
bun run fmt:check                      OK
bun node_modules/.bin/knip             OK
vitest --project chromium tests/scene tests/interval   167 pass
```

## Follow-ups

No new deferred work from this change. The complexity findings still open from
earlier audits of `packages/` are #1307, #1308, #1309, #1310, #1311, #1312,
#1318, #1320, #1327, #1328, #1329 and #1332 — all constant-factor.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1334" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->