### PR TITLE
fix(spec): key temporal decision cache by dataset evidence

### DIFF
--- a/.changeset/temporal-decision-cache-dataset.md
+++ b/.changeset/temporal-decision-cache-dataset.md
@@ -1,0 +1,13 @@
+---
+"@ggsvelte/spec": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+# Temporal decision cache keys by dataset evidence
+
+Migration: none — internal
+
+Multi-layer validation reused the first temporal decision for a field name across
+layers that read different datasets. The memo now keys by FieldEvidenceEntry
+identity so same-named fields keep independent temporal decisions.

--- a/packages/spec/src/validate-data-checks-temporal.ts
+++ b/packages/spec/src/validate-data-checks-temporal.ts
@@ -39,19 +39,31 @@ export function temporalParserUsable(parse: unknown): boolean {
   );
 }
 
-/** One Map per dataChecks() call — shared by position, color, and style checkers. */
-export type TemporalDecisionCache = Map<string, TemporalDecision | null | undefined>;
+/**
+ * One cache per dataChecks() call — shared by position, color, and style checkers.
+ *
+ * Outer key: field + parser + timezone + disambiguation.
+ * Inner key: the FieldEvidenceEntry object (null when info is missing). Layers
+ * that share a named dataset reuse the same entry object, so multi-consumer
+ * memoization still hits. Layers with different datasets get different entries
+ * and must not share a decision under the same field name (#1339).
+ */
+export type TemporalDecisionCache = Map<
+  string,
+  Map<FieldEvidenceEntry | null, TemporalDecision | null | undefined>
+>;
 
 /**
  * Resolve one field's temporal decision for scale compatibility checks.
  *
  * Memoized per dataChecks() call so multi-layer / multi-channel consumers of
- * the same field under the same parser+options pay O(n) once, not O(U·n).
+ * the same field evidence under the same parser+options pay O(n) once, not O(U·n).
  * When parser is auto and options match the evidence pass (no timezone /
  * disambiguation), reuse FieldEvidenceEntry.temporal instead of re-scanning.
  *
  * Cache key omits parseFailure and temporalKind — those only affect how the
- * decision is interpreted, not the decision itself.
+ * decision is interpreted, not the decision itself. Dataset identity is the
+ * FieldEvidenceEntry object identity (inner map key).
  */
 export function temporalDecisionForField(
   cache: TemporalDecisionCache,
@@ -62,7 +74,13 @@ export function temporalDecisionForField(
 ): TemporalDecision | null | undefined {
   const parserKey = parser === "auto" ? "auto" : canonicalTemporalParserKey(parser);
   const key = `${field}\0${parserKey}\0${options.timezone ?? ""}\0${options.disambiguation ?? ""}`;
-  if (cache.has(key)) return cache.get(key);
+  let byInfo = cache.get(key);
+  if (byInfo === undefined) {
+    byInfo = new Map();
+    cache.set(key, byInfo);
+  }
+  const infoKey = info ?? null;
+  if (byInfo.has(infoKey)) return byInfo.get(infoKey);
 
   let decision: TemporalDecision | null | undefined;
   if (info?.values === null || info?.values === undefined) {
@@ -79,7 +97,7 @@ export function temporalDecisionForField(
   } else {
     decision = parseTemporalColumn(info.values, parser, options).decision;
   }
-  cache.set(key, decision);
+  byInfo.set(infoKey, decision);
   return decision;
 }
 

--- a/packages/spec/src/validate-data-checks.ts
+++ b/packages/spec/src/validate-data-checks.ts
@@ -20,7 +20,6 @@
 import type { SpecError } from "./errors.js";
 import type { Aes, ChannelName } from "./schema.js";
 import type { ValidateLimits, ValidateOptions } from "./validate-data.js";
-import type { TemporalDecision } from "./temporal-column.js";
 import {
   resolveLayerFieldEvidence,
   type FieldEvidenceMap,
@@ -37,6 +36,7 @@ import {
   checkFiniteStyleScaleDataCompatibility,
   checkNumericStyleScaleDataCompatibility,
 } from "./validate-data-checks-style.js";
+import type { TemporalDecisionCache } from "./validate-data-checks-temporal.js";
 
 export { STAT_COLUMNS };
 
@@ -56,7 +56,8 @@ export function dataChecks(
 ): SpecError[] {
   const errors: SpecError[] = [];
   // One cache per dataChecks call — shared by position, color, and style checkers.
-  const temporalDecisionCache = new Map<string, TemporalDecision | null | undefined>();
+  // Nested by FieldEvidenceEntry so same-named fields on different datasets stay independent (#1339).
+  const temporalDecisionCache: TemporalDecisionCache = new Map();
   const scales = isRecord(spec["scales"]) ? spec["scales"] : undefined;
 
   // Pre-evidence: temporal axis configuration (errors even without data/profile).

--- a/packages/spec/tests/validate-tier2-temporal-reuse.test.ts
+++ b/packages/spec/tests/validate-tier2-temporal-reuse.test.ts
@@ -147,4 +147,54 @@ describe("tier 2 — temporal decision reuse (characterization)", () => {
     expect(errors.map((e) => e.code)).toEqual(["scale-type-mismatch", "scale-type-mismatch"]);
     expect(errors.every((e) => e.message.includes('field "city" is nominal'))).toBe(true);
   });
+
+  // #1339 — temporalDecisionForField must not share a decision across layers that
+  // read different datasets under the same field name.
+  it("rejects a non-temporal layer after a temporal layer when both map the same field name", () => {
+    const errors = errorsOf({
+      scales: { x: { type: "time" } },
+      layers: [
+        {
+          data: { columns: { t: ["2020-01-01", "2020-01-02"], y: [1, 2] } },
+          geom: "point",
+          aes: { x: { field: "t" }, y: { field: "y" } },
+        },
+        {
+          data: { columns: { t: ["apple", "banana"], y: [3, 4] } },
+          geom: "point",
+          aes: { x: { field: "t" }, y: { field: "y" } },
+        },
+      ],
+    });
+    // Without a per-dataset cache key, the date decision for layer 0 is reused for
+    // layer 1 and validation wrongly accepts fruit under a time scale.
+    expect(errors.map((e) => ({ code: e.code, path: e.path }))).toEqual([
+      { code: "scale-type-mismatch", path: "/layers/1/aes/x" },
+    ]);
+    expect(errors[0]?.message).toContain('field "t" is nominal');
+  });
+
+  it("accepts a temporal layer after a non-temporal layer when both map the same field name", () => {
+    const errors = errorsOf({
+      scales: { x: { type: "time" } },
+      layers: [
+        {
+          data: { columns: { t: ["apple", "banana"], y: [1, 2] } },
+          geom: "point",
+          aes: { x: { field: "t" }, y: { field: "y" } },
+        },
+        {
+          data: { columns: { t: ["2020-01-01", "2020-01-02"], y: [3, 4] } },
+          geom: "point",
+          aes: { x: { field: "t" }, y: { field: "y" } },
+        },
+      ],
+    });
+    // Without a per-dataset cache key, the nominal decision for layer 0 is reused
+    // for layer 1 and valid dates are wrongly rejected.
+    expect(errors.map((e) => ({ code: e.code, path: e.path }))).toEqual([
+      { code: "scale-type-mismatch", path: "/layers/0/aes/x" },
+    ]);
+    expect(errors[0]?.message).toContain('field "t" is nominal');
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #1339.

`temporalDecisionForField` memoized by field name + parser options only. Two
layers that map the same field name from different datasets shared one decision:
the first layer to run won for every later layer.

**Validation:** With `scales.x.type: "time"`, layer 0 dates + layer 1 fruit
(`apple`/`banana`) under field `t` returned `ok: true` (fruit silently accepted).
Reversed order rejected the valid date layer. After this change each layer gets
its own decision — only the fruit path mismatches, order-independent.

## Change

- Nest `TemporalDecisionCache` by `FieldEvidenceEntry` object identity (layers
  that share a named dataset still hit the same entry and keep one-scan memoization).
- Regression tests for both layer orders.

## Verification

```text
bun test packages/spec/tests/validate-tier2-temporal-reuse.test.ts packages/spec/tests/layer-data.test.ts
# 21 pass

bun test packages/spec
# 712 pass
```

## Follow-ups

None.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1348" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->