### PR TITLE
perf(core): decide stacked-area align without rescanning the grid per group

### DIFF
--- a/.changeset/olive-poems-repeat.md
+++ b/.changeset/olive-poems-repeat.md
@@ -1,0 +1,29 @@
+---
+"@ggsvelte/core": patch
+---
+
+# Decide the stacked-area align rescue without rescanning the grid per group
+
+Migration: none — internal
+
+Before rewriting a stacked-area frame, the auto-align rescue asks whether any
+group skips a shared-grid x inside its own range. It answered by walking the
+sorted grid once per group, and the "before this group starts" arm was a
+`continue` rather than a seek, so every group also paid for the whole prefix
+of grid values below its own minimum.
+
+Groups and distinct x both grow with the data and neither is capped, so that
+scan cost groups × grid-x. It now ranks the grid once and compares each group's
+size against the width of its own window, which is the same question answered
+by subtraction: every value a group holds is a grid value inside `[min, max]`,
+and `min` and `max` are themselves members, so the group is dense exactly when
+it holds one value per grid slot in that window.
+
+The decision is unchanged for every input, and so is the frame that follows
+from it.
+
+Scope honestly: the shape this helps is many series that each cover a dense
+window of a wider shared grid. A tidy stack where every group covers the whole
+grid already short-circuited on a size check, and when a group really does have
+a hole the rescue's own row expansion dwarfs the scan. On 100 staggered series
+over a 10,000-value grid the scan read 505,000 grid slots; it now reads 10,000.

--- a/packages/core/src/pipeline/frame-stats-align.ts
+++ b/packages/core/src/pipeline/frame-stats-align.ts
@@ -167,6 +167,14 @@ function needsStackAlign(
   }
   if (perGroup.size < 2) return null;
   const gridSorted = [...grid].toSorted((a, b) => a - b);
+  // Rank of each grid x, so a group's window width is a subtraction rather than
+  // a walk. Scanning the sorted grid per group cost groups × grid-x, and the
+  // `xv <= min` arm was a `continue` rather than a seek, so a group whose window
+  // starts late still paid for the whole prefix below it.
+  // Built on the first group that is not already the whole grid: a tidy stack
+  // where every group covers every x short-circuits below without ever needing
+  // ranks, and this runs per panel per area layer.
+  let rankOf: Map<number, number> | null = null;
   for (const set of perGroup.values()) {
     if (set.size === gridSorted.length) continue;
     let min = Infinity;
@@ -175,12 +183,19 @@ function needsStackAlign(
       if (v < min) min = v;
       if (v > max) max = v;
     }
-    for (const xv of gridSorted) {
-      if (xv <= min) continue;
-      if (xv >= max) break;
-      if (!set.has(xv)) {
-        return { groupCount: perGroup.size, gridSize: gridSorted.length, finiteRows };
-      }
+    if (rankOf === null) {
+      rankOf = new Map<number, number>();
+      for (let i = 0; i < gridSorted.length; i++) rankOf.set(gridSorted[i]!, i);
+    }
+    // Every member of `set` is a grid x, they are distinct, they all sit in
+    // [min, max], and min and max are themselves members. So the group covers
+    // its own window exactly when it holds one value per grid slot in it —
+    // anything short of that is the interior hole the scan looked for.
+    // Ranks, not values: the grid is not evenly spaced, so `max - min` counts
+    // gaps that were never grid x in the first place.
+    const span = rankOf.get(max)! - rankOf.get(min)! + 1;
+    if (set.size < span) {
+      return { groupCount: perGroup.size, gridSize: gridSorted.length, finiteRows };
     }
   }
   return null;

--- a/packages/core/tests/pipeline-m2/stack-align-grid-scan.test.ts
+++ b/packages/core/tests/pipeline-m2/stack-align-grid-scan.test.ts
@@ -1,0 +1,185 @@
+/**
+ * The stacked-area auto-align rescue first asks whether any group skips a
+ * shared-grid x inside its own range. It answered by walking the sorted grid
+ * per group, and the "before this group starts" arm was a `continue` rather
+ * than a seek, so every group paid for the whole prefix below its own minimum.
+ *
+ * Groups and distinct x both grow with the data, so that scan was
+ * groups × grid-x. The shape it costs most on is the ordinary one: many series
+ * that each cover a dense window of a wider shared grid and have no holes at
+ * all — exactly the case where the answer is "no rescue needed".
+ */
+import { describe, expect, it } from "bun:test";
+import { aes, gg } from "@ggsvelte/spec";
+import { runPipeline } from "../../src/pipeline.ts";
+import { size } from "./fixtures.ts";
+
+function areaModel(data: Record<string, unknown[]>) {
+  return runPipeline(
+    gg(data as never, aes({ x: "x", y: "y", fill: "g" }))
+      .geomArea()
+      .spec(),
+    size,
+  );
+}
+
+function aligned(model: ReturnType<typeof runPipeline>): boolean {
+  return model.advisories.some((a) => a.code === "stack-align-applied");
+}
+
+/**
+ * `count` series, each covering `width` consecutive grid x, starting `stride`
+ * apart. No series has an interior hole, so no rescue is needed — but every
+ * series sits above a prefix of grid values it does not carry.
+ */
+function staggered(count: number, width: number, stride: number) {
+  const x: number[] = [];
+  const y: number[] = [];
+  const g: string[] = [];
+  for (let s = 0; s < count; s++) {
+    for (let i = 0; i < width; i++) {
+      x.push(s * stride + i);
+      y.push(1 + (i % 3));
+      g.push(`s${s}`);
+    }
+  }
+  return { x, y, g };
+}
+
+/** Numeric-index reads of every sorted array built during `run`. */
+function gridReads(run: () => void): number {
+  const original = Array.prototype.toSorted;
+  let reads = 0;
+  // oxlint-disable-next-line no-extend-native -- only seam that sees the grid walk
+  Array.prototype.toSorted = function toSortedCounting(this: unknown[], ...args: never[]) {
+    const sorted: unknown[] = original.apply(this, args);
+    return new Proxy(sorted, {
+      get(target, property, receiver) {
+        if (typeof property === "string" && /^\d+$/.test(property)) reads += 1;
+        return Reflect.get(target, property, receiver) as unknown;
+      },
+    });
+  } as typeof Array.prototype.toSorted;
+  try {
+    run();
+  } finally {
+    // oxlint-disable-next-line no-extend-native -- restores the patch above
+    Array.prototype.toSorted = original;
+  }
+  return reads;
+}
+
+describe("stacked area auto-align grid scan", () => {
+  it("does not rescan the grid per group when no group has a hole", () => {
+    const data = staggered(100, 100, 100);
+    const rows = data.x.length;
+    let model: ReturnType<typeof runPipeline> | null = null;
+    const reads = gridReads(() => {
+      model = areaModel(data);
+    });
+    // The fixture makes row count and grid size equal, so the bound reads as
+    // "a handful of passes over the grid". The per-group walk took 51.5 of
+    // them; ranking the grid once takes a fixed number whatever the group
+    // count. The total also carries unrelated sorts elsewhere in the pipeline
+    // (stack positioning, discrete training), which is why the bound is loose
+    // rather than exact.
+    expect(rows).toBe(10_000);
+    expect(reads).toBeLessThan(rows * 5);
+    expect(aligned(model!)).toBe(false);
+    model!.dispose();
+  });
+
+  it("still rescues a group with an interior hole", () => {
+    // b skips x=2 while a covers 1..3, so b chords across a varying stack.
+    const model = areaModel({
+      x: [1, 2, 3, 1, 3],
+      y: [2, 2, 2, 3, 3],
+      g: ["a", "a", "a", "b", "b"],
+    });
+    expect(aligned(model)).toBe(true);
+    model.dispose();
+  });
+
+  it("leaves staggered windows alone when each is dense", () => {
+    // a covers 0..2, b covers 3..5. Neither skips anything inside its own
+    // range, so there is nothing to interpolate even though neither covers
+    // the shared grid.
+    const model = areaModel({
+      x: [0, 1, 2, 3, 4, 5],
+      y: [1, 2, 3, 3, 2, 1],
+      g: ["a", "a", "a", "b", "b", "b"],
+    });
+    expect(aligned(model)).toBe(false);
+    model.dispose();
+  });
+
+  it("leaves a single-sample group alone", () => {
+    // b holds one x, so its range is a point and cannot have an interior hole.
+    const model = areaModel({
+      x: [0, 1, 2, 1],
+      y: [1, 2, 3, 4],
+      g: ["a", "a", "a", "b"],
+    });
+    expect(aligned(model)).toBe(false);
+    model.dispose();
+  });
+
+  it("leaves groups that both cover the whole grid alone", () => {
+    const model = areaModel({
+      x: [0, 1, 2, 0, 1, 2],
+      y: [1, 2, 3, 3, 2, 1],
+      g: ["a", "a", "a", "b", "b", "b"],
+    });
+    expect(aligned(model)).toBe(false);
+    model.dispose();
+  });
+
+  it("ignores rows with no y when deciding", () => {
+    // The null-y row is skipped, which leaves b holding 1 and 3 while the
+    // shared grid carries 2 — still an interior hole.
+    const model = areaModel({
+      x: [1, 2, 3, 1, 2, 3],
+      y: [2, 2, 2, 3, null, 3],
+      g: ["a", "a", "a", "b", "b", "b"],
+    });
+    expect(aligned(model)).toBe(true);
+    model.dispose();
+  });
+
+  it("measures a group's window in grid slots, not in x distance", () => {
+    // The grid is 0, 10, 20 — not evenly spaced by 1. Group b holds 10 and 20,
+    // which are adjacent slots, so it is dense and needs no rescue. Sizing the
+    // window by `max - min` instead of by rank would call it a nine-value hole.
+    const model = areaModel({
+      x: [0, 10, 20, 10, 20],
+      y: [1, 2, 3, 2, 3],
+      g: ["a", "a", "a", "b", "b"],
+    });
+    expect(aligned(model)).toBe(false);
+    model.dispose();
+  });
+
+  it("finds a hole when a group's rows arrive out of order", () => {
+    // b's rows are 3 then 1, so a min/max pass that trusted arrival order would
+    // read the window backwards and miss the missing 2.
+    const model = areaModel({
+      x: [1, 2, 3, 3, 1],
+      y: [2, 2, 2, 3, 3],
+      g: ["a", "a", "a", "b", "b"],
+    });
+    expect(aligned(model)).toBe(true);
+    model.dispose();
+  });
+
+  it("does not rescue a group whose missing x are all outside its range", () => {
+    // c holds only 3 and 4 out of a 0..4 grid. Everything it lacks is below
+    // its own minimum, so the window is dense and no interpolation is due.
+    const model = areaModel({
+      x: [0, 1, 2, 3, 4, 3, 4],
+      y: [1, 1, 1, 1, 1, 2, 2],
+      g: ["a", "a", "a", "a", "a", "c", "c"],
+    });
+    expect(aligned(model)).toBe(false);
+    model.dispose();
+  });
+});


### PR DESCRIPTION
## What

Before rewriting a stacked-area frame, the auto-align rescue asks one question:
does any group skip a shared-grid x inside its own range? `needsStackAlign`
answered it by walking the sorted grid once per group — and the "before this
group starts" arm was a `continue` rather than a seek, so every group also paid
for the whole prefix of grid values below its own minimum.

```ts
for (const xv of gridSorted) {
  if (xv <= min) continue;   // continue, not a seek: walks the whole prefix
  if (xv >= max) break;
  if (!set.has(xv)) return { ... };
}
```

- **Before:** O(G × X)
- **After:** O(finiteRows + X)

**What n represents.** `G` is the number of grouping series — `perGroup` is keyed
by `groups[row]`, which comes from mapped data fields via `deriveLayerGroups`.
`X` is the number of distinct finite x, one `grid.add` per finite row. Neither is
capped: `STACK_ALIGN_MAX_ROWS` bounds the expansion *after* this check, not the
check. With G series each covering w distinct x over a union grid of X, the
input is G × w rows but the scan cost G × X.

**How often.** Once per panel per layer — `frame.ts:56` calls
`maybeStackAlignFrame`, and `prepare-panels-frames.ts:329` calls `buildFrame`
inside the panels × layers loop.

## How

Rank the grid once, then compare each group's size against the width of its own
window. Every value a group holds is a grid x inside `[min, max]`, the values are
distinct, and `min` and `max` are themselves members — so the group is dense
exactly when it holds one value per grid slot in that window, and a shortfall is
precisely the interior hole the scan looked for.

Ranks rather than values: the grid need not be evenly spaced, so `max - min`
would count gaps that were never grid x at all.

The rank map is built on the first group that is not already the whole grid, so
a tidy stack where every group covers every x still allocates nothing.

The decision is unchanged for every input, and so are the `stack-align-applied`
advisory and the `stack-align-skipped` warning — the returned payload is
computed entirely from state fixed before the loop, so which group triggers it
cannot change what comes back.

## Scope, stated plainly

This helps one shape: many series that each cover a dense window of a wider
shared grid. A tidy stack where every group covers the whole grid already
short-circuited on a size check and cost O(G). When a group really does have a
hole, the rescue's own row expansion dwarfs the scan. The reason to fix it is
that G and X are both uncapped and the staggered no-hole case is an ordinary
one, not that this was a render-path fire.

## Tests

New file `packages/core/tests/pipeline-m2/stack-align-grid-scan.test.ts` (9 tests).

The cost guard counts numeric reads of every sorted array built during
`runPipeline`, by wrapping `Array.prototype.toSorted` results in a counting
`Proxy` around one synchronous call and restoring in a `finally`. On 100
staggered series over a 10,000-value grid the scan read 505,000 grid slots; it
now reads 10,000. (The asserted total is looser than that because it also
carries unrelated sorts in stack positioning and discrete training.)

The other eight pin the decision: an interior hole still rescues; dense
staggered windows do not; a single-sample group does not; groups that both cover
the whole grid do not; a group whose missing x all sit outside its own range does
not; rows with no y are skipped; a group's window is measured in grid slots
rather than x distance; and a hole is still found when a group's rows arrive out
of order.

Every guard was mutation-tested. Killed: the original per-group walk (515,103
reads against a 50,000 bound), dropping the `+ 1`, `<=` for `<`, `>` for `<`,
returning null unconditionally, swapping min/max, ranking by insertion order,
sizing the window by value distance, and taking min/max from arrival order. The
last two were added after review showed a plausible wrong simplification shipped
green without them.

An independent differential run over 400,000 function-level inputs and 500
end-to-end datasets — comparing advisories, warnings and a scene fingerprint
against the previous implementation — found no disagreement.

## Verification

```
bun test packages/core packages/spec   2766 pass, 0 fail
bun run check                          OK
bun run lint                           OK
bun run lint:type-aware                OK
bun run fmt:check                      OK
bun node_modules/.bin/knip             OK
vitest --project chromium tests/scene  77 pass
```

## Follow-ups

Two findings from the same audit, both deferred because they are log factors
rather than class changes:

- ljodea/ggsvelte#1335 — band-axis tick thinning rebuilds every tick on each
  halving, O(k log k) where O(k) suffices
- ljodea/ggsvelte#1336 — `statAlign` re-derives by binary search the bracket its
  own merge cursor already holds, Θ(G·U·log m) where Θ(G·U) suffices

Considered and not filed: `stats/loess.ts` is genuinely Θ(n·q) over a group's
rows, but the module pins `surface="direct"`, `statistics="exact"` for R parity
and the inferred path is capped at 1000 rows — escaping it means a different
surface and breaks the fixture contract.

Still open from earlier audits, all constant-factor: #1307, #1308, #1309, #1310,
#1311, #1312, #1318, #1320, #1327, #1328, #1329, #1332.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1337" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->