### PR TITLE
perf(core): interpolate statAlign from the merge cursor

### DIFF
--- a/.changeset/stat-align-cursor-lerp.md
+++ b/.changeset/stat-align-cursor-lerp.md
@@ -1,0 +1,12 @@
+---
+"@ggsvelte/core": patch
+---
+
+# Interpolate statAlign from the merge cursor
+
+Migration: none — same aligned grid, y values, and source-row lineage; lower cost on large G·U expansions.
+
+`statAlign` no longer binary-searches each group's series once per shared-grid
+x. The merge cursor already used for source-row lineage supplies the
+interpolation bracket, so the per-output-row path is linear in the expansion
+size.

--- a/packages/core/src/stats/align.ts
+++ b/packages/core/src/stats/align.ts
@@ -125,18 +125,33 @@ export function statAlign(input: StatAlignInput): StatAlignResult {
     const series = seriesFromRows(x, y, rows);
     if (series === null) continue;
     const rep = rows[0]!;
-    // Grid and series are both ascending; a merge pointer finds the group's
-    // own samples so those output rows keep their source-row lineage.
+    // Grid and series are both ascending. One merge cursor advances to the
+    // first sample with xs[cursor] >= xq and supplies both source-row lineage
+    // and the interpolation bracket (right endpoint, or exact hit). That
+    // replaces a binary search per grid point (#1336).
     let cursor = 0;
+    const xs = series.xs;
+    const ys = series.ys;
+    const n = xs.length;
     for (let i = 0; i < grid.length; i++) {
       const xq = grid[i]!;
+      while (cursor < n && xs[cursor]! < xq) cursor++;
+      let yq = 0;
+      if (cursor < n && xs[cursor] === xq) {
+        yq = ys[cursor]!;
+      } else if (cursor > 0 && cursor < n) {
+        const x0 = xs[cursor - 1]!;
+        const y0 = ys[cursor - 1]!;
+        const x1 = xs[cursor]!;
+        const y1 = ys[cursor]!;
+        const t = (xq - x0) / (x1 - x0);
+        yq = y0 + t * (y1 - y0);
+      }
+      // else: cursor === 0 (before first) or cursor === n (after last) → 0
       outX.push(xq);
-      outY.push(lerpSeries(series.xs, series.ys, xq));
+      outY.push(yq);
       outG.push(g);
-      while (cursor < series.xs.length && series.xs[cursor]! < xq) cursor++;
-      outRow.push(
-        cursor < series.xs.length && series.xs[cursor] === xq ? series.rows[cursor]! : -1,
-      );
+      outRow.push(cursor < n && xs[cursor] === xq ? series.rows[cursor]! : -1);
       for (const key of Object.keys(carriedOut)) {
         carriedOut[key]!.push(carried[key]![rep]!);
       }

--- a/packages/core/tests/stats-align.test.ts
+++ b/packages/core/tests/stats-align.test.ts
@@ -54,4 +54,67 @@ describe("statAlign", () => {
     expect(result.carried.g![0]).toBe("a");
     expect(result.carried.g![3]).toBe("b");
   });
+
+  // Characterization for #1336: grid may start before / end after / land on
+  // samples; single-sample groups; sourceRows only on exact sample hits.
+  it("zeros before a group's first sample and after its last", () => {
+    // Group 0 spans [2,4]; union grid adds 0 and 6 from group 1.
+    const result = statAlign({
+      x: Float64Array.of(2, 4, 0, 6),
+      y: Float64Array.of(10, 20, 1, 1),
+      groups: [0, 0, 1, 1],
+      carried: {},
+    });
+    // grid [0,2,4,6]; group 0 first (rows 0-3)
+    expect([...result.x.subarray(0, 4)]).toEqual([0, 2, 4, 6]);
+    expect(result.y[0]).toBe(0); // before first
+    expect(result.y[1]).toBeCloseTo(10, 12); // exact
+    expect(result.y[2]).toBeCloseTo(20, 12); // exact
+    expect(result.y[3]).toBe(0); // after last
+    expect([...result.sourceRows.subarray(0, 4)]).toEqual([-1, 0, 1, -1]);
+  });
+
+  it("interpolates interior grid points between a group's samples", () => {
+    // Group 0: (0,0), (4,8); group 1 seeds grid x=2.
+    const result = statAlign({
+      x: Float64Array.of(0, 4, 2),
+      y: Float64Array.of(0, 8, 99),
+      groups: [0, 0, 1],
+      carried: {},
+    });
+    // grid [0,2,4]; group 0 rows 0-2
+    expect(result.y[0]).toBeCloseTo(0, 12);
+    expect(result.y[1]).toBeCloseTo(4, 12); // midpoint
+    expect(result.y[2]).toBeCloseTo(8, 12);
+    expect([...result.sourceRows.subarray(0, 3)]).toEqual([0, -1, 1]);
+  });
+
+  it("handles a single-sample group on a multi-point grid", () => {
+    // Group 0 only at x=1; group 1 owns 0 and 2.
+    const result = statAlign({
+      x: Float64Array.of(1, 0, 2),
+      y: Float64Array.of(7, 1, 1),
+      groups: [0, 1, 1],
+      carried: {},
+    });
+    // grid [0,1,2]; group 0 rows 0-2
+    expect([...result.y.subarray(0, 3)]).toEqual([0, 7, 0]);
+    expect([...result.sourceRows.subarray(0, 3)]).toEqual([-1, 0, -1]);
+  });
+
+  it("keeps last-wins y and source row on duplicate x within a group", () => {
+    const result = statAlign({
+      x: Float64Array.of(0, 0, 2, 1),
+      y: Float64Array.of(3, 9, 4, 50),
+      groups: [0, 0, 0, 1],
+      carried: {},
+    });
+    // grid [0,1,2]; group 0 rows 0-2 — at x=0 last-wins y=9, source row=1
+    expect(result.y[0]).toBeCloseTo(9, 12);
+    expect(result.y[1]).toBeCloseTo(6.5, 12); // lerp 9→4 at x=1
+    expect(result.y[2]).toBeCloseTo(4, 12);
+    expect(result.sourceRows[0]).toBe(1);
+    expect(result.sourceRows[1]).toBe(-1);
+    expect(result.sourceRows[2]).toBe(2);
+  });
 });


### PR DESCRIPTION
Fixes #1336

## What

`statAlign` expands every group onto the shared unique-x grid. The per-grid
loop already kept a monotone merge cursor for source-row lineage, then called
`lerpSeries`, which binary-searched the same ascending series for the rightmost
`xs[i] <= xq` — the bracket the cursor already holds.

- **Before:** Θ(G · U · log m) on the grid loop
- **After:** Θ(G · U) on the grid loop (still Θ(n log n) from per-group sorts)

`U` is distinct finite x across groups; `G` is group count; `m` is a group's
distinct-x count. The expansion floor is Θ(G · U) rows, so the log factor was
pure waste on the dominant term when the union grid is larger than any one
series (the usual sparse stacked-area case).

## How

Advance the cursor first, then:

| Cursor position | y |
|---|---|
| Exact sample (`xs[cursor] === xq`) | `ys[cursor]` |
| Interior gap (`0 < cursor < n`) | linear lerp between `cursor-1` and `cursor` |
| Before first or after last | `0` (unchanged contract) |

`lerpSeries` remains exported and unit-tested as the pure interpolator; the
per-output-row path no longer calls it.

## Tests

`packages/core/tests/stats-align.test.ts` — characterization for:

- grid points before a group's first sample and after its last
- interior interpolation
- single-sample group on a multi-point grid
- last-wins y / source row on duplicate x

Also green: pipeline align + stacked-area auto-align suites (37 tests).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1355" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->