### PR TITLE
fix(core): push sf geometry leaves without spreading large arrays

### DIFF
--- a/.changeset/sf-geometry-push-spread.md
+++ b/.changeset/sf-geometry-push-spread.md
@@ -1,0 +1,13 @@
+---
+"@ggsvelte/core": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+# Push sf geometry leaves without spreading large arrays
+
+Migration: none — internal
+
+`expandSfLeaves` and `representativePointsForGeometry` used `out.push(...items)`.
+Past the engine argument limit a large nested GeometryCollection or MultiPoint
+threw `RangeError`. Leaves and points are now pushed one element at a time.

--- a/packages/core/src/pipeline/sf-geometry.ts
+++ b/packages/core/src/pipeline/sf-geometry.ts
@@ -137,17 +137,18 @@ export function expandSfLeaves(geom: SfParsed, path: string, depth = 0): SfLeaf[
         );
       }
       const c = child as { type: string; coordinates?: unknown; geometries?: unknown };
-      out.push(
-        ...expandSfLeaves(
-          {
-            type: c.type,
-            ...(c.coordinates !== undefined && { coordinates: c.coordinates }),
-            ...(c.geometries !== undefined && { geometries: c.geometries }),
-          },
-          path,
-          depth + 1,
-        ),
+      // Push one leaf at a time — spread into push throws past the engine
+      // argument limit on large nested GeometryCollections (#1344).
+      const childLeaves = expandSfLeaves(
+        {
+          type: c.type,
+          ...(c.coordinates !== undefined && { coordinates: c.coordinates }),
+          ...(c.geometries !== undefined && { geometries: c.geometries }),
+        },
+        path,
+        depth + 1,
       );
+      for (const leaf of childLeaves) out.push(leaf);
     }
     return out;
   }
@@ -164,7 +165,9 @@ export function representativePointsForGeometry(
   const leaves = expandSfLeaves(geom, path);
   const out: SfPosition[] = [];
   for (const leaf of leaves) {
-    out.push(...representativePoints(leaf.type, leaf.coordinates));
+    // Per-element push: MultiPoint / multi-part leaves can exceed the engine
+    // argument limit when spread into push (#1344).
+    for (const pt of representativePoints(leaf.type, leaf.coordinates)) out.push(pt);
   }
   return out;
 }

--- a/packages/core/tests/pipeline-m2/sf-geometry-collection.test.ts
+++ b/packages/core/tests/pipeline-m2/sf-geometry-collection.test.ts
@@ -73,6 +73,33 @@ describe("expandSfLeaves (#809 GeometryCollection)", () => {
   it("rejects GeometryCollection without geometries array", () => {
     expect(() => expandSfLeaves({ type: "GeometryCollection" }, "/test")).toThrow(PipelineError);
   });
+
+  it("flattens a nested GeometryCollection past the engine spread argument limit (#1344)", () => {
+    // Nested GC: parent spreads the child's full leaf list into push(...).
+    // Flat GC of N Points does not crash (each child expands to one leaf).
+    // Engine limit is runtime-specific; on Bun 1.3.x bare push(...arr) ok at
+    // 5e5 and throws at 1e6 — pin n so the regression stays meaningful.
+    const n = 1_000_000;
+    const bulk = Array.from({ length: n }, () => 0);
+    expect(() => {
+      Array.prototype.push.apply([], bulk);
+    }).toThrow(RangeError);
+
+    const inner = Array.from({ length: n }, (_, i) => ({
+      type: "Point" as const,
+      coordinates: [i, i] as [number, number],
+    }));
+    const leaves = expandSfLeaves(
+      {
+        type: "GeometryCollection",
+        geometries: [{ type: "GeometryCollection", geometries: inner }],
+      },
+      "/test",
+    );
+    expect(leaves).toHaveLength(n);
+    expect(leaves[0]).toEqual({ type: "Point", coordinates: [0, 0] });
+    expect(leaves[n - 1]).toEqual({ type: "Point", coordinates: [n - 1, n - 1] });
+  });
 });
 
 describe("representativePointsForGeometry (#809 GC labels)", () => {
@@ -91,5 +118,21 @@ describe("representativePointsForGeometry (#809 GC labels)", () => {
       [0, 0],
       [2, 2],
     ]);
+  });
+
+  it("expands MultiPoint past the engine spread argument limit (#1344)", () => {
+    // representativePointsForGeometry pushes each leaf's points via spread;
+    // MultiPoint with n positions returns n points, then one push(...pts).
+    const n = 1_000_000;
+    const bulk = Array.from({ length: n }, () => 0);
+    expect(() => {
+      Array.prototype.push.apply([], bulk);
+    }).toThrow(RangeError);
+
+    const coordinates = Array.from({ length: n }, (_, i) => [i, i] as [number, number]);
+    const pts = representativePointsForGeometry({ type: "MultiPoint", coordinates }, "/test");
+    expect(pts).toHaveLength(n);
+    expect(pts[0]).toEqual([0, 0]);
+    expect(pts[n - 1]).toEqual([n - 1, n - 1]);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #1344.

`expandSfLeaves` and `representativePointsForGeometry` built result arrays with
`out.push(...items)`. Past the engine argument limit that throws
`RangeError: Maximum call stack size exceeded` — the same class of bug as the
style-scale collect fix (#1338 / #1343).

## Validation

Confirmed on Bun against `main`:

| Input | Result before |
| --- | --- |
| MultiPoint with 1e6 positions via `representativePointsForGeometry` | RangeError |
| Nested GeometryCollection (parent + child GC of 1e6 Points) via `expandSfLeaves` | RangeError |
| Flat GeometryCollection of 1e6 Points | ok (each child expands to one leaf) |

Call sites: `geom_sf` → `expandSfLeaves`; `stat_sf_coordinates` →
`representativePointsForGeometry`.

## Change

Push one leaf/point at a time, matching colour and style scale collect.

## Tests

- New unit regressions at `n = 1_000_000` (with a bare-spread probe so the test
  stays meaningful if engine limits change)
- Existing SF suite green:

```
bun test packages/core/tests/pipeline-m2/sf-geometry-collection.test.ts \
  packages/core/tests/pipeline-m2/sf-geometry.test.ts \
  packages/core/tests/pipeline-m2/geom-sf.test.ts \
  packages/core/tests/pipeline-m2/geom-sf-text.test.ts \
  packages/core/tests/pipeline-m2/geom-sf-label.test.ts
# 60 pass, 0 fail
```

## Follow-ups

None. Other `push(...array)` sites under pipeline (boxplot, scale training) pass
small fixed-size arrays, not row-length columns — not the same risk class.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1350" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->