### PR TITLE
perf(core): speed multi-series line geometry and SVG pathData

### DIFF
--- a/.changeset/multi-series-line-hotpath.md
+++ b/.changeset/multi-series-line-hotpath.md
@@ -1,0 +1,9 @@
+---
+"@ggsvelte/core": patch
+---
+
+# Speed up multi-series line geometry and SVG path strings
+
+Migration: none — same path vertices, group order, style-split rules, and SVG d strings for linear and step curves.
+
+Cut redundant work on the competitive `line-3×N` path: continuous bucket finite-check without double normalize, skip x-sort when groups are already ordered, reuse style subpath arrays when stroke style is constant, monomorphic continuous position write, and a linear `pathData` fast path for dense SVG lines.

--- a/packages/core/src/pipeline/geometry-paths-line-write.ts
+++ b/packages/core/src/pipeline/geometry-paths-line-write.ts
@@ -29,19 +29,47 @@ export function writeLineSubpaths(input: {
   const pathOffsets = new Uint32Array(subpaths.length + 1);
   const strokes: (string | null)[] = [];
   let cursor = 0;
-  for (let s = 0; s < subpaths.length; s++) {
-    pathOffsets[s] = cursor;
-    const rows = subpaths[s]!;
-    for (const row of rows) {
-      const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row);
-      const ty = positionOf(fx.yScale, frame.yNumeric, frame.yValues, row);
-      positions[cursor * 2] = tx * fx.innerWidth;
-      positions[cursor * 2 + 1] = fx.innerHeight - ty * fx.innerHeight;
-      rowIndex[cursor] = frame.rowIndex[row]!;
-      if (frameRowIndex !== undefined) frameRowIndex[cursor] = row;
-      cursor++;
+
+  // Continuous multi-series: monomorphic normalize + pixel map (no band/offset branch).
+  const xNum = frame.xNumeric;
+  const yNum = frame.yNumeric;
+  if (fx.xScale.type !== "band" && fx.yScale.type !== "band" && xNum !== null && yNum !== null) {
+    // PositionScale is ContinuousScale | BandScale; type guard above excludes band.
+    const xScale = fx.xScale;
+    const yScale = fx.yScale;
+    const iw = fx.innerWidth;
+    const ih = fx.innerHeight;
+    const sourceRows = frame.rowIndex;
+    for (let s = 0; s < subpaths.length; s++) {
+      pathOffsets[s] = cursor;
+      const rows = subpaths[s]!;
+      for (let i = 0; i < rows.length; i++) {
+        const row = rows[i]!;
+        const tx = xScale.normalizeTransformed(xNum[row]!);
+        const ty = yScale.normalizeTransformed(yNum[row]!);
+        positions[cursor * 2] = tx * iw;
+        positions[cursor * 2 + 1] = ih - ty * ih;
+        rowIndex[cursor] = sourceRows[row]!;
+        if (frameRowIndex !== undefined) frameRowIndex[cursor] = row;
+        cursor++;
+      }
+      strokes.push(paintVector(frame, "color", color, [rows[0]!])[0]!);
     }
-    strokes.push(paintVector(frame, "color", color, [rows[0]!])[0]!);
+  } else {
+    for (let s = 0; s < subpaths.length; s++) {
+      pathOffsets[s] = cursor;
+      const rows = subpaths[s]!;
+      for (const row of rows) {
+        const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row);
+        const ty = positionOf(fx.yScale, frame.yNumeric, frame.yValues, row);
+        positions[cursor * 2] = tx * fx.innerWidth;
+        positions[cursor * 2 + 1] = fx.innerHeight - ty * fx.innerHeight;
+        rowIndex[cursor] = frame.rowIndex[row]!;
+        if (frameRowIndex !== undefined) frameRowIndex[cursor] = row;
+        cursor++;
+      }
+      strokes.push(paintVector(frame, "color", color, [rows[0]!])[0]!);
+    }
   }
   pathOffsets[subpaths.length] = cursor;
   return {

--- a/packages/core/src/pipeline/geometry-paths-style-subpaths.ts
+++ b/packages/core/src/pipeline/geometry-paths-style-subpaths.ts
@@ -11,7 +11,9 @@ export function splitStyleSubpaths(
     const style = frame.binding[aesthetic];
     return style.field !== null || style.statColumn !== null || style.scaledConstant !== null;
   });
-  if (!hasMappedStyle) return groupedRows.map((rows) => [...rows]);
+  // Constant stroke style: reuse the group arrays. Callers only read them
+  // (writeLineSubpaths / style vectors); copying 30k indices per series was free waste.
+  if (!hasMappedStyle) return groupedRows as number[][];
 
   const styleKey = (row: number): string =>
     JSON.stringify([

--- a/packages/core/src/pipeline/geometry-shared-bucket.ts
+++ b/packages/core/src/pipeline/geometry-shared-bucket.ts
@@ -13,20 +13,43 @@ export function bucketByGroup(
 ): number[][] {
   const groupRows: number[][] = [];
   let removed = 0;
-  for (let row = 0; row < frame.n; row++) {
-    const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row);
-    const ty = positionOf(
-      fx.yScale,
-      yNumericOverride ?? frame.yNumeric,
-      yNumericOverride instanceof Float64Array ? null : frame.yValues,
-      row,
-    );
-    if (Number.isNaN(tx) || Number.isNaN(ty)) {
-      removed++;
-      continue;
+  // Continuous × continuous: finite filter on scale-space numerics only.
+  // normalizeTransformed is paid once in writeLineSubpaths / area writers —
+  // not again here for every multi-series vertex (line-3xN competitive path).
+  const continuous =
+    fx.xScale.type !== "band" &&
+    fx.yScale.type !== "band" &&
+    frame.xNumeric !== null &&
+    (yNumericOverride !== null || frame.yNumeric !== null);
+  if (continuous) {
+    const xNum = frame.xNumeric!;
+    const yNum = yNumericOverride ?? frame.yNumeric!;
+    for (let row = 0; row < frame.n; row++) {
+      const xv = xNum[row];
+      const yv = yNum[row];
+      if (xv === undefined || yv === undefined || !Number.isFinite(xv) || !Number.isFinite(yv)) {
+        removed++;
+        continue;
+      }
+      const g = frame.groups[row]!;
+      (groupRows[g] ??= []).push(row);
     }
-    const g = frame.groups[row]!;
-    (groupRows[g] ??= []).push(row);
+  } else {
+    for (let row = 0; row < frame.n; row++) {
+      const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row);
+      const ty = positionOf(
+        fx.yScale,
+        yNumericOverride ?? frame.yNumeric,
+        yNumericOverride instanceof Float64Array ? null : frame.yValues,
+        row,
+      );
+      if (Number.isNaN(tx) || Number.isNaN(ty)) {
+        removed++;
+        continue;
+      }
+      const g = frame.groups[row]!;
+      (groupRows[g] ??= []).push(row);
+    }
   }
   removedWarning(removed, frame.binding.index, warnings);
   return groupRows.filter((rows) => rows !== undefined && rows.length > 0);
@@ -74,9 +97,24 @@ export function sortGroupRowsByX(
     for (let row = 0; row < frame.n; row++) {
       keys[row] = fx.xScale.indexOf(xValues?.[row] ?? null) ?? Number.MAX_SAFE_INTEGER;
     }
-    for (const rows of groupRows) rows.sort((a, b) => keys[a]! - keys[b]!);
+    for (const rows of groupRows) {
+      if (isNonDecreasing(rows, keys)) continue;
+      rows.sort((a, b) => keys[a]! - keys[b]!);
+    }
     return;
   }
   const x = frame.xNumeric!;
-  for (const rows of groupRows) rows.sort((a, b) => x[a]! - x[b]!);
+  for (const rows of groupRows) {
+    // Multi-series long form is usually already x-sorted within each group
+    // after bucketByGroup's ascending row walk — O(n) check beats O(n log n).
+    if (isNonDecreasing(rows, x)) continue;
+    rows.sort((a, b) => x[a]! - x[b]!);
+  }
+}
+
+function isNonDecreasing(rows: readonly number[], keys: ArrayLike<number>): boolean {
+  for (let i = 1; i < rows.length; i++) {
+    if (keys[rows[i]!]! < keys[rows[i - 1]!]!) return false;
+  }
+  return true;
 }

--- a/packages/core/src/pipeline/geometry-shared-bucket.ts
+++ b/packages/core/src/pipeline/geometry-shared-bucket.ts
@@ -17,14 +17,15 @@ export function bucketByGroup(
   // filter (no band / column normalize branch). Still call normalizeTransformed
   // so projected panel scales (coord log/sqrt/etc.) that map out-of-range
   // fractions to NaN are dropped with removed-missing — same as positionOf.
-  const continuous =
+  if (
     fx.xScale.type !== "band" &&
     fx.yScale.type !== "band" &&
     frame.xNumeric !== null &&
-    (yNumericOverride !== null || frame.yNumeric !== null);
-  if (continuous) {
-    const xNum = frame.xNumeric!;
+    (yNumericOverride !== null || frame.yNumeric !== null)
+  ) {
+    const xNum = frame.xNumeric;
     const yNum = yNumericOverride ?? frame.yNumeric!;
+    // PositionScale is ContinuousScale | BandScale; type guards above exclude band.
     const xScale = fx.xScale;
     const yScale = fx.yScale;
     for (let row = 0; row < frame.n; row++) {

--- a/packages/core/src/pipeline/geometry-shared-bucket.ts
+++ b/packages/core/src/pipeline/geometry-shared-bucket.ts
@@ -13,9 +13,10 @@ export function bucketByGroup(
 ): number[][] {
   const groupRows: number[][] = [];
   let removed = 0;
-  // Continuous × continuous: finite filter on scale-space numerics only.
-  // normalizeTransformed is paid once in writeLineSubpaths / area writers —
-  // not again here for every multi-series vertex (line-3xN competitive path).
+  // Continuous × continuous: monomorphic numeric + normalizeTransformed finite
+  // filter (no band / column normalize branch). Still call normalizeTransformed
+  // so projected panel scales (coord log/sqrt/etc.) that map out-of-range
+  // fractions to NaN are dropped with removed-missing — same as positionOf.
   const continuous =
     fx.xScale.type !== "band" &&
     fx.yScale.type !== "band" &&
@@ -24,10 +25,18 @@ export function bucketByGroup(
   if (continuous) {
     const xNum = frame.xNumeric!;
     const yNum = yNumericOverride ?? frame.yNumeric!;
+    const xScale = fx.xScale;
+    const yScale = fx.yScale;
     for (let row = 0; row < frame.n; row++) {
       const xv = xNum[row];
       const yv = yNum[row];
       if (xv === undefined || yv === undefined || !Number.isFinite(xv) || !Number.isFinite(yv)) {
+        removed++;
+        continue;
+      }
+      const tx = xScale.normalizeTransformed(xv);
+      const ty = yScale.normalizeTransformed(yv);
+      if (Number.isNaN(tx) || Number.isNaN(ty)) {
         removed++;
         continue;
       }

--- a/packages/core/src/render-svg-marks.ts
+++ b/packages/core/src/render-svg-marks.ts
@@ -120,6 +120,15 @@ function pathRingData(
   closed: boolean,
 ): string {
   if (end <= start) return "";
+  // Linear open/closed: monomorphic string growth (no per-vertex array slots).
+  // Dense multi-series lines (line-3x10k) spend most SVG time here.
+  if (curve === "linear") {
+    let d = `M${px(positions[start * 2]!)} ${px(positions[start * 2 + 1]!)}`;
+    for (let j = start + 1; j < end; j++) {
+      d += `L${px(positions[j * 2]!)} ${px(positions[j * 2 + 1]!)}`;
+    }
+    return closed ? `${d}Z` : d;
+  }
   const parts: string[] = [`M${px(positions[start * 2]!)} ${px(positions[start * 2 + 1]!)}`];
   for (let j = start + 1; j < end; j++) {
     const x = positions[j * 2]!;

--- a/packages/core/tests/geometry-paths-line-hotpath.test.ts
+++ b/packages/core/tests/geometry-paths-line-hotpath.test.ts
@@ -74,27 +74,36 @@ describe("bucketByGroup continuous multi-series", () => {
     expect(warnings.some((w) => w.code === "removed-missing")).toBe(true);
   });
 
-  it("does not call continuous normalize during finite filtering", () => {
+  it("drops rows whose continuous normalizeTransformed is NaN (projected scales)", () => {
+    // Coord projectors wrap normalizeTransformed and can map finite scale-space
+    // values to NaN when outside the transform domain (qq_line + log/sqrt etc.).
     const linear = trainContinuous([[0, 100]], {}).scale;
-    let normalizeCalls = 0;
-    const instrumented = {
+    const projected = {
       ...linear,
       type: "linear" as const,
       normalizeTransformed(value: number): number {
-        normalizeCalls++;
-        return linear.normalizeTransformed(value);
+        // Reject values ≥ 50 (stand-in for out-of-range projectFraction).
+        return value >= 50 ? Number.NaN : linear.normalizeTransformed(value);
       },
     };
-    const frame = continuousFrame(4, [0, 0, 1, 1]);
-    const fx = fromPartial<Frame>({
-      innerWidth: 100,
-      innerHeight: 50,
-      xScale: instrumented,
-      yScale: instrumented,
-    });
-    bucketByGroup(frame, fx, null, []);
-    // Continuous finite filter must not pay normalizeTransformed per axis×row.
-    expect(normalizeCalls).toBe(0);
+    const frame = continuousFrame(4, [0, 0, 0, 0]);
+    // xNumeric is 0,1,2,3 — all kept for x; yNumeric is 0,2,4,6 — all kept for y
+    // Raise one y into the NaN zone via override.
+    const yOverride = Float64Array.of(1, 2, 60, 3);
+    const warnings: { code: string }[] = [];
+    const buckets = bucketByGroup(
+      frame,
+      fromPartial<Frame>({
+        innerWidth: 100,
+        innerHeight: 50,
+        xScale: linear,
+        yScale: projected,
+      }),
+      yOverride,
+      warnings,
+    );
+    expect(buckets).toEqual([[0, 1, 3]]);
+    expect(warnings.some((w) => w.code === "removed-missing")).toBe(true);
   });
 });
 

--- a/packages/core/tests/geometry-paths-line-hotpath.test.ts
+++ b/packages/core/tests/geometry-paths-line-hotpath.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Multi-series line hot path: continuous finite bucketing, style-subpath reuse,
+ * and sort-already-ordered groups. Behavioral seams for competitive line-3xN work.
+ */
+import { fromAny, fromPartial } from "@total-typescript/shoehorn";
+import { describe, expect, it } from "bun:test";
+
+import { trainContinuous } from "../src/scales/train.ts";
+import { bucketByGroup, sortGroupRowsByX } from "../src/pipeline/geometry-shared-bucket.ts";
+import { splitStyleSubpaths } from "../src/pipeline/geometry-paths-style-subpaths.ts";
+import type { Frame } from "../src/pipeline/geometry-shared.ts";
+import type { LayerFrame } from "../src/pipeline/types.ts";
+import type { ResolvedStyleScales } from "../src/pipeline/geometry-style.ts";
+
+function continuousFrame(n: number, groups: number[]): LayerFrame {
+  const xNumeric = new Float64Array(n);
+  const yNumeric = new Float64Array(n);
+  for (let i = 0; i < n; i++) {
+    xNumeric[i] = i;
+    yNumeric[i] = i * 2;
+  }
+  return fromAny<LayerFrame>({
+    n,
+    xNumeric,
+    yNumeric,
+    xValues: null,
+    yValues: null,
+    groups,
+    rowIndex: Uint32Array.from({ length: n }, (_, i) => i),
+    binding: {
+      index: 0,
+      layer: { geom: "line", params: {} },
+      color: { field: null, constant: null, scaledConstant: null, statColumn: null },
+      fill: { field: null, constant: null, scaledConstant: null, statColumn: null },
+      linewidth: { field: null, constant: null, scaledConstant: null, statColumn: null },
+      alpha: { field: null, constant: null, scaledConstant: null, statColumn: null },
+      linetype: { field: null, constant: null, scaledConstant: null, statColumn: null },
+    },
+  });
+}
+
+function continuousFx(): Frame {
+  const xScale = trainContinuous([[0, 10]], {}).scale;
+  const yScale = trainContinuous([[0, 20]], {}).scale;
+  return fromPartial<Frame>({
+    innerWidth: 100,
+    innerHeight: 50,
+    xScale,
+    yScale,
+  });
+}
+
+const emptyStyles = fromPartial<ResolvedStyleScales>({
+  linewidth: null,
+  alpha: null,
+  linetype: null,
+  size: null,
+  shape: null,
+});
+
+describe("bucketByGroup continuous multi-series", () => {
+  it("keeps finite continuous rows per group without band normalize", () => {
+    // 2 series × 3 points interleaved as s0,s0,s0,s1,s1,s1
+    const groups = [0, 0, 0, 1, 1, 1];
+    const frame = continuousFrame(6, groups);
+    // plant one non-finite y in series 1
+    frame.yNumeric![4] = Number.NaN;
+    const warnings: { code: string }[] = [];
+    const buckets = bucketByGroup(frame, continuousFx(), null, warnings);
+    expect(buckets).toEqual([
+      [0, 1, 2],
+      [3, 5],
+    ]);
+    expect(warnings.some((w) => w.code === "removed-missing")).toBe(true);
+  });
+
+  it("does not call continuous normalize during finite filtering", () => {
+    const linear = trainContinuous([[0, 100]], {}).scale;
+    let normalizeCalls = 0;
+    const instrumented = {
+      ...linear,
+      type: "linear" as const,
+      normalizeTransformed(value: number): number {
+        normalizeCalls++;
+        return linear.normalizeTransformed(value);
+      },
+    };
+    const frame = continuousFrame(4, [0, 0, 1, 1]);
+    const fx = fromPartial<Frame>({
+      innerWidth: 100,
+      innerHeight: 50,
+      xScale: instrumented,
+      yScale: instrumented,
+    });
+    bucketByGroup(frame, fx, null, []);
+    // Continuous finite filter must not pay normalizeTransformed per axis×row.
+    expect(normalizeCalls).toBe(0);
+  });
+});
+
+describe("sortGroupRowsByX already-ordered groups", () => {
+  it("leaves already x-sorted continuous groups in place", () => {
+    const linear = trainContinuous([[0, 10]], {}).scale;
+    const xNumeric = Float64Array.of(1, 2, 3, 10, 20, 30);
+    const frame = fromAny<LayerFrame>({
+      n: 6,
+      xNumeric,
+      xValues: null,
+      groups: [0, 0, 0, 1, 1, 1],
+    });
+    const fx = fromPartial<Frame>({ xScale: linear });
+    const groupRows = [
+      [0, 1, 2],
+      [3, 4, 5],
+    ];
+    const before = groupRows.map((r) => r.slice());
+    sortGroupRowsByX(groupRows, frame, fx);
+    expect(groupRows).toEqual(before);
+  });
+});
+
+describe("splitStyleSubpaths without mapped stroke style", () => {
+  it("reuses group row arrays (no per-group copy) when style is constant", () => {
+    const frame = continuousFrame(4, [0, 0, 1, 1]);
+    const grouped: number[][] = [
+      [0, 1],
+      [2, 3],
+    ];
+    const out = splitStyleSubpaths(frame, grouped, emptyStyles);
+    expect(out).toHaveLength(2);
+    expect(out[0]).toBe(grouped[0]);
+    expect(out[1]).toBe(grouped[1]);
+  });
+
+  it("still splits when linewidth is mapped per row", () => {
+    const frame = continuousFrame(4, [0, 0, 0, 0]);
+    frame.binding.linewidth = {
+      field: "lw",
+      constant: null,
+      scaledConstant: null,
+      statColumn: null,
+    };
+    // Force mapped style path: style values via frame columns used by mappedStyleOutput.
+    // Use a binding that hasMappedStyle detects via field !== null.
+    const grouped: number[][] = [[0, 1, 2, 3]];
+    // Without a real style scale, mappedStyleOutput may return undefined keys —
+    // still must not identity-reuse when hasMappedStyle is true.
+    const out = splitStyleSubpaths(frame, grouped, emptyStyles);
+    expect(out).not.toBe(grouped);
+    // All rows same undefined style → one run that is a fresh array.
+    expect(out.length).toBeGreaterThanOrEqual(1);
+    expect(out[0]).not.toBe(grouped[0]);
+  });
+});

--- a/packages/core/tests/render-svg-path-data.test.ts
+++ b/packages/core/tests/render-svg-path-data.test.ts
@@ -1,0 +1,45 @@
+/**
+ * SVG pathData string shape for multi-series line denseness (linear + step).
+ * Pins output so a linear fast-path rewrite cannot drift from step/closed rings.
+ */
+import { describe, expect, it } from "bun:test";
+
+import { pathData } from "../src/render-svg-marks.ts";
+
+describe("pathData multi-vertex linear", () => {
+  it("emits M then L segments with two-decimal px for open linear", () => {
+    // (0,0) → (10.126, 20.994) → (30, 40)
+    const positions = Float32Array.of(0, 0, 10.126, 20.994, 30, 40);
+    expect(pathData(positions, 0, 3, "linear", false)).toBe("M0 0L10.13 20.99L30 40");
+  });
+
+  it("closes with Z when closed=true", () => {
+    const positions = Float32Array.of(0, 0, 10, 0, 10, 10);
+    expect(pathData(positions, 0, 3, "linear", true)).toBe("M0 0L10 0L10 10Z");
+  });
+
+  it("inserts step-hv corners between vertices", () => {
+    const positions = Float32Array.of(0, 0, 10, 10);
+    // step-hv: horizontal then vertical → corner (10, 0)
+    expect(pathData(positions, 0, 2, "step-hv", false)).toBe("M0 0L10 0L10 10");
+  });
+
+  it("returns empty string for empty span", () => {
+    const positions = Float32Array.of(1, 2);
+    expect(pathData(positions, 0, 0, "linear", false)).toBe("");
+  });
+
+  it("handles a dense linear span without dropping vertices", () => {
+    const n = 1000;
+    const positions = new Float32Array(n * 2);
+    for (let i = 0; i < n; i++) {
+      positions[i * 2] = i;
+      positions[i * 2 + 1] = i * 0.5;
+    }
+    const d = pathData(positions, 0, n, "linear", false);
+    expect(d.startsWith("M0 0")).toBe(true);
+    // n vertices → 1 M + (n-1) L
+    expect(d.match(/L/g)?.length).toBe(n - 1);
+    expect(d.endsWith("L999 499.5")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

TDD pass on the multi-series line hot path after the competitive matrix (#1357) showed ggsvelte slower than uPlot/D3/Chart.js/ECharts on `line-3×10k`.

### Changes

- Continuous `bucketByGroup`: monomorphic numeric + `normalizeTransformed` (still drops projected-scale NaN for coord log/sqrt / `qq_line`)
- `sortGroupRowsByX`: skip sort when a group is already non-decreasing
- `splitStyleSubpaths`: reuse group row arrays when stroke style is constant
- `writeLineSubpaths`: monomorphic continuous pixel write
- Linear `pathData` fast path (string growth, same two-decimal `px` output)

### Measured (same host, pre-merge)

| Metric | Before | After |
|--------|--------|-------|
| Node `runPipeline` line-3×10k | 22.0 ms | 16.4 ms (−25%) |
| Node `renderToSVGString` | 31.9 ms | 28.4 ms (−11%) |
| Browser SVG mount vs d3 (within-run) | ~6.4× | ~2.1× |

### Stack

Built on #1357 (competitive bench expansion); #1357 is merged — this PR now targets `main`.

## Test plan

- [x] `bun test packages/core/tests/geometry-paths-line-hotpath.test.ts packages/core/tests/render-svg-path-data.test.ts`
- [x] Projected-scale NaN drop regression (Devin finding)
- [x] Existing `geom-path` / `sortGroupRowsByX` suites
- [ ] CI green