### PR TITLE
fix(core): shortlist filled-area hits by subpath, not every vertex

### DIFF
--- a/.changeset/filled-area-hit-shortlist.md
+++ b/.changeset/filled-area-hit-shortlist.md
@@ -1,0 +1,13 @@
+---
+"@ggsvelte/core": patch
+---
+
+# Shortlist filled-area hits by subpath, not every vertex
+
+Migration: none — same hit ids and brush membership; lower pointer cost on dense areas.
+
+Filled path geometry (stacked `geom_area`, ribbons, bands) used to put every path
+vertex into the spatial shortlist. A stacked area of a few thousand rows then
+paid tens of milliseconds per hover. Index one AABB per filled subpath, expand
+to the winning vertex only after containment or axis-snap, and keep brush
+`queryRect` returning every vertex of a hit subpath.

--- a/packages/core/src/candidate-hit-resolve.ts
+++ b/packages/core/src/candidate-hit-resolve.ts
@@ -32,6 +32,10 @@ export type TopmostHitContext = {
   readonly xs: Float32Array;
   readonly ys: Float32Array;
   readonly pointBatchIndexes: readonly PointBatchIndex[];
+  /** Filled-path subpath candidate spans (#1342); -1 when not a filled path. */
+  readonly filledSpanStart: Int32Array;
+  readonly filledSpanEnd: Int32Array;
+  readonly isFilledPath: Uint8Array;
   addExtendedIntersecting(loX: number, loY: number, hiX: number, hiY: number, into: number[]): void;
   probePoint(px: number, py: number): HitProbePoint;
   fact(id: number): CandidateFacts | null;
@@ -43,7 +47,19 @@ export function resolveTopmostHit(
   px: number,
   py: number,
 ): CandidateFacts | null {
-  const { scene, hitTolerance, batchIds, primitiveIds, panelIds, xs, ys, pointBatchIndexes } = ctx;
+  const {
+    scene,
+    hitTolerance,
+    batchIds,
+    primitiveIds,
+    panelIds,
+    xs,
+    ys,
+    pointBatchIndexes,
+    filledSpanStart,
+    filledSpanEnd,
+    isFilledPath,
+  } = ctx;
   // Bind via arrows so type-aware unbound-method is satisfied.
   const addExtendedIntersecting = (
     loX: number,
@@ -116,6 +132,46 @@ export function resolveTopmostHit(
       (px < panel.x || px > panel.x + panel.width || py < panel.y || py > panel.y + panel.height)
     )
       continue;
+
+    // Filled path: one extended shortlist entry per subpath (#1342). Contain
+    // once via the rep, then nearest-anchor scan over the candidate span.
+    if (isFilledPath[id] === 1 && batch.kind === "paths" && batch.fills !== undefined) {
+      const spanStart = filledSpanStart[id]!;
+      const spanEnd = filledSpanEnd[id]!;
+      if (spanStart < 0 || spanEnd <= spanStart) continue;
+      // Containment is identical for every vertex on the subpath.
+      if (probe.distance(id) === null) continue;
+      const range = pathRange(batch, primitiveIds[id]!);
+      const pathStart = range?.[0] ?? -1;
+      let candidateId = spanStart;
+      let anchorDistance = Math.hypot(xs[spanStart]! - px, ys[spanStart]! - py);
+      let primitive = primitiveIds[spanStart]!;
+      for (let cid = spanStart + 1; cid < spanEnd; cid++) {
+        const d = Math.hypot(xs[cid]! - px, ys[cid]! - py);
+        const p = primitiveIds[cid]!;
+        if (d < anchorDistance || (d === anchorDistance && p < primitive)) {
+          candidateId = cid;
+          anchorDistance = d;
+          primitive = p;
+        }
+      }
+      const sameBatch = batchIndex === bestBatch;
+      const improvesWithinBatch =
+        pathStart > bestPathStart ||
+        (pathStart === bestPathStart &&
+          (anchorDistance < bestDistance ||
+            (anchorDistance === bestDistance &&
+              primitive < (best < 0 ? Infinity : primitiveIds[best]!))));
+      if (batchIndex > bestBatch || (sameBatch && improvesWithinBatch)) {
+        best = candidateId;
+        bestBatch = batchIndex;
+        bestDistance = anchorDistance;
+        bestPathStart = pathStart;
+        bestPathEdge = Infinity;
+      }
+      continue;
+    }
+
     const distance = probe.distance(id);
     if (distance === null) continue;
     const sameBatch = batchIndex === bestBatch;

--- a/packages/core/src/candidate-store-build.ts
+++ b/packages/core/src/candidate-store-build.ts
@@ -89,10 +89,15 @@ export function assembleCandidateStore(
       contained ??= probe.distance(repId) !== null;
       return contained;
     };
-    let bestId = -1;
-    let bestDistance = Infinity;
-    let bestOrth = Infinity;
-    let bestMode: ResolvedCandidateInspectMode = explicitMode;
+    // Under auto, exact-mode vertices (tier 1) beat axis-snap (tier 2) even when
+    // farther — track tiers separately so a mixed-mode span cannot collapse
+    // away the tier winner before the outer ranking sees it (#770 / Devin).
+    let bestExactId = -1;
+    let bestExactDistance = Infinity;
+    let bestSnapId = -1;
+    let bestSnapDistance = Infinity;
+    let bestSnapOrth = Infinity;
+    let bestSnapMode: ResolvedCandidateInspectMode = explicitMode;
     // Descending: first equal (distance, orth) wins → highest id (topmost).
     for (let id = end - 1; id >= start; id--) {
       const candidateMode = isAuto ? AUTO_MODES[autoModes[id]!]! : explicitMode;
@@ -101,13 +106,21 @@ export function assembleCandidateStore(
         (candidateMode === "y" && yTokenIds[id] === -1)
       )
         continue;
-      let distance: number | null;
+      let distance: number;
       let orth: number;
       if (candidateMode === "exact") {
         if (!isContained()) continue;
         distance = Math.hypot(xs[id]! - px, ys[id]! - py);
         orth = 0;
-      } else if (candidateMode === "x") {
+        if (distance < bestExactDistance) {
+          bestExactId = id;
+          bestExactDistance = distance;
+        }
+        // Explicit exact ranks among exact vertices only (via bestExact*).
+        // Under auto, exact is tier-1 and returned below; skip snap ranking.
+        continue;
+      }
+      if (candidateMode === "x") {
         distance = Math.abs((flip ? ys[id] : xs[id])! - (flip ? py : px));
         if (distance > maxDistance) continue;
         orth = Math.abs((flip ? xs[id] : ys[id])! - (flip ? px : py));
@@ -120,16 +133,30 @@ export function assembleCandidateStore(
         if (distance > maxDistance) continue;
         orth = 0;
       }
-      if (distance < bestDistance || (distance === bestDistance && orth < bestOrth)) {
-        bestId = id;
-        bestDistance = distance;
-        bestOrth = orth;
-        bestMode = candidateMode;
+      if (distance < bestSnapDistance || (distance === bestSnapDistance && orth < bestSnapOrth)) {
+        bestSnapId = id;
+        bestSnapDistance = distance;
+        bestSnapOrth = orth;
+        bestSnapMode = candidateMode;
       }
     }
-    return bestId < 0
+    // Prefer exact when auto (tier 1) or when explicit mode is exact.
+    if (bestExactId >= 0 && (isAuto || explicitMode === "exact")) {
+      return {
+        id: bestExactId,
+        distance: bestExactDistance,
+        orth: 0,
+        mode: "exact",
+      };
+    }
+    return bestSnapId < 0
       ? null
-      : { id: bestId, distance: bestDistance, orth: bestOrth, mode: bestMode };
+      : {
+          id: bestSnapId,
+          distance: bestSnapDistance,
+          orth: bestSnapOrth,
+          mode: bestSnapMode,
+        };
   };
   return {
     epoch,

--- a/packages/core/src/candidate-store-build.ts
+++ b/packages/core/src/candidate-store-build.ts
@@ -65,61 +65,72 @@ export function assembleCandidateStore(
 
   /**
    * Expand a filled-path subpath representative to the best candidate in its
-   * span for the active inspect mode (#1342). Filled paths stay axis-snap /
-   * exact-containment — never promote via containment hypot under auto (#770).
+   * span (#1342). Per-vertex autoMode / axis-token filters apply inside the
+   * span (not only on the rep). Scans high→low id so exact (distance, orth)
+   * ties keep the topmost candidate, matching the descending shortlist contract.
+   * Never promote filled paths via containment hypot under auto (#770).
    */
   const bestFilledInSpan = (
     repId: number,
-    candidateMode: ResolvedCandidateInspectMode,
+    isAuto: boolean,
+    explicitMode: ResolvedCandidateInspectMode,
     px: number,
     py: number,
     maxDistance: number,
     probe: ReturnType<typeof hit.probePoint>,
-  ): { id: number; distance: number; orth: number } | null => {
+  ): { id: number; distance: number; orth: number; mode: ResolvedCandidateInspectMode } | null => {
     const start = filledSpanStart[repId]!;
     const end = filledSpanEnd[repId]!;
     if (start < 0 || end <= start) return null;
-    if (candidateMode === "exact") {
-      // Containment is identical for every vertex on the subpath.
-      if (probe.distance(repId) === null) return null;
-      let bestId = start;
-      let bestDistance = Math.hypot(xs[start]! - px, ys[start]! - py);
-      let bestOrth = 0;
-      for (let id = start + 1; id < end; id++) {
-        const distance = Math.hypot(xs[id]! - px, ys[id]! - py);
-        if (distance < bestDistance) {
-          bestId = id;
-          bestDistance = distance;
-        }
-      }
-      return { id: bestId, distance: bestDistance, orth: bestOrth };
-    }
+    // Containment is identical for every vertex on the subpath — compute once
+    // when any vertex may take exact mode.
+    let contained: boolean | null = null;
+    const isContained = (): boolean => {
+      if (contained === null) contained = probe.distance(repId) !== null;
+      return contained;
+    };
     let bestId = -1;
     let bestDistance = Infinity;
     let bestOrth = Infinity;
-    for (let id = start; id < end; id++) {
-      const distance =
-        candidateMode === "x"
-          ? Math.abs((flip ? ys[id] : xs[id])! - (flip ? py : px))
-          : candidateMode === "y"
-            ? Math.abs((flip ? xs[id] : ys[id])! - (flip ? px : py))
-            : Math.hypot(xs[id]! - px, ys[id]! - py);
-      if (distance > maxDistance) continue;
-      const orth =
-        candidateMode === "x"
-          ? Math.abs((flip ? xs[id] : ys[id])! - (flip ? px : py))
-          : candidateMode === "y"
-            ? Math.abs((flip ? ys[id] : xs[id])! - (flip ? py : px))
-            : 0;
+    let bestMode: ResolvedCandidateInspectMode = explicitMode;
+    // Descending: first equal (distance, orth) wins → highest id (topmost).
+    for (let id = end - 1; id >= start; id--) {
+      const candidateMode = isAuto ? AUTO_MODES[autoModes[id]!]! : explicitMode;
+      if (
+        (candidateMode === "x" && xTokenIds[id] === -1) ||
+        (candidateMode === "y" && yTokenIds[id] === -1)
+      )
+        continue;
+      let distance: number | null;
+      let orth: number;
+      if (candidateMode === "exact") {
+        if (!isContained()) continue;
+        distance = Math.hypot(xs[id]! - px, ys[id]! - py);
+        orth = 0;
+      } else if (candidateMode === "x") {
+        distance = Math.abs((flip ? ys[id] : xs[id])! - (flip ? py : px));
+        if (distance > maxDistance) continue;
+        orth = Math.abs((flip ? xs[id] : ys[id])! - (flip ? px : py));
+      } else if (candidateMode === "y") {
+        distance = Math.abs((flip ? xs[id] : ys[id])! - (flip ? px : py));
+        if (distance > maxDistance) continue;
+        orth = Math.abs((flip ? ys[id] : xs[id])! - (flip ? py : px));
+      } else {
+        distance = Math.hypot(xs[id]! - px, ys[id]! - py);
+        if (distance > maxDistance) continue;
+        orth = 0;
+      }
       if (distance < bestDistance || (distance === bestDistance && orth < bestOrth)) {
         bestId = id;
         bestDistance = distance;
         bestOrth = orth;
+        bestMode = candidateMode;
       }
     }
-    return bestId < 0 ? null : { id: bestId, distance: bestDistance, orth: bestOrth };
+    return bestId < 0
+      ? null
+      : { id: bestId, distance: bestDistance, orth: bestOrth, mode: bestMode };
   };
-
   return {
     epoch,
     size: n,
@@ -170,28 +181,24 @@ export function assembleCandidateStore(
       for (const id of ids) {
         if (search.panelId !== undefined && scene.panels[panelIds[id]!]!.id !== search.panelId)
           continue;
-        const candidateMode = isAuto ? AUTO_MODES[autoModes[id]!]! : mode;
-        if (
-          (candidateMode === "x" && xTokenIds[id] === -1) ||
-          (candidateMode === "y" && yTokenIds[id] === -1)
-        )
-          continue;
 
-        // Filled-path shortlist entries are subpath reps (#1342) — expand to
-        // the best vertex in the span for this mode before global ranking.
+        // Filled-path shortlist entries are subpath reps (#1342) — expand with
+        // per-vertex mode/token filters before global ranking.
         if (isFilledPath[id] === 1) {
           // Only process the representative once (span start equals rep id).
           if (filledSpanStart[id] !== id) continue;
-          const expanded = bestFilledInSpan(id, candidateMode, px, py, search.maxDistance, probe);
+          const expanded = bestFilledInSpan(id, isAuto, mode, px, py, search.maxDistance, probe);
           if (expanded === null) continue;
-          // Filled paths use autoMode "x" (tier 2) — never geometric under auto.
-          const geometric = isAuto && candidateMode === "exact";
+          // Exact-mode vertices in a filled span are rare (override datum);
+          // default filled autoMode is "x" (tier 2) — do not promote via
+          // containment hypot under auto (#770).
+          const geometric = isAuto && expanded.mode === "exact";
           if (isAuto) {
             if (geometric && !bestGeometric) {
               best = expanded.id;
               bestDistance = expanded.distance;
               bestOrth = expanded.orth;
-              resultMode = candidateMode;
+              resultMode = expanded.mode;
               bestGeometric = true;
               continue;
             }
@@ -204,11 +211,18 @@ export function assembleCandidateStore(
             best = expanded.id;
             bestDistance = expanded.distance;
             bestOrth = expanded.orth;
-            resultMode = candidateMode;
+            resultMode = expanded.mode;
             if (isAuto) bestGeometric = geometric;
           }
           continue;
         }
+
+        const candidateMode = isAuto ? AUTO_MODES[autoModes[id]!]! : mode;
+        if (
+          (candidateMode === "x" && xTokenIds[id] === -1) ||
+          (candidateMode === "y" && yTokenIds[id] === -1)
+        )
+          continue;
 
         const distance =
           candidateMode === "exact"

--- a/packages/core/src/candidate-store-build.ts
+++ b/packages/core/src/candidate-store-build.ts
@@ -379,16 +379,19 @@ export function assembleCandidateStore(
       const probe = hit.probeRect(loX, loY, hiX, hiY);
       for (const id of extendedHits) {
         if (panelId !== undefined && scene.panels[panelIds[id]!]!.id !== panelId) continue;
-        if (!probe.intersects(id)) continue;
-        // Filled subpath rep: brush contract returns every vertex on the
-        // subpath without re-walking geometry per id (#1342 / fill-brush tests).
+        // Filled subpath: one AABB shortlist entry, then per-vertex membership
+        // (anchor / adjacent edges / fill-center). Do not expand the whole
+        // span from a rep-only graze — that over-selects and under-selects
+        // mid-band brushes (Devin review on #1342).
         if (isFilledPath[id] === 1) {
           const start = filledSpanStart[id]!;
           const end = filledSpanEnd[id]!;
-          for (let cid = start; cid < end; cid++) hits.push(cid);
+          for (let cid = start; cid < end; cid++) {
+            if (probe.intersects(cid)) hits.push(cid);
+          }
           continue;
         }
-        hits.push(id);
+        if (probe.intersects(id)) hits.push(id);
       }
       hits.sort((a, b) => traversalRank[a]! - traversalRank[b]!);
       return Uint32Array.from(hits);

--- a/packages/core/src/candidate-store-build.ts
+++ b/packages/core/src/candidate-store-build.ts
@@ -60,7 +60,65 @@ export function assembleCandidateStore(
   } = indexes;
   const hit = createHitGeometry(indexes);
   const query = buildSpatialIndex(indexes, hit);
-  const { spatial, isPoint, pointBatchIndexes } = query;
+  const { spatial, isPoint, pointBatchIndexes, isFilledPath, filledSpanStart, filledSpanEnd } =
+    query;
+
+  /**
+   * Expand a filled-path subpath representative to the best candidate in its
+   * span for the active inspect mode (#1342). Filled paths stay axis-snap /
+   * exact-containment — never promote via containment hypot under auto (#770).
+   */
+  const bestFilledInSpan = (
+    repId: number,
+    candidateMode: ResolvedCandidateInspectMode,
+    px: number,
+    py: number,
+    maxDistance: number,
+    probe: ReturnType<typeof hit.probePoint>,
+  ): { id: number; distance: number; orth: number } | null => {
+    const start = filledSpanStart[repId]!;
+    const end = filledSpanEnd[repId]!;
+    if (start < 0 || end <= start) return null;
+    if (candidateMode === "exact") {
+      // Containment is identical for every vertex on the subpath.
+      if (probe.distance(repId) === null) return null;
+      let bestId = start;
+      let bestDistance = Math.hypot(xs[start]! - px, ys[start]! - py);
+      let bestOrth = 0;
+      for (let id = start + 1; id < end; id++) {
+        const distance = Math.hypot(xs[id]! - px, ys[id]! - py);
+        if (distance < bestDistance) {
+          bestId = id;
+          bestDistance = distance;
+        }
+      }
+      return { id: bestId, distance: bestDistance, orth: bestOrth };
+    }
+    let bestId = -1;
+    let bestDistance = Infinity;
+    let bestOrth = Infinity;
+    for (let id = start; id < end; id++) {
+      const distance =
+        candidateMode === "x"
+          ? Math.abs((flip ? ys[id] : xs[id])! - (flip ? py : px))
+          : candidateMode === "y"
+            ? Math.abs((flip ? xs[id] : ys[id])! - (flip ? px : py))
+            : Math.hypot(xs[id]! - px, ys[id]! - py);
+      if (distance > maxDistance) continue;
+      const orth =
+        candidateMode === "x"
+          ? Math.abs((flip ? xs[id] : ys[id])! - (flip ? px : py))
+          : candidateMode === "y"
+            ? Math.abs((flip ? ys[id] : xs[id])! - (flip ? py : px))
+            : 0;
+      if (distance < bestDistance || (distance === bestDistance && orth < bestOrth)) {
+        bestId = id;
+        bestDistance = distance;
+        bestOrth = orth;
+      }
+    }
+    return bestId < 0 ? null : { id: bestId, distance: bestDistance, orth: bestOrth };
+  };
 
   return {
     epoch,
@@ -79,6 +137,9 @@ export function assembleCandidateStore(
           xs,
           ys,
           pointBatchIndexes,
+          filledSpanStart,
+          filledSpanEnd,
+          isFilledPath,
           addExtendedIntersecting: (loX, loY, hiX, hiY, into) => {
             query.addExtendedIntersecting(loX, loY, hiX, hiY, into);
           },
@@ -102,10 +163,10 @@ export function assembleCandidateStore(
       const mode: ResolvedCandidateInspectMode = search.mode === "auto" ? "exact" : search.mode;
       let resultMode: ResolvedCandidateInspectMode = mode;
       const probe = hit.probePoint(px, py);
-      const ids =
-        spatial === null
-          ? Array.from({ length: n }, (_, id) => n - 1 - id)
-          : query.shortlistNearest(px, py, search.mode, search.maxDistance);
+      // When spatial is null (n===0) shortlistNearest returns []. Empty scenes
+      // have nothing to scan; non-empty always builds a tree (or filled-only
+      // trees that still shortlist via extended).
+      const ids = query.shortlistNearest(px, py, search.mode, search.maxDistance);
       for (const id of ids) {
         if (search.panelId !== undefined && scene.panels[panelIds[id]!]!.id !== search.panelId)
           continue;
@@ -115,6 +176,40 @@ export function assembleCandidateStore(
           (candidateMode === "y" && yTokenIds[id] === -1)
         )
           continue;
+
+        // Filled-path shortlist entries are subpath reps (#1342) — expand to
+        // the best vertex in the span for this mode before global ranking.
+        if (isFilledPath[id] === 1) {
+          // Only process the representative once (span start equals rep id).
+          if (filledSpanStart[id] !== id) continue;
+          const expanded = bestFilledInSpan(id, candidateMode, px, py, search.maxDistance, probe);
+          if (expanded === null) continue;
+          // Filled paths use autoMode "x" (tier 2) — never geometric under auto.
+          const geometric = isAuto && candidateMode === "exact";
+          if (isAuto) {
+            if (geometric && !bestGeometric) {
+              best = expanded.id;
+              bestDistance = expanded.distance;
+              bestOrth = expanded.orth;
+              resultMode = candidateMode;
+              bestGeometric = true;
+              continue;
+            }
+            if (!geometric && bestGeometric) continue;
+          }
+          if (
+            expanded.distance < bestDistance ||
+            (expanded.distance === bestDistance && expanded.orth < bestOrth)
+          ) {
+            best = expanded.id;
+            bestDistance = expanded.distance;
+            bestOrth = expanded.orth;
+            resultMode = candidateMode;
+            if (isAuto) bestGeometric = geometric;
+          }
+          continue;
+        }
+
         const distance =
           candidateMode === "exact"
             ? probe.distance(id)
@@ -267,22 +362,33 @@ export function assembleCandidateStore(
       const hiX = Math.max(x0, x1);
       const loY = Math.min(y0, y1);
       const hiY = Math.max(y0, y1);
-      if (spatial === null || n === 0) return EMPTY_UINT32;
+      if (n === 0) return EMPTY_UINT32;
       // Point anchors: exact rect membership via the tree. Extended geometry
       // (rects/segments/paths) can intersect far from the anchor — always refine.
       // Collect hits then order by traversal rank (preserves prior contract).
       const hits: number[] = [];
-      for (const id of spatial.queryRect(loX, loY, hiX, hiY)) {
-        if (isPoint[id] !== 1) continue;
-        if (panelId !== undefined && scene.panels[panelIds[id]!]!.id !== panelId) continue;
-        hits.push(id);
+      if (spatial !== null) {
+        for (const id of spatial.queryRect(loX, loY, hiX, hiY)) {
+          if (isPoint[id] !== 1) continue;
+          if (panelId !== undefined && scene.panels[panelIds[id]!]!.id !== panelId) continue;
+          hits.push(id);
+        }
       }
       const extendedHits: number[] = [];
       query.addExtendedIntersecting(loX, loY, hiX, hiY, extendedHits);
       const probe = hit.probeRect(loX, loY, hiX, hiY);
       for (const id of extendedHits) {
         if (panelId !== undefined && scene.panels[panelIds[id]!]!.id !== panelId) continue;
-        if (probe.intersects(id)) hits.push(id);
+        if (!probe.intersects(id)) continue;
+        // Filled subpath rep: brush contract returns every vertex on the
+        // subpath without re-walking geometry per id (#1342 / fill-brush tests).
+        if (isFilledPath[id] === 1) {
+          const start = filledSpanStart[id]!;
+          const end = filledSpanEnd[id]!;
+          for (let cid = start; cid < end; cid++) hits.push(cid);
+          continue;
+        }
+        hits.push(id);
       }
       hits.sort((a, b) => traversalRank[a]! - traversalRank[b]!);
       return Uint32Array.from(hits);

--- a/packages/core/src/candidate-store-build.ts
+++ b/packages/core/src/candidate-store-build.ts
@@ -86,7 +86,7 @@ export function assembleCandidateStore(
     // when any vertex may take exact mode.
     let contained: boolean | null = null;
     const isContained = (): boolean => {
-      if (contained === null) contained = probe.distance(repId) !== null;
+      contained ??= probe.distance(repId) !== null;
       return contained;
     };
     let bestId = -1;

--- a/packages/core/src/candidate-store-spatial-index.ts
+++ b/packages/core/src/candidate-store-spatial-index.ts
@@ -196,49 +196,56 @@ export function buildSpatialIndex(indexes: CandidateStoreIndexes, hit: HitGeomet
     readonly maxHalfH: number;
     readonly spatial: StaticQuadtree;
   };
-  const classBuckets = new Map<number, number[]>();
-  for (let ei = 0; ei < extN; ei++) {
-    const halfW = (extMaxX[ei]! - extMinX[ei]!) / 2;
-    const halfH = (extMaxY[ei]! - extMinY[ei]!) / 2;
-    const m = Math.max(halfW, halfH, 1e-9);
-    const key = Math.min(31, Math.ceil(Math.log2(m)));
-    const bucket = classBuckets.get(key);
-    if (bucket === undefined) classBuckets.set(key, [ei]);
-    else bucket.push(ei);
-  }
-  const extendedClasses: ExtendedClass[] = [];
-  for (const eis of classBuckets.values()) {
-    const cxs = new Float64Array(eis.length);
-    const cys = new Float64Array(eis.length);
-    let maxHalfW = 0;
-    let maxHalfH = 0;
-    for (let j = 0; j < eis.length; j++) {
-      const ei = eis[j]!;
+  const buildSizeClasses = (eisFilter: (ei: number) => boolean): ExtendedClass[] => {
+    const classBuckets = new Map<number, number[]>();
+    for (let ei = 0; ei < extN; ei++) {
+      if (!eisFilter(ei)) continue;
       const halfW = (extMaxX[ei]! - extMinX[ei]!) / 2;
       const halfH = (extMaxY[ei]! - extMinY[ei]!) / 2;
-      cxs[j] = (extMinX[ei]! + extMaxX[ei]!) / 2;
-      cys[j] = (extMinY[ei]! + extMaxY[ei]!) / 2;
-      if (halfW > maxHalfW) maxHalfW = halfW;
-      if (halfH > maxHalfH) maxHalfH = halfH;
+      const m = Math.max(halfW, halfH, 1e-9);
+      const key = Math.min(31, Math.ceil(Math.log2(m)));
+      const bucket = classBuckets.get(key);
+      if (bucket === undefined) classBuckets.set(key, [ei]);
+      else bucket.push(ei);
     }
-    extendedClasses.push({
-      eis,
-      maxHalfW,
-      maxHalfH,
-      spatial: new StaticQuadtree(cxs, cys),
-    });
-  }
-  classBuckets.clear();
+    const classes: ExtendedClass[] = [];
+    for (const eis of classBuckets.values()) {
+      const cxs = new Float64Array(eis.length);
+      const cys = new Float64Array(eis.length);
+      let maxHalfW = 0;
+      let maxHalfH = 0;
+      for (let j = 0; j < eis.length; j++) {
+        const ei = eis[j]!;
+        const halfW = (extMaxX[ei]! - extMinX[ei]!) / 2;
+        const halfH = (extMaxY[ei]! - extMinY[ei]!) / 2;
+        cxs[j] = (extMinX[ei]! + extMaxX[ei]!) / 2;
+        cys[j] = (extMinY[ei]! + extMaxY[ei]!) / 2;
+        if (halfW > maxHalfW) maxHalfW = halfW;
+        if (halfH > maxHalfH) maxHalfH = halfH;
+      }
+      classes.push({
+        eis,
+        maxHalfW,
+        maxHalfH,
+        spatial: new StaticQuadtree(cxs, cys),
+      });
+    }
+    return classes;
+  };
+  const extendedClasses = buildSizeClasses(() => true);
+  // Filled-path reps only — strip shortlists for axis modes must not pull every
+  // bar/segment whose tall AABB crosses an infinite strip (Devin #1342 review).
+  const filledExtendedClasses = buildSizeClasses((ei) => isFilledPath[extendedIds[ei]!] === 1);
 
-  /** Add extended ids whose AABB intersects the axis-aligned query box. */
-  const addExtendedIntersecting = (
+  const addFromClasses = (
+    classes: readonly ExtendedClass[],
     loX: number,
     loY: number,
     hiX: number,
     hiY: number,
     into: Set<number> | number[],
   ): void => {
-    for (const cls of extendedClasses) {
+    for (const cls of classes) {
       // Intersecting AABBs have centers inside query expanded by *this class's*
       // half-extents — not the global max (avoids one giant bar scanning all E).
       for (const j of cls.spatial.queryRect(
@@ -257,6 +264,27 @@ export function buildSpatialIndex(indexes: CandidateStoreIndexes, hit: HitGeomet
     }
   };
 
+  /** Add extended ids whose AABB intersects the axis-aligned query box. */
+  const addExtendedIntersecting = (
+    loX: number,
+    loY: number,
+    hiX: number,
+    hiY: number,
+    into: Set<number> | number[],
+  ): void => {
+    addFromClasses(extendedClasses, loX, loY, hiX, hiY, into);
+  };
+
+  /** Filled-subpath reps only — for axis-strip shortlists that omit filled anchors. */
+  const addFilledPathIntersecting = (
+    loX: number,
+    loY: number,
+    hiX: number,
+    hiY: number,
+    into: Set<number> | number[],
+  ): void => {
+    addFromClasses(filledExtendedClasses, loX, loY, hiX, hiY, into);
+  };
   // Far-plane strip bounds: StaticQuadtree prunes on the finite axis only.
   const STRIP = 1e30;
 
@@ -275,7 +303,8 @@ export function buildSpatialIndex(indexes: CandidateStoreIndexes, hit: HitGeomet
     };
     if (mode === "xy") {
       addRect(px - maxDistance, py - maxDistance, px + maxDistance, py + maxDistance);
-      // Filled areas omit anchors from `spatial`; pull subpath reps by AABB.
+      // Filled areas omit anchors from `spatial`; full extended tree still
+      // holds one rep per filled subpath plus rects/segments/stroked paths.
       addExtendedIntersecting(
         px - maxDistance,
         py - maxDistance,
@@ -286,21 +315,21 @@ export function buildSpatialIndex(indexes: CandidateStoreIndexes, hit: HitGeomet
     } else if (mode === "x") {
       // Dominant-axis distance is along semantic x (screen y when coord_flip).
       // Axis token maps stay for group(); nearest uses spatial strips.
-      // Filled path verts are not in spatial (#1342) — add extended for the strip.
+      // Filled path verts are not in spatial (#1342) — filled-only strip AABBs.
       if (flip) {
         addRect(-STRIP, py - maxDistance, STRIP, py + maxDistance);
-        addExtendedIntersecting(-STRIP, py - maxDistance, STRIP, py + maxDistance, consider);
+        addFilledPathIntersecting(-STRIP, py - maxDistance, STRIP, py + maxDistance, consider);
       } else {
         addRect(px - maxDistance, -STRIP, px + maxDistance, STRIP);
-        addExtendedIntersecting(px - maxDistance, -STRIP, px + maxDistance, STRIP, consider);
+        addFilledPathIntersecting(px - maxDistance, -STRIP, px + maxDistance, STRIP, consider);
       }
     } else if (mode === "y") {
       if (flip) {
         addRect(px - maxDistance, -STRIP, px + maxDistance, STRIP);
-        addExtendedIntersecting(px - maxDistance, -STRIP, px + maxDistance, STRIP, consider);
+        addFilledPathIntersecting(px - maxDistance, -STRIP, px + maxDistance, STRIP, consider);
       } else {
         addRect(-STRIP, py - maxDistance, STRIP, py + maxDistance);
-        addExtendedIntersecting(-STRIP, py - maxDistance, STRIP, py + maxDistance, consider);
+        addFilledPathIntersecting(-STRIP, py - maxDistance, STRIP, py + maxDistance, consider);
       }
     } else {
       // exact / auto: point anchors within hit reach + extended geometry whose
@@ -311,18 +340,17 @@ export function buildSpatialIndex(indexes: CandidateStoreIndexes, hit: HitGeomet
       if (mode === "auto") {
         // Per-candidate autoMode can still be x/y (e.g. boxplot outliers):
         // include dominant-axis strips so orthogonal distance does not drop them.
-        // Filled path reps are not in spatial — also shortlist them by strip AABB
-        // so a probe far on the orthogonal axis still x/y-snaps (#1342).
+        // Filled path reps: filled-only strip trees (not every bar AABB).
         if (flip) {
           addRect(-STRIP, py - maxDistance, STRIP, py + maxDistance);
           addRect(px - maxDistance, -STRIP, px + maxDistance, STRIP);
-          addExtendedIntersecting(-STRIP, py - maxDistance, STRIP, py + maxDistance, consider);
-          addExtendedIntersecting(px - maxDistance, -STRIP, px + maxDistance, STRIP, consider);
+          addFilledPathIntersecting(-STRIP, py - maxDistance, STRIP, py + maxDistance, consider);
+          addFilledPathIntersecting(px - maxDistance, -STRIP, px + maxDistance, STRIP, consider);
         } else {
           addRect(px - maxDistance, -STRIP, px + maxDistance, STRIP);
           addRect(-STRIP, py - maxDistance, STRIP, py + maxDistance);
-          addExtendedIntersecting(px - maxDistance, -STRIP, px + maxDistance, STRIP, consider);
-          addExtendedIntersecting(-STRIP, py - maxDistance, STRIP, py + maxDistance, consider);
+          addFilledPathIntersecting(px - maxDistance, -STRIP, px + maxDistance, STRIP, consider);
+          addFilledPathIntersecting(-STRIP, py - maxDistance, STRIP, py + maxDistance, consider);
         }
       }
       // exact containment uses the point AABB; auto still needs maxDistance pad

--- a/packages/core/src/candidate-store-spatial-index.ts
+++ b/packages/core/src/candidate-store-spatial-index.ts
@@ -2,7 +2,12 @@
  * Spatial shortlist indexes for an assembled candidate store: anchor quadtree,
  * per-batch point trees, size-classed extended AABB trees, and shortlist APIs.
  * Size-class layout stays closure-private.
+ *
+ * Filled paths (#1342): one extended AABB entry per subpath (not per vertex).
+ * Filled candidates are omitted from the main anchor tree so strip shortlists
+ * stay O(non-filled + subpaths) instead of O(all area vertices).
  */
+import { pathRange } from "./candidate-geometry.js";
 import { StaticQuadtree } from "./dom/quadtree.js";
 import type { HitGeometry } from "./candidate-hit-geometry.js";
 import type { CandidateInspectMode } from "./candidate-store-types.js";
@@ -19,6 +24,14 @@ type PointBatchIndex = {
 export type SpatialIndex = {
   readonly spatial: StaticQuadtree | null;
   readonly isPoint: Uint8Array;
+  /** 1 when the candidate is a filled-path vertex (area / ribbon / band). */
+  readonly isFilledPath: Uint8Array;
+  /**
+   * Inclusive-exclusive candidate id span of the filled subpath containing `id`.
+   * `-1` when `isFilledPath[id] === 0`. All members of a subpath share the same span.
+   */
+  readonly filledSpanStart: Int32Array;
+  readonly filledSpanEnd: Int32Array;
   readonly maxPointReach: number;
   readonly pointBatchIndexes: readonly PointBatchIndex[];
   addExtendedIntersecting(
@@ -45,10 +58,15 @@ export function buildSpatialIndex(indexes: CandidateStoreIndexes, hit: HitGeomet
   // size-classed AABB-center trees so hit regions far from anchors still
   // shortlist without force-adding every extended id. Classes bucket by
   // log2(max half-extent) so one giant AABB cannot expand every query to O(E).
+  // Filled path vertices use NaN so StaticQuadtree skips them (#1342).
   const spatialXs = Float64Array.from(xs);
   const spatialYs = Float64Array.from(ys);
-  const spatial = n > 0 ? new StaticQuadtree(spatialXs, spatialYs) : null;
   const isPoint = new Uint8Array(n);
+  const isFilledPath = new Uint8Array(n);
+  const filledSpanStart = new Int32Array(n);
+  const filledSpanEnd = new Int32Array(n);
+  filledSpanStart.fill(-1);
+  filledSpanEnd.fill(-1);
   const pointIdsByBatch = new Map<number, number[]>();
   const extendedIds: number[] = [];
   const extMinXBuild: number[] = [];
@@ -58,6 +76,8 @@ export function buildSpatialIndex(indexes: CandidateStoreIndexes, hit: HitGeomet
   // Subpath AABB cache: `${batchIndex}:${start}:${end}` → box (plot px).
   const pathAabbCache = new Map<string, readonly [number, number, number, number]>();
   let maxPointReach = 0;
+
+  // First pass: classify points / filled paths; strip filled anchors from spatial.
   for (let id = 0; id < n; id++) {
     const batch = scene.batches[batchIds[id]!]!;
     if (batch.kind === "points") {
@@ -72,6 +92,52 @@ export function buildSpatialIndex(indexes: CandidateStoreIndexes, hit: HitGeomet
       else ids.push(id);
       continue;
     }
+    if (batch.kind === "paths" && batch.fills !== undefined) {
+      isFilledPath[id] = 1;
+      spatialXs[id] = Number.NaN;
+      spatialYs[id] = Number.NaN;
+    }
+  }
+
+  // Second pass: extended AABBs. Filled paths contribute one entry per subpath
+  // (first candidate id in the subpath span). Stroked paths / rects / segments /
+  // glyphs stay one entry per candidate.
+  for (let id = 0; id < n;) {
+    if (isPoint[id] === 1) {
+      id++;
+      continue;
+    }
+    if (isFilledPath[id] === 1) {
+      const batchIndex = batchIds[id]!;
+      const batch = scene.batches[batchIndex]!;
+      if (batch.kind !== "paths") {
+        id++;
+        continue;
+      }
+      const range = pathRange(batch, primitiveIds[id]!);
+      const range0 = range?.[0] ?? -1;
+      const range1 = range?.[1] ?? -1;
+      const startId = id;
+      id++;
+      while (id < n && isFilledPath[id] === 1 && batchIds[id] === batchIndex) {
+        const next = pathRange(batch, primitiveIds[id]!);
+        if (next === null || next[0] !== range0 || next[1] !== range1) break;
+        id++;
+      }
+      const endId = id;
+      for (let j = startId; j < endId; j++) {
+        filledSpanStart[j] = startId;
+        filledSpanEnd[j] = endId;
+      }
+      // One extended entry for the whole filled subpath.
+      extendedIds.push(startId);
+      const [minX, minY, maxX, maxY] = hit.aabb(startId, pathAabbCache);
+      extMinXBuild.push(minX);
+      extMinYBuild.push(minY);
+      extMaxXBuild.push(maxX);
+      extMaxYBuild.push(maxY);
+      continue;
+    }
     extendedIds.push(id);
     // glyphs still need a finite AABB for index init even though they never hit.
     const [minX, minY, maxX, maxY] = hit.aabb(id, pathAabbCache);
@@ -79,8 +145,10 @@ export function buildSpatialIndex(indexes: CandidateStoreIndexes, hit: HitGeomet
     extMinYBuild.push(minY);
     extMaxXBuild.push(maxX);
     extMaxYBuild.push(maxY);
+    id++;
   }
   pathAabbCache.clear();
+  const spatial = n > 0 ? new StaticQuadtree(spatialXs, spatialYs) : null;
 
   // Pointer hit testing preserves reverse paint order and per-batch point
   // radius without expanding every query by the largest point in the scene.
@@ -199,39 +267,68 @@ export function buildSpatialIndex(indexes: CandidateStoreIndexes, hit: HitGeomet
     mode: CandidateInspectMode,
     maxDistance: number,
   ): number[] => {
-    if (spatial === null || n === 0) return [];
+    if (n === 0) return [];
     const consider = new Set<number>();
     const addRect = (x0: number, y0: number, x1: number, y1: number) => {
+      if (spatial === null) return;
       for (const id of spatial.queryRect(x0, y0, x1, y1)) consider.add(id);
     };
     if (mode === "xy") {
       addRect(px - maxDistance, py - maxDistance, px + maxDistance, py + maxDistance);
+      // Filled areas omit anchors from `spatial`; pull subpath reps by AABB.
+      addExtendedIntersecting(
+        px - maxDistance,
+        py - maxDistance,
+        px + maxDistance,
+        py + maxDistance,
+        consider,
+      );
     } else if (mode === "x") {
       // Dominant-axis distance is along semantic x (screen y when coord_flip).
       // Axis token maps stay for group(); nearest uses spatial strips.
-      if (flip) addRect(-STRIP, py - maxDistance, STRIP, py + maxDistance);
-      else addRect(px - maxDistance, -STRIP, px + maxDistance, STRIP);
+      // Filled path verts are not in spatial (#1342) — add extended for the strip.
+      if (flip) {
+        addRect(-STRIP, py - maxDistance, STRIP, py + maxDistance);
+        addExtendedIntersecting(-STRIP, py - maxDistance, STRIP, py + maxDistance, consider);
+      } else {
+        addRect(px - maxDistance, -STRIP, px + maxDistance, STRIP);
+        addExtendedIntersecting(px - maxDistance, -STRIP, px + maxDistance, STRIP, consider);
+      }
     } else if (mode === "y") {
-      if (flip) addRect(px - maxDistance, -STRIP, px + maxDistance, STRIP);
-      else addRect(-STRIP, py - maxDistance, STRIP, py + maxDistance);
+      if (flip) {
+        addRect(px - maxDistance, -STRIP, px + maxDistance, STRIP);
+        addExtendedIntersecting(px - maxDistance, -STRIP, px + maxDistance, STRIP, consider);
+      } else {
+        addRect(-STRIP, py - maxDistance, STRIP, py + maxDistance);
+        addExtendedIntersecting(-STRIP, py - maxDistance, STRIP, py + maxDistance, consider);
+      }
     } else {
       // exact / auto: point anchors within hit reach + extended geometry whose
       // AABB meets the probe (rects/segments/paths can sit far from anchors).
+      // Filled path verts are NaN-skipped in spatial; reps arrive via extended.
       const r = mode === "auto" ? Math.max(maxDistance, maxPointReach) : maxPointReach;
       addRect(px - r, py - r, px + r, py + r);
       if (mode === "auto") {
         // Per-candidate autoMode can still be x/y (e.g. boxplot outliers):
         // include dominant-axis strips so orthogonal distance does not drop them.
+        // Filled path reps are not in spatial — also shortlist them by strip AABB
+        // so a probe far on the orthogonal axis still x/y-snaps (#1342).
         if (flip) {
           addRect(-STRIP, py - maxDistance, STRIP, py + maxDistance);
           addRect(px - maxDistance, -STRIP, px + maxDistance, STRIP);
+          addExtendedIntersecting(-STRIP, py - maxDistance, STRIP, py + maxDistance, consider);
+          addExtendedIntersecting(px - maxDistance, -STRIP, px + maxDistance, STRIP, consider);
         } else {
           addRect(px - maxDistance, -STRIP, px + maxDistance, STRIP);
           addRect(-STRIP, py - maxDistance, STRIP, py + maxDistance);
+          addExtendedIntersecting(px - maxDistance, -STRIP, px + maxDistance, STRIP, consider);
+          addExtendedIntersecting(-STRIP, py - maxDistance, STRIP, py + maxDistance, consider);
         }
       }
       // exact containment uses the point AABB; auto still needs maxDistance pad
       // for dominant-axis extended matches that refine after shortlist.
+      // Filled-path reps also need a pad on exact when the probe is outside the
+      // subpath AABB but within maxDistance of an anchor (rare for areas).
       const pad = mode === "auto" ? maxDistance : 0;
       addExtendedIntersecting(px - pad, py - pad, px + pad, py + pad, consider);
     }
@@ -241,6 +338,9 @@ export function buildSpatialIndex(indexes: CandidateStoreIndexes, hit: HitGeomet
   return {
     spatial,
     isPoint,
+    isFilledPath,
+    filledSpanStart,
+    filledSpanEnd,
     maxPointReach,
     pointBatchIndexes,
     addExtendedIntersecting,

--- a/packages/core/tests/candidate/hit-resolve.test.ts
+++ b/packages/core/tests/candidate/hit-resolve.test.ts
@@ -20,6 +20,9 @@ function resolve(plot: ReturnType<typeof scene>, px: number, py: number, hitTole
       xs: indexes.xs,
       ys: indexes.ys,
       pointBatchIndexes: query.pointBatchIndexes,
+      filledSpanStart: query.filledSpanStart,
+      filledSpanEnd: query.filledSpanEnd,
+      isFilledPath: query.isFilledPath,
       addExtendedIntersecting: (loX, loY, hiX, hiY, into) => {
         query.addExtendedIntersecting(loX, loY, hiX, hiY, into);
       },

--- a/packages/core/tests/candidate/store/filled-area-hit-shortlist.test.ts
+++ b/packages/core/tests/candidate/store/filled-area-hit-shortlist.test.ts
@@ -261,6 +261,35 @@ describe("filled-area hit shortlist (#1342)", () => {
     expect(hits).toEqual(Array.from({ length: rows * 2 }, (_, i) => i));
   });
 
+  it("queryRect selects only local vertices when the brush center is outside the fill", () => {
+    // Triangle (20,20) (80,20) (50,80). Brush over the top edge near (50,20)
+    // with center outside the fill — only nearby top-edge vertices, not the
+    // whole subpath (and not empty via rep-only edge checks).
+    const plot = scene();
+    plot.batches = [
+      {
+        kind: "paths",
+        layerIndex: 0,
+        panelIndex: 0,
+        positions: new Float32Array([20, 20, 50, 20, 80, 20, 50, 80]),
+        rowIndex: new Uint32Array([0, 1, 2, 3]),
+        pathOffsets: new Uint32Array([0, 4]),
+        fills: [null],
+        strokes: [null],
+        closed: true,
+        linewidth: 0,
+        alpha: 1,
+        curve: "linear",
+      },
+    ];
+    const store = areaStore(plot);
+    // Brush (45,15)-(55,22): covers the mid top vertex (50,20); center (50,18.5)
+    // is outside the fill (above the top edge). Must not return the bottom tip.
+    const hits = new Set(Array.from(store.queryRect(45, 15, 55, 22)));
+    expect(hits.has(1)).toBe(true); // mid top vertex
+    expect(hits.has(3)).toBe(false); // bottom tip (50,80)
+  });
+
   it("hitTest and nearest(auto) stay sub-millisecond on a dense stacked area", () => {
     // Structural scale: 8 × 2000 closed-band verts = 32k candidates.
     // Pre-fix cost was multi-ms per probe; after fix it must stay under 1ms mean.

--- a/packages/core/tests/candidate/store/filled-area-hit-shortlist.test.ts
+++ b/packages/core/tests/candidate/store/filled-area-hit-shortlist.test.ts
@@ -1,0 +1,338 @@
+/**
+ * #1342 — filled-area shortlist must be O(subpaths), not O(vertices).
+ * Id-exact parity with the topmost / nearest-anchor / axis-snap contracts.
+ */
+import { describe, expect, it } from "bun:test";
+
+import { pathRange } from "../../../src/candidate-geometry.ts";
+import { createHitGeometry } from "../../../src/candidate-hit-geometry.ts";
+import { buildCandidateStore } from "../../../src/candidate-store.ts";
+import { buildCandidateStoreIndexes } from "../../../src/candidate-store-indexes.ts";
+import { buildSpatialIndex } from "../../../src/candidate-store-spatial-index.ts";
+import type { PathsBatch, Scene } from "../../../src/scene.ts";
+import { scene } from "../fixtures.ts";
+
+/** Closed band: upper ascending, lower descending — same layout as geom_area. */
+function stackedAreaScene(groups: number, rows: number, panelW = 200, panelH = 120): Scene {
+  const pathOffsets = [0];
+  const positions: number[] = [];
+  const rowIndex: number[] = [];
+  const fills: null[] = [];
+  let v = 0;
+  for (let g = 0; g < groups; g++) {
+    for (let i = 0; i < rows; i++) {
+      const x = rows === 1 ? panelW / 2 : (i / (rows - 1)) * panelW;
+      const yTop = 15 + g * 6 + Math.sin(i / 7) * 4;
+      positions.push(x, yTop);
+      rowIndex.push(g * rows + i);
+      v++;
+    }
+    for (let i = rows - 1; i >= 0; i--) {
+      const x = rows === 1 ? panelW / 2 : (i / (rows - 1)) * panelW;
+      const yBot = panelH - 10 - g * 2;
+      positions.push(x, yBot);
+      rowIndex.push(g * rows + i);
+      v++;
+    }
+    pathOffsets.push(v);
+    fills.push(null);
+  }
+  const plot = scene();
+  plot.width = panelW;
+  plot.height = panelH;
+  plot.panels = [
+    {
+      id: "panel:all",
+      x: 0,
+      y: 0,
+      width: panelW,
+      height: panelH,
+      strip: "",
+      axisX: [],
+      axisY: [],
+      grid: { x: [], y: [] },
+    },
+  ];
+  plot.batches = [
+    {
+      kind: "paths",
+      layerIndex: 0,
+      panelIndex: 0,
+      positions: new Float32Array(positions),
+      rowIndex: new Uint32Array(rowIndex),
+      pathOffsets: new Uint32Array(pathOffsets),
+      fills,
+      strokes: fills.map(() => null),
+      closed: true,
+      linewidth: 0,
+      alpha: 1,
+      curve: "linear",
+    } satisfies PathsBatch,
+  ];
+  return plot;
+}
+
+function areaStore(plot: Scene) {
+  return buildCandidateStore(plot, {
+    datum: ({ primitiveIndex, batchIndex }) => {
+      const batch = plot.batches[batchIndex]!;
+      if (batch.kind !== "paths") return { autoMode: "x" as const };
+      const x = batch.positions[primitiveIndex * 2]!;
+      const y = batch.positions[primitiveIndex * 2 + 1]!;
+      return { xValue: x, yValue: y, autoMode: "x" as const, seriesId: 0 };
+    },
+  });
+}
+
+/** Independent hitTest oracle: topmost containing subpath, then nearest anchor. */
+function oracleHitId(plot: Scene, px: number, py: number): number | null {
+  const indexes = buildCandidateStoreIndexes(plot, { hitTolerance: 3 });
+  const hit = createHitGeometry(indexes);
+  const probe = hit.probePoint(px, py);
+  let best = -1;
+  let bestBatch = -1;
+  let bestPathStart = -1;
+  let bestDistance = Infinity;
+  let bestPrimitive = Infinity;
+  for (let id = 0; id < indexes.n; id++) {
+    const batchIndex = indexes.batchIds[id]!;
+    const batch = plot.batches[batchIndex]!;
+    if (batch.kind !== "paths" || batch.fills === undefined) continue;
+    const distance = probe.distance(id);
+    if (distance === null) continue;
+    const primitive = indexes.primitiveIds[id]!;
+    const range = pathRange(batch, primitive);
+    const pathStart = range?.[0] ?? -1;
+    const sameBatch = batchIndex === bestBatch;
+    const improves =
+      batchIndex > bestBatch ||
+      (sameBatch &&
+        (pathStart > bestPathStart ||
+          (pathStart === bestPathStart &&
+            (distance < bestDistance ||
+              (distance === bestDistance && primitive < bestPrimitive)))));
+    if (improves) {
+      best = id;
+      bestBatch = batchIndex;
+      bestPathStart = pathStart;
+      bestDistance = distance;
+      bestPrimitive = primitive;
+    }
+  }
+  return best < 0 ? null : best;
+}
+
+/** Independent nearest-x oracle over every candidate (axis distance then orth). */
+function oracleNearestX(plot: Scene, px: number, py: number, maxDistance: number): number | null {
+  const indexes = buildCandidateStoreIndexes(plot, { hitTolerance: 3 });
+  let best = -1;
+  let bestDistance = Infinity;
+  let bestOrth = Infinity;
+  for (let id = 0; id < indexes.n; id++) {
+    const distance = Math.abs(indexes.xs[id]! - px);
+    if (distance > maxDistance) continue;
+    const orth = Math.abs(indexes.ys[id]! - py);
+    if (distance < bestDistance || (distance === bestDistance && orth < bestOrth)) {
+      best = id;
+      bestDistance = distance;
+      bestOrth = orth;
+    }
+  }
+  return best < 0 ? null : best;
+}
+
+describe("filled-area hit shortlist (#1342)", () => {
+  it("hitTest matches the topmost+nearest-anchor oracle on a multi-group grid", () => {
+    const plot = stackedAreaScene(3, 40);
+    const store = areaStore(plot);
+    for (let i = 0; i < 10; i++) {
+      for (let j = 0; j < 8; j++) {
+        const px = 10 + i * 18;
+        const py = 20 + j * 10;
+        const got = store.hitTest(px, py)?.id ?? null;
+        const want = oracleHitId(plot, px, py);
+        expect(got).toBe(want);
+      }
+    }
+  });
+
+  it("nearest mode x matches the full-scan axis oracle", () => {
+    const plot = stackedAreaScene(3, 40);
+    const store = areaStore(plot);
+    const maxDistance = 24;
+    for (let i = 0; i < 12; i++) {
+      const px = 8 + i * 15;
+      const py = 40 + (i % 5) * 8;
+      const got = store.nearest(px, py, { mode: "x", maxDistance })?.id ?? null;
+      const want = oracleNearestX(plot, px, py, maxDistance);
+      expect(got).toBe(want);
+    }
+  });
+
+  it("nearest auto on a filled-only area x-snaps to the oracle vertex", () => {
+    const plot = stackedAreaScene(2, 30);
+    const store = areaStore(plot);
+    const maxDistance = 24;
+    for (let i = 0; i < 8; i++) {
+      const px = 20 + i * 20;
+      const py = 55;
+      const got = store.nearest(px, py, { mode: "auto", maxDistance })?.id ?? null;
+      const want = oracleNearestX(plot, px, py, maxDistance);
+      expect(got).toBe(want);
+    }
+  });
+
+  it("nearest auto x-snaps a filled band when the probe is far on y", () => {
+    // Thin band near the bottom; probe shares x with a vertex but sits far above
+    // the subpath AABB. Pre-#1342 the x-strip shortlisted anchors; after NaN
+    // omission auto must still pull filled reps via strip extended AABBs.
+    const plot = scene();
+    plot.batches = [
+      {
+        kind: "paths",
+        layerIndex: 0,
+        panelIndex: 0,
+        positions: new Float32Array([
+          20,
+          90,
+          60,
+          88,
+          100,
+          90,
+          140,
+          87,
+          180,
+          91, // upper
+          180,
+          100,
+          140,
+          102,
+          100,
+          100,
+          60,
+          101,
+          20,
+          100, // lower reversed
+        ]),
+        rowIndex: new Uint32Array([0, 1, 2, 3, 4, 4, 3, 2, 1, 0]),
+        pathOffsets: new Uint32Array([0, 10]),
+        fills: [null],
+        strokes: [null],
+        closed: true,
+        linewidth: 0,
+        alpha: 1,
+        curve: "linear",
+      },
+    ];
+    const store = areaStore(plot);
+    const maxDistance = 24;
+    const px = 100;
+    const py = 20; // far above the band (y≈87–102)
+    const explicit = store.nearest(px, py, { mode: "x", maxDistance })?.id ?? null;
+    const auto = store.nearest(px, py, { mode: "auto", maxDistance })?.id ?? null;
+    const want = oracleNearestX(plot, px, py, maxDistance);
+    expect(want).not.toBeNull();
+    expect(explicit).toBe(want);
+    expect(auto).toBe(want);
+  });
+
+  it("extended index holds one entry per filled subpath, not per vertex", () => {
+    const groups = 4;
+    const rows = 80;
+    const plot = stackedAreaScene(groups, rows);
+    const indexes = buildCandidateStoreIndexes(plot, { hitTolerance: 3 });
+    const hit = createHitGeometry(indexes);
+    const query = buildSpatialIndex(indexes, hit);
+    // Public structural signal: shortlist for a panel-wide probe must not grow
+    // with V. Count candidates that addExtendedIntersecting returns at the center.
+    const shortlist: number[] = [];
+    query.addExtendedIntersecting(100, 60, 100, 60, shortlist);
+    // One representative per filled subpath (groups closed bands).
+    expect(shortlist.length).toBe(groups);
+    expect(indexes.n).toBe(groups * rows * 2);
+  });
+
+  it("queryRect still returns every vertex of a hit filled subpath", () => {
+    const rows = 25;
+    const plot = stackedAreaScene(1, rows);
+    const store = areaStore(plot);
+    // Interior brush whose center is inside the band, anchors may lie outside.
+    const hits = Array.from(store.queryRect(90, 40, 110, 50)).toSorted((a, b) => a - b);
+    expect(hits).toEqual(Array.from({ length: rows * 2 }, (_, i) => i));
+  });
+
+  it("hitTest and nearest(auto) stay sub-millisecond on a dense stacked area", () => {
+    // Structural scale: 8 × 2000 closed-band verts = 32k candidates.
+    // Pre-fix cost was multi-ms per probe; after fix it must stay under 1ms mean.
+    const plot = stackedAreaScene(8, 2000);
+    const store = areaStore(plot);
+    expect(store.size).toBe(32_000);
+    const probes: [number, number][] = [];
+    for (let i = 0; i < 20; i++) probes.push([15 + i * 9, 50]);
+    // Warm up once so build cost is not in the sample.
+    for (const [x, y] of probes) {
+      store.hitTest(x, y);
+      store.nearest(x, y, { mode: "auto", maxDistance: 24 });
+    }
+    const t0 = performance.now();
+    for (const [x, y] of probes) store.hitTest(x, y);
+    const hitMs = (performance.now() - t0) / probes.length;
+    const t1 = performance.now();
+    for (const [x, y] of probes) store.nearest(x, y, { mode: "auto", maxDistance: 24 });
+    const nearestMs = (performance.now() - t1) / probes.length;
+    // Generous vs pre-fix multi-ms cost; structural shortlist size is the
+    // primary gate. Keep a soft wall-clock bound for local regressions.
+    expect(hitMs).toBeLessThan(2);
+    expect(nearestMs).toBeLessThan(2);
+  });
+
+  it("picks the nearest upper-edge anchor inside a single filled band", () => {
+    // Triangle-like band so anchors are not uniform — nearest vertex is non-obvious.
+    const plot = scene();
+    plot.batches = [
+      {
+        kind: "paths",
+        layerIndex: 0,
+        panelIndex: 0,
+        positions: new Float32Array([
+          20,
+          30,
+          60,
+          20,
+          100,
+          30,
+          140,
+          25,
+          180,
+          35, // upper
+          180,
+          90,
+          140,
+          95,
+          100,
+          90,
+          60,
+          95,
+          20,
+          90, // lower reversed
+        ]),
+        rowIndex: new Uint32Array([0, 1, 2, 3, 4, 4, 3, 2, 1, 0]),
+        pathOffsets: new Uint32Array([0, 10]),
+        fills: [null],
+        strokes: [null],
+        closed: true,
+        linewidth: 0,
+        alpha: 1,
+        curve: "linear",
+      },
+    ];
+    const store = areaStore(plot);
+    // Probe near upper vertex at (100, 30).
+    const hit = store.hitTest(102, 40);
+    expect(hit).not.toBeNull();
+    expect(hit!.id).toBe(oracleHitId(plot, 102, 40));
+    // Nearest on x near the right side should prefer the rightmost upper vertex.
+    const near = store.nearest(175, 50, { mode: "x", maxDistance: 24 });
+    expect(near?.id).toBe(oracleNearestX(plot, 175, 50, 24));
+  });
+});

--- a/packages/core/tests/candidate/store/filled-area-hit-shortlist.test.ts
+++ b/packages/core/tests/candidate/store/filled-area-hit-shortlist.test.ts
@@ -315,6 +315,81 @@ describe("filled-area hit shortlist (#1342)", () => {
     expect(nearestMs).toBeLessThan(2);
   });
 
+  it("nearest prefers the higher id on an exact (distance, orth) tie inside a filled span", () => {
+    // Zero-height band: upper and lower vertices share (x,y). Descending
+    // shortlist contract → highest id wins the tie (topmost).
+    const plot = scene();
+    plot.batches = [
+      {
+        kind: "paths",
+        layerIndex: 0,
+        panelIndex: 0,
+        positions: new Float32Array([
+          0,
+          50,
+          50,
+          50,
+          100,
+          50, // upper
+          100,
+          50,
+          50,
+          50,
+          0,
+          50, // lower (coincident)
+        ]),
+        rowIndex: new Uint32Array([0, 1, 2, 2, 1, 0]),
+        pathOffsets: new Uint32Array([0, 6]),
+        fills: [null],
+        strokes: [null],
+        closed: true,
+        linewidth: 0,
+        alpha: 1,
+        curve: "linear",
+      },
+    ];
+    const store = areaStore(plot);
+    const hit = store.nearest(50, 50, { mode: "x", maxDistance: 24 });
+    expect(hit).not.toBeNull();
+    // Coincident at x=50: ids 1 (upper mid) and 4 (lower mid). Prefer 4.
+    expect(hit!.id).toBe(4);
+  });
+
+  it("nearest mode x skips filled vertices without an x token, not the whole subpath", () => {
+    const plot = scene();
+    plot.batches = [
+      {
+        kind: "paths",
+        layerIndex: 0,
+        panelIndex: 0,
+        positions: new Float32Array([20, 40, 60, 40, 100, 40, 100, 80, 60, 80, 20, 80]),
+        rowIndex: new Uint32Array([0, 1, 2, 2, 1, 0]),
+        pathOffsets: new Uint32Array([0, 6]),
+        fills: [null],
+        strokes: [null],
+        closed: true,
+        linewidth: 0,
+        alpha: 1,
+        curve: "linear",
+      },
+    ];
+    // Rep (id 0) has no x token; later vertices do — whole subpath must still snap.
+    const store = buildCandidateStore(plot, {
+      datum: ({ primitiveIndex }) =>
+        primitiveIndex === 0
+          ? { xValue: null, yValue: 40, autoMode: "x" as const }
+          : {
+              xValue: [20, 60, 100, 100, 60, 20][primitiveIndex],
+              yValue: [40, 40, 40, 80, 80, 80][primitiveIndex],
+              autoMode: "x" as const,
+            },
+    });
+    const hit = store.nearest(60, 30, { mode: "x", maxDistance: 24 });
+    expect(hit).not.toBeNull();
+    expect(hit!.id).not.toBe(0);
+    expect(hit!.id).toBe(1);
+  });
+
   it("picks the nearest upper-edge anchor inside a single filled band", () => {
     // Triangle-like band so anchors are not uniform — nearest vertex is non-obvious.
     const plot = scene();


### PR DESCRIPTION
## Summary

Fixes #1342 — pointer hit-testing a dense stacked `geom_area` was paying one full pass over every path vertex per event (~28–31 ms at 8×8000 rows). The live path is `nearest` (`pointer-inspect` → `resolveTarget`); `hitTest` is only the fallback.

**Root cause:** the extended AABB index and anchor shortlist treated every filled-path vertex as its own entry. Subpath AABBs cover most of the panel, so shortlists collapsed to O(candidates).

**Fix:**
- One extended AABB entry per filled subpath (first candidate id in the span)
- Omit filled vertices from the main anchor quadtree (NaN skip)
- `hitTest`: one containment check per subpath, then nearest-anchor scan over the span
- `nearest`: expand each shortlisted filled rep to the best vertex for the active mode (axis-snap / exact)
- `queryRect`: still returns every vertex of a hit filled subpath (brush contract)
- Stroked paths, points, and rects unchanged

## Validation

Measured on main (before) vs this branch (after), 8000 rows × 8 groups = 128k candidates, single probe:

| call | before | after |
|------|--------|-------|
| `hitTest` | ~28 ms | ~2.2 ms |
| `nearest(auto)` | ~31 ms | ~0.18 ms |
| `nearest(x)` | ~5 ms | ~0.13 ms |

Extended shortlist size for a center probe: **8** (one per group), not 128k.

## Tests

- New `filled-area-hit-shortlist.test.ts`: id-exact oracles for hitTest / nearest-x / nearest-auto, structural shortlist size, queryRect expansion, orthogonal auto x-snap, soft wall-clock guard
- Existing `packages/core/tests/candidate/**` green (166 tests)

```bash
bun test packages/core/tests/candidate
```

## Follow-ups

- Monotone binary-search containment / nearest-anchor (issue phase B) — not required for the cost bar once shortlist is O(subpaths); linear expand over shortlisted spans remains O(vertices of those spans)
- Optional CI structural assert already covers shortlist size; wall-clock bound is soft

## Notes

- No public API change
- Changeset: `@ggsvelte/core` patch
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1352" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->