### PR TITLE
perf(core): retag band ticks in place when thinning labelEvery

### DIFF
--- a/.changeset/band-thin-no-rebuild.md
+++ b/.changeset/band-thin-no-rebuild.md
@@ -1,0 +1,12 @@
+---
+"@ggsvelte/core": patch
+---
+
+# Band-axis tick thinning no longer rebuilds every tick on each halving
+
+Migration: none — same chosen labelEvery, tick values, labels, and labeled flags;
+lower cost when a vertical band axis has many categories.
+
+Vertical band axes used to call `deriveTicks` once per `labelEvery` doubling
+during margin degradation. Only the `labeled` flag depends on every, so the
+loop now flips flags in place after a single derivation.

--- a/packages/core/src/layout/layout.ts
+++ b/packages/core/src/layout/layout.ts
@@ -75,6 +75,13 @@ function maxLabeledWidth(axis: AxisTicks, measurer: TextMeasurer, fontSize: numb
   return max;
 }
 
+/** Retag band ticks for a new labelEvery without rebuilding values or labels (#1335). */
+function applyBandLabelEvery(axis: AxisTicks, every: number): void {
+  for (let i = 0; i < axis.ticks.length; i++) {
+    axis.ticks[i]!.labeled = i % every === 0;
+  }
+}
+
 /** Measure preserved labels without mutating the semantic guide plan. */
 function presentForLayout(axis: AxisTicks, preserve: boolean): AxisTicks {
   if (!preserve) return axis;
@@ -212,18 +219,21 @@ export function layoutPass(margins: Margins, input: LayoutInput, theme: LayoutTh
     yLabelW + leftFixed > capLeft
   ) {
     // Degrade 1: tick thinning.
+    // Band axes: only the labeled flag depends on every — flip flags in place
+    // instead of re-deriving and re-formatting all k ticks each doubling (#1335).
     while (yLabelW + leftFixed > capLeft) {
       if (input.y.type === "band") {
         if (yEvery * 2 >= y.ticks.length) break;
         yEvery *= 2;
+        applyBandLabelEvery(y, yEvery);
       } else {
         if (yCount <= 2) break;
         yCount = Math.max(2, Math.floor(yCount / 2));
+        y = presentForLayout(
+          deriveTicks(input.y, yCount, input.formatY, yEvery, yContext),
+          yPreserve,
+        );
       }
-      y = presentForLayout(
-        deriveTicks(input.y, yCount, input.formatY, yEvery, yContext),
-        yPreserve,
-      );
       degradations.push("y:thin");
       yLabelW = maxLabeledWidth(y, measurer, fontSize);
     }
@@ -267,16 +277,19 @@ export function layoutPass(margins: Margins, input: LayoutInput, theme: LayoutTh
     for (;;) {
       if (lastXLabelW <= capRight) break;
       if (input.x.type === "band") {
+        // Unreachable when the measured band planner set guidePlan, but the
+        // legacy simple-band path (no domain.band) still enters here.
         if (xEvery * 2 >= x.ticks.length) break;
         xEvery *= 2;
+        applyBandLabelEvery(x, xEvery);
       } else {
         if (xCount <= 2) break;
         xCount = Math.max(2, Math.floor(xCount / 2));
+        x = presentForLayout(
+          deriveTicks(input.x, xCount, input.formatX, xEvery, xContext),
+          xPreserve,
+        );
       }
-      x = presentForLayout(
-        deriveTicks(input.x, xCount, input.formatX, xEvery, xContext),
-        xPreserve,
-      );
       degradations.push("x:thin");
       computeXEndWidths();
     }

--- a/packages/core/tests/layout/band-thin-once.test.ts
+++ b/packages/core/tests/layout/band-thin-once.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Band y tick thinning must not rebuild every tick on each labelEvery doubling (#1335).
+ *
+ * Only the `labeled` flag depends on every; values, labels, and domainIndex stay
+ * fixed. Counting formatY calls observes rebuilds without spying on deriveTicks.
+ */
+import { describe, expect, it } from "bun:test";
+
+import { layout, layoutPass, DEFAULT_LAYOUT_THEME } from "../../src/layout/layout.ts";
+import { band, base, lin, measurer, theme } from "./fixtures.ts";
+
+function longCategories(k: number): string[] {
+  return Array.from({ length: k }, (_, i) => `Category with a long name number ${i}`);
+}
+
+describe("band y thinning rebuild cost (#1335)", () => {
+  it("formats each category once per layoutPass while thinning labelEvery", () => {
+    const k = 64;
+    const cats = longCategories(k);
+    let formats = 0;
+    const formatY = (v: string | number) => {
+      formats++;
+      return String(v);
+    };
+    // One pass only so the budget is k, not 2k.
+    layoutPass(
+      theme.marginPriors,
+      {
+        width: 400,
+        height: 300,
+        x: lin(0, 100),
+        y: band(...cats),
+        measurer,
+        formatY,
+      },
+      theme,
+    );
+    expect(formats).toBe(k);
+  });
+
+  it("keeps the same chosen labelEvery, labeled mask, and degradation order", () => {
+    const k = 64;
+    const cats = longCategories(k);
+    const r = layout(
+      base({
+        width: 400,
+        height: 300,
+        x: lin(0, 100),
+        y: band(...cats),
+      }),
+    );
+    // Characterisation of the current thinning outcome (must not change).
+    expect(r.y.labelEvery).toBe(32);
+    expect(r.y.ticks).toHaveLength(k);
+    expect(r.y.ticks.map((t) => t.value)).toEqual(cats);
+    for (let i = 0; i < k; i++) {
+      expect(r.y.ticks[i]!.labeled).toBe(i % r.y.labelEvery === 0);
+    }
+    expect(r.degradations[0]).toBe("y:thin");
+    expect(r.degradations).toContain("y:truncate");
+  });
+
+  it("stops doubling when the next every would cover the whole tick list", () => {
+    // Very tight capLeft forces the loop to the break arm rather than fitting.
+    const cats = longCategories(8);
+    const r = layout(
+      base({
+        width: 80,
+        height: 200,
+        x: lin(0, 10),
+        y: band(...cats),
+        theme: {
+          ...DEFAULT_LAYOUT_THEME,
+          maxMarginFraction: 0.05,
+        },
+      }),
+    );
+    // last successful double: every=4 (4*2=8 not < 8, so break). Labeled at 0,4.
+    expect(r.y.labelEvery).toBe(4);
+    expect(r.y.ticks.filter((t) => t.labeled).map((t) => t.value)).toEqual([cats[0], cats[4]]);
+  });
+});


### PR DESCRIPTION
Fixes #1335

## What

Vertical band axes (horizontal bar charts, or categorical y after
`coord_flip`) degrade under a tight left margin by doubling `labelEvery`.
Each round used to call `deriveTicks`, which rebuilds all k tick objects and
re-runs the formatter. Only the `labeled` flag depends on `every`.

- **Before:** O(k log k) allocate-and-format while thinning
- **After:** O(k) total — one derivation, then in-place flag flips

Measured path: k=64 long labels used to format 384 times per `layoutPass`
(1 + 5 doublings); now 64.

Horizontal band axes still go through the measured `planBandAxis` planner
(`guidePlan` set), so their thinning loop is unchanged. The same in-place
path covers the legacy simple-band x branch (no `domain.band` context).

Linear/time axes still re-derive: tick *values* change when the count halves.

## How

`applyBandLabelEvery(axis, every)` sets `ticks[i].labeled = i % every === 0`.
The y (and legacy x) thinning loops call it instead of `deriveTicks` when
`type === "band"`. Degradation order and entries are unchanged.

## Tests

`packages/core/tests/layout/band-thin-once.test.ts`:

- formatY call count equals category count for one `layoutPass`
- chosen `labelEvery`, value list, labeled mask, and degradations stay fixed
- break when the next double would cover the whole list

Full `packages/core/tests/layout/` suite green (42).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1358" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->