### PR TITLE
perf(spec): snapshot layer data once on geom sugar paths

### DIFF
--- a/.changeset/builder-geom-single-snapshot.md
+++ b/.changeset/builder-geom-single-snapshot.md
@@ -1,0 +1,11 @@
+---
+"@ggsvelte/spec": patch
+---
+
+# Builder geom sugar deep-copies layer data once, not twice
+
+Migration: none — same `.spec()` output and mutation isolation; one less
+O(rows×cols) snapshot on `geom*({ data })`.
+
+`layerFrom` no longer calls `toAuthoringDataRef`. Every geom sugar path is
+`this.layer(layerFrom(...))`, and `layer()` remains the single defensive copy.

--- a/packages/spec/src/builder-core.ts
+++ b/packages/spec/src/builder-core.ts
@@ -63,10 +63,10 @@ export function layerFrom(
   },
 ): LayerInput {
   const { aes: layerAes, render, position, positionParams, stat, data, ...params } = options;
-  // Snapshot authoring data immediately so later mutation of the caller's array
-  // cannot leak into the builder; portable Date→ISO conversion happens in .spec().
-  const withData =
-    data === undefined ? {} : { data: toAuthoringDataRef(data) as LayerInput["data"] };
+  // Do not snapshot here: every geom sugar path is `this.layer(layerFrom(...))`,
+  // and `layer()` is the single defensive-copy point (#1280). Snapshotting in
+  // both places deep-copied every row twice on `geom*({ data })`.
+  const withData = data === undefined ? {} : { data: data as LayerInput["data"] };
   return {
     geom,
     ...(stat !== undefined && { stat }),
@@ -104,13 +104,15 @@ export class GGBuilderCore {
 
   /** Add a layer (canonical form — the geom* methods are sugar for this). */
   layer(layer: LayerInput): GGBuilder {
-    // Snapshot authoring data at insertion (same as geom* sugar via layerFrom)
-    // so later mutation of caller-owned arrays cannot leak into .spec().
+    // Sole snapshot for layer data: geom sugar and direct `.layer({ data })`
+    // both land here. Later mutation of caller-owned arrays cannot leak into
+    // `.spec()`; portable Date→ISO conversion still happens in `toPortable`.
     if (layer.data === undefined) {
       return this.#with({ layers: [...this.#state.layers, layer] });
     }
-    // layer.data is AuthoringDataRef at rest; cast through DataInput for snapshot.
-    const data: DataInput = layer.data;
+    // layer.data may be raw DataInput (geom sugar) or an AuthoringDataRef
+    // already; toAuthoringDataRef accepts both.
+    const data: DataInput = layer.data as DataInput;
     const snapped = { ...layer, data: toAuthoringDataRef(data) } as LayerInput;
     return this.#with({ layers: [...this.#state.layers, snapped] });
   }
@@ -214,7 +216,7 @@ export class GGBuilderCore {
     const calendarFields = calendarDateFields(this.#state);
     const portableLayers = layers.map((layer) => {
       if (layer.data === undefined) return layer;
-      // layerFrom stores AuthoringDataRef snapshots as LayerInput.data; portable
+      // layer() stores AuthoringDataRef snapshots as LayerInput.data; portable
       // ISO conversion runs here with the final calendar-date field set.
       return {
         ...layer,

--- a/packages/spec/src/builder-core.ts
+++ b/packages/spec/src/builder-core.ts
@@ -112,8 +112,10 @@ export class GGBuilderCore {
     }
     // layer.data may be raw DataInput (geom sugar) or an AuthoringDataRef
     // already; toAuthoringDataRef accepts both.
-    const data: DataInput = layer.data as DataInput;
-    const snapped = { ...layer, data: toAuthoringDataRef(data) } as LayerInput;
+    const snapped = {
+      ...layer,
+      data: toAuthoringDataRef(layer.data),
+    } as LayerInput;
     return this.#with({ layers: [...this.#state.layers, snapped] });
   }
 

--- a/packages/spec/tests/builder-data.test.ts
+++ b/packages/spec/tests/builder-data.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "bun:test";
 
 import { calendarDateFields, toAuthoringDataRef, toDataRef } from "../src/builder-data.ts";
 import { aes, gg } from "../src/builder.ts";
+import { layerFrom } from "../src/builder-core.ts";
 
 const rows = [
   { x: 1, y: 2, cls: "a" },
@@ -59,5 +60,54 @@ describe("builder-data — authoring forms", () => {
       },
     });
     expect([...fields].toSorted()).toEqual(["group", "when"]);
+  });
+});
+
+describe("builder geom sugar — single snapshot (#1280)", () => {
+  it("layerFrom does not deep-copy layer data; layer() is the snapshot point", () => {
+    const source = [
+      { x: 1, y: 2 },
+      { x: 3, y: 4 },
+    ];
+    // Geom sugar is this.layer(layerFrom(...)). Snapshotting in both places
+    // deep-copied every row twice; layerFrom must pass the caller's ref through.
+    const assembled = layerFrom("point", { data: source });
+    expect(assembled.data).toBe(source);
+  });
+
+  it("geom sugar still isolates caller mutation after the geom call", () => {
+    const plotRows = [
+      { x: 0, y: 0 },
+      { x: 1, y: 1 },
+    ];
+    const layerRows = [
+      { x: 10, y: 20 },
+      { x: 30, y: 40 },
+    ];
+    const builder = gg(plotRows, aes({ x: "x", y: "y" })).geomPoint({ data: layerRows });
+    // Mutate after the geom call — must not leak into .spec().
+    layerRows[0]!.x = 999;
+    layerRows.push({ x: 50, y: 60 });
+    const spec = builder.spec();
+    expect(spec.layers[0]!.data).toEqual({
+      values: [
+        { x: 10, y: 20 },
+        { x: 30, y: 40 },
+      ],
+    });
+  });
+
+  it("geom sugar with layer data matches direct .layer() parity", () => {
+    const layerRows = [
+      { x: 1, y: 2, g: "a" },
+      { x: 3, y: 4, g: "b" },
+    ];
+    const viaSugar = gg(rows, aes({ x: "x", y: "y" }))
+      .geomPoint({ data: layerRows, alpha: 0.5 })
+      .spec();
+    const viaLayer = gg(rows, aes({ x: "x", y: "y" }))
+      .layer({ geom: "point", data: layerRows, params: { alpha: 0.5 } })
+      .spec();
+    expect(viaSugar).toEqual(viaLayer);
   });
 });


### PR DESCRIPTION
Fixes #1280

## What

Every `geom*({ data })` path is `this.layer(layerFrom(geom, options))`.
Both `layerFrom` and `layer()` called `toAuthoringDataRef`, so each insertion
deep-copied every row twice (O(rows × cols) each, up to the documented
100k-row authoring limit).

Direct `.layer({ data })` already cloned once. Geom sugar now matches that.

## How

- `layerFrom`: pass `data` through without snapshotting
- `layer()`: remains the sole defensive copy before state insertion

## Tests

`packages/spec/tests/builder-data.test.ts`:

- `layerFrom` returns the caller's data reference (no intermediate clone)
- Caller mutation after `geomPoint({ data })` does not leak into `.spec()`
- Geom sugar with layer data matches direct `.layer()` parity

Also green: builder + geom parity suites (25 tests).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1370" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->