### PR TITLE
perf(core): intern a stat mark's group lineage once, not once per mark

### DIFF
--- a/.changeset/olive-pugs-tickle.md
+++ b/.changeset/olive-pugs-tickle.md
@@ -1,0 +1,41 @@
+---
+"@ggsvelte/core": patch
+---
+
+# Intern a stat mark's group lineage once instead of once per mark
+
+Migration: none — internal
+
+A stat mark's lineage is the whole group it summarizes. The per-group row bucket
+is built once and frozen, and `LineageStore` interns such an array by identity so
+a group is tokenized once however many marks point at it. Two things defeated
+that, and either one alone kept the work at marks × group rows:
+
+- The represented-rows fallback returned `[...baseRows]`. A clone is not frozen,
+  so it never matched the identity cache and every mark paid a fresh set build,
+  sort and join over its whole group. The three indexed arms directly above it
+  already return the shared frozen bucket for exactly this reason.
+- The cache lookup sat behind `Object.isFrozen`, which walks the array in this
+  engine. Guarding a hash lookup with a linear check costs one pass over the
+  members per call — the very rescan the cache exists to avoid.
+
+Both quantities grow with the data: marks are stat output rows, and a group's
+size is a share of the input. For a single-group plot both are the row count, so
+the cost was quadratic. Measured on a `stat: "ecdf"` line, forcing the deferred
+candidate store:
+
+| rows | before   | after |
+| ---- | -------- | ----- |
+| 2000 | 572 ms   | 38 ms |
+| 4000 | 1987 ms  | 54 ms |
+| 8000 | 10203 ms | 84 ms |
+
+A `stat: "connect"` line goes from 21135 ms to 100 ms at 8000 rows. The curve is
+now flat where it used to quadruple with each doubling.
+
+This is construction work behind a lazy gate, so it does not show up in render
+timings — it lands as a freeze on the first hover, hit-test or keyboard
+traversal after a render.
+
+Lineage membership is unchanged: stats that narrow their group (`smooth`,
+`summary`, `boxplot`, binned counts) still clone and filter.

--- a/packages/core/src/identity.ts
+++ b/packages/core/src/identity.ts
@@ -16,7 +16,12 @@ export class LineageStore<Key extends PropertyKey = PropertyKey> {
 
   intern(keys: Iterable<Key>): LineageRef {
     // Shared frozen arrays (identity-index buckets) intern once; skip re-sort/tokenize.
-    if (Array.isArray(keys) && Object.isFrozen(keys)) {
+    // Look the array up before asking whether it is frozen: `Object.isFrozen`
+    // walks the array in this engine, so guarding a hash lookup with it costs
+    // one pass over the members per call — the very rescan this cache exists to
+    // avoid. Only frozen arrays are ever stored below, and freezing cannot be
+    // undone, so a hit is still sound.
+    if (Array.isArray(keys)) {
       const cached = this.#byArray.get(keys);
       if (cached !== undefined) return cached;
     }

--- a/packages/core/src/pipeline/candidate-construction/datum.ts
+++ b/packages/core/src/pipeline/candidate-construction/datum.ts
@@ -74,7 +74,7 @@ export function resolveRepresentedSourceRows(input: {
   frameRow: number;
   lineage: LineageStore<number>;
   primitiveIndex: number;
-}): { representedRows: number[]; sourceOrder: number; lineageKey: number } {
+}): { representedRows: readonly number[]; sourceOrder: number; lineageKey: number } {
   const {
     outlierSourceRow,
     sourceRow,
@@ -94,7 +94,7 @@ export function resolveRepresentedSourceRows(input: {
 
   // Outliers already pin an exact source row — do not re-expand via aggregate
   // group×x / bin indexes (those buckets contain every row the box represents).
-  let representedRows =
+  let representedRows: readonly number[] =
     outlierSourceRow === null
       ? (sourceRowsByGroup.get(`${panelIndex}:${layerIndex}:${group}`) ?? [])
       : [outlierSourceRow];

--- a/packages/core/src/pipeline/candidate-construction/represented-rows.ts
+++ b/packages/core/src/pipeline/candidate-construction/represented-rows.ts
@@ -81,7 +81,7 @@ export function filterRepresentedSourceRows(input: {
   sourceRowsByGroupBin?: Map<string, number[]>;
   /** Precomputed finite-y rows per `${panel}:${layer}:${group}` (smooth/summary/boxplot). */
   sourceRowsByGroupY?: Map<string, number[]>;
-}): number[] {
+}): readonly number[] {
   const { frame, table, frameRow } = input;
   const stat = frame.binding.layer.stat ?? "identity";
   const aggregateXField = frame.binding.xField;
@@ -132,6 +132,11 @@ export function filterRepresentedSourceRows(input: {
     const indexed = input.sourceRowsByGroupBin.get(`${indexKeyPrefix}:${frameRow}`);
     if (indexed !== undefined) return indexed;
   }
+
+  // Nothing to narrow: hand back the shared frozen bucket, exactly as the
+  // indexed arms above do. A clone is not frozen and so misses LineageStore's
+  // identity cache, which made every mark re-tokenize its whole group.
+  if (!needsX && !needsBin && !needsY) return input.baseRows;
 
   // Fallback without index maps: clone then filter (parity with pure filters).
   let representedRows = [...input.baseRows];

--- a/packages/core/tests/lineage-group-intern.test.ts
+++ b/packages/core/tests/lineage-group-intern.test.ts
@@ -1,0 +1,237 @@
+/**
+ * A stat mark's lineage is the whole group it summarizes. The per-group bucket
+ * is built once and frozen, and `LineageStore` interns such an array by identity
+ * so a group is tokenized once however many marks point at it.
+ *
+ * Two things defeated that: the represented-rows fallback handed back a clone,
+ * which is not frozen and so never matched the identity cache; and the cache
+ * lookup sat behind an `Object.isFrozen` check that walks the array in this
+ * engine. Either one alone leaves the work quadratic — marks x group rows.
+ */
+import { describe, expect, it } from "bun:test";
+
+import { aes, gg } from "@ggsvelte/spec";
+
+import { LineageStore } from "../src/identity.ts";
+import { runPipeline } from "../src/pipeline.ts";
+
+/**
+ * Two measurements while `run` builds a candidate store:
+ *  - `distinctArrays`: how many *different* arrays are handed to `intern`.
+ *    Sharing one frozen bucket across a group's marks makes this 1; cloning
+ *    per mark makes it one per mark.
+ *  - `frozenCheckElements`: elements walked by `Object.isFrozen` during
+ *    construction. That check is linear in this engine, so putting it in front
+ *    of the identity cache costs a pass over the group per mark.
+ */
+function internStats(run: () => ReturnType<typeof runPipeline>): {
+  distinctArrays: number;
+  frozenCheckElements: number;
+  candidates: number;
+} {
+  // oxlint-disable-next-line typescript/unbound-method -- re-invoked with .call below
+  const originalIntern = LineageStore.prototype.intern;
+  const originalIsFrozen = Object.isFrozen;
+  const arrays = new Set<object>();
+  let frozenCheckElements = 0;
+  LineageStore.prototype.intern = function counting(this: LineageStore, keys: Iterable<never>) {
+    if (Array.isArray(keys)) arrays.add(keys);
+    return originalIntern.call(this, keys);
+  } as typeof originalIntern;
+  Object.isFrozen = function countingIsFrozen(value: unknown) {
+    if (Array.isArray(value)) frozenCheckElements += value.length;
+    return originalIsFrozen(value);
+  } as typeof Object.isFrozen;
+  try {
+    const model = run();
+    // The candidate store is deferred; querying it forces construction.
+    const candidates = model.candidates.size;
+    for (let id = 0; id < candidates; id++) model.candidates.candidate(id);
+    model.dispose();
+    return { distinctArrays: arrays.size, frozenCheckElements, candidates };
+  } finally {
+    LineageStore.prototype.intern = originalIntern;
+    Object.isFrozen = originalIsFrozen;
+  }
+}
+
+function xOnly(n: number) {
+  return { x: Array.from({ length: n }, (_, i) => (i * 0.37) % 101) };
+}
+
+function xy(n: number) {
+  return {
+    x: Array.from({ length: n }, (_, i) => (i * 0.37) % 101),
+    y: Array.from({ length: n }, (_, i) => (i * 7) % 53),
+  };
+}
+
+describe("stat lineage interning", () => {
+  it("hands every mark of a group the same bucket array", () => {
+    // ecdf emits one mark per distinct x and every mark's lineage is the whole
+    // single group. Cloning the bucket per mark gave one array per mark.
+    const n = 400;
+    const { distinctArrays, candidates } = internStats(() =>
+      runPipeline(
+        gg(xOnly(n), aes({ x: "x" }))
+          .geomLine({ stat: "ecdf" } as never)
+          .spec(),
+        { width: 640, height: 400 },
+      ),
+    );
+    expect(candidates).toBeGreaterThan(n / 2);
+    // The group's bucket, plus the handful of singleton arrays interned for
+    // marks that do carry a source row. Cloning gave one array per mark — 401
+    // here — so the bound only has to sit far below the candidate count.
+    expect(distinctArrays).toBeLessThan(10);
+  });
+
+  it("does not walk the group to reach the identity cache", () => {
+    const n = 400;
+    const { frozenCheckElements } = internStats(() =>
+      runPipeline(
+        gg(xOnly(n), aes({ x: "x" }))
+          .geomLine({ stat: "ecdf" } as never)
+          .spec(),
+        { width: 640, height: 400 },
+      ),
+    );
+    // `Object.isFrozen` is linear in this engine, so asking it once per mark
+    // about an n-element bucket is itself the quadratic. It belongs behind the
+    // cache lookup, not in front of it.
+    expect(frozenCheckElements).toBeLessThan(n * 3);
+  });
+
+  it("keeps every candidate's lineage membership unchanged", () => {
+    // Sharing the bucket must not change who is in a mark's lineage.
+    const model = runPipeline(
+      gg(xOnly(60), aes({ x: "x" }))
+        .geomLine({ stat: "ecdf" } as never)
+        .spec(),
+      { width: 640, height: 400 },
+    );
+    const seen: number[][] = [];
+    for (let id = 0; id < model.candidates.size; id++) {
+      const candidate = model.candidates.candidate(id);
+      if (candidate === null) continue;
+      seen.push([...model.lineage.keys(candidate.lineage)].toSorted((a, b) => a - b));
+    }
+    expect(seen.length).toBeGreaterThan(1);
+    // Every ecdf mark summarizes the whole group, so each lineage is all 60 rows.
+    for (const keys of seen) {
+      expect(keys.length).toBe(60);
+      expect(keys.at(0)).toBe(0);
+      expect(keys.at(-1)).toBe(59);
+    }
+    model.dispose();
+  });
+
+  it("still clones and narrows when a filter applies", async () => {
+    // Reach the changed line the way the finite-y cache tests do: call the
+    // filter directly with no index maps, so the fallback arm runs. Through
+    // runPipeline a boxplot returns at the indexed group-by-x arm above it and
+    // never gets here.
+    const { preparePanels } = await import("../src/pipeline/prepare-panels.ts");
+    const { filterRepresentedSourceRows } =
+      await import("../src/pipeline/candidate-construction/represented-rows.ts");
+    const { normalize } = await import("@ggsvelte/spec");
+
+    const prepared = preparePanels(
+      normalize({
+        data: {
+          values: [
+            { g: "a", y: 1 },
+            { g: "a", y: Number.NaN },
+            { g: "a", y: 3 },
+            { g: "b", y: 4 },
+          ],
+        },
+        layers: [
+          { geom: "pointrange", stat: "summary", aes: { x: { field: "g" }, y: { field: "y" } } },
+        ],
+      }),
+      { width: 640, height: 400 },
+      [],
+      [],
+    );
+    const frame = prepared.panelFrames[0]![0]!;
+    const baseRows = Object.freeze([0, 1, 2]);
+    const narrowed = filterRepresentedSourceRows({
+      frame,
+      table: prepared.table,
+      frameRow: 0,
+      baseRows,
+    });
+    // summary sets the finite-y filter, so row 1 (NaN y) must be dropped and the
+    // result must be a new array, not the bucket handed straight back.
+    expect([...narrowed]).toEqual([0, 2]);
+    expect(narrowed).not.toBe(baseRows);
+
+    // smooth sets the finite-y filter without the x one, so it pins that term
+    // of the guard on its own.
+    const smoothPrepared = preparePanels(
+      normalize({
+        data: {
+          values: [
+            { x: 1, y: 1 },
+            { x: 2, y: Number.NaN },
+            { x: 3, y: 3 },
+          ],
+        },
+        layers: [{ geom: "line", stat: "smooth", aes: { x: { field: "x" }, y: { field: "y" } } }],
+      }),
+      { width: 640, height: 400 },
+      [],
+      [],
+    );
+    const smoothFrame = smoothPrepared.panelFrames[0]![0]!;
+    const smoothBase = Object.freeze([0, 1, 2]);
+    const smoothNarrowed = filterRepresentedSourceRows({
+      frame: smoothFrame,
+      table: smoothPrepared.table,
+      frameRow: 0,
+      baseRows: smoothBase,
+    });
+    expect([...smoothNarrowed]).toEqual([0, 2]);
+    expect(smoothNarrowed).not.toBe(smoothBase);
+  });
+
+  it("leaves identity geoms at one source row per mark", () => {
+    const model = runPipeline(
+      gg(xy(30), aes({ x: "x", y: "y" }))
+        .geomPoint()
+        .spec(),
+      { width: 640, height: 400 },
+    );
+    let checked = 0;
+    for (let id = 0; id < model.candidates.size; id++) {
+      const candidate = model.candidates.candidate(id);
+      if (candidate === null) continue;
+      expect(model.lineage.count(candidate.lineage)).toBe(1);
+      checked += 1;
+    }
+    expect(checked).toBe(30);
+    model.dispose();
+  });
+});
+
+describe("LineageStore identity cache", () => {
+  it("does not cache an array it cannot trust to stay put", async () => {
+    // The identity cache is consulted before `Object.isFrozen`, which is only
+    // sound because nothing stores an unfrozen array. Drop that guard and a
+    // caller could mutate an array after interning it and get the stale ref
+    // back — so pin it here rather than leaving it to a comment.
+    const { LineageStore: Store } = await import("../src/identity.ts");
+    const store = new Store<number>();
+    const mutable = [1, 2];
+    const first = store.intern(mutable);
+    mutable.push(3);
+    const second = store.intern(mutable);
+    expect(second).not.toBe(first);
+    expect([...store.keys(second)].toSorted((a, b) => a - b)).toEqual([1, 2, 3]);
+
+    // A frozen array is safe to cache, and interning it twice is one entry.
+    const frozen = Object.freeze([7, 8]);
+    expect(store.intern(frozen)).toBe(store.intern(frozen));
+  });
+});


### PR DESCRIPTION
## What

A stat mark's lineage is the whole group it summarizes. The per-group row bucket
is built once and frozen (`candidate-construction/identity-index.ts:133`), and
`LineageStore` interns such an array by identity so a group is tokenized once
however many marks point at it.

Two things defeated that, and **either one alone left the work quadratic**:

1. `candidate-construction/represented-rows.ts:137` returned `[...baseRows]`.
   A clone is not frozen, so it never matched the identity cache and every mark
   paid a fresh `Set` build, `sort` and `join` over its whole group. The three
   indexed arms directly above it already return the shared frozen bucket, and
   their comments say exactly why — "return the frozen array as-is so
   LineageStore can WeakMap-intern once — no clone".
2. `identity.ts:19` put the cache lookup behind `Object.isFrozen(keys)`. That
   check walks the array in this engine, so guarding a hash lookup with it cost
   one pass over the members per call — the very rescan the cache exists to
   avoid.

- **Before:** Θ(M · g log g)
- **After:** Θ(M + n)

**What n represents.** `M` is candidate primitives — stat output rows, one per
distinct x per group for `ecdf`, one per distinct `(group, x, y)` for `sum`, one
per sample for `qq`. `g` is the source rows in a mark's group; the bucket is
filled one row at a time over every input row
(`candidate-construction/identity-index.ts:84-88`). Neither is capped, and for a
single-group plot both equal the row count.

## Measurements

A `stat: "ecdf"` line, forcing the deferred candidate store and walking every
candidate:

| rows | before | after |
| ---- | ------ | ----- |
| 2000 | 572 ms | 38 ms |
| 4000 | 1987 ms | 54 ms |
| 8000 | 10203 ms | 84 ms |

`stat: "connect"` at 8000 rows: 21135 ms → 100 ms. The curve is flat where it
used to quadruple on each doubling; `geom_point` was and remains linear.

An independent reviewer reproduced this on a slower baseline and measured each
half in isolation — with only one half applied, 8000 rows still costs 14–17 s.
Each half halves the constant; only both together flatten the curve.

**When it runs.** Construction work behind a lazy gate
(`candidate-store.ts:76`), so it never appears in render timings. It lands as a
freeze on the user's first hover, hit-test or keyboard traversal after a render.

## Safety

Many marks now share one array where each previously held a clone. The buckets
are frozen before any consumer sees them, so an in-place write throws rather
than corrupting silently. The only production consumer of the returned array is
`lineage.intern`, which builds a fresh `unique` and sorts that, never its input;
`datum.ts` discards `representedRows` after taking the ref. Interaction code
never sees the bucket — `lineage.keys(ref)` returns the store's own frozen
members entry.

Reordering the cache lookup is sound because `#byArray` is only ever written
under `Object.isFrozen`, and freezing cannot be undone. That invariant now has a
test rather than only a comment.

Some internal return types widened to `readonly number[]`. Nothing new is
exported.

## Tests

New file `packages/core/tests/lineage-group-intern.test.ts` (6 tests).

Two cost guards: one asserts a group's marks are handed the same bucket array
(cloning gave 401 distinct arrays for 401 marks); the other counts elements
walked by `Object.isFrozen` during construction. Each guard dies on its own
half's revert.

The rest pin behaviour: lineage membership and ordering unchanged for `ecdf`;
identity geoms still one source row per mark; the fallback still clones and
narrows when a filter applies — checked by calling the filter directly with no
index maps, since through `runPipeline` a boxplot returns at the indexed arm and
never reaches the changed line; and `LineageStore` refuses to cache an array it
cannot trust to stay put.

Mutation-tested. Killed: reverting either half; inverting the guard; cloning in
the early return; deleting the cache lookup; dropping the `needsX` or `needsY`
term; and caching unfrozen arrays. The `needsBin` term is unreachable through
`runPipeline` — the bin index never misses when it is set — so it stays unpinned
and I am saying so rather than implying otherwise. Returning `baseRows`
unconditionally is caught by the existing `finite-y cache` and
`aggregate lineage index (#184)` suites with 6 failures.

## Verification

```
bun test packages/core packages/spec   2772 pass, 0 fail
bun run check                          OK
bun run lint                           OK
bun run lint:type-aware                OK
bun run fmt:check                      OK
bun node_modules/.bin/knip             OK
vitest --project chromium tests/inspection tests/scene   218 pass
```

## Follow-ups

From the same audit, filed rather than shipped:

- ljodea/ggsvelte#1340 — facet guide plans duplicate the shared band domain once
  per panel. Real but explicitly **not** a complexity-class change; filed with
  that sizing stated.

Still open from earlier audits: #1307–#1312, #1318, #1320, #1327–#1329, #1332,
#1335, #1336, #1338, #1339.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1341" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->