### PR TITLE
perf(docs): eager-load only the first gallery row of previews

### DIFF
--- a/apps/docs/src/routes/examples/+page.svelte
+++ b/apps/docs/src/routes/examples/+page.svelte
@@ -140,17 +140,21 @@
     </div>
   {:else}
     <ul class="example-grid">
-      {#each results as entry (entry.id)}
+      {#each results as entry, index (entry.id)}
         <li>
           <a href={`${base}/examples/${entry.id}`} aria-label={entry.title}>
             <figure>
               <div class="preview-paper">
+                <!-- First six cover a typical first screen; the rest stay lazy
+                     so cold gallery transfers do not pull ~2MB of PNG up front. -->
                 <img
                   src={`${base}${entry.previewPath}`}
                   alt=""
                   width="640"
                   height={entry.vrHeight ?? 400}
-                  loading="lazy"
+                  loading={index < 6 ? "eager" : "lazy"}
+                  decoding="async"
+                  fetchpriority={index < 6 ? "high" : "low"}
                 />
               </div>
             </figure>
@@ -181,6 +185,11 @@
     padding: 0;
     list-style: none;
     grid-template-columns: repeat(auto-fill, minmax(min(100%, 17rem), 1fr));
+  }
+
+  .example-grid > li {
+    content-visibility: auto;
+    contain-intrinsic-size: auto 14rem;
   }
 
   figure {

--- a/scripts/docs-gallery-preview-priority.test.ts
+++ b/scripts/docs-gallery-preview-priority.test.ts
@@ -1,0 +1,19 @@
+/**
+ * Gallery first-screen previews stay eager; the rest stay lazy so cold loads
+ * do not pull the full ~2MB PNG corpus up front.
+ */
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const root = path.join(import.meta.dirname, "..");
+const page = readFileSync(path.join(root, "apps/docs/src/routes/examples/+page.svelte"), "utf8");
+
+describe("docs gallery preview priority", () => {
+  it("eagers only the first six results and lazy-loads the rest", () => {
+    expect(page).toContain('loading={index < 6 ? "eager" : "lazy"}');
+    expect(page).toContain('fetchpriority={index < 6 ? "high" : "low"}');
+    expect(page).toContain('decoding="async"');
+    expect(page).toContain("content-visibility: auto");
+  });
+});


### PR DESCRIPTION
Eager-load only the first six gallery previews; lazy + low fetchpriority for the rest; content-visibility on grid items. Defers home SVG externalization and Roboto woff2 to a follow-up.

Test: bun test scripts/docs-gallery-preview-priority.test.ts

Depends on #1363.