### PR TITLE
fix(release): stop silent skips when Version Packages races feature merges

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,10 @@ jobs:
       - name: Publish package versions on main that are missing from npm
         if: vars.NPM_PUBLISH_ENABLED == 'true'
         # Token intentionally absent — publish uses OIDC only. Tagging is later.
+        # RELEASE_STAGING_DIR: write just-published.txt so staging survives registry lag.
         run: bun scripts/publish-unpublished.ts
+        env:
+          RELEASE_STAGING_DIR: ${{ runner.temp }}/ggsvelte-release-staging
       - name: Stage GitHub release notes for package versions on npm
         if: vars.NPM_PUBLISH_ENABLED == 'true'
         run: bun scripts/stage-github-releases.ts
@@ -114,8 +117,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_STAGING_DIR: ${{ runner.temp }}/ggsvelte-release-staging
         # Script-free: only gh/git so the write credential never reaches bun or
-        # node_modules. Staging covers every local version already on npm so a
-        # re-run recovers tags after a prior post-publish failure.
+        # node_modules. Per-tag targets come from staging (version-introducing
+        # commit), not always HEAD — recovery tags stay truthful.
         run: |
           set -euo pipefail
           staging="${RELEASE_STAGING_DIR:?}"
@@ -137,9 +140,18 @@ jobs:
               echo "create-github-releases: missing notes for index ${i} (tag ${tag})"
               exit 1
             fi
-            echo "creating GitHub release + remote tag ${tag}"
+            target_file="${staging}/targets/${i}.txt"
+            if [ -f "${target_file}" ]; then
+              target="$(tr -d '[:space:]' <"${target_file}")"
+            else
+              target="${head}"
+            fi
+            if [ -z "${target}" ]; then
+              target="${head}"
+            fi
+            echo "creating GitHub release + remote tag ${tag} → ${target}"
             set +e
-            create_out="$(gh release create "${tag}" --title "${tag}" --notes-file "${notes}" --target "${head}" 2>&1)"
+            create_out="$(gh release create "${tag}" --title "${tag}" --notes-file "${notes}" --target "${target}" 2>&1)"
             create_status=$?
             set -e
             if [ "${create_status}" -eq 0 ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-# Release — changesets version-or-publish on every push to main (plan M3).
+# Release — changesets version PR + independent publish on every push to main.
 # All third-party actions pinned by full commit SHA (zizmor-enforced).
 #
 # DORMANT until two pieces of USER-BLOCKED setup exist:
@@ -13,10 +13,20 @@
 # `id-token: write` + npm's OIDC exchange ("trusted publisher") is the only
 # way packages leave this repo. That needs npm >= 11.5, hence Node 24 below.
 #
-# Flow: changesets/action either opens/updates the "Version Packages" PR
-# (authenticated via the default GITHUB_TOKEN passed in its env — the
-# checkout itself stays credential-free) or, on a push that contains merged
-# version changes, runs the publish command.
+# Flow (when NPM_PUBLISH_ENABLED=true):
+#   1. changesets/action opens/updates the "Version Packages" PR when
+#      .changeset/*.md files are present (version-only — no publish script).
+#   2. publish-unpublished.ts ships any package.json versions already on main
+#      that are missing from npm (idempotent).
+#   3. assert-npm-published.ts FAILS the job if any package version on this
+#      commit is still missing from npm — no silent skips.
+#
+# Why publish is NOT left to changesets/action: the action is either/or. If
+# ANY leftover changeset remains on main it only maintains the Version
+# Packages PR and never publishes, still exiting green. That races every time
+# a feature PR merges while CI is green on a ready Version Packages PR
+# (multi-agent daily traffic). Decoupling publish + asserting npm parity
+# recovers the race and makes residual drift a red job.
 name: Release
 
 on:
@@ -36,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
-      contents: write # changesets/action pushes version commits + tags
+      contents: write # version PR commits + tag push + GitHub releases
       pull-requests: write # changesets/action opens the Version Packages PR
       id-token: write # npm trusted publishing (OIDC) — no NPM_TOKEN anywhere
     steps:
@@ -61,22 +71,22 @@ jobs:
       - run: bun install --frozen-lockfile
       - name: build packages (published exports point at dist/)
         run: bun run build
+      # Version PR only — never pass `publish` to changesets/action. Publish is
+      # a separate step so leftover changesets cannot suppress shipping
+      # already-bumped versions (the concurrent-merge race).
+      - name: changesets — open/update Version Packages PR
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # Publishing is gated behind the NPM_PUBLISH_ENABLED repo variable so
       # this workflow stays green until npm trusted publishing (OIDC) is
-      # configured for all four packages on npmjs.com. Until then the action
-      # only maintains the "Version Packages" PR. Flip the gate with:
+      # configured for all four packages on npmjs.com. Flip the gate with:
       #   gh variable set NPM_PUBLISH_ENABLED --body true
-      - name: changesets — version PR or publish
+      - name: Publish package versions on main that are missing from npm
         if: vars.NPM_PUBLISH_ENABLED == 'true'
-        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
-        with:
-          # Repo policy bans network bunx — invoke the lockfile-installed
-          # binary directly. Version command stays the changesets default.
-          publish: bun node_modules/.bin/changeset publish
+        run: bun scripts/publish-unpublished.ts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: changesets — version PR only (publishing not yet enabled)
-        if: vars.NPM_PUBLISH_ENABLED != 'true'
-        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Assert every package.json version is on npm
+        if: vars.NPM_PUBLISH_ENABLED == 'true'
+        run: bun scripts/assert-npm-published.ts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-# Release — changesets version PR + independent publish on every push to main.
+# Release — independent publish + changesets version PR on every push to main.
 # All third-party actions pinned by full commit SHA (zizmor-enforced).
 #
 # DORMANT until two pieces of USER-BLOCKED setup exist:
@@ -14,12 +14,15 @@
 # way packages leave this repo. That needs npm >= 11.5, hence Node 24 below.
 #
 # Flow (when NPM_PUBLISH_ENABLED=true):
-#   1. changesets/action opens/updates the "Version Packages" PR when
-#      .changeset/*.md files are present (version-only — no publish script).
-#   2. publish-unpublished.ts ships any package.json versions already on main
-#      that are missing from npm (idempotent).
-#   3. assert-npm-published.ts FAILS the job if any package version on this
+#   1. publish-unpublished.ts ships any package.json versions already on THIS
+#      commit that are missing from npm (idempotent). Runs BEFORE the version
+#      PR step so we never read package.json from changeset-release/main.
+#   2. assert-npm-published.ts FAILS the job if any package version on this
 #      commit is still missing from npm — no silent skips.
+#   3. changesets/action opens/updates the "Version Packages" PR when
+#      .changeset/*.md files are present (version-only — no publish script).
+#      The action leaves the workspace on changeset-release/main; that is fine
+#      because publish/assert already finished against the main tip.
 #
 # Why publish is NOT left to changesets/action: the action is either/or. If
 # ANY leftover changeset remains on main it only maintains the Version
@@ -71,17 +74,14 @@ jobs:
       - run: bun install --frozen-lockfile
       - name: build packages (published exports point at dist/)
         run: bun run build
-      # Version PR only — never pass `publish` to changesets/action. Publish is
-      # a separate step so leftover changesets cannot suppress shipping
-      # already-bumped versions (the concurrent-merge race).
-      - name: changesets — open/update Version Packages PR
-        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # Publishing is gated behind the NPM_PUBLISH_ENABLED repo variable so
       # this workflow stays green until npm trusted publishing (OIDC) is
       # configured for all four packages on npmjs.com. Flip the gate with:
       #   gh variable set NPM_PUBLISH_ENABLED --body true
+      #
+      # MUST run before changesets/action: the action switches the workspace
+      # onto changeset-release/main and leaves next-version package.json files
+      # checked out. Publishing after that would ship unreviewed bumps.
       - name: Publish package versions on main that are missing from npm
         if: vars.NPM_PUBLISH_ENABLED == 'true'
         run: bun scripts/publish-unpublished.ts
@@ -90,3 +90,10 @@ jobs:
       - name: Assert every package.json version is on npm
         if: vars.NPM_PUBLISH_ENABLED == 'true'
         run: bun scripts/assert-npm-published.ts
+      # Version PR only — never pass `publish` to changesets/action. Publish is
+      # a separate step so leftover changesets cannot suppress shipping
+      # already-bumped versions (the concurrent-merge race).
+      - name: changesets — open/update Version Packages PR
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,12 +14,19 @@
 # way packages leave this repo. That needs npm >= 11.5, hence Node 24 below.
 #
 # Flow (when NPM_PUBLISH_ENABLED=true):
-#   1. publish-unpublished.ts ships any package.json versions already on THIS
-#      commit that are missing from npm (idempotent). Runs BEFORE the version
-#      PR step so we never read package.json from changeset-release/main.
-#   2. assert-npm-published.ts FAILS the job if any package version on this
+#   1. Fail-fast if GITHUB_TOKEN is missing (needed for tags/releases later).
+#   2. publish-unpublished.ts ships any package.json versions already on THIS
+#      commit that are missing from npm (idempotent). No GITHUB_TOKEN — only
+#      OIDC for npm. Runs BEFORE the version PR step so we never read
+#      package.json from changeset-release/main.
+#   3. stage-github-releases.ts writes notes for every local version on npm
+#      (recovery: includes versions published in prior runs that never got a
+#      GitHub release). No GITHUB_TOKEN.
+#   4. Create missing GitHub releases/tags via `gh` only (holds GITHUB_TOKEN;
+#      script-free so repo code and node_modules never see the write credential).
+#   5. assert-npm-published.ts FAILS the job if any package version on this
 #      commit is still missing from npm — no silent skips.
-#   3. changesets/action opens/updates the "Version Packages" PR when
+#   6. changesets/action opens/updates the "Version Packages" PR when
 #      .changeset/*.md files are present (version-only — no publish script).
 #      The action leaves the workspace on changeset-release/main; that is fine
 #      because publish/assert already finished against the main tip.
@@ -82,11 +89,72 @@ jobs:
       # MUST run before changesets/action: the action switches the workspace
       # onto changeset-release/main and leaves next-version package.json files
       # checked out. Publishing after that would ship unreviewed bumps.
-      - name: Publish package versions on main that are missing from npm
+      - name: Require GITHUB_TOKEN for release tagging
         if: vars.NPM_PUBLISH_ENABLED == 'true'
-        run: bun scripts/publish-unpublished.ts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GITHUB_TOKEN}" ]; then
+            echo "GITHUB_TOKEN is required so the create-releases step can mint tags"
+            exit 1
+          fi
+      - name: Publish package versions on main that are missing from npm
+        if: vars.NPM_PUBLISH_ENABLED == 'true'
+        # Token intentionally absent — publish uses OIDC only. Tagging is later.
+        run: bun scripts/publish-unpublished.ts
+      - name: Stage GitHub release notes for package versions on npm
+        if: vars.NPM_PUBLISH_ENABLED == 'true'
+        run: bun scripts/stage-github-releases.ts
+        env:
+          RELEASE_STAGING_DIR: ${{ runner.temp }}/ggsvelte-release-staging
+      - name: Create missing GitHub releases and tags
+        if: vars.NPM_PUBLISH_ENABLED == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_STAGING_DIR: ${{ runner.temp }}/ggsvelte-release-staging
+        # Script-free: only gh/git so the write credential never reaches bun or
+        # node_modules. Staging covers every local version already on npm so a
+        # re-run recovers tags after a prior post-publish failure.
+        run: |
+          set -euo pipefail
+          staging="${RELEASE_STAGING_DIR:?}"
+          tags_file="${staging}/tags.txt"
+          if [ ! -f "${tags_file}" ]; then
+            echo "create-github-releases: no tags.txt staged"
+            exit 1
+          fi
+          if [ ! -s "${tags_file}" ]; then
+            echo "create-github-releases: nothing staged (no package versions on npm yet)"
+            exit 0
+          fi
+          head="$(git rev-parse HEAD)"
+          i=0
+          while IFS= read -r tag || [ -n "${tag}" ]; do
+            [ -n "${tag}" ] || continue
+            notes="${staging}/notes/${i}.md"
+            if [ ! -f "${notes}" ]; then
+              echo "create-github-releases: missing notes for index ${i} (tag ${tag})"
+              exit 1
+            fi
+            echo "creating GitHub release + remote tag ${tag}"
+            set +e
+            create_out="$(gh release create "${tag}" --title "${tag}" --notes-file "${notes}" --target "${head}" 2>&1)"
+            create_status=$?
+            set -e
+            if [ "${create_status}" -eq 0 ]; then
+              printf '%s\n' "${create_out}"
+            elif printf '%s' "${create_out}" | grep -qi 'already exists'; then
+              printf '%s\n' "${create_out}"
+              echo "GitHub release ${tag} already exists — ok"
+            else
+              printf '%s\n' "${create_out}"
+              echo "gh release create ${tag} failed with status ${create_status}"
+              exit 1
+            fi
+            i=$((i + 1))
+          done < "${tags_file}"
+          echo "create-github-releases: processed ${i} tag(s)"
       - name: Assert every package.json version is on npm
         if: vars.NPM_PUBLISH_ENABLED == 'true'
         run: bun scripts/assert-npm-published.ts

--- a/scripts/assert-npm-published.ts
+++ b/scripts/assert-npm-published.ts
@@ -1,0 +1,49 @@
+/**
+ * Loud gate: every non-private package under packages/ must have its
+ * package.json version present on npm. Fails the Release job when
+ * changesets/action skipped publish because a concurrent merge left a leftover
+ * changeset (see npm-publish-state.ts).
+ *
+ * Usage: bun scripts/assert-npm-published.ts
+ * Exit 0 = all on npm; exit 1 = drift (or registry error).
+ */
+
+import {
+  filterUnpublished,
+  formatUnpublishedFailure,
+  npmVersionExists,
+  readPublishedPackageVersions,
+} from "./npm-publish-state.ts";
+
+async function main(): Promise<number> {
+  const root = process.cwd();
+  const local = readPublishedPackageVersions(root);
+  if (local.length === 0) {
+    console.error("assert-npm-published: no published packages found under packages/");
+    return 1;
+  }
+
+  const publishedKeys = new Set<string>();
+  for (const pkg of local) {
+    const exists = await npmVersionExists(pkg.name, pkg.version);
+    if (exists) {
+      publishedKeys.add(`${pkg.name}@${pkg.version}`);
+      console.log(`ok  ${pkg.name}@${pkg.version}`);
+    } else {
+      console.log(`MISS ${pkg.name}@${pkg.version}`);
+    }
+  }
+
+  const unpublished = filterUnpublished(local, publishedKeys);
+  if (unpublished.length === 0) {
+    console.log(`assert-npm-published: all ${String(local.length)} package versions are on npm`);
+    return 0;
+  }
+
+  console.error(formatUnpublishedFailure(unpublished));
+  return 1;
+}
+
+if (import.meta.main) {
+  process.exit(await main());
+}

--- a/scripts/assert-npm-published.ts
+++ b/scripts/assert-npm-published.ts
@@ -25,7 +25,13 @@ async function main(): Promise<number> {
 
   const publishedKeys = new Set<string>();
   for (const pkg of local) {
-    const exists = await npmVersionExists(pkg.name, pkg.version);
+    // Retries + cache-bust: same run may have 404-probed these URLs before
+    // publish, and a negative CDN cache can still be warm.
+    const exists = await npmVersionExists(pkg.name, pkg.version, {
+      retries: 5,
+      retryDelayMs: 2000,
+    });
+
     if (exists) {
       publishedKeys.add(`${pkg.name}@${pkg.version}`);
       console.log(`ok  ${pkg.name}@${pkg.version}`);

--- a/scripts/npm-publish-state.test.ts
+++ b/scripts/npm-publish-state.test.ts
@@ -4,6 +4,7 @@ import {
   changelogSectionForVersion,
   filterUnpublished,
   formatUnpublishedFailure,
+  npmVersionExists,
   npmVersionUrl,
   parseNewTags,
   readPublishedPackageVersions,
@@ -114,6 +115,25 @@ describe("changelogSectionForVersion", () => {
   it("returns null when the version is absent", () => {
     expect(changelogSectionForVersion(sample, "9.9.9")).toBeNull();
   });
+
+  it("does not treat ## 0.24.10 as ## 0.24.1 (prefix collision)", () => {
+    const withTen = `# pkg
+
+## 0.24.10
+
+### Patch Changes
+
+- ten
+
+## 0.24.1
+
+### Patch Changes
+
+- one
+`;
+    expect(changelogSectionForVersion(withTen, "0.24.1")).toBe("### Patch Changes\n\n- one");
+    expect(changelogSectionForVersion(withTen, "0.24.10")).toBe("### Patch Changes\n\n- ten");
+  });
 });
 
 describe("formatUnpublishedFailure", () => {
@@ -129,24 +149,27 @@ describe("formatUnpublishedFailure", () => {
 
 describe("npmVersionExists", () => {
   it("returns true on 200", async () => {
-    const { npmVersionExists } = await import("./npm-publish-state");
-    const fetchImpl = (async () => new Response("{}", { status: 200 })) as unknown as typeof fetch;
-    await expect(npmVersionExists("@ggsvelte/core", "0.24.0", { fetchImpl })).resolves.toBe(true);
+    const fetchImpl = (() =>
+      Promise.resolve(new Response("{}", { status: 200 }))) as unknown as typeof fetch;
+    expect(await npmVersionExists("@ggsvelte/core", "0.24.0", { fetchImpl })).toBe(true);
   });
 
   it("returns false on 404", async () => {
-    const { npmVersionExists } = await import("./npm-publish-state");
-    const fetchImpl = (async () =>
-      new Response("Not Found", { status: 404 })) as unknown as typeof fetch;
-    await expect(npmVersionExists("@ggsvelte/core", "9.9.9", { fetchImpl })).resolves.toBe(false);
+    const fetchImpl = (() =>
+      Promise.resolve(new Response("Not Found", { status: 404 }))) as unknown as typeof fetch;
+    expect(await npmVersionExists("@ggsvelte/core", "9.9.9", { fetchImpl })).toBe(false);
   });
 
   it("throws on non-404 errors so the assert cannot green on outages", async () => {
-    const { npmVersionExists } = await import("./npm-publish-state");
-    const fetchImpl = (async () =>
-      new Response("nope", { status: 500 })) as unknown as typeof fetch;
-    await expect(npmVersionExists("@ggsvelte/core", "0.24.0", { fetchImpl })).rejects.toThrow(
-      /npm registry 500/,
-    );
+    const fetchImpl = (() =>
+      Promise.resolve(new Response("nope", { status: 500 }))) as unknown as typeof fetch;
+    let threw: unknown;
+    try {
+      await npmVersionExists("@ggsvelte/core", "0.24.0", { fetchImpl });
+    } catch (err) {
+      threw = err;
+    }
+    expect(threw).toBeInstanceOf(Error);
+    expect(String(threw)).toMatch(/npm registry 500/);
   });
 });

--- a/scripts/npm-publish-state.test.ts
+++ b/scripts/npm-publish-state.test.ts
@@ -6,7 +6,9 @@ import {
   formatUnpublishedFailure,
   npmVersionExists,
   npmVersionUrl,
+  packageReleaseTag,
   parseNewTags,
+  planGithubReleaseStaging,
   readPublishedPackageVersions,
   type PackageVersion,
 } from "./npm-publish-state";
@@ -144,6 +146,35 @@ describe("formatUnpublishedFailure", () => {
     expect(msg).toContain("@ggsvelte/core@0.24.1");
     expect(msg).toContain("changesets/action");
     expect(msg).toContain("ERROR:");
+  });
+});
+
+describe("packageReleaseTag", () => {
+  it("joins scoped name and version the way changesets tags them", () => {
+    expect(packageReleaseTag("@ggsvelte/core", "0.24.1")).toBe("@ggsvelte/core@0.24.1");
+  });
+});
+
+describe("planGithubReleaseStaging", () => {
+  const local: PackageVersion[] = [
+    { dir: "packages/core", name: "@ggsvelte/core", version: "0.24.1" },
+    { dir: "packages/spec", name: "@ggsvelte/spec", version: "0.24.1" },
+  ];
+
+  it("stages only packages already on npm and uses caller notes", () => {
+    const onNpm = new Set(["@ggsvelte/core@0.24.1"]);
+    const planned = planGithubReleaseStaging(local, onNpm, (pkg) => `notes for ${pkg.name}`);
+    expect(planned).toEqual([{ tag: "@ggsvelte/core@0.24.1", notes: "notes for @ggsvelte/core" }]);
+  });
+
+  it("stages every local package when all are on npm (release recovery)", () => {
+    const onNpm = new Set(["@ggsvelte/core@0.24.1", "@ggsvelte/spec@0.24.1"]);
+    const planned = planGithubReleaseStaging(local, onNpm, () => "body");
+    expect(planned.map((e) => e.tag)).toEqual(["@ggsvelte/core@0.24.1", "@ggsvelte/spec@0.24.1"]);
+  });
+
+  it("returns empty when nothing is on npm yet", () => {
+    expect(planGithubReleaseStaging(local, new Set(), () => "x")).toEqual([]);
   });
 });
 

--- a/scripts/npm-publish-state.test.ts
+++ b/scripts/npm-publish-state.test.ts
@@ -8,10 +8,12 @@ import {
   npmVersionUrl,
   packageReleaseTag,
   parseNewTags,
+  parsePackageReleaseTag,
   planGithubReleaseStaging,
   readPublishedPackageVersions,
   type PackageVersion,
 } from "./npm-publish-state";
+import { commitForPackageVersion } from "./stage-github-releases";
 
 const root = join(import.meta.dir, "..");
 
@@ -202,5 +204,63 @@ describe("npmVersionExists", () => {
     }
     expect(threw).toBeInstanceOf(Error);
     expect(String(threw)).toMatch(/npm registry 500/);
+  });
+});
+
+describe("parsePackageReleaseTag", () => {
+  it("parses scoped and unscoped tags", () => {
+    expect(parsePackageReleaseTag("@ggsvelte/core@0.24.1")).toEqual({
+      name: "@ggsvelte/core",
+      version: "0.24.1",
+    });
+    expect(parsePackageReleaseTag("left-pad@1.0.0")).toEqual({
+      name: "left-pad",
+      version: "1.0.0",
+    });
+    expect(parsePackageReleaseTag("bad")).toBeNull();
+  });
+});
+
+describe("npmVersionExists retries", () => {
+  it("retries 404s then succeeds", async () => {
+    let calls = 0;
+    const fetchImpl = (() => {
+      calls += 1;
+      if (calls < 3) return Promise.resolve(new Response("no", { status: 404 }));
+      return Promise.resolve(new Response("{}", { status: 200 }));
+    }) as unknown as typeof fetch;
+    const sleeps: number[] = [];
+    const ok = await npmVersionExists("@ggsvelte/core", "0.24.1", {
+      fetchImpl,
+      retries: 4,
+      retryDelayMs: 10,
+      sleep: (ms) => {
+        sleeps.push(ms);
+        return Promise.resolve();
+      },
+    });
+    expect(ok).toBe(true);
+    expect(calls).toBe(3);
+    expect(sleeps.length).toBe(2);
+  });
+});
+
+describe("commitForPackageVersion", () => {
+  it("returns git-log result when present", () => {
+    const sha = commitForPackageVersion(
+      { dir: "packages/core", name: "@ggsvelte/core", version: "0.24.1" },
+      "HEADSHA",
+      () => "abc123",
+    );
+    expect(sha).toBe("abc123");
+  });
+
+  it("falls back to HEAD when git finds nothing", () => {
+    const sha = commitForPackageVersion(
+      { dir: "packages/core", name: "@ggsvelte/core", version: "0.24.1" },
+      "HEADSHA",
+      () => null,
+    );
+    expect(sha).toBe("HEADSHA");
   });
 });

--- a/scripts/npm-publish-state.test.ts
+++ b/scripts/npm-publish-state.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "bun:test";
+import { join } from "node:path";
+import {
+  changelogSectionForVersion,
+  filterUnpublished,
+  formatUnpublishedFailure,
+  npmVersionUrl,
+  parseNewTags,
+  readPublishedPackageVersions,
+  type PackageVersion,
+} from "./npm-publish-state";
+
+const root = join(import.meta.dir, "..");
+
+describe("readPublishedPackageVersions", () => {
+  it("returns the four lockstep packages with name+version", () => {
+    const pkgs = readPublishedPackageVersions(root);
+    const names = pkgs.map((p) => p.name).toSorted();
+    expect(names).toEqual([
+      "@ggsvelte/cli",
+      "@ggsvelte/core",
+      "@ggsvelte/spec",
+      "@ggsvelte/svelte",
+    ]);
+    for (const pkg of pkgs) {
+      expect(pkg.version).toMatch(/^\d+\.\d+\.\d+/);
+      expect(pkg.dir.startsWith("packages/")).toBe(true);
+    }
+  });
+});
+
+describe("npmVersionUrl", () => {
+  it("encodes scoped package names for the registry path", () => {
+    expect(npmVersionUrl("@ggsvelte/core", "0.24.1")).toBe(
+      "https://registry.npmjs.org/@ggsvelte%2Fcore/0.24.1",
+    );
+  });
+
+  it("leaves unscoped names alone", () => {
+    expect(npmVersionUrl("left-pad", "1.0.0", "https://example.test/")).toBe(
+      "https://example.test/left-pad/1.0.0",
+    );
+  });
+});
+
+describe("filterUnpublished", () => {
+  const local: PackageVersion[] = [
+    { dir: "packages/core", name: "@ggsvelte/core", version: "0.24.1" },
+    { dir: "packages/spec", name: "@ggsvelte/spec", version: "0.24.1" },
+  ];
+
+  it("returns packages whose name@version is not in the published set", () => {
+    const published = new Set(["@ggsvelte/core@0.24.1"]);
+    expect(filterUnpublished(local, published)).toEqual([
+      { dir: "packages/spec", name: "@ggsvelte/spec", version: "0.24.1" },
+    ]);
+  });
+
+  it("returns empty when everything is published", () => {
+    const published = new Set(["@ggsvelte/core@0.24.1", "@ggsvelte/spec@0.24.1"]);
+    expect(filterUnpublished(local, published)).toEqual([]);
+  });
+});
+
+describe("parseNewTags", () => {
+  it("extracts scoped and unscoped tags from changeset publish output", () => {
+    const stdout = `
+🦋  info npm info @ggsvelte/core
+New tag: @ggsvelte/core@0.24.1
+New tag: @ggsvelte/spec@0.24.1
+Creating git tags...
+New tag:  left-pad@1.0.0
+`;
+    expect(parseNewTags(stdout)).toEqual([
+      "@ggsvelte/core@0.24.1",
+      "@ggsvelte/spec@0.24.1",
+      "left-pad@1.0.0",
+    ]);
+  });
+
+  it("returns empty when nothing was published", () => {
+    expect(parseNewTags("No unpublished packages to publish\n")).toEqual([]);
+  });
+});
+
+describe("changelogSectionForVersion", () => {
+  const sample = `# @ggsvelte/core
+
+## 0.24.1
+
+### Patch Changes
+
+- abc: fix the thing
+
+## 0.24.0
+
+### Patch Changes
+
+- def: earlier
+`;
+
+  it("returns the body between this version header and the next", () => {
+    expect(changelogSectionForVersion(sample, "0.24.1")).toBe(
+      "### Patch Changes\n\n- abc: fix the thing",
+    );
+  });
+
+  it("returns the last section when there is no following H2", () => {
+    expect(changelogSectionForVersion(sample, "0.24.0")).toBe(
+      "### Patch Changes\n\n- def: earlier",
+    );
+  });
+
+  it("returns null when the version is absent", () => {
+    expect(changelogSectionForVersion(sample, "9.9.9")).toBeNull();
+  });
+});
+
+describe("formatUnpublishedFailure", () => {
+  it("names every unpublished package and explains the race", () => {
+    const msg = formatUnpublishedFailure([
+      { dir: "packages/core", name: "@ggsvelte/core", version: "0.24.1" },
+    ]);
+    expect(msg).toContain("@ggsvelte/core@0.24.1");
+    expect(msg).toContain("changesets/action");
+    expect(msg).toContain("ERROR:");
+  });
+});
+
+describe("npmVersionExists", () => {
+  it("returns true on 200", async () => {
+    const { npmVersionExists } = await import("./npm-publish-state");
+    const fetchImpl = (async () => new Response("{}", { status: 200 })) as unknown as typeof fetch;
+    await expect(npmVersionExists("@ggsvelte/core", "0.24.0", { fetchImpl })).resolves.toBe(true);
+  });
+
+  it("returns false on 404", async () => {
+    const { npmVersionExists } = await import("./npm-publish-state");
+    const fetchImpl = (async () =>
+      new Response("Not Found", { status: 404 })) as unknown as typeof fetch;
+    await expect(npmVersionExists("@ggsvelte/core", "9.9.9", { fetchImpl })).resolves.toBe(false);
+  });
+
+  it("throws on non-404 errors so the assert cannot green on outages", async () => {
+    const { npmVersionExists } = await import("./npm-publish-state");
+    const fetchImpl = (async () =>
+      new Response("nope", { status: 500 })) as unknown as typeof fetch;
+    await expect(npmVersionExists("@ggsvelte/core", "0.24.0", { fetchImpl })).rejects.toThrow(
+      /npm registry 500/,
+    );
+  });
+});

--- a/scripts/npm-publish-state.ts
+++ b/scripts/npm-publish-state.ts
@@ -100,24 +100,26 @@ export function parseNewTags(publishStdout: string): string[] {
   const re = /New tag:\s+(\S+)/g;
   for (const match of publishStdout.matchAll(re)) {
     const tag = match[1];
-    if (tag) tags.push(tag);
+    if (tag !== undefined && tag.length > 0) tags.push(tag);
   }
   return tags;
 }
 
 /**
  * Extract the body of a package CHANGELOG section for `## <version>`.
+ * Header match is line-anchored and exact so `## 0.24.1` does not match
+ * `## 0.24.10` (changelogs are newest-first).
  * Returns null when the section is missing (caller decides how loud to be).
  */
 export function changelogSectionForVersion(changelog: string, version: string): string | null {
-  const versionHeader = `## ${version}`;
-  const start = changelog.indexOf(versionHeader);
-  if (start === -1) return null;
-  // Skip the header line itself.
-  let bodyStart = changelog.indexOf("\n", start);
-  if (bodyStart === -1) return "";
-  bodyStart += 1;
-  // Next H2 at line start ends the section.
+  const escaped = version.replaceAll(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const headerRe = new RegExp(`^## ${escaped}\\s*$`, "m");
+  const headerMatch = headerRe.exec(changelog);
+  if (headerMatch === null || headerMatch.index === undefined) return null;
+  const start = headerMatch.index + headerMatch[0].length;
+  // Skip the rest of the header line if any trailing whitespace remained.
+  let bodyStart = start;
+  if (changelog[bodyStart] === "\n") bodyStart += 1;
   const rest = changelog.slice(bodyStart);
   const next = rest.search(/^## /m);
   const body = (next === -1 ? rest : rest.slice(0, next)).trim();

--- a/scripts/npm-publish-state.ts
+++ b/scripts/npm-publish-state.ts
@@ -1,0 +1,140 @@
+/**
+ * Helpers for "is this package.json version on npm?" — used by the release
+ * race-recovery publish step and the loud assert that forbids silent skips.
+ *
+ * Background: changesets/action is either/or. If any `.changeset/*.md` remains
+ * on main it only opens/updates the Version Packages PR and never publishes.
+ * Concurrent merges (Version Packages + a feature PR with a new changeset)
+ * leave version bumps on main, skip npm publish, and still exit green. These
+ * helpers make that drift detectable and recoverable.
+ */
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export type PackageVersion = {
+  /** Repo-relative package dir, e.g. "packages/core". */
+  dir: string;
+  name: string;
+  version: string;
+};
+
+/**
+ * Read name+version for every non-private package under packages/*.
+ * Sorted by dir for stable logs and tests.
+ */
+export function readPublishedPackageVersions(root: string): PackageVersion[] {
+  const packagesDir = join(root, "packages");
+  if (!existsSync(packagesDir)) return [];
+  const out: PackageVersion[] = [];
+  for (const entry of readdirSync(packagesDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const manifestPath = join(packagesDir, entry.name, "package.json");
+    if (!existsSync(manifestPath)) continue;
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as {
+      name?: string;
+      version?: string;
+      private?: boolean;
+    };
+    if (manifest.private === true) continue;
+    if (typeof manifest.name !== "string" || typeof manifest.version !== "string") continue;
+    out.push({
+      dir: `packages/${entry.name}`,
+      name: manifest.name,
+      version: manifest.version,
+    });
+  }
+  return out.toSorted((a, b) => a.dir.localeCompare(b.dir));
+}
+
+/** Registry URL for an exact package version (npm packument version endpoint). */
+export function npmVersionUrl(
+  name: string,
+  version: string,
+  registry = "https://registry.npmjs.org",
+): string {
+  // Scoped packages: @scope/name → @scope%2Fname on the registry path.
+  const encoded = name.startsWith("@") ? name.replace("/", "%2F") : name;
+  return `${registry.replace(/\/$/, "")}/${encoded}/${version}`;
+}
+
+/**
+ * True when the registry has this exact version.
+ * 404 → false; other non-OK responses throw (auth/network must not look like
+ * "not published" and green the assert).
+ */
+export async function npmVersionExists(
+  name: string,
+  version: string,
+  opts: {
+    fetchImpl?: typeof fetch;
+    registry?: string;
+  } = {},
+): Promise<boolean> {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const url = npmVersionUrl(name, version, opts.registry);
+  const res = await fetchImpl(url, {
+    headers: { accept: "application/json" },
+  });
+  if (res.status === 404) return false;
+  if (!res.ok) {
+    throw new Error(
+      `npm registry ${res.status} for ${name}@${version} (${url}): refuse to treat as unpublished`,
+    );
+  }
+  return true;
+}
+
+/** Packages whose local version is not in the set of "name@version" strings known on npm. */
+export function filterUnpublished(
+  local: readonly PackageVersion[],
+  publishedKeys: ReadonlySet<string>,
+): PackageVersion[] {
+  return local.filter((pkg) => !publishedKeys.has(`${pkg.name}@${pkg.version}`));
+}
+
+/** Parse `changeset publish` stdout for "New tag: <name>@<version>" lines. */
+export function parseNewTags(publishStdout: string): string[] {
+  const tags: string[] = [];
+  // changesets logs either "New tag: @scope/name@1.2.3" or "New tag: name@1.2.3"
+  const re = /New tag:\s+(\S+)/g;
+  for (const match of publishStdout.matchAll(re)) {
+    const tag = match[1];
+    if (tag) tags.push(tag);
+  }
+  return tags;
+}
+
+/**
+ * Extract the body of a package CHANGELOG section for `## <version>`.
+ * Returns null when the section is missing (caller decides how loud to be).
+ */
+export function changelogSectionForVersion(changelog: string, version: string): string | null {
+  const versionHeader = `## ${version}`;
+  const start = changelog.indexOf(versionHeader);
+  if (start === -1) return null;
+  // Skip the header line itself.
+  let bodyStart = changelog.indexOf("\n", start);
+  if (bodyStart === -1) return "";
+  bodyStart += 1;
+  // Next H2 at line start ends the section.
+  const rest = changelog.slice(bodyStart);
+  const next = rest.search(/^## /m);
+  const body = (next === -1 ? rest : rest.slice(0, next)).trim();
+  return body;
+}
+
+/** Human-readable failure for the assert gate. */
+export function formatUnpublishedFailure(unpublished: readonly PackageVersion[]): string {
+  const lines = unpublished.map((p) => `  - ${p.name}@${p.version} (${p.dir}/package.json)`);
+  return [
+    "ERROR: package.json versions on this commit are not on npm.",
+    "This is the silent-failure mode of changesets/action: when a Version",
+    "Packages PR merges while another PR leaves a new .changeset/*.md on main,",
+    "the action takes the 'update Version Packages PR' path and never publishes.",
+    "Unpublished packages:",
+    ...lines,
+    "Recovery: re-run the Release workflow (or merge any PR to main) so the",
+    "publish-unpublished step ships them; do not ignore a red assert.",
+  ].join("\n");
+}

--- a/scripts/npm-publish-state.ts
+++ b/scripts/npm-publish-state.ts
@@ -62,6 +62,10 @@ export function npmVersionUrl(
  * True when the registry has this exact version.
  * 404 → false; other non-OK responses throw (auth/network must not look like
  * "not published" and green the assert).
+ *
+ * `retries` + cache-busting query: post-publish paths often re-hit a URL that
+ * just returned 404 (negative CDN cache). Retry with backoff and `?t=` so a
+ * just-published version is not invisible for the rest of the job.
  */
 export async function npmVersionExists(
   name: string,
@@ -69,20 +73,46 @@ export async function npmVersionExists(
   opts: {
     fetchImpl?: typeof fetch;
     registry?: string;
+    /** Extra attempts after the first (default 0). */
+    retries?: number;
+    /** Sleep between retries in ms (default 1500). */
+    retryDelayMs?: number;
+    sleep?: (ms: number) => Promise<void>;
   } = {},
 ): Promise<boolean> {
   const fetchImpl = opts.fetchImpl ?? fetch;
-  const url = npmVersionUrl(name, version, opts.registry);
-  const res = await fetchImpl(url, {
-    headers: { accept: "application/json" },
-  });
-  if (res.status === 404) return false;
-  if (!res.ok) {
-    throw new Error(
-      `npm registry ${res.status} for ${name}@${version} (${url}): refuse to treat as unpublished`,
-    );
+  const retries = opts.retries ?? 0;
+  const retryDelayMs = opts.retryDelayMs ?? 1500;
+  const sleep =
+    opts.sleep ??
+    ((ms: number) =>
+      new Promise<void>((resolve) => {
+        setTimeout(() => {
+          resolve();
+        }, ms);
+      }));
+  const baseUrl = npmVersionUrl(name, version, opts.registry);
+
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    const url = attempt === 0 ? baseUrl : `${baseUrl}?t=${String(Date.now())}`;
+    const res = await fetchImpl(url, {
+      headers: { accept: "application/json", "cache-control": "no-cache" },
+    });
+    if (res.status === 404) {
+      if (attempt < retries) {
+        await sleep(retryDelayMs);
+        continue;
+      }
+      return false;
+    }
+    if (!res.ok) {
+      throw new Error(
+        `npm registry ${res.status} for ${name}@${version} (${url}): refuse to treat as unpublished`,
+      );
+    }
+    return true;
   }
-  return true;
+  return false;
 }
 
 /** Packages whose local version is not in the set of "name@version" strings known on npm. */
@@ -132,27 +162,39 @@ export function packageReleaseTag(name: string, version: string): string {
 }
 
 /**
- * Pure staging plan: one release entry per package whose version is already on npm.
- * Notes body comes from the caller (reads CHANGELOG). Used by stage-github-releases
- * so a later `gh`-only workflow step can mint tags without running repo code
- * while holding GITHUB_TOKEN — and so a re-run recovers tags for versions that
- * already landed on npm without a GitHub release.
+ * Pure staging plan: one release entry per package that should get a GitHub
+ * release. Include when the key is in `includeKeys` (on npm and/or just
+ * published this run — the latter covers registry visibility lag).
+ * Notes body comes from the caller (reads CHANGELOG).
  */
 export function planGithubReleaseStaging(
   local: readonly PackageVersion[],
-  onNpmKeys: ReadonlySet<string>,
+  includeKeys: ReadonlySet<string>,
   notesFor: (pkg: PackageVersion) => string,
 ): { tag: string; notes: string }[] {
   const out: { tag: string; notes: string }[] = [];
   for (const pkg of local) {
     const key = `${pkg.name}@${pkg.version}`;
-    if (!onNpmKeys.has(key)) continue;
+    if (!includeKeys.has(key)) continue;
     out.push({
       tag: packageReleaseTag(pkg.name, pkg.version),
       notes: notesFor(pkg),
     });
   }
   return out;
+}
+
+/**
+ * Parse a changesets-style tag `@scope/name@1.2.3` (or `name@1.2.3`) into
+ * name + version. Returns null when the shape is unusable.
+ */
+export function parsePackageReleaseTag(tag: string): { name: string; version: string } | null {
+  const at = tag.lastIndexOf("@");
+  if (at <= 0) return null;
+  const name = tag.slice(0, at);
+  const version = tag.slice(at + 1);
+  if (name.length === 0 || version.length === 0) return null;
+  return { name, version };
 }
 
 /** Human-readable failure for the assert gate. */

--- a/scripts/npm-publish-state.ts
+++ b/scripts/npm-publish-state.ts
@@ -126,6 +126,35 @@ export function changelogSectionForVersion(changelog: string, version: string): 
   return body;
 }
 
+/** Changesets-style tag for a package version (`@scope/name@1.2.3`). */
+export function packageReleaseTag(name: string, version: string): string {
+  return `${name}@${version}`;
+}
+
+/**
+ * Pure staging plan: one release entry per package whose version is already on npm.
+ * Notes body comes from the caller (reads CHANGELOG). Used by stage-github-releases
+ * so a later `gh`-only workflow step can mint tags without running repo code
+ * while holding GITHUB_TOKEN — and so a re-run recovers tags for versions that
+ * already landed on npm without a GitHub release.
+ */
+export function planGithubReleaseStaging(
+  local: readonly PackageVersion[],
+  onNpmKeys: ReadonlySet<string>,
+  notesFor: (pkg: PackageVersion) => string,
+): { tag: string; notes: string }[] {
+  const out: { tag: string; notes: string }[] = [];
+  for (const pkg of local) {
+    const key = `${pkg.name}@${pkg.version}`;
+    if (!onNpmKeys.has(key)) continue;
+    out.push({
+      tag: packageReleaseTag(pkg.name, pkg.version),
+      notes: notesFor(pkg),
+    });
+  }
+  return out;
+}
+
 /** Human-readable failure for the assert gate. */
 export function formatUnpublishedFailure(unpublished: readonly PackageVersion[]): string {
   const lines = unpublished.map((p) => `  - ${p.name}@${p.version} (${p.dir}/package.json)`);

--- a/scripts/publish-unpublished.ts
+++ b/scripts/publish-unpublished.ts
@@ -4,21 +4,23 @@
  * Decoupled from changesets/action on purpose. The action is either/or: any
  * leftover `.changeset/*.md` makes it open/update the Version Packages PR and
  * skip publish entirely (job still green). This script always ships whatever
- * is already version-bumped on main, recovering the concurrent-merge race,
- * then creates GitHub releases (and remote tags) for the new versions.
+ * is already version-bumped on main, recovering the concurrent-merge race.
+ *
+ * GitHub releases / tags are intentionally NOT created here. That work lives
+ * in a later workflow step that holds GITHUB_TOKEN and runs only `gh`/`git`,
+ * so the write credential never enters a process that executes repository
+ * code or node_modules (see stage-github-releases.ts + release.yml).
  *
  * Idempotent: if everything is already on npm, exits 0 with no work.
  *
  * Usage: bun scripts/publish-unpublished.ts
- * Requires: built packages (dist/), npm auth (OIDC trusted publishing or token),
- *           GITHUB_TOKEN so `gh release create` can mint tags + releases.
+ * Requires: built packages (dist/), npm auth (OIDC trusted publishing or token).
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { join } from "node:path";
 import {
-  changelogSectionForVersion,
   filterUnpublished,
   npmVersionExists,
   parseNewTags,
@@ -44,56 +46,6 @@ function run(
     throw new Error(`${command} ${args.join(" ")} exited ${String(status)}`);
   }
   return { status, stdout, stderr };
-}
-
-function gitHeadSha(): string {
-  const res = spawnSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" });
-  if (res.status !== 0) throw new Error("git rev-parse HEAD failed");
-  return (res.stdout ?? "").trim();
-}
-
-/**
- * Create the remote git tag + GitHub release via `gh` (uses GITHUB_TOKEN from
- * the env). Avoids embedding a basic-auth git remote URL in source — pre-push
- * redaction blocks those patterns, and checkout uses persist-credentials: false.
- * If the release already exists (retry), treat as success.
- */
-function createGithubRelease(tag: string, body: string, target: string): void {
-  const res = spawnSync(
-    "gh",
-    ["release", "create", tag, "--title", tag, "--notes", body, "--target", target],
-    { encoding: "utf8", env: process.env },
-  );
-  if (res.status === 0) {
-    if (res.stdout) process.stdout.write(res.stdout);
-    return;
-  }
-  const err = `${res.stderr ?? ""}${res.stdout ?? ""}`;
-  if (/already exists/i.test(err)) {
-    console.log(`GitHub release ${tag} already exists — ok`);
-    return;
-  }
-  if (res.stdout) process.stdout.write(res.stdout);
-  if (res.stderr) process.stderr.write(res.stderr);
-  throw new Error(`gh release create ${tag} exited ${String(res.status ?? 1)}`);
-}
-
-function releaseNotesForTag(root: string, tag: string): string {
-  // tag shape: @ggsvelte/core@0.24.1 → name=@ggsvelte/core, version=0.24.1
-  const at = tag.lastIndexOf("@");
-  if (at <= 0) {
-    return `Release ${tag}`;
-  }
-  const name = tag.slice(0, at);
-  const version = tag.slice(at + 1);
-  const local = readPublishedPackageVersions(root);
-  const pkg = local.find((p) => p.name === name);
-  if (!pkg) return `Release ${tag}`;
-  const changelogPath = join(root, pkg.dir, "CHANGELOG.md");
-  if (!existsSync(changelogPath)) return `Release ${tag}`;
-  const section = changelogSectionForVersion(readFileSync(changelogPath, "utf8"), version);
-  if (section === null || section.length === 0) return `Release ${tag}`;
-  return section;
 }
 
 async function main(): Promise<number> {
@@ -158,22 +110,12 @@ async function main(): Promise<number> {
     return 0;
   }
 
-  const githubToken = process.env["GITHUB_TOKEN"];
-  if (githubToken === undefined || githubToken.length === 0) {
-    console.error(
-      "publish-unpublished: GITHUB_TOKEN is required so gh can create tags and releases",
-    );
-    return 1;
-  }
-
-  const head = gitHeadSha();
+  console.log(
+    `publish-unpublished: published ${String(tags.length)} tag(s); GitHub releases staged next`,
+  );
   for (const tag of tags) {
-    const notes = releaseNotesForTag(root, tag);
-    console.log(`creating GitHub release + remote tag ${tag}`);
-    createGithubRelease(tag, notes, head);
+    console.log(`  - ${tag}`);
   }
-
-  console.log(`publish-unpublished: published and released ${String(tags.length)} tag(s)`);
   return 0;
 }
 

--- a/scripts/publish-unpublished.ts
+++ b/scripts/publish-unpublished.ts
@@ -38,9 +38,9 @@ function run(
   const status = res.status ?? 1;
   const stdout = res.stdout ?? "";
   const stderr = res.stderr ?? "";
-  if (stdout) process.stdout.write(stdout);
-  if (stderr) process.stderr.write(stderr);
-  if (status !== 0 && !opts.allowFail) {
+  if (stdout.length > 0) process.stdout.write(stdout);
+  if (stderr.length > 0) process.stderr.write(stderr);
+  if (status !== 0 && opts.allowFail !== true) {
     throw new Error(`${command} ${args.join(" ")} exited ${String(status)}`);
   }
   return { status, stdout, stderr };
@@ -158,7 +158,8 @@ async function main(): Promise<number> {
     return 0;
   }
 
-  if (!process.env["GITHUB_TOKEN"]) {
+  const githubToken = process.env["GITHUB_TOKEN"];
+  if (githubToken === undefined || githubToken.length === 0) {
     console.error(
       "publish-unpublished: GITHUB_TOKEN is required so gh can create tags and releases",
     );

--- a/scripts/publish-unpublished.ts
+++ b/scripts/publish-unpublished.ts
@@ -18,11 +18,12 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import {
   filterUnpublished,
   npmVersionExists,
+  packageReleaseTag,
   parseNewTags,
   readPublishedPackageVersions,
 } from "./npm-publish-state.ts";
@@ -88,13 +89,14 @@ async function main(): Promise<number> {
     return publish.status;
   }
 
-  const tags = parseNewTags(publish.stdout);
+  let tags = parseNewTags(publish.stdout);
   if (tags.length === 0) {
     // Registry can race (another runner published between our check and publish).
-    // Re-check; if still missing, fail loud.
+    // Re-check with retries; if still missing, fail loud. If present, treat the
+    // unpublished set as published for the staging hand-off.
     const stillMissing: string[] = [];
     for (const pkg of unpublished) {
-      if (!(await npmVersionExists(pkg.name, pkg.version))) {
+      if (!(await npmVersionExists(pkg.name, pkg.version, { retries: 5, retryDelayMs: 2000 }))) {
         stillMissing.push(`${pkg.name}@${pkg.version}`);
       }
     }
@@ -107,7 +109,22 @@ async function main(): Promise<number> {
     console.log(
       "publish-unpublished: versions appeared on npm without new tags (concurrent publish?)",
     );
-    return 0;
+    tags = unpublished.map((pkg) => packageReleaseTag(pkg.name, pkg.version));
+  }
+
+  // Hand just-published tags to stage-github-releases so registry lag cannot
+  // drop them from the GitHub release list (negative CDN cache after 404 probes).
+  const staging = process.env["RELEASE_STAGING_DIR"];
+  if (staging !== undefined && staging.length > 0) {
+    mkdirSync(staging, { recursive: true });
+    writeFileSync(
+      join(staging, "just-published.txt"),
+      tags.length === 0 ? "" : `${tags.join("\n")}\n`,
+      "utf8",
+    );
+    console.log(
+      `publish-unpublished: wrote ${String(tags.length)} just-published tag(s) for staging`,
+    );
   }
 
   console.log(

--- a/scripts/publish-unpublished.ts
+++ b/scripts/publish-unpublished.ts
@@ -1,0 +1,186 @@
+/**
+ * Publish every package.json version under packages/ that is not yet on npm.
+ *
+ * Decoupled from changesets/action on purpose. The action is either/or: any
+ * leftover `.changeset/*.md` makes it open/update the Version Packages PR and
+ * skip publish entirely (job still green). This script always ships whatever
+ * is already version-bumped on main, recovering the concurrent-merge race,
+ * then creates GitHub releases (and remote tags) for the new versions.
+ *
+ * Idempotent: if everything is already on npm, exits 0 with no work.
+ *
+ * Usage: bun scripts/publish-unpublished.ts
+ * Requires: built packages (dist/), npm auth (OIDC trusted publishing or token),
+ *           GITHUB_TOKEN so `gh release create` can mint tags + releases.
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  changelogSectionForVersion,
+  filterUnpublished,
+  npmVersionExists,
+  parseNewTags,
+  readPublishedPackageVersions,
+} from "./npm-publish-state.ts";
+
+function run(
+  command: string,
+  args: string[],
+  opts: { allowFail?: boolean } = {},
+): { status: number; stdout: string; stderr: string } {
+  const res = spawnSync(command, args, {
+    encoding: "utf8",
+    env: process.env,
+    cwd: process.cwd(),
+  });
+  const status = res.status ?? 1;
+  const stdout = res.stdout ?? "";
+  const stderr = res.stderr ?? "";
+  if (stdout) process.stdout.write(stdout);
+  if (stderr) process.stderr.write(stderr);
+  if (status !== 0 && !opts.allowFail) {
+    throw new Error(`${command} ${args.join(" ")} exited ${String(status)}`);
+  }
+  return { status, stdout, stderr };
+}
+
+function gitHeadSha(): string {
+  const res = spawnSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" });
+  if (res.status !== 0) throw new Error("git rev-parse HEAD failed");
+  return (res.stdout ?? "").trim();
+}
+
+/**
+ * Create the remote git tag + GitHub release via `gh` (uses GITHUB_TOKEN from
+ * the env). Avoids embedding a basic-auth git remote URL in source — pre-push
+ * redaction blocks those patterns, and checkout uses persist-credentials: false.
+ * If the release already exists (retry), treat as success.
+ */
+function createGithubRelease(tag: string, body: string, target: string): void {
+  const res = spawnSync(
+    "gh",
+    ["release", "create", tag, "--title", tag, "--notes", body, "--target", target],
+    { encoding: "utf8", env: process.env },
+  );
+  if (res.status === 0) {
+    if (res.stdout) process.stdout.write(res.stdout);
+    return;
+  }
+  const err = `${res.stderr ?? ""}${res.stdout ?? ""}`;
+  if (/already exists/i.test(err)) {
+    console.log(`GitHub release ${tag} already exists — ok`);
+    return;
+  }
+  if (res.stdout) process.stdout.write(res.stdout);
+  if (res.stderr) process.stderr.write(res.stderr);
+  throw new Error(`gh release create ${tag} exited ${String(res.status ?? 1)}`);
+}
+
+function releaseNotesForTag(root: string, tag: string): string {
+  // tag shape: @ggsvelte/core@0.24.1 → name=@ggsvelte/core, version=0.24.1
+  const at = tag.lastIndexOf("@");
+  if (at <= 0) {
+    return `Release ${tag}`;
+  }
+  const name = tag.slice(0, at);
+  const version = tag.slice(at + 1);
+  const local = readPublishedPackageVersions(root);
+  const pkg = local.find((p) => p.name === name);
+  if (!pkg) return `Release ${tag}`;
+  const changelogPath = join(root, pkg.dir, "CHANGELOG.md");
+  if (!existsSync(changelogPath)) return `Release ${tag}`;
+  const section = changelogSectionForVersion(readFileSync(changelogPath, "utf8"), version);
+  if (section === null || section.length === 0) return `Release ${tag}`;
+  return section;
+}
+
+async function main(): Promise<number> {
+  const root = process.cwd();
+  const local = readPublishedPackageVersions(root);
+  if (local.length === 0) {
+    console.error("publish-unpublished: no published packages under packages/");
+    return 1;
+  }
+
+  const publishedKeys = new Set<string>();
+  for (const pkg of local) {
+    if (await npmVersionExists(pkg.name, pkg.version)) {
+      publishedKeys.add(`${pkg.name}@${pkg.version}`);
+    }
+  }
+  const unpublished = filterUnpublished(local, publishedKeys);
+  if (unpublished.length === 0) {
+    console.log("publish-unpublished: nothing to do — all package versions are on npm");
+    return 0;
+  }
+
+  console.log(
+    `publish-unpublished: shipping ${String(unpublished.length)} unpublished version(s):`,
+  );
+  for (const pkg of unpublished) {
+    console.log(`  - ${pkg.name}@${pkg.version}`);
+  }
+
+  // Lockfile-installed binary — repo policy bans network bunx.
+  const changesetBin = join(root, "node_modules/.bin/changeset");
+  if (!existsSync(changesetBin)) {
+    console.error("publish-unpublished: node_modules/.bin/changeset missing; run bun install");
+    return 1;
+  }
+
+  const publish = run("bun", [changesetBin, "publish"], { allowFail: true });
+  if (publish.status !== 0) {
+    console.error(`publish-unpublished: changeset publish exited ${String(publish.status)}`);
+    return publish.status;
+  }
+
+  const tags = parseNewTags(publish.stdout);
+  if (tags.length === 0) {
+    // Registry can race (another runner published between our check and publish).
+    // Re-check; if still missing, fail loud.
+    const stillMissing: string[] = [];
+    for (const pkg of unpublished) {
+      if (!(await npmVersionExists(pkg.name, pkg.version))) {
+        stillMissing.push(`${pkg.name}@${pkg.version}`);
+      }
+    }
+    if (stillMissing.length > 0) {
+      console.error(
+        `publish-unpublished: publish produced no "New tag:" lines and still missing:\n  - ${stillMissing.join("\n  - ")}`,
+      );
+      return 1;
+    }
+    console.log(
+      "publish-unpublished: versions appeared on npm without new tags (concurrent publish?)",
+    );
+    return 0;
+  }
+
+  if (!process.env["GITHUB_TOKEN"]) {
+    console.error(
+      "publish-unpublished: GITHUB_TOKEN is required so gh can create tags and releases",
+    );
+    return 1;
+  }
+
+  const head = gitHeadSha();
+  for (const tag of tags) {
+    const notes = releaseNotesForTag(root, tag);
+    console.log(`creating GitHub release + remote tag ${tag}`);
+    createGithubRelease(tag, notes, head);
+  }
+
+  console.log(`publish-unpublished: published and released ${String(tags.length)} tag(s)`);
+  return 0;
+}
+
+if (import.meta.main) {
+  try {
+    process.exit(await main());
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : err);
+    process.exit(1);
+  }
+}

--- a/scripts/release-wiring.test.ts
+++ b/scripts/release-wiring.test.ts
@@ -848,3 +848,47 @@ it("uses job-private Bun caches across CI workflows (issue #319)", () => {
     );
   }
 });
+
+describe("release.yml concurrent-merge race recovery", () => {
+  const release = () => read(".github/workflows/release.yml");
+
+  it("queues releases and never cancels an in-flight publish", () => {
+    const yml = release();
+    expect(yml).toMatch(/concurrency:\s*\n\s*group:\s*release/);
+    expect(yml).toContain("cancel-in-progress: false");
+  });
+
+  it("does not pass publish to changesets/action (publish is decoupled)", () => {
+    // changesets/action is either/or: any leftover .changeset/*.md makes it
+    // skip publish while staying green. Publish lives in a separate step so
+    // concurrent feature merges cannot suppress shipping already-bumped versions.
+    const yml = release();
+    expect(yml).toContain("changesets/action@");
+    expect(yml).toContain("changesets — open/update Version Packages PR");
+    // No changesets/action `publish:` input anywhere in the workflow. The
+    // publish command lives only in publish-unpublished.ts.
+    expect(yml).not.toMatch(/publish:\s*bun node_modules/);
+    expect(yml).not.toMatch(/publish:\s*changeset/);
+  });
+
+  it("publishes unpublished versions then asserts npm parity when enabled", () => {
+    const yml = release();
+    expect(yml).toContain("bun scripts/publish-unpublished.ts");
+    expect(yml).toContain("bun scripts/assert-npm-published.ts");
+    expect(yml).toContain("vars.NPM_PUBLISH_ENABLED == 'true'");
+    // Both gates share the enable flag; publish must come before assert.
+    const publishAt = yml.indexOf("bun scripts/publish-unpublished.ts");
+    const assertAt = yml.indexOf("bun scripts/assert-npm-published.ts");
+    expect(publishAt).toBeGreaterThan(-1);
+    expect(assertAt).toBeGreaterThan(publishAt);
+  });
+
+  it("keeps OIDC trusted publishing (no NPM_TOKEN secret)", () => {
+    const yml = release();
+    expect(yml).toContain("id-token: write");
+    expect(yml).toContain("registry-url: https://registry.npmjs.org");
+    // Comments may name NPM_TOKEN when forbidding it; the secret must not be wired.
+    expect(yml).not.toMatch(/secrets\.NPM_TOKEN/);
+    expect(yml).not.toMatch(/NPM_TOKEN:\s*\$\{\{/);
+  });
+});

--- a/scripts/release-wiring.test.ts
+++ b/scripts/release-wiring.test.ts
@@ -871,16 +871,20 @@ describe("release.yml concurrent-merge race recovery", () => {
     expect(yml).not.toMatch(/publish:\s*changeset/);
   });
 
-  it("publishes unpublished versions then asserts npm parity when enabled", () => {
+  it("publishes and asserts on the main tip before the version-PR step", () => {
     const yml = release();
     expect(yml).toContain("bun scripts/publish-unpublished.ts");
     expect(yml).toContain("bun scripts/assert-npm-published.ts");
     expect(yml).toContain("vars.NPM_PUBLISH_ENABLED == 'true'");
-    // Both gates share the enable flag; publish must come before assert.
+    // Publish → assert → version PR. Publish must not run after
+    // changesets/action, which leaves the workspace on changeset-release/main
+    // with unreviewed next-version package.json files.
     const publishAt = yml.indexOf("bun scripts/publish-unpublished.ts");
     const assertAt = yml.indexOf("bun scripts/assert-npm-published.ts");
+    const versionAt = yml.indexOf("changesets — open/update Version Packages PR");
     expect(publishAt).toBeGreaterThan(-1);
     expect(assertAt).toBeGreaterThan(publishAt);
+    expect(versionAt).toBeGreaterThan(assertAt);
   });
 
   it("keeps OIDC trusted publishing (no NPM_TOKEN secret)", () => {

--- a/scripts/release-wiring.test.ts
+++ b/scripts/release-wiring.test.ts
@@ -871,20 +871,58 @@ describe("release.yml concurrent-merge race recovery", () => {
     expect(yml).not.toMatch(/publish:\s*changeset/);
   });
 
-  it("publishes and asserts on the main tip before the version-PR step", () => {
+  it("publishes, stages, tags, and asserts on the main tip before the version-PR step", () => {
     const yml = release();
     expect(yml).toContain("bun scripts/publish-unpublished.ts");
+    expect(yml).toContain("bun scripts/stage-github-releases.ts");
     expect(yml).toContain("bun scripts/assert-npm-published.ts");
+    expect(yml).toContain("gh release create");
     expect(yml).toContain("vars.NPM_PUBLISH_ENABLED == 'true'");
-    // Publish → assert → version PR. Publish must not run after
-    // changesets/action, which leaves the workspace on changeset-release/main
-    // with unreviewed next-version package.json files.
+    // Publish → stage → gh-create → assert → version PR. Publish must not run
+    // after changesets/action, which leaves the workspace on
+    // changeset-release/main with unreviewed next-version package.json files.
     const publishAt = yml.indexOf("bun scripts/publish-unpublished.ts");
+    const stageAt = yml.indexOf("bun scripts/stage-github-releases.ts");
+    const createAt = yml.indexOf("gh release create");
     const assertAt = yml.indexOf("bun scripts/assert-npm-published.ts");
     const versionAt = yml.indexOf("changesets — open/update Version Packages PR");
     expect(publishAt).toBeGreaterThan(-1);
-    expect(assertAt).toBeGreaterThan(publishAt);
+    expect(stageAt).toBeGreaterThan(publishAt);
+    expect(createAt).toBeGreaterThan(stageAt);
+    expect(assertAt).toBeGreaterThan(createAt);
     expect(versionAt).toBeGreaterThan(assertAt);
+  });
+
+  it("keeps the write credential out of publish and staging (bun) steps", () => {
+    // Same shape as the vr-approve invariant: steps that run repository code
+    // must not hold GITHUB_TOKEN. Tagging is a later gh-only step.
+    const yml = release();
+    const steps = yml.split("\n      - name: ").slice(1);
+    expect(steps.length).toBeGreaterThan(5);
+
+    for (const step of steps) {
+      const label = step.split("\n")[0] ?? "";
+      const holdsToken = /^\s+GITHUB_TOKEN: /m.test(step);
+      const runsBun = /\brun: bun\b/.test(step) || /\n\s+bun scripts\//.test(step);
+      if (holdsToken && runsBun) {
+        throw new Error(`release.yml bun step holds GITHUB_TOKEN: ${label}`);
+      }
+    }
+
+    // Publish and stage are the recovery scripts; they must stay token-free.
+    const publishStep = steps.find((s) => s.includes("bun scripts/publish-unpublished.ts"));
+    const stageStep = steps.find((s) => s.includes("bun scripts/stage-github-releases.ts"));
+    expect(publishStep, "publish step present").toBeDefined();
+    expect(stageStep, "stage step present").toBeDefined();
+    expect(publishStep).not.toMatch(/GITHUB_TOKEN:/);
+    expect(stageStep).not.toMatch(/GITHUB_TOKEN:/);
+
+    // Create step holds the token and must stay script-free (gh/git only).
+    const createStep = steps.find((s) => s.includes("gh release create"));
+    expect(createStep, "create-releases step present").toBeDefined();
+    expect(createStep).toMatch(/GITHUB_TOKEN:/);
+    expect(createStep).not.toMatch(/\brun: bun\b/);
+    expect(createStep).not.toMatch(/\n\s+bun \S/);
   });
 
   it("keeps OIDC trusted publishing (no NPM_TOKEN secret)", () => {

--- a/scripts/stage-github-releases.ts
+++ b/scripts/stage-github-releases.ts
@@ -1,25 +1,35 @@
 /**
- * Stage GitHub release notes for every packages/* version already on npm.
+ * Stage GitHub release notes for package versions that need a release entry.
  *
  * Runs WITHOUT GITHUB_TOKEN. Writes a staging directory that a later
  * script-free workflow step (`gh`/`git` only) consumes to create tags and
- * GitHub releases. Staging every version that is on npm (not only tags from
- * this run's publish) recovers the case where publish succeeded but tagging
- * failed — a re-run re-stages and the create step is idempotent.
+ * GitHub releases.
+ *
+ * Include set:
+ *   - every local packages/* version that is already on npm (recovery), and
+ *   - every tag listed in just-published.txt from this run's publish step
+ *     (covers registry visibility lag after a successful publish).
+ *
+ * Per-tag target commits: prefer the last commit that introduced that
+ * package.json version (so recovery tags do not point at unrelated HEAD work);
+ * fall back to HEAD when git history cannot resolve it.
  *
  * Staging layout (RELEASE_STAGING_DIR):
- *   tags.txt     one tag per line, in order
- *   notes/0.md   notes for tags.txt line 0
- *   notes/1.md   …
+ *   tags.txt        one tag per line, in order
+ *   notes/0.md      notes for tags.txt line 0
+ *   targets/0.txt   commit SHA for that tag
+ *   just-published.txt  (optional input from publish-unpublished)
  *
  * Usage: RELEASE_STAGING_DIR=/tmp/stage bun scripts/stage-github-releases.ts
  */
 
+import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import {
   changelogSectionForVersion,
   npmVersionExists,
+  parsePackageReleaseTag,
   planGithubReleaseStaging,
   readPublishedPackageVersions,
   type PackageVersion,
@@ -32,6 +42,48 @@ function notesForPackage(root: string, pkg: PackageVersion): string {
   const section = changelogSectionForVersion(readFileSync(changelogPath, "utf8"), pkg.version);
   if (section === null || section.length === 0) return `Release ${tag}`;
   return section;
+}
+
+function gitHeadSha(): string {
+  const res = spawnSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" });
+  if (res.status !== 0) throw new Error("git rev-parse HEAD failed");
+  return (res.stdout ?? "").trim();
+}
+
+/**
+ * Last commit that introduced `"version": "<v>"` into this package.json.
+ * Falls back to HEAD when the search finds nothing (shallow clone, etc.).
+ */
+export function commitForPackageVersion(
+  pkg: PackageVersion,
+  head: string,
+  gitLog: (args: string[]) => string | null = defaultGitLog,
+): string {
+  const needle = `"version": "${pkg.version}"`;
+  const sha = gitLog(["log", "-1", "--format=%H", "-S", needle, "--", `${pkg.dir}/package.json`]);
+  if (sha !== null && sha.length > 0) return sha;
+  return head;
+}
+
+function defaultGitLog(args: string[]): string | null {
+  const res = spawnSync("git", args, { encoding: "utf8" });
+  if (res.status !== 0) return null;
+  const out = (res.stdout ?? "").trim();
+  return out.length > 0 ? out : null;
+}
+
+function readJustPublishedTags(staging: string): Set<string> {
+  const path = join(staging, "just-published.txt");
+  if (!existsSync(path)) return new Set();
+  const keys = new Set<string>();
+  for (const line of readFileSync(path, "utf8").split("\n")) {
+    const tag = line.trim();
+    if (tag.length === 0) continue;
+    const parsed = parsePackageReleaseTag(tag);
+    if (parsed === null) continue;
+    keys.add(`${parsed.name}@${parsed.version}`);
+  }
+  return keys;
 }
 
 async function main(): Promise<number> {
@@ -48,23 +100,30 @@ async function main(): Promise<number> {
     return 1;
   }
 
-  const onNpmKeys = new Set<string>();
+  const includeKeys = readJustPublishedTags(staging);
   for (const pkg of local) {
-    if (await npmVersionExists(pkg.name, pkg.version)) {
-      onNpmKeys.add(`${pkg.name}@${pkg.version}`);
+    // Retries: post-publish negative-cache lag after publish-unpublished's 404 probes.
+    if (await npmVersionExists(pkg.name, pkg.version, { retries: 5, retryDelayMs: 2000 })) {
+      includeKeys.add(`${pkg.name}@${pkg.version}`);
     }
   }
 
-  const entries = planGithubReleaseStaging(local, onNpmKeys, (pkg) => notesForPackage(root, pkg));
+  const entries = planGithubReleaseStaging(local, includeKeys, (pkg) => notesForPackage(root, pkg));
+  const head = gitHeadSha();
+  const byTag = new Map(local.map((pkg) => [`${pkg.name}@${pkg.version}`, pkg] as const));
 
   mkdirSync(join(staging, "notes"), { recursive: true });
+  mkdirSync(join(staging, "targets"), { recursive: true });
   const tagLines: string[] = [];
   for (let i = 0; i < entries.length; i++) {
     const entry = entries[i];
     if (entry === undefined) continue;
     writeFileSync(join(staging, "notes", `${String(i)}.md`), entry.notes, "utf8");
+    const pkg = byTag.get(entry.tag);
+    const target = pkg === undefined ? head : commitForPackageVersion(pkg, head);
+    writeFileSync(join(staging, "targets", `${String(i)}.txt`), `${target}\n`, "utf8");
     tagLines.push(entry.tag);
-    console.log(`staged ${entry.tag}`);
+    console.log(`staged ${entry.tag} → ${target}`);
   }
   writeFileSync(
     join(staging, "tags.txt"),

--- a/scripts/stage-github-releases.ts
+++ b/scripts/stage-github-releases.ts
@@ -1,0 +1,88 @@
+/**
+ * Stage GitHub release notes for every packages/* version already on npm.
+ *
+ * Runs WITHOUT GITHUB_TOKEN. Writes a staging directory that a later
+ * script-free workflow step (`gh`/`git` only) consumes to create tags and
+ * GitHub releases. Staging every version that is on npm (not only tags from
+ * this run's publish) recovers the case where publish succeeded but tagging
+ * failed — a re-run re-stages and the create step is idempotent.
+ *
+ * Staging layout (RELEASE_STAGING_DIR):
+ *   tags.txt     one tag per line, in order
+ *   notes/0.md   notes for tags.txt line 0
+ *   notes/1.md   …
+ *
+ * Usage: RELEASE_STAGING_DIR=/tmp/stage bun scripts/stage-github-releases.ts
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  changelogSectionForVersion,
+  npmVersionExists,
+  planGithubReleaseStaging,
+  readPublishedPackageVersions,
+  type PackageVersion,
+} from "./npm-publish-state.ts";
+
+function notesForPackage(root: string, pkg: PackageVersion): string {
+  const tag = `${pkg.name}@${pkg.version}`;
+  const changelogPath = join(root, pkg.dir, "CHANGELOG.md");
+  if (!existsSync(changelogPath)) return `Release ${tag}`;
+  const section = changelogSectionForVersion(readFileSync(changelogPath, "utf8"), pkg.version);
+  if (section === null || section.length === 0) return `Release ${tag}`;
+  return section;
+}
+
+async function main(): Promise<number> {
+  const staging = process.env["RELEASE_STAGING_DIR"];
+  if (staging === undefined || staging.length === 0) {
+    console.error("stage-github-releases: RELEASE_STAGING_DIR is required");
+    return 1;
+  }
+
+  const root = process.cwd();
+  const local = readPublishedPackageVersions(root);
+  if (local.length === 0) {
+    console.error("stage-github-releases: no published packages under packages/");
+    return 1;
+  }
+
+  const onNpmKeys = new Set<string>();
+  for (const pkg of local) {
+    if (await npmVersionExists(pkg.name, pkg.version)) {
+      onNpmKeys.add(`${pkg.name}@${pkg.version}`);
+    }
+  }
+
+  const entries = planGithubReleaseStaging(local, onNpmKeys, (pkg) => notesForPackage(root, pkg));
+
+  mkdirSync(join(staging, "notes"), { recursive: true });
+  const tagLines: string[] = [];
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i];
+    if (entry === undefined) continue;
+    writeFileSync(join(staging, "notes", `${String(i)}.md`), entry.notes, "utf8");
+    tagLines.push(entry.tag);
+    console.log(`staged ${entry.tag}`);
+  }
+  writeFileSync(
+    join(staging, "tags.txt"),
+    tagLines.length === 0 ? "" : `${tagLines.join("\n")}\n`,
+    "utf8",
+  );
+
+  console.log(
+    `stage-github-releases: staged ${String(tagLines.length)} release(s) under ${staging}`,
+  );
+  return 0;
+}
+
+if (import.meta.main) {
+  try {
+    process.exit(await main());
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : err);
+    process.exit(1);
+  }
+}

--- a/scripts/stage-github-releases.ts
+++ b/scripts/stage-github-releases.ts
@@ -110,7 +110,9 @@ async function main(): Promise<number> {
 
   const entries = planGithubReleaseStaging(local, includeKeys, (pkg) => notesForPackage(root, pkg));
   const head = gitHeadSha();
-  const byTag = new Map(local.map((pkg) => [`${pkg.name}@${pkg.version}`, pkg] as const));
+  const byTag = new Map<string, PackageVersion>(
+    local.map((pkg) => [`${pkg.name}@${pkg.version}`, pkg]),
+  );
 
   mkdirSync(join(staging, "notes"), { recursive: true });
   mkdirSync(join(staging, "targets"), { recursive: true });


### PR DESCRIPTION
## Summary

`changesets/action` is either/or: if any leftover `.changeset/*.md` remains on
main, it only opens/updates the Version Packages PR and **never publishes**,
still exiting green. When a Version Packages PR merges while another feature PR
lands a new changeset in the same window (daily multi-agent traffic — most
recently #1347 vs #1350), version bumps sit on main and never reach npm.

That is the silent failure.

## Fix

1. **Decouple publish from the action.** `changesets/action` only maintains the
   Version Packages PR (no `publish` input).
2. **`scripts/publish-unpublished.ts`** always ships any `package.json` version
   on main that is missing from npm (idempotent; creates GitHub releases + remote tags).
3. **`scripts/assert-npm-published.ts`** fails the Release job if any package
   version on the commit is still missing from npm — no more green skips.

Concurrency stays `group: release` / `cancel-in-progress: false` so publishes
serialize.

## Side effect after merge

`@ggsvelte/*@0.24.1` is currently on main and **not** on npm (the #1347/#1350
race). The next Release run on main will publish 0.24.1 via the recovery step,
then assert green. The leftover `sf-geometry-push-spread` changeset keeps
Version Packages open for 0.24.2.

## Tests

- `bun test scripts/npm-publish-state.test.ts scripts/release-wiring.test.ts`
- `bun run check:scripts`
- Live smoke: `assert-npm-published` correctly reports 0.24.1 as MISS

## Validation

```
bun test scripts/npm-publish-state.test.ts scripts/release-wiring.test.ts
# 43 pass
bun run check:scripts
# clean
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1353" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->