### PR TITLE
fix(core): collect style scale values without spreading row columns

### DIFF
--- a/.changeset/style-scale-collect-arg-limit.md
+++ b/.changeset/style-scale-collect-arg-limit.md
@@ -1,0 +1,13 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+# Collect style scale values without spreading row columns
+
+Migration: none — internal
+
+Mapped style aesthetics collected frame values with `values.push(...mapped)`.
+Past the engine argument limit that threw `RangeError` on large data. Values
+are now pushed one element at a time, matching the colour collect path.

--- a/packages/core/src/pipeline/scale-style-collect.ts
+++ b/packages/core/src/pipeline/scale-style-collect.ts
@@ -52,7 +52,10 @@ export function collectStyleValues(input: {
         anyDiscrete = true;
       }
       if (binding.field !== null) anyIndexable = true;
-      values.push(...mapped);
+      // One push per element — never spread a row-length column into push.
+      // Spread hits the engine argument limit (RangeError) on large data (#1338).
+      // Match the colour path in scale-color-collect.ts.
+      for (const v of mapped) values.push(v);
     }
     if (binding.scaledConstant !== null) {
       anyField = true;

--- a/packages/core/tests/scale-style-collect.test.ts
+++ b/packages/core/tests/scale-style-collect.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Style aesthetic value collection for scale training.
+ *
+ * Large mapped style columns must not be spread into Array.prototype.push —
+ * that hits the engine argument limit and throws RangeError (#1338). Match the
+ * colour path: iterate and push one element at a time.
+ */
+import { describe, expect, it } from "bun:test";
+import { fromAny } from "@total-typescript/shoehorn";
+
+import { collectStyleValues } from "../src/pipeline/scale-style-collect.ts";
+import type { LayerBinding, LayerFrame } from "../src/pipeline/types.js";
+import { ColumnTable } from "../src/table.js";
+
+function sizeBinding(overrides: Partial<LayerBinding["size"]> = {}): LayerBinding {
+  return fromAny<LayerBinding>({
+    layer: { geom: "point", aes: {} },
+    index: 0,
+    xField: "x",
+    yField: "y",
+    color: { field: null, constant: null, scaledConstant: null },
+    fill: { field: null, constant: null, scaledConstant: null },
+    size: { field: "s", statColumn: null, constant: null, scaledConstant: null, ...overrides },
+    linewidth: { field: null, statColumn: null, constant: null, scaledConstant: null },
+    alpha: { field: null, statColumn: null, constant: null, scaledConstant: null },
+    shape: { field: null, statColumn: null, constant: null, scaledConstant: null },
+    linetype: { field: null, statColumn: null, constant: null, scaledConstant: null },
+    ruleForm: null,
+  });
+}
+
+describe("collectStyleValues", () => {
+  it("preserves mapped order and appends scaled constants", () => {
+    const table = ColumnTable.fromRows([{ x: 1, y: 1, s: 1 }]);
+    const binding = sizeBinding();
+    const frame = fromAny<LayerFrame>({
+      binding,
+      table,
+      n: 3,
+      sizeValues: [1, 2, 3],
+    });
+    const constantBinding = sizeBinding({
+      field: null,
+      scaledConstant: 99,
+    });
+    const constantFrame = fromAny<LayerFrame>({
+      binding: constantBinding,
+      table,
+      n: 1,
+      sizeValues: null,
+    });
+    const result = collectStyleValues({
+      aesthetic: "size",
+      frames: [frame, constantFrame],
+      bindings: [binding, constantBinding],
+      table,
+      sourceTable: table,
+    });
+    expect(result.values).toEqual([1, 2, 3, 99]);
+  });
+
+  it("collects a style column past the engine spread argument limit", () => {
+    // Engine argument limit is runtime-specific. On Bun 1.3.x here, bare
+    // push(...arr) succeeds at 5e5 and throws at 1e6. Pin n to a size that
+    // actually throws under spread on *this* runtime so the test stays red
+    // without the fix and green with it.
+    const n = 1_000_000;
+    // Prove the engine still rejects a row-length spread into push on this
+    // runtime so the regression test stays meaningful if limits change.
+    const bulk = Array.from({ length: n }, () => 0);
+    expect(() => {
+      Array.prototype.push.apply([], bulk);
+    }).toThrow(RangeError);
+
+    // Prefer Float64Array: size/linewidth/alpha often arrive as typed columns.
+    const mapped = new Float64Array(n);
+    for (let i = 0; i < n; i++) mapped[i] = i % 50;
+
+    // Keep the field branch cheap: has() false so we only exercise the push path.
+    const table = fromAny({
+      has: () => false,
+      discreteness: () => "continuous",
+    });
+    const binding = sizeBinding();
+    const frame = fromAny<LayerFrame>({
+      binding,
+      table,
+      n,
+      sizeValues: mapped,
+    });
+
+    const result = collectStyleValues({
+      aesthetic: "size",
+      frames: [frame],
+      bindings: [binding],
+      table: table as never,
+      sourceTable: table as never,
+    });
+    expect(result.values.length).toBe(n);
+    expect(result.values[0]).toBe(0);
+    expect(result.values[n - 1]).toBe((n - 1) % 50);
+    expect(result.anyField).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1338.

Mapped style aesthetics (`size`, `linewidth`, `alpha`, `shape`, `linetype`) collect
frame values with `values.push(...mapped)`. On large row counts that spread hits the
JS engine argument limit and throws `RangeError: Maximum call stack size exceeded`.
Colour/fill collection already avoids this with a per-element push loop.

**Validation:** On Bun 1.3.14, `runPipeline` with mapped `size` and n=1_000_000 threw;
the same plot with mapped `color` succeeded. After this change both succeed.

## Change

- `packages/core/src/pipeline/scale-style-collect.ts`: replace `push(...mapped)` with
  `for (const v of mapped) values.push(v)` (same pattern as `scale-color-collect.ts`).
- New unit tests: order/content characterization, and a regression that first proves
  this runtime rejects a row-length `push` apply, then asserts collect does not throw
  on a 1e6 `Float64Array` size column.

## Verification

```text
bun test packages/core/tests/scale-style-collect.test.ts
# 2 pass

bun test packages/core/tests/pipeline-style-families/ packages/core/tests/scale-color-collect.test.ts packages/core/tests/scale-style-collect.test.ts
# 41 pass

# issue repro
runPipeline(gg(1e6-row data, aes size).geomPoint().spec(), …) → OK
```

Colour path is untouched.

## Follow-ups

- `sf-geometry.ts` also spreads into `push` for geometry-collection children and
  representative points; not verified at a reachable size in this issue. Filing
  separately if not already open.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1343" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->