### PR TITLE
fix(skill): teach v0.21 row identity; mark plot-level key deprecated

### DIFF
--- a/.changeset/skill-row-identity-key-deprecation.md
+++ b/.changeset/skill-row-identity-key-deprecation.md
@@ -1,0 +1,14 @@
+---
+"@ggsvelte/svelte": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+# Teach v0.21 row identity; mark plot-level key deprecated
+
+Migration: none — skill docs only
+
+SKILL.md still listed `key` as a first-class GGPlot prop and told agents to
+always give a stable key after #1254/#1257 moved durable identity onto
+Inspect / Select / createPlotInteraction. Align the lead skill with
+references/interactions.md so agents stop generating the deprecated surface.

--- a/packages/svelte/skills/ggsvelte/SKILL.md
+++ b/packages/svelte/skills/ggsvelte/SKILL.md
@@ -117,13 +117,15 @@ z-order (points above smooth here). Every geom takes aesthetics through one
 direct props (`size={3}`); structural props are `data`, `stat`, `position`,
 `positionParams`, `render`.
 
-`<GGPlot>` props: `spec`, `data`, `aes`, `layers`, `key`, `width`
+`<GGPlot>` props: `spec`, `data`, `aes`, `layers`, `width`
 (number | "container"), `height`, `a11y`, `ariaLabel`, the interaction props
 (`select`, `zoom`, `tool`, `interaction`, `interactionScope`; prefer
 `<Inspect>` for inspection and `<GuideLegend channel focus>` /
 `<GuideLegend channel filter>` for legend interaction — do not put
 `inspect` / `legendFocus` / `legendFilter` on `<GGPlot>` in new code), the
-`on*` handlers, and `children`.
+`on*` handlers, and `children`. Plot-level `key` is **deprecated** since
+0.21 — prefer `identity` on `<Inspect>`, object-form `select`, or
+`createPlotInteraction` (default: `id` column when present, else row index).
 Instance methods: `resetScales()`, `setZoom()`.
 
 Precedence: `spec` wins over everything else. For mark layers, an explicit
@@ -287,12 +289,16 @@ per-layer aes override, sf/map — each as validated JSON plus a Svelte twin:
 Opt-in host capabilities: `<Inspect />` for tooltips and crosshairs;
 `select` / `zoom` on `<GGPlot>`; legend emphasis and data-changing filter via
 `<GuideLegend channel="color" focus />` / `filter` (per aesthetic; host-only,
-not in `guideLegend()` / PortableSpec). Always give a stable `key` when
-selection or linked views must survive filtering or refreshes. Link plots by
-sharing one `createPlotInteraction()` controller and matching
-`interactionScope` channels; observe everything through `oninteraction` or
-per-capability handlers. Faceted interval presets, the controller API,
-`Tooltip`, handler payloads, and diagnostics:
+not in `guideLegend()` / PortableSpec). Row identity for selection, legend
+focus, and linked views **defaults** to an `id` column when present, else
+the row index (order-stable only) — ordinary charts omit custom identity.
+Override with `identity` on `<Inspect>`, object-form `select`, or
+`createPlotInteraction` when a non-`id` durable field or accessor is needed
+(for example `<Inspect identity="year" />`). Plot-level `key` is deprecated
+since 0.21. Link plots by sharing one `createPlotInteraction()` controller
+and matching `interactionScope` channels; observe everything through
+`oninteraction` or per-capability handlers. Faceted interval presets, the
+controller API, `Tooltip`, handler payloads, and diagnostics:
 [references/interactions.md](references/interactions.md) — read it before
 writing any interactive or linked-view code.
 

--- a/scripts/skill-content.test.ts
+++ b/scripts/skill-content.test.ts
@@ -153,8 +153,9 @@ describe("skill teaches v0.21 row identity, not plot-level key", () => {
     const keyMentions = [...skill.matchAll(/`key`/g)];
     expect(keyMentions.length).toBeGreaterThan(0);
     for (const match of keyMentions) {
-      const start = Math.max(0, match.index! - 40);
-      const end = Math.min(skill.length, match.index! + match[0].length + 40);
+      const index = match.index ?? 0;
+      const start = Math.max(0, index - 40);
+      const end = Math.min(skill.length, index + match[0].length + 40);
       expect(skill.slice(start, end).toLowerCase()).toMatch(/deprecat/);
     }
   });

--- a/scripts/skill-content.test.ts
+++ b/scripts/skill-content.test.ts
@@ -136,6 +136,45 @@ describe("skill Svelte fences use v0.20 interaction children", () => {
 });
 
 /**
+ * v0.21 row identity: default id-column / row-index; prefer identity on
+ * Inspect / Select / createPlotInteraction. Plot-level key is deprecated.
+ * SKILL.md must not teach key as a first-class prop or as the required
+ * identity surface (#1286 / #1254 / #1257).
+ */
+describe("skill teaches v0.21 row identity, not plot-level key", () => {
+  const skill = readFileSync(join(SKILL_DIR, "SKILL.md"), "utf8");
+  const interactions = FILES.find((f) => f.name === "references/interactions.md");
+
+  it("SKILL.md nowhere recommends plot-level key without a deprecation note", () => {
+    // Bare first-class listing from pre-0.21 skill (the #1286 bug).
+    expect(skill).not.toMatch(/`layers`, `key`, `width`/);
+    expect(skill).not.toMatch(/Always give a stable `key`/);
+    // Every remaining backtick-key mention in SKILL.md is the deprecation note.
+    const keyMentions = [...skill.matchAll(/`key`/g)];
+    expect(keyMentions.length).toBeGreaterThan(0);
+    for (const match of keyMentions) {
+      const start = Math.max(0, match.index! - 40);
+      const end = Math.min(skill.length, match.index! + match[0].length + 40);
+      expect(skill.slice(start, end).toLowerCase()).toMatch(/deprecat/);
+    }
+  });
+
+  it("SKILL.md Interactions section teaches identity defaults", () => {
+    expect(skill).toMatch(/Row identity for selection/);
+    expect(skill).toMatch(/`id` column when present/);
+    expect(skill).toMatch(/`identity` on `<Inspect>`/);
+    expect(skill).toMatch(/Plot-level `key` is deprecated/);
+  });
+
+  it("interactions.md marks plot-level key deprecated and prefers identity", () => {
+    expect(interactions).toBeDefined();
+    expect(interactions!.markdown).toMatch(/Plot-level `key` is deprecated/);
+    expect(interactions!.markdown).toMatch(/\| `key`\s*\|[^\n]*\*\*deprecated\*\* since 0\.21/);
+    expect(interactions!.markdown).toMatch(/Prefer this over plot-level `key`/);
+  });
+});
+
+/**
  * #1200 postmortem: an agent read PortableSpec.layers[] (marks only) plus a
  * false "are not layers" comment and filed issues claiming Scale/Theme/Guide/
  * Labs/Coord/Facet/Legend were "non-layer grammar components." They are Layer

--- a/skills/ggsvelte/SKILL.md
+++ b/skills/ggsvelte/SKILL.md
@@ -117,13 +117,15 @@ z-order (points above smooth here). Every geom takes aesthetics through one
 direct props (`size={3}`); structural props are `data`, `stat`, `position`,
 `positionParams`, `render`.
 
-`<GGPlot>` props: `spec`, `data`, `aes`, `layers`, `key`, `width`
+`<GGPlot>` props: `spec`, `data`, `aes`, `layers`, `width`
 (number | "container"), `height`, `a11y`, `ariaLabel`, the interaction props
 (`select`, `zoom`, `tool`, `interaction`, `interactionScope`; prefer
 `<Inspect>` for inspection and `<GuideLegend channel focus>` /
 `<GuideLegend channel filter>` for legend interaction — do not put
 `inspect` / `legendFocus` / `legendFilter` on `<GGPlot>` in new code), the
-`on*` handlers, and `children`.
+`on*` handlers, and `children`. Plot-level `key` is **deprecated** since
+0.21 — prefer `identity` on `<Inspect>`, object-form `select`, or
+`createPlotInteraction` (default: `id` column when present, else row index).
 Instance methods: `resetScales()`, `setZoom()`.
 
 Precedence: `spec` wins over everything else. For mark layers, an explicit
@@ -287,12 +289,16 @@ per-layer aes override, sf/map — each as validated JSON plus a Svelte twin:
 Opt-in host capabilities: `<Inspect />` for tooltips and crosshairs;
 `select` / `zoom` on `<GGPlot>`; legend emphasis and data-changing filter via
 `<GuideLegend channel="color" focus />` / `filter` (per aesthetic; host-only,
-not in `guideLegend()` / PortableSpec). Always give a stable `key` when
-selection or linked views must survive filtering or refreshes. Link plots by
-sharing one `createPlotInteraction()` controller and matching
-`interactionScope` channels; observe everything through `oninteraction` or
-per-capability handlers. Faceted interval presets, the controller API,
-`Tooltip`, handler payloads, and diagnostics:
+not in `guideLegend()` / PortableSpec). Row identity for selection, legend
+focus, and linked views **defaults** to an `id` column when present, else
+the row index (order-stable only) — ordinary charts omit custom identity.
+Override with `identity` on `<Inspect>`, object-form `select`, or
+`createPlotInteraction` when a non-`id` durable field or accessor is needed
+(for example `<Inspect identity="year" />`). Plot-level `key` is deprecated
+since 0.21. Link plots by sharing one `createPlotInteraction()` controller
+and matching `interactionScope` channels; observe everything through
+`oninteraction` or per-capability handlers. Faceted interval presets, the
+controller API, `Tooltip`, handler payloads, and diagnostics:
 [references/interactions.md](references/interactions.md) — read it before
 writing any interactive or linked-view code.
 


### PR DESCRIPTION
## Summary

- **Bug:** After #1254 / #1257 moved durable row identity onto Inspect / Select / `createPlotInteraction`, `skills/ggsvelte/SKILL.md` still listed plot-level `key` as a first-class `<GGPlot>` prop and told agents to “always give a stable `key`.” Agents reading the skill top-down learned the deprecated surface first.
- **Fix:** Align `SKILL.md` with `references/interactions.md`: mark `key` deprecated, teach the default (`id` column, else row index) and `identity` overrides.
- **Guard:** `scripts/skill-content.test.ts` locks the contract so the pre-0.21 wording cannot return.

Closes #1286.

## Test plan

- [x] `bun test scripts/skill-content.test.ts scripts/skill-sync.test.ts` (57 pass)
- [ ] CI green on the PR
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1346" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->