### PR TITLE
perf(docs): intent-gate example and lesson live charts

### DIFF
--- a/apps/docs/src/lib/components/ExampleLiveFrame.svelte
+++ b/apps/docs/src/lib/components/ExampleLiveFrame.svelte
@@ -1,18 +1,19 @@
 <script lang="ts">
   /**
    * Example detail frame: paint the gallery PNG first, then upgrade to the
-   * live Example.svelte chart near the viewport so first paint / LCP do not
-   * wait on the chart stack.
+   * live Example.svelte chart only after user intent (hover/focus) so SPA nav
+   * and scroll stay responsive. Near-viewport auto-upgrade pulled the full
+   * chart stack as soon as a specimen approached the fold.
    *
    * `?vr` forces an immediate upgrade so visual regression can wait on
-   * `.gg-plot-root[data-gg-ready]` without racing IntersectionObserver.
+   * `.gg-plot-root[data-gg-ready]` without racing intent handlers.
    */
   import { base } from "$app/paths";
   import { onMount } from "svelte";
   import type { Component } from "svelte";
 
   import { loadExampleComponent } from "$lib/examples";
-  import { observeNearViewport } from "$lib/near-viewport";
+  import { observeUserIntent } from "$lib/load-on-intent";
 
   const {
     exampleId,
@@ -44,7 +45,7 @@
   }
 
   // Kick off the VR import as soon as the client module runs (before paint
-  // settles). onMount still owns near-viewport upgrades for normal visits.
+  // settles). onMount still owns intent-gated upgrades for normal visits.
   if (typeof window !== "undefined") {
     const params = new URLSearchParams(window.location.search);
     if (params.has("vr")) startLoad();
@@ -63,9 +64,7 @@
         cancelled = true;
       };
     }
-    const stop = observeNearViewport(el, startLoad, {
-      rootMargin: "480px 0px",
-    });
+    const stop = observeUserIntent(el, startLoad);
     return () => {
       cancelled = true;
       stop();
@@ -77,6 +76,9 @@
   class="gg-example-frame"
   class:full-width={fullWidth}
   bind:this={host}
+  tabindex="0"
+  role="group"
+  aria-label={`${title} (hover or focus to load the interactive chart)`}
   style={`--example-vr-width:${String(width)}px;--example-vr-height:${String(height)}px`}
 >
   {#if Live !== null}
@@ -104,6 +106,11 @@
 
   .gg-example-frame.full-width {
     max-width: none;
+  }
+
+  .gg-example-frame:focus-visible {
+    outline: 2px solid var(--ink, #111);
+    outline-offset: 4px;
   }
 
   .example-preview {

--- a/apps/docs/src/lib/components/ExampleLiveFrame.svelte
+++ b/apps/docs/src/lib/components/ExampleLiveFrame.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   /**
    * Example detail frame: paint the gallery PNG first, then upgrade to the
-   * live Example.svelte chart only after user intent (hover/focus) so SPA nav
-   * and scroll stay responsive. Near-viewport auto-upgrade pulled the full
-   * chart stack as soon as a specimen approached the fold.
+   * live Example.svelte chart only after user intent (hover/focus/button) so
+   * SPA nav and scroll stay responsive. Near-viewport auto-upgrade pulled the
+   * full chart stack as soon as a specimen approached the fold.
    *
    * `?vr` forces an immediate upgrade so visual regression can wait on
    * `.gg-plot-root[data-gg-ready]` without racing intent handlers.
@@ -76,9 +76,6 @@
   class="gg-example-frame"
   class:full-width={fullWidth}
   bind:this={host}
-  tabindex="0"
-  role="group"
-  aria-label={`${title} (hover or focus to load the interactive chart)`}
   style={`--example-vr-width:${String(width)}px;--example-vr-height:${String(height)}px`}
 >
   {#if Live !== null}
@@ -93,11 +90,15 @@
       decoding="async"
       fetchpriority="high"
     />
+    <button type="button" class="load-interactive" onclick={startLoad}>
+      Load interactive chart
+    </button>
   {/if}
 </div>
 
 <style>
   .gg-example-frame {
+    position: relative;
     margin: 2.5rem 0;
     width: 100%;
     max-width: var(--example-vr-width);
@@ -108,15 +109,30 @@
     max-width: none;
   }
 
-  .gg-example-frame:focus-visible {
-    outline: 2px solid var(--ink, #111);
-    outline-offset: 4px;
-  }
-
   .example-preview {
     display: block;
     width: 100%;
     height: auto;
     background: #fff;
+  }
+
+  .load-interactive {
+    position: absolute;
+    right: 0.75rem;
+    bottom: 0.75rem;
+    margin: 0;
+    padding: 0.4rem 0.7rem;
+    border: 1px solid var(--line, #ccc);
+    border-radius: 0.35rem;
+    background: color-mix(in srgb, var(--paper, #fff) 92%, transparent);
+    color: var(--ink, #111);
+    font: inherit;
+    font-size: 0.85rem;
+    cursor: pointer;
+  }
+
+  .load-interactive:focus-visible {
+    outline: 2px solid var(--ink, #111);
+    outline-offset: 2px;
   }
 </style>

--- a/apps/docs/src/lib/components/LessonFinishedChart.svelte
+++ b/apps/docs/src/lib/components/LessonFinishedChart.svelte
@@ -22,7 +22,7 @@
     LESSON_CHART_WIDTH,
     sakuraFinishedHeight,
   } from "$lib/generated/lesson-charts";
-  import { observeNearViewport } from "$lib/near-viewport";
+  import { observeUserIntent } from "$lib/load-on-intent";
   import type { PlotInspectionChange } from "@ggsvelte/svelte";
   import { kyotoSakura } from "@ggsvelte/svelte/data";
 
@@ -152,18 +152,15 @@
       });
     };
 
-    // Shared helper — no idle-load. An early dynamic import + fold still
-    // monopolizes the main thread and stalls header clicks (#972).
-    // When IntersectionObserver is missing (SSR/tests), observeNearViewport
-    // fires immediately so the chart still upgrades, matching ThemeSpecimen.
-    const stopNear = observeNearViewport(target, loadLivePlot, {
-      rootMargin: "240px 0px",
-    });
+    // Intent only — near-viewport auto-upgrade still folded 838 points as
+    // soon as the chart approached the fold and stalled chrome (#972).
+    // Match ThemeSpecimen / ExampleLiveFrame: static shell until hover/focus.
+    const stopIntent = observeUserIntent(target, loadLivePlot);
 
     return () => {
       cancelled = true;
       observer?.disconnect();
-      stopNear();
+      stopIntent();
     };
   });
 </script>

--- a/apps/docs/src/lib/components/LessonFinishedChart.svelte
+++ b/apps/docs/src/lib/components/LessonFinishedChart.svelte
@@ -123,11 +123,24 @@
     return `${mon} ${day}, ${yearPart}`;
   }
 
+  let loadStarted = false;
+  let cancelled = false;
+
+  function loadLivePlot(): void {
+    if (loadStarted || LivePlot !== null) return;
+    loadStarted = true;
+    void import("@ggsvelte/svelte").then((mod) => {
+      if (!cancelled) {
+        LivePlot = mod.GGPlot;
+        LiveInspect = mod.Inspect;
+      }
+    });
+  }
+
   onMount(() => {
     const target = host;
     if (target === undefined) return;
-    let cancelled = false;
-    let loadStarted = false;
+    cancelled = false;
 
     const observer =
       typeof ResizeObserver === "undefined"
@@ -140,17 +153,6 @@
             }
           });
     observer?.observe(target);
-
-    const loadLivePlot = (): void => {
-      if (loadStarted || cancelled) return;
-      loadStarted = true;
-      void import("@ggsvelte/svelte").then((mod) => {
-        if (!cancelled) {
-          LivePlot = mod.GGPlot;
-          LiveInspect = mod.Inspect;
-        }
-      });
-    };
 
     // Intent only — near-viewport auto-upgrade still folded 838 points as
     // soon as the chart approached the fold and stalled chrome (#972).
@@ -198,11 +200,15 @@
       height={LESSON_CHART_HEIGHT}
       alt={ariaLabel}
     />
+    <button type="button" class="load-interactive" onclick={loadLivePlot}>
+      Load interactive chart
+    </button>
   {/if}
 </div>
 
 <style>
   .lesson-output {
+    position: relative;
     min-width: 0;
     overflow: hidden;
     background: #fff;
@@ -222,6 +228,26 @@
     display: block;
     width: 100%;
     height: auto;
+  }
+
+  .load-interactive {
+    position: absolute;
+    right: 0.75rem;
+    bottom: 0.75rem;
+    margin: 0;
+    padding: 0.4rem 0.7rem;
+    border: 1px solid #c5cad6;
+    border-radius: 0.35rem;
+    background: color-mix(in srgb, #fff 92%, transparent);
+    color: #172033;
+    font: inherit;
+    font-size: 0.85rem;
+    cursor: pointer;
+  }
+
+  .load-interactive:focus-visible {
+    outline: 2px solid #172033;
+    outline-offset: 2px;
   }
 
   .sakura-tooltip {

--- a/scripts/docs-chart-intent-load.test.ts
+++ b/scripts/docs-chart-intent-load.test.ts
@@ -51,4 +51,14 @@ describe("docs chart intent-gated load", () => {
     expect(sequential).toContain("observeUserIntent");
     expect(sequential).not.toContain("observeNearViewport");
   });
+
+  it("loads example and lesson live charts only after user intent", () => {
+    const frame = read("lib/components/ExampleLiveFrame.svelte");
+    expect(frame).toContain("observeUserIntent");
+    expect(frame).not.toContain("observeNearViewport");
+
+    const lesson = read("lib/components/LessonFinishedChart.svelte");
+    expect(lesson).toContain("observeUserIntent");
+    expect(lesson).not.toContain("observeNearViewport");
+  });
 });

--- a/scripts/docs-example-png-first.test.ts
+++ b/scripts/docs-example-png-first.test.ts
@@ -30,16 +30,19 @@ describe("docs example PNG-first (PR3)", () => {
     expect(page).toContain("{#key data.entry.id}");
   });
 
-  it("defers Example.svelte via user intent or ?vr eager load", () => {
+  it("defers Example.svelte via user intent, button, or ?vr eager load", () => {
     const frame = read("lib/components/ExampleLiveFrame.svelte");
     expect(frame).toContain("loadExampleComponent");
     expect(frame).toContain("observeUserIntent");
     expect(frame).not.toContain("observeNearViewport");
+    expect(frame).toContain("Load interactive chart");
     expect(frame).toContain('has("vr")');
     expect(frame).toContain("example-preview");
     expect(frame).toContain("previewPath");
     // VR starts the import at module init, not only in onMount.
     expect(frame).toContain('typeof window !== "undefined"');
+    // Keyboard path is a real button (not tabindex on a noninteractive div).
+    expect(frame).not.toContain('tabindex="0"');
   });
 
   it("keeps loadExample for callers that still need the full bundle", () => {

--- a/scripts/docs-example-png-first.test.ts
+++ b/scripts/docs-example-png-first.test.ts
@@ -30,10 +30,11 @@ describe("docs example PNG-first (PR3)", () => {
     expect(page).toContain("{#key data.entry.id}");
   });
 
-  it("defers Example.svelte via near-viewport or ?vr eager load", () => {
+  it("defers Example.svelte via user intent or ?vr eager load", () => {
     const frame = read("lib/components/ExampleLiveFrame.svelte");
     expect(frame).toContain("loadExampleComponent");
-    expect(frame).toContain("observeNearViewport");
+    expect(frame).toContain("observeUserIntent");
+    expect(frame).not.toContain("observeNearViewport");
     expect(frame).toContain('has("vr")');
     expect(frame).toContain("example-preview");
     expect(frame).toContain("previewPath");

--- a/tests/visual/docs-progressive-search.spec.ts
+++ b/tests/visual/docs-progressive-search.spec.ts
@@ -36,11 +36,12 @@ test("each step shows its own delta and the finished chart is live", async ({ pa
   ]);
 
   // Intermediate steps are build-time SVGs; Make it interactive is the one live
-  // plot (hydrate near-viewport, #972). Before that scroll, every step is an img.
+  // plot (intent-gated, #972). Before engage, every step is an img.
   await expect(steps.locator("img.lesson-chart")).toHaveCount(4);
   await expect(steps.locator(".gg-plot-root")).toHaveCount(0);
   const finishedChart = page.locator(".finished-chart");
   await finishedChart.scrollIntoViewIfNeeded();
+  await finishedChart.getByRole("button", { name: "Load interactive chart" }).click();
   const finished = finishedChart.locator(".gg-plot-root");
   await expect(finished).toHaveAttribute("data-gg-ready", "true", {
     timeout: 45_000,
@@ -54,6 +55,7 @@ test("the finished chart answers keyboard inspection", async ({ page }) => {
   await page.goto("/guide/getting-started?theme=light");
   const finishedChart = page.locator(".finished-chart");
   await finishedChart.scrollIntoViewIfNeeded();
+  await finishedChart.getByRole("button", { name: "Load interactive chart" }).click();
   const capture = finishedChart.locator(".gg-capture");
   await expect(capture).toBeVisible({ timeout: 45_000 });
   await capture.focus();
@@ -77,6 +79,7 @@ test("the finished chart drops its band fills and names the epochs in forced col
   await page.goto("/guide/getting-started?theme=light");
   const finished = page.locator(".finished-chart");
   await finished.scrollIntoViewIfNeeded();
+  await finished.getByRole("button", { name: "Load interactive chart" }).click();
   await expect(finished.locator(".gg-plot-root")).toHaveAttribute("data-gg-ready", "true", {
     timeout: 45_000,
   });

--- a/tests/visual/helpers/deterministic.ts
+++ b/tests/visual/helpers/deterministic.ts
@@ -18,9 +18,16 @@ export async function settleVisualState(page: Page, expectedPlots = 1): Promise<
       });
     });
   });
-  // 30s: example pages may cold-import the chart stack after a PNG placeholder
-  // (ExampleLiveFrame / near-viewport upgrade). First smoke case after a fresh
-  // worker is the slow path; cached modules keep later cases well under this.
+  // Example / lesson charts are intent-gated (hover or "Load interactive").
+  // Trigger intent so VR smoke cases still get a live plot without near-viewport
+  // auto-upgrade pulling the chart stack on every fold approach.
+  const loadButtons = page.getByRole("button", { name: "Load interactive chart" });
+  const n = await loadButtons.count();
+  for (let i = 0; i < n; i += 1) {
+    await loadButtons.nth(i).click();
+  }
+  // 30s: cold-import of the chart stack after a PNG placeholder. First smoke
+  // case after a fresh worker is the slow path; later cases stay well under.
   await expect(page.locator('.gg-plot-root[data-gg-ready="true"]')).toHaveCount(expectedPlots, {
     timeout: 30_000,
   });

--- a/tests/visual/helpers/deterministic.ts
+++ b/tests/visual/helpers/deterministic.ts
@@ -19,12 +19,20 @@ export async function settleVisualState(page: Page, expectedPlots = 1): Promise<
     });
   });
   // Example / lesson charts are intent-gated (hover or "Load interactive").
-  // Trigger intent so VR smoke cases still get a live plot without near-viewport
-  // auto-upgrade pulling the chart stack on every fold approach.
-  const loadButtons = page.getByRole("button", { name: "Load interactive chart" });
-  const n = await loadButtons.count();
-  for (let i = 0; i < n; i += 1) {
-    await loadButtons.nth(i).click();
+  // `?vr` already starts the import at module init — do not click load buttons
+  // there (they race the upgrade and can hang Playwright's actionability checks).
+  const hasVr = await page.evaluate(() => new URL(location.href).searchParams.has("vr"));
+  if (!hasVr) {
+    const loadButtons = page.getByRole("button", { name: "Load interactive chart" });
+    const n = await loadButtons.count();
+    for (let i = 0; i < n; i += 1) {
+      const btn = loadButtons.nth(i);
+      if (await btn.isVisible().catch(() => false)) {
+        await btn.click({ timeout: 5_000 }).catch(() => {
+          /* button may unmount mid-upgrade */
+        });
+      }
+    }
   }
   // 30s: cold-import of the chart stack after a PNG placeholder. First smoke
   // case after a fresh worker is the slow path; later cases stay well under.


### PR DESCRIPTION
Intent-gate ExampleLiveFrame and LessonFinishedChart (hover/focus, or ?vr for visual regression). Near-viewport auto-upgrade forced the full chart stack as soon as a specimen approached the fold and stalled SPA path changes.

Test: bun test scripts/docs-example-png-first.test.ts scripts/docs-chart-intent-load.test.ts

Depends on #1361.