### PR TITLE
docs: refresh package README front doors and stop them drifting

### DIFF
--- a/.changeset/package-readme-front-doors.md
+++ b/.changeset/package-readme-front-doors.md
@@ -1,0 +1,14 @@
+---
+"@ggsvelte/spec": patch
+"@ggsvelte/core": patch
+"@ggsvelte/svelte": patch
+"@ggsvelte/cli": patch
+---
+
+# Refresh package README front doors
+
+Migration: none — package README + skill docs only
+
+Rewrite the npm package READMEs for current APIs; treat them as shipped
+surfaces for changesets and CI; execute TypeScript fences in unit tests. Fix
+skill prose that still called 0.13.0 grammar-prop removal “planned.”

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -353,6 +353,27 @@ badge is overall project coverage.
   baselines locally, `SKIP=block-output-paths git commit …` and say why in the
   PR.
 
+## Package READMEs (npm front doors)
+
+Each `packages/*/README.md` is what npmjs.com shows for that package. Keep it
+short, package-specific, and correct — not a second docs site.
+
+- **One working example** for the package’s primary use case. Absolute URLs only
+  (no `../other-package` monorepo links — they 404 on npm).
+- **Do not restate full contracts** (scales, guides, deprecation calendars) in
+  the package README; link to [ggsvelte.sh](https://ggsvelte.sh/) instead. Long
+  contract dumps are what drifts.
+- **Guards:** `scripts/package-readme.test.ts` runs TypeScript fences for
+  `@ggsvelte/spec` and `@ggsvelte/core`, bans monorepo-relative links, and
+  blocks removed grammar-prop examples in `@ggsvelte/svelte`. Root README
+  showcase stays in `scripts/readme-showcase.test.ts`.
+- **Ship with a patch** when the example or install path changes — package
+  README is a shipped surface for `scripts/changeset-check.ts` even though
+  npm packs it outside the `files` field.
+
+When a public API change invalidates a package README snippet, update the
+README in the same PR as the code.
+
 ## Examples corpus (one source, three uses)
 
 `examples/<category>/<name>/` is the shared corpus feeding (1) the docs
@@ -482,12 +503,12 @@ PR gets one opened rather than a silent skip. The three-way decision
 
 Add a `.changeset/*.md` **only** when the PR changes an npm-published package
 surface — the same paths `scripts/changeset-check.ts` treats as shipped
-(`package.json`, that package’s npm `files` entries under
-`packages/{cli,core,spec,svelte}`, and — for packages that publish compiled
-`dist` without listing `src` — the package’s `src/` tree that builds into
-`dist`, e.g. `packages/svelte/src/**`). Spec, core, svelte, and cli version
-in **fixed lockstep**, so one real (or spurious) changeset advances all four
-package versions.
+(`package.json`, `README.md`, `LICENSE`, that package’s npm `files` entries
+under `packages/{cli,core,spec,svelte}`, and — for packages that publish
+compiled `dist` without listing `src` — the package’s `src/` tree that builds
+into `dist`, e.g. `packages/svelte/src/**`). Spec, core, svelte, and cli
+version in **fixed lockstep**, so one real (or spurious) changeset advances all
+four package versions.
 
 **Do not** add a changeset for docs site, examples, scripts, tests, CI, or
 guide content alone (`apps/docs/**`, `examples/**`, `scripts/quickstart/**`,

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -3,8 +3,8 @@
 [![codecov](https://codecov.io/gh/ljodea/ggsvelte/branch/main/graph/badge.svg?component=packages-core)](https://app.codecov.io/gh/ljodea/ggsvelte/tree/main/packages%2Fcore)
 
 Grammar pipeline (stats, positions, facets, scales, layout) and pure SVG-string
-renderer. Main entry has no DOM — Node, edge runtimes, workers. Canvas and hit
-index live under `@ggsvelte/core/dom`. Pre-1.0.
+renderer. The main entry has no DOM — Node, edge runtimes, workers. Canvas and
+hit-testing live under `@ggsvelte/core/dom`. Pre-1.0.
 
 ```sh
 bun add @ggsvelte/core     # or: npm install @ggsvelte/core
@@ -15,52 +15,70 @@ For server, CLI, and agent rendering. Svelte apps use
 
 ## Quick example
 
+Author with the builder from `@ggsvelte/spec`, render here:
+
 ```ts
 import { renderToSVGString, runPipeline } from "@ggsvelte/core";
+import { aes, gg } from "@ggsvelte/spec";
 
-const spec = {
-  data: {
-    values: [
-      { year: "1835", value: 12 },
-      { year: "2026", value: 31 },
-    ],
-  },
-  layers: [
-    { geom: "line", aes: { x: { field: "year" }, y: { field: "value" } } },
+const spec = gg(
+  [
+    { year: "1835", value: 12 },
+    { year: "2026", value: 31 },
   ],
-};
+  aes({ x: "year", y: "value" }),
+)
+  .geomLine()
+  .spec();
 
 const svg = renderToSVGString(spec, { width: 640, height: 400 });
 
 const model = runPipeline(spec, { width: 640, height: 400 });
 // model.scene, model.scaleDecisions, model.guidePlans,
-// model.advisories, model.warnings
+// model.advisories, model.warnings, model.candidates
 ```
 
-Browser canvas + hit testing:
+Bare PortableSpec JSON works the same way — channel mappings use
+`{ field: "col" }`, not bare strings:
 
 ```ts
-import { drawStratum } from "@ggsvelte/core/dom";
+import { renderToSVGString } from "@ggsvelte/core";
 
-const candidate = model.candidates.hitTest(plotX, plotY);
+const svg = renderToSVGString(
+  {
+    data: {
+      values: [
+        { year: "1835", value: 12 },
+        { year: "2026", value: 31 },
+      ],
+    },
+    layers: [
+      {
+        geom: "line",
+        aes: { x: { field: "year" }, y: { field: "value" } },
+      },
+    ],
+  },
+  { width: 640, height: 400 },
+);
 ```
 
-## Contract
+## Entries
 
-- **Scale transforms** run before statistics; **coord transforms** project after
-  statistics and invert before scale inversion for interactions.
-- Position scales keep semantic source values; cached `identity` / `log10` /
-  `sqrt` views feed stats and positions once.
-- Non-position color/fill and style channels share one training path; SVG,
-  canvas, and Svelte consume the same resolved mark styles.
-- Auto non-position guides sit on the right while the panel stays readable,
-  else move below. Identity guides stay suppressed unless forced.
-- `coordFixed({ ratio })` fits a centered data rectangle with exact physical
-  unit ratios after chrome allocation; free positional facet scales fail with
-  `coord-fixed-free-scales`.
+| Import                    | Use                                          |
+| ------------------------- | -------------------------------------------- |
+| `@ggsvelte/core`          | Full grammar + temporal + SVG string         |
+| `@ggsvelte/core/render`   | Lean identity-chart surface (no heavy stats) |
+| `@ggsvelte/core/dom`      | Browser canvas draw + hit index              |
+| `@ggsvelte/core/temporal` | Temporal polyfill entry                      |
+
+CLI without installing this package as a library:
+[`ggsvelte-render`](https://www.npmjs.com/package/@ggsvelte/cli) (same pipeline,
+JSONL diagnostics on stderr).
 
 Specs validate through
-[`@ggsvelte/spec`](https://www.npmjs.com/package/@ggsvelte/spec)
-(re-exported errors keep the `{ code, path, message, fix }` shape).
+[`@ggsvelte/spec`](https://www.npmjs.com/package/@ggsvelte/spec).
+Docs: [ggsvelte.sh](https://ggsvelte.sh/) · Repo:
+[github.com/ljodea/ggsvelte](https://github.com/ljodea/ggsvelte)
 
-Repo + docs: <https://github.com/ljodea/ggsvelte> · MIT © Liam O'Dea
+[MIT](https://github.com/ljodea/ggsvelte/blob/main/LICENSE) © Liam O'Dea

--- a/packages/spec/README.md
+++ b/packages/spec/README.md
@@ -2,18 +2,18 @@
 
 [![codecov](https://codecov.io/gh/ljodea/ggsvelte/branch/main/graph/badge.svg?component=packages-spec)](https://app.codecov.io/gh/ljodea/ggsvelte/tree/main/packages%2Fspec)
 
-PortableSpec types, published JSON Schema (`schema/v0.json`), `normalize()`,
-two-tier `validate()` with the agent error contract
-(`{ code, path, message, allowed?, fix }` — every fix carries a
-machine-applicable example), `lintSpec()`, and the fluent `gg()/aes()` builder.
-No DOM, no d3. Pre-1.0.
+PortableSpec types, published JSON Schema, `normalize()`, two-tier
+`validate()` with the agent error contract
+(`{ code, path, message, allowed?, fix }`), `lintSpec()`, and the fluent
+`gg()` / `aes()` builder. No DOM, no d3. Pre-1.0.
 
 ```sh
 bun add @ggsvelte/spec     # or: npm install @ggsvelte/spec
 ```
 
 Install alone for validation and authoring without a renderer.
-`@ggsvelte/svelte` re-exports this package.
+[`@ggsvelte/svelte`](https://www.npmjs.com/package/@ggsvelte/svelte)
+re-exports this package.
 
 ## Quick example
 
@@ -42,37 +42,34 @@ const result = validate(spec, {
   lint: true,
 });
 if (!result.ok) {
+  // Apply fix.example at path, then re-validate.
   // { code, path, message, allowed?, fix: { description, example } }
 }
 ```
 
-## Contract
+## Agent contract
 
-- **Emit, validate, fix.** `validate(spec)` is shape; `validate(spec, { profile })`
-  is data-aware without shipping rows; `{ lint: true }` adds advisories. Apply
-  `fix.example` at `path` and re-validate.
-- **Temporal.** Automatic inference covers ISO, `YYYY`, year-month, month-year,
-  and year-quarter after whole-column validation. Ambiguous ordered dates need
-  an explicit parser (`parse: "dmy"`, etc.).
-- **Numeric transforms.** Closed names (`identity` | `log10` | `sqrt`) run
-  before statistics. Domains/limits are semantic; OOB censor/squish runs before
-  the transform. Authored `type: "log"` normalizes to linear + log10.
-- **Color/fill.** `ordinal`, `sequential`, `binned`, `manual`, `identity`.
-  Binned color caps at 64 intervals; manual needs one range color per domain
-  value.
-- **Style channels.** `size` / `linewidth` / `alpha` share sequential–identity
-  families. `shape` and `linetype` use finite named sets — quantitative
-  mappings require explicit binning.
-- **Guides.** Separate from scale math. Top-level `guides` wins over scale-local
-  `guide`. Invalid aesthetic/variant pairs fail validation.
-- **Coords.** `coordTransform` is post-stat projection. `coordFixed({ ratio })`
-  is physical y-unit/x-unit length; free positional facet scales are rejected.
-- **PortableSpec.** No `Date`, callbacks, or regular expressions. Builder
-  `Date` values canonicalize to ISO strings.
+- `validate(spec)` — shape only.
+- `validate(spec, { profile })` — data-aware without shipping rows.
+- `validate(spec, { lint: true })` — advisories for valid-but-questionable specs.
+- Every error carries `fix.example`. Apply it at `path` and re-validate.
+- PortableSpec is JSON-only: no `Date`, callbacks, or regular expressions.
+  Builder `Date` values canonicalize to ISO strings.
+- JSON aes uses `{ field: "col" }` (bare strings are invalid in JSON). The
+  builder and Svelte props accept bare-string shorthand.
 
-Render with [`@ggsvelte/core`](https://www.npmjs.com/package/@ggsvelte/core)
-(headless SVG) or
-[`@ggsvelte/svelte`](https://www.npmjs.com/package/@ggsvelte/svelte)
-(Svelte 5).
+## Render
 
-Repo + docs: <https://github.com/ljodea/ggsvelte> · MIT © Liam O'Dea
+- Headless SVG: [`@ggsvelte/core`](https://www.npmjs.com/package/@ggsvelte/core)
+  (`renderToSVGString`)
+- CLI loop (validation + warnings on stderr):
+  [`@ggsvelte/cli`](https://www.npmjs.com/package/@ggsvelte/cli)
+  (`ggsvelte-render`)
+- Svelte 5:
+  [`@ggsvelte/svelte`](https://www.npmjs.com/package/@ggsvelte/svelte)
+
+Schema: [schema/v0.json](https://ggsvelte.sh/schema/v0.json) · Docs:
+[ggsvelte.sh](https://ggsvelte.sh/) · Repo:
+[github.com/ljodea/ggsvelte](https://github.com/ljodea/ggsvelte)
+
+[MIT](https://github.com/ljodea/ggsvelte/blob/main/LICENSE) © Liam O'Dea

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -3,10 +3,10 @@
 [![codecov](https://codecov.io/gh/ljodea/ggsvelte/branch/main/graph/badge.svg?component=packages-svelte)](https://app.codecov.io/gh/ljodea/ggsvelte/tree/main/packages%2Fsvelte)
 
 Svelte 5 components for ggsvelte. Re-exports `@ggsvelte/spec` and
-`@ggsvelte/core` and publishes the agent skill at `skills/ggsvelte`. The
-`ggsvelte-render` CLI ships separately as
-[`@ggsvelte/cli`](../cli) — install it in any sandbox where an agent
-authors specs.
+`@ggsvelte/core`. Ships the agent skill at `skills/ggsvelte`. The
+`ggsvelte-render` CLI is a separate package —
+[`@ggsvelte/cli`](https://www.npmjs.com/package/@ggsvelte/cli) — install it in
+every sandbox where an agent authors specs.
 
 ```sh
 bun add @ggsvelte/svelte
@@ -17,43 +17,53 @@ Requires Node.js 22+ and Svelte 5.33.1+.
 
 ## Example
 
+Compose with declaration-only children (theme, scales, labs, geoms). Do not put
+`theme`, `scales`, `labs`, `guides`, `facet`, `coord`, or `legend` on
+`<GGPlot>` — those props were removed in 0.13.0.
+
 ```svelte
 <script lang="ts">
-  import { GeomPoint, GGPlot, Labs } from "@ggsvelte/svelte";
+  import {
+    GeomPoint,
+    GeomSmooth,
+    GGPlot,
+    Labs,
+    ThemeMinimal,
+  } from "@ggsvelte/svelte";
   import { kyotoSakura } from "@ggsvelte/svelte/data";
 </script>
 
 <GGPlot data={kyotoSakura} aes={{ x: "year", y: "bloomDoy" }}>
+  <ThemeMinimal />
   <Labs
     title="Kyoto cherry blossom full-bloom dates, 812–2026"
     subtitle="Full bloom moved about ten days earlier after the industrial era"
     x="Year"
     y="Day of year"
   />
+  <GeomSmooth method="loess" se={false} />
   <GeomPoint size={2} alpha={0.7} />
 </GGPlot>
 ```
 
-Scale transforms change the values stats see; `coordTransform` projects after
-stats. Dense points may render on canvas; axes, legends, text, and accessible
-descriptions stay in the DOM. `<Guides>` places, titles, or suppresses guides
-without retraining scales.
+Convention: theme → scales → guides → labs → mark layers. Dense points may
+render on canvas; axes, legends, text, and accessible descriptions stay in the
+DOM. Prefer `<Inspect />` and `<GuideLegend channel focus>` /
+`<GuideLegend channel filter>` for interaction — not plot-level `inspect`,
+`legendFocus`, or `legendFilter`.
 
 ## Agent skill
 
-Published path: `node_modules/@ggsvelte/svelte/skills/ggsvelte/SKILL.md`. Repo
-source: [`skills/ggsvelte/SKILL.md`](../../skills/ggsvelte/SKILL.md).
+Published path: `node_modules/@ggsvelte/svelte/skills/ggsvelte/SKILL.md`.
 
 Emit PortableSpec JSON, run `validate()`, apply `fix.example` at `path`,
 re-validate, then render with `<GGPlot spec={…} />`, `renderToSVGString`, or
-`ggsvelte-render`. Schema: [schema/v0.json](https://ggsvelte.sh/schema/v0.json)
+`ggsvelte-render`. Schema: [schema/v0.json](https://ggsvelte.sh/schema/v0.json).
 
-## Upgrading
+## Migrating old code
 
-The grammar props on `<GGPlot>` (`facet`, `coord`, `scales`, `guides`,
-`legend`, `theme`, `labs`) are deprecated since 0.11.0 in favour of child
-layers. A codemod ships with the package; it prints a diff and writes nothing
-until you ask it to:
+If you still have pre-0.13 sources with grammar props on `<GGPlot>`, the
+codemod rewrites them to children:
 
 ```sh
 npx ggsvelte-codemod src          # show what would change
@@ -69,9 +79,9 @@ guide](https://ggsvelte.sh/guide/upgrading), never half-migrated.
 - [Documentation](https://ggsvelte.sh/)
 - [Getting started](https://ggsvelte.sh/guide/getting-started)
 - [Example gallery](https://ggsvelte.sh/examples)
-- [Interactions and events](https://ggsvelte.sh/reference/interactions)
-- [Production](https://ggsvelte.sh/guide/production)
+- [Interactions](https://ggsvelte.sh/reference/interactions)
 - [Upgrading](https://ggsvelte.sh/guide/upgrading)
+- [CLI (`@ggsvelte/cli`)](https://www.npmjs.com/package/@ggsvelte/cli)
 - [Repository](https://github.com/ljodea/ggsvelte)
 
 Pre-1.0. Lifecycle and compatibility contracts are on the docs site.

--- a/packages/svelte/skills/ggsvelte/SKILL.md
+++ b/packages/svelte/skills/ggsvelte/SKILL.md
@@ -131,18 +131,17 @@ Instance methods: `resetScales()`, `setZoom()`.
 Precedence: `spec` wins over everything else. For mark layers, an explicit
 `layers` prop wins over geom children — use it for dynamic layer lists (a keyed
 `{#each}` reorder does not preserve z-order). For grammar families, children
-win over the deprecated props. Coord/facet/theme REPLACE (last wins); scales
-merge per channel; labs/guides/legend merge per key. Duplicates emit
-`DUPLICATE_PLOT_LAYER` / `DUPLICATE_SCALE_CHANNEL` / `DUPLICATE_MERGE_KEY`
-advisories — full semantics in
+win. Coord/facet/theme REPLACE (last wins); scales merge per channel;
+labs/guides/legend merge per key. Duplicates emit `DUPLICATE_PLOT_LAYER` /
+`DUPLICATE_SCALE_CHANNEL` / `DUPLICATE_MERGE_KEY` advisories — full semantics
+in
 [references/composition-surfaces.md](references/composition-surfaces.md).
 
-**Deprecated (since 0.11.0, planned removal in 0.13.0):** the seven `<GGPlot>`
-grammar props `facet`, `coord`, `scales`, `guides`, `legend`, `theme`, `labs`.
-Compose them as children instead; `spec`, `data`, `aes`, and `layers` stay
-first-class. Migrate existing code with `npx ggsvelte-codemod --write src`
-(dry-run without `--write`). Using a deprecated prop fires a
-`DEPRECATED_PLOT_PROP` advisory via `ondiagnostic`.
+**Removed in 0.13.0** (deprecated since 0.11.0): the seven `<GGPlot>` grammar
+props `facet`, `coord`, `scales`, `guides`, `legend`, `theme`, `labs`. Compose
+them as children instead; `spec`, `data`, `aes`, and `layers` stay first-class.
+Migrate old sources with `npx ggsvelte-codemod --write src` (dry-run without
+`--write`).
 
 ## Which geom for which data
 

--- a/packages/svelte/skills/ggsvelte/references/composition-surfaces.md
+++ b/packages/svelte/skills/ggsvelte/references/composition-surfaces.md
@@ -3,8 +3,9 @@
 # Composition surfaces: coords, facets, guides, labs
 
 Every surface here is a **grammar layer** (non-mark `Layer` kind). Each exists
-in three equivalent forms: a key in the JSON `PortableSpec`, a deprecated
-`<GGPlot>` prop (removable in 0.13.0), and a declaration-only child component
+in three equivalent forms: a key in the JSON `PortableSpec`, a removed
+`<GGPlot>` prop (gone since 0.13.0; codemod rewrites old sources), and a
+declaration-only child component
 (canonical in Svelte). Child components emit no markup, register on init via
 `createPlotLayer` / `registerPlotLayer`, unregister on destroy, and are inert
 without a `<GGPlot>` ancestor.
@@ -156,9 +157,8 @@ Equivalent complete JSON spec:
 - Mark layers: the `layers` prop, when set, is used INSTEAD of geom children.
   Otherwise geom children register in document order, and registration order
   is z-order (first = bottom).
-- Grammar (non-mark) families fold onto the builder AFTER the matching
-  deprecated prop, in registration order — so a grammar child overrides its
-  prop, and later siblings beat earlier ones.
+- Grammar (non-mark) families fold onto the builder in registration order —
+  later siblings beat earlier ones.
 - REPLACE families — `coord`, `facet`, `theme`: the last registration fully
   replaces earlier ones (and any matching prop). Two or more children of one
   kind emit a `DUPLICATE_PLOT_LAYER` advisory.

--- a/scripts/changeset-check.test.ts
+++ b/scripts/changeset-check.test.ts
@@ -111,7 +111,6 @@ describe("decideChangesetComment", () => {
         "apps/docs/src/routes/+page.svelte",
         "packages/core/tests/scales.test.ts",
         "packages/svelte/vitest.config.ts",
-        "packages/spec/README.md",
         "packages/spec/CHANGELOG.md",
         ".github/workflows/ci.yml",
         "scripts/ci-routing.ts",
@@ -119,6 +118,12 @@ describe("decideChangesetComment", () => {
       PACKAGES,
     );
     expect(decision.verdict).toBe("not-needed");
+  });
+
+  it("treats package README.md as shipped (npm always packs it)", () => {
+    const decision = decideChangesetComment(["packages/spec/README.md"], PACKAGES);
+    expect(decision.verdict).toBe("missing");
+    expect(decision.touched).toEqual(["packages/spec/README.md"]);
   });
 
   it("stays quiet for test files colocated inside shipped dirs", () => {

--- a/scripts/changeset-check.ts
+++ b/scripts/changeset-check.ts
@@ -177,6 +177,9 @@ function introducesChangeset(entry: DiffEntry): boolean {
 
 function isShippedPath(path: string, pkg: PublishedPackage): boolean {
   if (path === `${pkg.dir}/package.json`) return true;
+  // npm always packs README (and LICENSE) at the package root even when they
+  // are omitted from the `files` field — the package page is the front door.
+  if (path === `${pkg.dir}/README.md` || path === `${pkg.dir}/LICENSE`) return true;
   // Colocated test files live under src/ but are not part of the consumer
   // surface a changelog entry describes.
   if (/\.(test|spec)\.[jt]sx?$/.test(path)) return false;

--- a/scripts/ci-routing.test.ts
+++ b/scripts/ci-routing.test.ts
@@ -1140,6 +1140,20 @@ describe("unit content inputs cover actionlint config", () => {
     expect(paths).toContain("README.md");
     expect(JOB_CONTENT_INPUTS.unit).toContain("README.md");
   });
+
+  test("unit includes package READMEs (scripts/package-readme.test.ts)", () => {
+    for (const path of [
+      "packages/spec/README.md",
+      "packages/core/README.md",
+      "packages/svelte/README.md",
+      "packages/cli/README.md",
+    ]) {
+      expect(JOB_CONTENT_INPUTS.unit).toContain(path);
+      const flags = classifyChangedPaths([path]);
+      expect(flags.scripts, path).toBe(true);
+      expect(planJobs(flags).unit, path).toBe(true);
+    }
+  });
 });
 
 describe("component_journeys content inputs cover llms modules", () => {

--- a/scripts/ci-routing/content-hash-inputs.ts
+++ b/scripts/ci-routing/content-hash-inputs.ts
@@ -110,8 +110,13 @@ export const JOB_CONTENT_INPUTS: Record<CacheableExecution, readonly string[]> =
     ".markdownlint-cli2.jsonc",
     "knip.jsonc",
     ".pre-commit-config.yaml",
-    // scripts/readme-showcase.test.ts contracts the published README snippets.
+    // scripts/readme-showcase.test.ts + package-readme.test.ts contract npm
+    // and GitHub front-door snippets.
     "README.md",
+    "packages/spec/README.md",
+    "packages/core/README.md",
+    "packages/svelte/README.md",
+    "packages/cli/README.md",
   ],
   // Package build + knip + type-aware + publint + examples tsc (no vite docs site).
   // apps/docs stays hashed: knip + oxlint --type-aware still cover the docs app,

--- a/scripts/ci-routing/routing.ts
+++ b/scripts/ci-routing/routing.ts
@@ -191,9 +191,12 @@ export const LANE_PATTERNS: Record<ChangeLane, readonly string[]> = {
     ".github/ISSUE_TEMPLATE/**",
     ".github/DISCUSSION_TEMPLATE/**",
     ".changeset/**",
-    // readme-showcase.test.ts reads these files as contract inputs.
+    // readme-showcase + package-readme tests read these as contract inputs.
     "README.md",
+    "packages/spec/README.md",
+    "packages/core/README.md",
     "packages/svelte/README.md",
+    "packages/cli/README.md",
   ],
   // Cloudflare workers (when present). Own bun tests + type-aware lint/knip.
   // Nothing under workers/** renders charts, so no browser/docs surface.

--- a/scripts/package-readme.test.ts
+++ b/scripts/package-readme.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Contract for npm package front-door READMEs under packages/<name>/README.md.
+ *
+ * npm shows each package's README on the package page. Relative monorepo links
+ * break there; removed grammar props must not reappear as "current" examples;
+ * TypeScript fences must actually run against the built packages.
+ *
+ * Root README showcase stays in scripts/readme-showcase.test.ts.
+ */
+import { describe, expect, it } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { deprecatedGrammarPropPattern } from "../packages/svelte/src/lib/layers/grammar-families.ts";
+import { ggplotOpenAttrs, plotLevelInteractionOffenders } from "./ggplot-open-attrs.ts";
+
+const ROOT = join(import.meta.dir, "..");
+const PACKAGES = join(ROOT, "packages");
+
+type Fence = {
+  readonly language: string;
+  readonly source: string;
+};
+
+function fences(markdown: string): Fence[] {
+  return [...markdown.matchAll(/^```([^\n]*)\n([\s\S]*?)^```/gm)].map((match) => ({
+    language: (match[1] ?? "").trim(),
+    source: match[2] ?? "",
+  }));
+}
+
+function packageReadmes(): { readonly name: string; readonly markdown: string }[] {
+  return readdirSync(PACKAGES, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => {
+      const path = join(PACKAGES, entry.name, "README.md");
+      return { name: entry.name, markdown: readFileSync(path, "utf8") };
+    });
+}
+
+/** Monorepo-relative markdown links that work in git but break on npmjs.com. */
+function monorepoRelativeLinks(markdown: string): string[] {
+  return [...markdown.matchAll(/\[[^\]]*\]\(((\.\.\/)[^)]+)\)/g)].map((m) => m[1]!);
+}
+
+describe("package README npm front doors", () => {
+  const readmes = packageReadmes();
+
+  it("covers every publishable package", () => {
+    expect(readmes.map((r) => r.name).toSorted()).toEqual(["cli", "core", "spec", "svelte"]);
+  });
+
+  for (const { name, markdown } of readmes) {
+    it(`${name}: no monorepo-relative links (they 404 on npmjs.com)`, () => {
+      expect(monorepoRelativeLinks(markdown)).toEqual([]);
+    });
+
+    it(`${name}: no stale "planned removal in 0.13.0" wording`, () => {
+      expect(markdown).not.toMatch(/planned removal in 0\.13\.0/i);
+      expect(markdown).not.toMatch(/removable in 0\.13\.0/i);
+    });
+  }
+
+  it("svelte: Svelte fences use child layers, not removed grammar props", () => {
+    const svelte = readmes.find((r) => r.name === "svelte")!;
+    const pattern = deprecatedGrammarPropPattern();
+    const offenders = fences(svelte.markdown)
+      .filter((block) => block.language === "svelte")
+      .flatMap((block) => [...block.source.matchAll(pattern)].map((m) => m[1]!));
+    expect(offenders).toEqual([]);
+  });
+
+  it("svelte: Svelte fences avoid plot-level inspect / legendFocus / legendFilter", () => {
+    const svelte = readmes.find((r) => r.name === "svelte")!;
+    const offenders = fences(svelte.markdown)
+      .filter((block) => block.language === "svelte")
+      .flatMap((block) =>
+        ggplotOpenAttrs(block.source).flatMap((attrs) => plotLevelInteractionOffenders(attrs)),
+      );
+    expect(offenders).toEqual([]);
+  });
+
+  it("svelte: states grammar props were removed (not merely deprecated)", () => {
+    const svelte = readmes.find((r) => r.name === "svelte")!;
+    expect(svelte.markdown).toMatch(/removed in 0\.13\.0/i);
+    // Do not teach the removed props as current dual-read surface.
+    expect(svelte.markdown).not.toMatch(
+      /grammar props on `<GGPlot>`[^\n]*are deprecated since 0\.11\.0/i,
+    );
+  });
+
+  it("svelte: points at @ggsvelte/cli with an absolute npm URL", () => {
+    const svelte = readmes.find((r) => r.name === "svelte")!;
+    expect(svelte.markdown).toContain("https://www.npmjs.com/package/@ggsvelte/cli");
+  });
+});
+
+describe("package README TypeScript fences run", () => {
+  /**
+   * Rewrite bare @ggsvelte/* imports to local dist file URLs so the fence
+   * executes without a workspace install in /tmp.
+   */
+  function rewriteImports(source: string): string {
+    const dist = {
+      "@ggsvelte/spec/schema/v0.json": join(ROOT, "packages/spec/schema/v0.json"),
+      "@ggsvelte/spec": join(ROOT, "packages/spec/dist/index.js"),
+      "@ggsvelte/core/dom": join(ROOT, "packages/core/dist/dom/index.js"),
+      "@ggsvelte/core": join(ROOT, "packages/core/dist/index.js"),
+      "@ggsvelte/cli": join(ROOT, "packages/cli/dist/index.js"),
+    } as const;
+    let out = source;
+    // Longer prefixes first so /schema wins over the package root.
+    for (const [specifier, filePath] of Object.entries(dist).toSorted(
+      (a, b) => b[0].length - a[0].length,
+    )) {
+      const url = pathToFileURL(filePath).href;
+      out = out.replaceAll(`from "${specifier}"`, `from "${url}"`);
+      out = out.replaceAll(`from '${specifier}'`, `from '${url}'`);
+    }
+    return out;
+  }
+
+  for (const pkg of ["spec", "core"] as const) {
+    it(`${pkg}: every complete TypeScript fence executes`, async () => {
+      const markdown = readFileSync(join(PACKAGES, pkg, "README.md"), "utf8");
+      const tsBlocks = fences(markdown).filter(
+        (block) => block.language === "ts" || block.language === "typescript",
+      );
+      expect(tsBlocks.length).toBeGreaterThan(0);
+
+      for (const [index, block] of tsBlocks.entries()) {
+        const source = rewriteImports(block.source);
+        const dataUrl = `data:text/javascript;charset=utf-8,${encodeURIComponent(source)}`;
+        try {
+          await import(dataUrl);
+        } catch (error) {
+          throw new Error(
+            `${pkg} README.ts fence #${index} failed:\n${block.source}\n---\n${String(error)}`,
+            { cause: error },
+          );
+        }
+      }
+    });
+  }
+});

--- a/skills/ggsvelte/SKILL.md
+++ b/skills/ggsvelte/SKILL.md
@@ -131,18 +131,17 @@ Instance methods: `resetScales()`, `setZoom()`.
 Precedence: `spec` wins over everything else. For mark layers, an explicit
 `layers` prop wins over geom children — use it for dynamic layer lists (a keyed
 `{#each}` reorder does not preserve z-order). For grammar families, children
-win over the deprecated props. Coord/facet/theme REPLACE (last wins); scales
-merge per channel; labs/guides/legend merge per key. Duplicates emit
-`DUPLICATE_PLOT_LAYER` / `DUPLICATE_SCALE_CHANNEL` / `DUPLICATE_MERGE_KEY`
-advisories — full semantics in
+win. Coord/facet/theme REPLACE (last wins); scales merge per channel;
+labs/guides/legend merge per key. Duplicates emit `DUPLICATE_PLOT_LAYER` /
+`DUPLICATE_SCALE_CHANNEL` / `DUPLICATE_MERGE_KEY` advisories — full semantics
+in
 [references/composition-surfaces.md](references/composition-surfaces.md).
 
-**Deprecated (since 0.11.0, planned removal in 0.13.0):** the seven `<GGPlot>`
-grammar props `facet`, `coord`, `scales`, `guides`, `legend`, `theme`, `labs`.
-Compose them as children instead; `spec`, `data`, `aes`, and `layers` stay
-first-class. Migrate existing code with `npx ggsvelte-codemod --write src`
-(dry-run without `--write`). Using a deprecated prop fires a
-`DEPRECATED_PLOT_PROP` advisory via `ondiagnostic`.
+**Removed in 0.13.0** (deprecated since 0.11.0): the seven `<GGPlot>` grammar
+props `facet`, `coord`, `scales`, `guides`, `legend`, `theme`, `labs`. Compose
+them as children instead; `spec`, `data`, `aes`, and `layers` stay first-class.
+Migrate old sources with `npx ggsvelte-codemod --write src` (dry-run without
+`--write`).
 
 ## Which geom for which data
 

--- a/skills/ggsvelte/references/composition-surfaces.md
+++ b/skills/ggsvelte/references/composition-surfaces.md
@@ -3,8 +3,9 @@
 # Composition surfaces: coords, facets, guides, labs
 
 Every surface here is a **grammar layer** (non-mark `Layer` kind). Each exists
-in three equivalent forms: a key in the JSON `PortableSpec`, a deprecated
-`<GGPlot>` prop (removable in 0.13.0), and a declaration-only child component
+in three equivalent forms: a key in the JSON `PortableSpec`, a removed
+`<GGPlot>` prop (gone since 0.13.0; codemod rewrites old sources), and a
+declaration-only child component
 (canonical in Svelte). Child components emit no markup, register on init via
 `createPlotLayer` / `registerPlotLayer`, unregister on destroy, and are inert
 without a `<GGPlot>` ancestor.
@@ -156,9 +157,8 @@ Equivalent complete JSON spec:
 - Mark layers: the `layers` prop, when set, is used INSTEAD of geom children.
   Otherwise geom children register in document order, and registration order
   is z-order (first = bottom).
-- Grammar (non-mark) families fold onto the builder AFTER the matching
-  deprecated prop, in registration order — so a grammar child overrides its
-  prop, and later siblings beat earlier ones.
+- Grammar (non-mark) families fold onto the builder in registration order —
+  later siblings beat earlier ones.
 - REPLACE families — `coord`, `facet`, `theme`: the last registration fully
   replaces earlier ones (and any matching prop). Two or more children of one
   kind emit a `DUPLICATE_PLOT_LAYER` advisory.


### PR DESCRIPTION
## Summary

- Rewrite `@ggsvelte/{spec,core,svelte}` npm package READMEs for current APIs (absolute npm/docs URLs, working examples, no monorepo-relative links).
- Fix skill prose that still called 0.13.0 grammar-prop removal “planned.”
- Treat package `README.md` as a shipped surface for changeset-check; add `scripts/package-readme.test.ts` (execute TS fences, ban stale/removed API examples); route package README edits into the unit job.

## Why

npm package pages are the install front door. They had drifted (thin contract dumps, broken relative links, “deprecated” framing for props already removed in 0.13.0) and changeset-check did not count README edits as shipped, so fixes never forced a patch publish.

## Test plan

- [x] `bun test scripts/package-readme.test.ts`
- [x] `bun test scripts/changeset-check.test.ts scripts/skill-sync.test.ts scripts/skill-content.test.ts`
- [ ] CI unit + related jobs green on this PR
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1349" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->