### PR TITLE
perf(core): normalize only band span extremes in project()

### DIFF
--- a/.changeset/band-project-span-ends.md
+++ b/.changeset/band-project-span-ends.md
@@ -1,0 +1,12 @@
+---
+"@ggsvelte/core": patch
+---
+
+# Band interval project() normalizes only domain extremes
+
+Migration: none — identical projected spans for contiguous and non-contiguous
+band selections; lower cost on large category brushes.
+
+`projectedSpan` used to call `scale.normalize` for every selected key to find
+min/max centers. Centers are monotone in domain index, so it now tracks the
+extreme indices in one pass and normalizes only those two values.

--- a/packages/core/src/semantic-viewport.ts
+++ b/packages/core/src/semantic-viewport.ts
@@ -142,13 +142,22 @@ function semanticDomain(
   return first <= last ? [first, last] : [last, first];
 }
 
-function bandValueIndex(scale: PositionScale): ReadonlyMap<string, CellValue> {
-  const valuesByKey = new Map<string, CellValue>();
+/** Band key lookup: domain value plus its domain index (for extent without re-normalize). */
+type BandKeyEntry = {
+  readonly value: CellValue;
+  readonly index: number;
+};
+
+function bandValueIndex(scale: PositionScale): ReadonlyMap<string, BandKeyEntry> {
+  const valuesByKey = new Map<string, BandKeyEntry>();
   if (scale.type !== "band") return valuesByKey;
+  let index = 0;
   for (const value of scale.rawDomain) {
     const cell = value as CellValue;
     const key = encodeKey(cell);
-    if (!valuesByKey.has(key)) valuesByKey.set(key, cell);
+    // First-seen wins, matching trainBand's index map.
+    if (!valuesByKey.has(key)) valuesByKey.set(key, { value: cell, index });
+    index += 1;
   }
   return valuesByKey;
 }
@@ -163,23 +172,23 @@ function bandValueIndex(scale: PositionScale): ReadonlyMap<string, CellValue> {
  * step dropped it.
  */
 function bandSpanForKeys(
-  valuesByKey: ReadonlyMap<string, CellValue>,
+  valuesByKey: ReadonlyMap<string, BandKeyEntry>,
   keys: readonly string[],
 ): readonly [CellValue, CellValue] | undefined {
   let firstIndex = -1;
   let first: CellValue | undefined;
   for (let i = 0; i < keys.length; i++) {
-    const value = valuesByKey.get(keys[i]!);
-    if (value !== undefined) {
-      first = value;
+    const entry = valuesByKey.get(keys[i]!);
+    if (entry !== undefined) {
+      first = entry.value;
       firstIndex = i;
       break;
     }
   }
   if (firstIndex === -1) return undefined;
   for (let i = keys.length - 1; i > firstIndex; i--) {
-    const value = valuesByKey.get(keys[i]!);
-    if (value !== undefined) return [first!, value];
+    const entry = valuesByKey.get(keys[i]!);
+    if (entry !== undefined) return [first!, entry.value];
   }
   // Only one key landed on the axis; it is both ends.
   return [first!, first!];
@@ -189,28 +198,41 @@ function projectedSpan(
   scale: PositionScale,
   selection: SemanticViewportAxisSelection | undefined,
   coord: PanelCoordProjector["x"] | undefined,
-  bandValuesByKey: ReadonlyMap<string, CellValue>,
+  bandValuesByKey: ReadonlyMap<string, BandKeyEntry>,
 ): readonly [number, number] {
   if (selection === undefined) return [0, 1];
   let first: number | undefined;
   let last: number | undefined;
   if (selection.kind === "band") {
     if (scale.type !== "band") return [0, 1];
-    // One pass over the keys, never `Math.min(...centers)`: `keys` is caller-
-    // supplied and unbounded, and spreading it passes one argument per key,
-    // which RangeErrors on a wide enough band brush (same hazard grouping.ts
-    // avoids for `Math.max(...groups)`).
-    let minCenter = Infinity;
-    let maxCenter = -Infinity;
+    // Span is min/max of band centers, expanded by half a step. Centers are
+    // monotone in domain index (including reverse), so track the extreme
+    // indices and normalize only those two values — not every selected key
+    // (#1332). Still one pass over keys: non-contiguous selections can put
+    // extremes anywhere in the list. Never `Math.min(...centers)`: spreading
+    // unbounded keys RangeErrors (same hazard as grouping.ts).
+    let minIndex = Infinity;
+    let maxIndex = -Infinity;
+    let minValue: CellValue | undefined;
+    let maxValue: CellValue | undefined;
     for (const key of selection.keys) {
-      const value = bandValuesByKey.get(key);
-      if (value === undefined) continue;
-      const center = scale.normalize(value);
-      if (center === undefined) continue;
-      if (center < minCenter) minCenter = center;
-      if (center > maxCenter) maxCenter = center;
+      const entry = bandValuesByKey.get(key);
+      if (entry === undefined) continue;
+      if (entry.index < minIndex) {
+        minIndex = entry.index;
+        minValue = entry.value;
+      }
+      if (entry.index > maxIndex) {
+        maxIndex = entry.index;
+        maxValue = entry.value;
+      }
     }
-    if (minCenter === Infinity) return [0, 1];
+    if (minValue === undefined || maxValue === undefined) return [0, 1];
+    const c0 = scale.normalize(minValue);
+    const c1 = minIndex === maxIndex ? c0 : scale.normalize(maxValue);
+    if (c0 === undefined || c1 === undefined) return [0, 1];
+    const minCenter = Math.min(c0, c1);
+    const maxCenter = Math.max(c0, c1);
     const halfStep = scale.step / 2;
     first = Math.max(0, minCenter - halfStep);
     last = Math.min(1, maxCenter + halfStep);
@@ -266,7 +288,7 @@ function createPanel(
   coord: PanelCoordProjector | undefined,
   flipped: boolean,
   candidates: CandidateStore,
-  indexFor: (scale: PositionScale) => ReadonlyMap<string, CellValue>,
+  indexFor: (scale: PositionScale) => ReadonlyMap<string, BandKeyEntry>,
 ): SemanticViewportPanel {
   const xBandValuesByKey = indexFor(scales.x);
   const yBandValuesByKey = indexFor(scales.y);
@@ -322,7 +344,7 @@ function createPanel(
       const resolveAxis = (
         scale: PositionScale,
         axis: SemanticViewportAxisSelection | undefined,
-        bandValuesByKey: ReadonlyMap<string, CellValue>,
+        bandValuesByKey: ReadonlyMap<string, BandKeyEntry>,
       ): readonly [CellValue, CellValue] | undefined => {
         if (axis === undefined) return undefined;
         if (axis.kind === "continuous") return axis.domain;
@@ -387,8 +409,8 @@ export function createSemanticViewport(input: CreateSemanticViewportInput): Sema
   // a copy of it per panel. Key on the object: free scales give each panel its
   // own scale, so they still get their own index. The map is local to this
   // viewport and never written after it is built, so panels can share it.
-  const bandIndexByScale = new WeakMap<PositionScale, ReadonlyMap<string, CellValue>>();
-  const indexFor = (scale: PositionScale): ReadonlyMap<string, CellValue> => {
+  const bandIndexByScale = new WeakMap<PositionScale, ReadonlyMap<string, BandKeyEntry>>();
+  const indexFor = (scale: PositionScale): ReadonlyMap<string, BandKeyEntry> => {
     let index = bandIndexByScale.get(scale);
     if (index === undefined) {
       index = bandValueIndex(scale);

--- a/packages/core/tests/semantic-viewport.test.ts
+++ b/packages/core/tests/semantic-viewport.test.ts
@@ -723,4 +723,142 @@ describe("RenderModel semantic viewport", () => {
     model.dispose();
     model.dispose();
   });
+
+  // --- #1332: project() normalizes only the domain extremes, not every key ---
+
+  it("projects a band selection by normalizing only the domain extremes (#1332)", () => {
+    const categories = Array.from({ length: 200 }, (_, i) => `c${i}`);
+    const model = runPipeline(
+      gg(
+        categories.map((category, i) => ({ category, y: i })),
+        aes({ x: "category", y: "y" }),
+      )
+        .geomPoint()
+        .spec(),
+      { width: 400, height: 300 },
+    );
+    const scale = model.scales.panels[0]?.x ?? model.scales.x;
+    let normalizeCalls = 0;
+    const original = scale.normalize.bind(scale);
+    scale.normalize = (value: unknown) => {
+      normalizeCalls += 1;
+      return original(value);
+    };
+    const panel = model.viewport.panel(model.scene.panels[0]!.id)!;
+    const keys = categories.map((category) => encodeKey(category));
+    const pixels = panel.project({ x: { kind: "band", keys } });
+    // Contiguous full domain: two extremes, one normalize each.
+    expect(normalizeCalls).toBe(2);
+    expect(pixels.x0).toBeCloseTo(model.scene.panels[0]!.x, 10);
+    expect(pixels.x1).toBeCloseTo(model.scene.panels[0]!.x + model.scene.panels[0]!.width, 10);
+    model.dispose();
+  });
+
+  it("projects non-contiguous band keys from domain extremes, not list ends (#1332)", () => {
+    // Keys ordered b, a, d — list ends are b and d, but the selection's domain
+    // extremes are a and d. The span must cover a→d.
+    const model = runPipeline(
+      gg(
+        [
+          { category: "a", y: 1 },
+          { category: "b", y: 2 },
+          { category: "c", y: 3 },
+          { category: "d", y: 4 },
+        ],
+        aes({ x: "category", y: "y" }),
+      )
+        .geomPoint()
+        .spec(),
+      { width: 400, height: 300 },
+    );
+    const scenePanel = model.scene.panels[0]!;
+    const panel = model.viewport.panel(scenePanel.id)!;
+    const shuffled = panel.project({
+      x: {
+        kind: "band",
+        keys: [encodeKey("b"), encodeKey("a"), encodeKey("d")],
+      },
+    });
+    const full = panel.project({
+      x: {
+        kind: "band",
+        keys: [encodeKey("a"), encodeKey("b"), encodeKey("c"), encodeKey("d")],
+      },
+    });
+    // a is the leftmost category; d the rightmost. Missing c does not shrink
+    // the outer extent when a and d are both selected.
+    expect(shuffled.x0).toBeCloseTo(full.x0, 10);
+    expect(shuffled.x1).toBeCloseTo(full.x1, 10);
+    expect(shuffled.x0).toBeCloseTo(scenePanel.x, 10);
+    expect(shuffled.x1).toBeCloseTo(scenePanel.x + scenePanel.width, 10);
+    model.dispose();
+  });
+
+  it("projects a reversed band axis from the same extremes (#1332)", () => {
+    const model = runPipeline(
+      gg(
+        [
+          { category: "a", y: 1 },
+          { category: "b", y: 2 },
+          { category: "c", y: 3 },
+          { category: "d", y: 4 },
+        ],
+        aes({ x: "category", y: "y" }),
+      )
+        .geomPoint()
+        .scales({ x: { reverse: true } })
+        .spec(),
+      { width: 400, height: 300 },
+    );
+    const scenePanel = model.scene.panels[0]!;
+    const panel = model.viewport.panel(scenePanel.id)!;
+    // Contiguous b,c under reverse: a is rightmost in screen space.
+    const pixels = panel.project({
+      x: { kind: "band", keys: [encodeKey("b"), encodeKey("c")] },
+    });
+    // Domain indices 1 and 2 of 4; reverse flips centers. Edge-to-edge of b,c
+    // is the middle half of the panel still — reverse swaps left/right but
+    // the expanded half-step span width is the same.
+    expect(pixels.x1 - pixels.x0).toBeCloseTo(scenePanel.width * 0.5, 10);
+    expect(pixels.x0).toBeCloseTo(scenePanel.x + scenePanel.width * 0.25, 10);
+    expect(pixels.x1).toBeCloseTo(scenePanel.x + scenePanel.width * 0.75, 10);
+    model.dispose();
+  });
+
+  it("projects a band y selection the same way (#1332)", () => {
+    const model = runPipeline(
+      gg(
+        [
+          { x: 1, category: "a" },
+          { x: 2, category: "b" },
+          { x: 3, category: "c" },
+          { x: 4, category: "d" },
+        ],
+        aes({ x: "x", y: "category" }),
+      )
+        .geomPoint()
+        .spec(),
+      { width: 400, height: 300 },
+    );
+    const scenePanel = model.scene.panels[0]!;
+    const panel = model.viewport.panel(scenePanel.id)!;
+    const scale = model.scales.panels[0]?.y ?? model.scales.y;
+    let normalizeCalls = 0;
+    const original = scale.normalize.bind(scale);
+    scale.normalize = (value: unknown) => {
+      normalizeCalls += 1;
+      return original(value);
+    };
+    const pixels = panel.project({
+      y: {
+        kind: "band",
+        keys: [encodeKey("d"), encodeKey("a"), encodeKey("c")],
+      },
+    });
+    expect(normalizeCalls).toBe(2);
+    // a..d cover the full y band domain.
+    expect(pixels.y0).toBeCloseTo(scenePanel.y, 10);
+    expect(pixels.y1).toBeCloseTo(scenePanel.y + scenePanel.height, 10);
+    model.dispose();
+  });
 });


### PR DESCRIPTION
Fixes #1332

## What

`SemanticViewport.project` turns a band key selection into a pixel span by
finding min/max band centers and expanding each by half a step.
`projectedSpan` used to call `scale.normalize` for every selected key.

After #1333, `resolve` on the same precise-bounds path reads two keys;
`project` still paid O(selection) normalize. With 400 categories:

| call | before | after |
|---|---|---|
| `resolve` | 2 | 2 |
| `project` normalize | 400 | 2 |

## How

Band centers are monotone in domain index (including `reverse`). One pass
over the keys tracks the extreme domain indices; only those two values are
normalized. Non-contiguous selections stay correct — list ends are not
assumed to be domain extremes.

The band key index (`bandValueIndex`) now stores `{ value, index }` so the
pass does not re-run `indexOf` / `encodeKey` per key.

## Tests

`packages/core/tests/semantic-viewport.test.ts`:

- 200-key selection: exactly 2 `normalize` calls; full-panel span
- Non-contiguous shuffled keys: span matches domain extremes, not list ends
- Reversed band axis: same half-step expansion
- Band y axis: 2 normalizes, full vertical span

Also green: existing project/resolve and band-index suites (33 tests).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1368" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->