### PR TITLE
fix(core): share frozen band domain across facet guide plans

### DIFF
--- a/.changeset/share-band-guide-domain.md
+++ b/.changeset/share-band-guide-domain.md
@@ -1,0 +1,15 @@
+---
+"@ggsvelte/core": patch
+"@ggsvelte/spec": patch
+"@ggsvelte/svelte": patch
+"@ggsvelte/cli": patch
+---
+
+# Share frozen band domain across facet guide plans
+
+Migration: none — internal memory hygiene; guide plan domain contents and freeze contract unchanged.
+
+Under fixed facet scales, band axis guide plans reused to copy `scale.rawDomain`
+once per panel. Reuse the already-frozen array when present so panels share one
+object. Free scales still get distinct domains because each panel trains its own
+`rawDomain`.

--- a/packages/core/src/layout/basic-axis.ts
+++ b/packages/core/src/layout/basic-axis.ts
@@ -39,7 +39,9 @@ export function planBasicAxis(input: {
     temporalKind: null,
     domain:
       input.scale.type === "band"
-        ? Object.freeze(input.scale.rawDomain.map((value) => value as CellValue))
+        ? Object.isFrozen(input.scale.rawDomain)
+          ? (input.scale.rawDomain as readonly CellValue[])
+          : Object.freeze(input.scale.rawDomain.map((value) => value as CellValue))
         : Object.freeze([input.scale.domain[0], input.scale.domain[1]] as const),
     direction: input.config?.reverse === true ? ("descending" as const) : ("ascending" as const),
     source,

--- a/packages/core/src/layout/layout-derive-ticks.ts
+++ b/packages/core/src/layout/layout-derive-ticks.ts
@@ -106,7 +106,10 @@ function bandGuidePlan(
     scaleType: "band" as const,
     transform: "identity" as const,
     temporalKind: null,
-    domain: Object.freeze(rawCategories.map((value) => value as CellValue)),
+    // Reuse frozen scale.rawDomain across fixed-scale facet panels (#1340).
+    domain: Object.isFrozen(rawCategories)
+      ? (rawCategories as readonly CellValue[])
+      : Object.freeze(rawCategories.map((value) => value as CellValue)),
     direction: reverse ? ("descending" as const) : ("ascending" as const),
     source: context.config.breaks === undefined ? ("automatic" as const) : ("explicit" as const),
     interval: null,

--- a/packages/core/tests/layout/band-domain-share.test.ts
+++ b/packages/core/tests/layout/band-domain-share.test.ts
@@ -22,7 +22,7 @@ describe("planBasicAxis band domain reuse (#1340)", () => {
       scale,
       ticks: scale.domain.map((value, domainIndex) => ({
         value: domainIndex,
-        label: String(value),
+        label: value,
         labeled: true,
         domainIndex,
       })),

--- a/packages/core/tests/layout/band-domain-share.test.ts
+++ b/packages/core/tests/layout/band-domain-share.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Facet band guide plans should reuse a frozen scale.rawDomain for the
+ * `domain` field instead of allocating a fresh copy per panel (#1340).
+ */
+import { describe, expect, it } from "bun:test";
+
+import { aes, gg } from "@ggsvelte/spec";
+
+import { planBasicAxis } from "../../src/layout/basic-axis.ts";
+import { runPipeline } from "../../src/pipeline.ts";
+import { trainBand, trainContinuous } from "../../src/scales/train.ts";
+
+const size = { width: 640, height: 400 };
+
+describe("planBasicAxis band domain reuse (#1340)", () => {
+  it("reuses frozen scale.rawDomain by reference", () => {
+    const scale = trainBand([["a", "b", "c"]]);
+    expect(Object.isFrozen(scale.rawDomain)).toBe(true);
+    const plan = planBasicAxis({
+      aesthetic: "x",
+      panelIndex: 0,
+      scale,
+      ticks: scale.domain.map((value, domainIndex) => ({
+        value: domainIndex,
+        label: String(value),
+        labeled: true,
+        domainIndex,
+      })),
+      config: undefined,
+    });
+    expect(plan.domain).toBe(scale.rawDomain);
+    expect(Object.isFrozen(plan.domain)).toBe(true);
+    expect(plan.domain).toEqual(["a", "b", "c"]);
+  });
+
+  it("freezes a copy when rawDomain is not already frozen", () => {
+    const scale = trainBand([["a", "b"]]);
+    const mutableRaw = ["x", "y"] as unknown[];
+    const patched = { ...scale, rawDomain: mutableRaw as readonly unknown[] };
+    const plan = planBasicAxis({
+      aesthetic: "x",
+      panelIndex: 0,
+      scale: patched,
+      ticks: [
+        { value: 0, label: "x", labeled: true, domainIndex: 0 },
+        { value: 1, label: "y", labeled: true, domainIndex: 1 },
+      ],
+      config: undefined,
+    });
+    expect(plan.domain).not.toBe(mutableRaw);
+    expect(Object.isFrozen(plan.domain)).toBe(true);
+    expect(plan.domain).toEqual(["x", "y"]);
+  });
+
+  it("keeps a two-element frozen domain for continuous axes", () => {
+    const { scale } = trainContinuous([Float64Array.of(0, 10)], { type: "linear" });
+    const plan = planBasicAxis({
+      aesthetic: "y",
+      panelIndex: 0,
+      scale,
+      ticks: [
+        { value: 0, label: "0", labeled: true },
+        { value: 10, label: "10", labeled: true },
+      ],
+      config: undefined,
+    });
+    expect(plan.domain).toHaveLength(2);
+    expect(plan.domain).toEqual([scale.domain[0], scale.domain[1]]);
+    expect(Object.isFrozen(plan.domain)).toBe(true);
+  });
+});
+
+describe("facet band guide domain sharing (#1340)", () => {
+  const rows = [
+    { cat: "a", y: 1, g: "p1" },
+    { cat: "b", y: 2, g: "p1" },
+    { cat: "a", y: 3, g: "p2" },
+    { cat: "b", y: 4, g: "p2" },
+    { cat: "c", y: 5, g: "p2" },
+  ];
+
+  it("fixed facet scales share one band domain array across panels", () => {
+    const model = runPipeline(
+      gg(rows, aes({ x: "cat", y: "y" }))
+        .geomCol()
+        .facet({ wrap: "g" })
+        .spec(),
+      size,
+    );
+    const bandPlans = model.guidePlans.filter(
+      (plan) => plan.type === "axis" && plan.scaleType === "band" && plan.aesthetic === "x",
+    );
+    expect(bandPlans.length).toBeGreaterThan(1);
+    const first = bandPlans[0]!.domain;
+    expect(Object.isFrozen(first)).toBe(true);
+    for (const plan of bandPlans) {
+      expect(plan.domain).toBe(first);
+      expect(plan.domain).toEqual(first);
+    }
+    // Shared object is the trained scale rawDomain.
+    expect(model.scales.x.type).toBe("band");
+    if (model.scales.x.type === "band") {
+      expect(first).toBe(model.scales.x.rawDomain);
+    }
+  });
+
+  it("free-x facet scales keep distinct domain arrays per panel", () => {
+    const model = runPipeline(
+      gg(rows, aes({ x: "cat", y: "y" }))
+        .geomCol()
+        .facet({ wrap: "g", scales: "free_x" })
+        .spec(),
+      size,
+    );
+    const bandPlans = model.guidePlans.filter(
+      (plan) => plan.type === "axis" && plan.scaleType === "band" && plan.aesthetic === "x",
+    );
+    expect(bandPlans.length).toBeGreaterThan(1);
+    // p1 has {a,b}, p2 has {a,b,c} under free_x — contents differ; objects must too.
+    const domains = bandPlans.map((plan) => plan.domain);
+    for (const domain of domains) {
+      expect(Object.isFrozen(domain)).toBe(true);
+    }
+    // At least one pair of panels should not share the same array object.
+    const distinct = new Set(domains);
+    expect(distinct.size).toBe(domains.length);
+  });
+});


### PR DESCRIPTION
## Summary

- Band axis guide plans (`bandGuidePlan`, `planBasicAxis`) reused to `map`+`freeze` `scale.rawDomain` once per facet panel even when that array is already frozen and shared under fixed scales.
- Reuse the frozen array when `Object.isFrozen(rawCategories)`; otherwise keep the copy+freeze path for unfrozen fallbacks.
- Free-scale facets still get distinct domains (each panel trains its own `rawDomain`). Continuous axes keep a two-element domain.

Closes #1340

## Test plan

- [x] `bun test packages/core/tests/layout/band-domain-share.test.ts` (unit + facet pipeline)
- [x] Related band layout / pipeline-band tests green
- [ ] CI
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1345" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->