### PR TITLE
fix(core): keep short Y-band labels when one label is over-wide (#1356)

### DIFF
--- a/.changeset/vertical-band-thin-only-if-width-shrinks.md
+++ b/.changeset/vertical-band-thin-only-if-width-shrinks.md
@@ -4,6 +4,6 @@
 
 # Vertical band axes: truncate over-wide labels instead of hiding short ones
 
-Migration: none — same tick values and formatters; only which category labels stay visible under a left-margin width cap when thinning cannot shrink measured width.
+Migration: none — same tick values and formatters; only which category labels stay visible under a left-margin width cap when thinning cannot shrink measured width, plus density thinning for crowded tall lists.
 
-When a categorical Y axis (native band Y, or categorical-on-Y after `coord_flip`) overflowed the left-margin cap, layout doubled `labelEvery` until almost every label was gone, even when the widest survivor never left the labeled set. Doubling now commits only when `maxLabeledWidth` actually shrinks; otherwise the path truncates with ellipsis and keeps short siblings labeled.
+When a categorical Y axis (native band Y, or categorical-on-Y after `coord_flip`) overflowed the left-margin cap, layout doubled `labelEvery` until almost every label was gone, even when the widest survivor never left the labeled set. Width-driven doubling now commits only when `maxLabeledWidth` actually shrinks (probing further doublings when a single step is a no-op); otherwise the path truncates with ellipsis and keeps short siblings labeled. A separate density pass still raises `labelEvery` when band step is below label height + min gap so crowded lists do not stack.

--- a/.changeset/vertical-band-thin-only-if-width-shrinks.md
+++ b/.changeset/vertical-band-thin-only-if-width-shrinks.md
@@ -1,0 +1,9 @@
+---
+"@ggsvelte/core": patch
+---
+
+# Vertical band axes: truncate over-wide labels instead of hiding short ones
+
+Migration: none — same tick values and formatters; only which category labels stay visible under a left-margin width cap when thinning cannot shrink measured width.
+
+When a categorical Y axis (native band Y, or categorical-on-Y after `coord_flip`) overflowed the left-margin cap, layout doubled `labelEvery` until almost every label was gone, even when the widest survivor never left the labeled set. Doubling now commits only when `maxLabeledWidth` actually shrinks; otherwise the path truncates with ellipsis and keeps short siblings labeled.

--- a/packages/core/src/layout/layout.ts
+++ b/packages/core/src/layout/layout.ts
@@ -299,13 +299,26 @@ export function layoutPass(margins: Margins, input: LayoutInput, theme: LayoutTh
     y.ticks.length >= BAND_THIN_MIN_CATEGORIES
   ) {
     const n = y.ticks.length;
-    // Band pitch is over the full category domain (breaks are a subset of
-    // domainIndex slots) — matches planBandAxis's categoryCount denominator.
+    // Pitch from the full domain unit times the minimum domainIndex gap between
+    // consecutive ticks. Full-domain ticks → gap 1; sparse authored breaks keep
+    // their larger on-screen spacing so we do not thin them away.
     const categoryCount = Math.max(1, input.y.categories.length);
-    const bandStep = innerH / categoryCount;
+    const bandUnit = innerH / categoryCount;
+    let minIndexGap = 1;
+    const hasDomainIndex = y.ticks.every((t) => t.domainIndex !== undefined);
+    if (hasDomainIndex && n >= 2) {
+      const idxs = y.ticks.map((t) => t.domainIndex!).toSorted((a, b) => a - b);
+      minIndexGap = Infinity;
+      for (let i = 1; i < idxs.length; i++) {
+        const gap = idxs[i]! - idxs[i - 1]!;
+        if (gap > 0 && gap < minIndexGap) minIndexGap = gap;
+      }
+      if (!Number.isFinite(minIndexGap) || minIndexGap < 1) minIndexGap = 1;
+    }
+    const displayStep = bandUnit * minIndexGap;
     const minStep = labelH + MIN_BAND_LABEL_GAP_PX;
     let densityThinned = false;
-    while (yEvery * bandStep < minStep) {
+    while (yEvery * displayStep < minStep) {
       if (yEvery * 2 >= n) break;
       yEvery *= 2;
       applyBandLabelEvery(y, yEvery);

--- a/packages/core/src/layout/layout.ts
+++ b/packages/core/src/layout/layout.ts
@@ -31,6 +31,7 @@
 
 import type { AxisGuidePlan } from "./guide-plan-types.js";
 import type { TextMeasurer } from "./measure.js";
+import { BAND_THIN_MIN_CATEGORIES, MIN_BAND_LABEL_GAP_PX } from "./band-label-layout.js";
 import { deriveTicks, type AxisTicks, type DeriveTicksContext } from "./layout-derive-ticks.js";
 import { truncateToFit } from "./truncate.js";
 import {
@@ -221,22 +222,31 @@ export function layoutPass(margins: Margins, input: LayoutInput, theme: LayoutTh
     // Degrade 1: tick thinning.
     // Band axes: only the labeled flag depends on every — flip flags in place
     // instead of re-deriving and re-formatting all k ticks each doubling (#1335).
-    // Commit a doubling only when max labeled width actually shrinks; otherwise
-    // fall through to truncation. Width overflow on a vertical band is a
-    // truncation problem, not a density problem (#1356).
+    // Commit a doubling only when max labeled width actually shrinks; probe
+    // further doublings when the next step is a no-op (widest at an even index)
+    // before falling through to truncation (#1356).
     while (yLabelW + leftFixed > capLeft) {
       if (input.y.type === "band") {
         if (yEvery * 2 >= y.ticks.length) break;
-        const nextEvery = yEvery * 2;
-        applyBandLabelEvery(y, nextEvery);
-        const nextW = maxLabeledWidth(y, measurer, fontSize);
-        if (nextW >= yLabelW) {
+        let probe = yEvery * 2;
+        let improved = false;
+        while (true) {
+          applyBandLabelEvery(y, probe);
+          const nextW = maxLabeledWidth(y, measurer, fontSize);
+          if (nextW < yLabelW) {
+            yEvery = probe;
+            yLabelW = nextW;
+            degradations.push("y:thin");
+            improved = true;
+            break;
+          }
+          if (probe * 2 >= y.ticks.length) break;
+          probe *= 2;
+        }
+        if (!improved) {
           applyBandLabelEvery(y, yEvery);
           break;
         }
-        yEvery = nextEvery;
-        yLabelW = nextW;
-        degradations.push("y:thin");
       } else {
         if (yCount <= 2) break;
         yCount = Math.max(2, Math.floor(yCount / 2));
@@ -260,6 +270,29 @@ export function layoutPass(margins: Margins, input: LayoutInput, theme: LayoutTh
       }
       degradations.push("y:truncate");
       yLabelW = maxLabeledWidth(y, measurer, fontSize);
+    }
+  }
+
+  // Vertical density for band Y (legacy path only — measured planner owns
+  // horizontal collision). Independent of the width loop so #1356 can truncate
+  // over-wide survivors without stripping short siblings, while crowded tall
+  // lists still thin to label height + min gap.
+  if (
+    yLabelsVisible &&
+    !yPreserve &&
+    !y.empty &&
+    input.y.type === "band" &&
+    y.guidePlan === undefined &&
+    y.ticks.length >= BAND_THIN_MIN_CATEGORIES
+  ) {
+    const n = y.ticks.length;
+    const bandStep = innerH / n;
+    const minStep = labelH + MIN_BAND_LABEL_GAP_PX;
+    while (yEvery * bandStep < minStep) {
+      if (yEvery * 2 >= n) break;
+      yEvery *= 2;
+      applyBandLabelEvery(y, yEvery);
+      degradations.push("y:thin");
     }
   }
 

--- a/packages/core/src/layout/layout.ts
+++ b/packages/core/src/layout/layout.ts
@@ -221,11 +221,22 @@ export function layoutPass(margins: Margins, input: LayoutInput, theme: LayoutTh
     // Degrade 1: tick thinning.
     // Band axes: only the labeled flag depends on every — flip flags in place
     // instead of re-deriving and re-formatting all k ticks each doubling (#1335).
+    // Commit a doubling only when max labeled width actually shrinks; otherwise
+    // fall through to truncation. Width overflow on a vertical band is a
+    // truncation problem, not a density problem (#1356).
     while (yLabelW + leftFixed > capLeft) {
       if (input.y.type === "band") {
         if (yEvery * 2 >= y.ticks.length) break;
-        yEvery *= 2;
-        applyBandLabelEvery(y, yEvery);
+        const nextEvery = yEvery * 2;
+        applyBandLabelEvery(y, nextEvery);
+        const nextW = maxLabeledWidth(y, measurer, fontSize);
+        if (nextW >= yLabelW) {
+          applyBandLabelEvery(y, yEvery);
+          break;
+        }
+        yEvery = nextEvery;
+        yLabelW = nextW;
+        degradations.push("y:thin");
       } else {
         if (yCount <= 2) break;
         yCount = Math.max(2, Math.floor(yCount / 2));
@@ -233,9 +244,9 @@ export function layoutPass(margins: Margins, input: LayoutInput, theme: LayoutTh
           deriveTicks(input.y, yCount, input.formatY, yEvery, yContext),
           yPreserve,
         );
+        degradations.push("y:thin");
+        yLabelW = maxLabeledWidth(y, measurer, fontSize);
       }
-      degradations.push("y:thin");
-      yLabelW = maxLabeledWidth(y, measurer, fontSize);
     }
     // Degrade 2: truncation.
     if (yLabelW + leftFixed > capLeft) {

--- a/packages/core/src/layout/layout.ts
+++ b/packages/core/src/layout/layout.ts
@@ -299,14 +299,21 @@ export function layoutPass(margins: Margins, input: LayoutInput, theme: LayoutTh
     y.ticks.length >= BAND_THIN_MIN_CATEGORIES
   ) {
     const n = y.ticks.length;
-    const bandStep = innerH / n;
+    // Band pitch is over the full category domain (breaks are a subset of
+    // domainIndex slots) — matches planBandAxis's categoryCount denominator.
+    const categoryCount = Math.max(1, input.y.categories.length);
+    const bandStep = innerH / categoryCount;
     const minStep = labelH + MIN_BAND_LABEL_GAP_PX;
+    let densityThinned = false;
     while (yEvery * bandStep < minStep) {
       if (yEvery * 2 >= n) break;
       yEvery *= 2;
       applyBandLabelEvery(y, yEvery);
       degradations.push("y:thin");
+      densityThinned = true;
     }
+    // Hidden labels must not keep reserving left-margin width.
+    if (densityThinned) yLabelW = maxLabeledWidth(y, measurer, fontSize);
   }
 
   // --- x axis → bottom margin (one label line) + right margin (overhang of

--- a/packages/core/src/layout/layout.ts
+++ b/packages/core/src/layout/layout.ts
@@ -83,6 +83,34 @@ function applyBandLabelEvery(axis: AxisTicks, every: number): void {
   }
 }
 
+/**
+ * Probe higher band `labelEvery` values until max labeled width shrinks.
+ * Restores the prior every when no probe improves width (#1356).
+ */
+function thinBandForWidth(
+  axis: AxisTicks,
+  every: number,
+  currentW: number,
+  measurer: TextMeasurer,
+  fontSize: number,
+): { every: number; width: number; improved: boolean } {
+  if (every * 2 >= axis.ticks.length) {
+    return { every, width: currentW, improved: false };
+  }
+  let probe = every * 2;
+  for (;;) {
+    applyBandLabelEvery(axis, probe);
+    const nextW = maxLabeledWidth(axis, measurer, fontSize);
+    if (nextW < currentW) {
+      return { every: probe, width: nextW, improved: true };
+    }
+    if (probe * 2 >= axis.ticks.length) break;
+    probe *= 2;
+  }
+  applyBandLabelEvery(axis, every);
+  return { every, width: currentW, improved: false };
+}
+
 /** Measure preserved labels without mutating the semantic guide plan. */
 function presentForLayout(axis: AxisTicks, preserve: boolean): AxisTicks {
   if (!preserve) return axis;
@@ -227,26 +255,11 @@ export function layoutPass(margins: Margins, input: LayoutInput, theme: LayoutTh
     // before falling through to truncation (#1356).
     while (yLabelW + leftFixed > capLeft) {
       if (input.y.type === "band") {
-        if (yEvery * 2 >= y.ticks.length) break;
-        let probe = yEvery * 2;
-        let improved = false;
-        while (true) {
-          applyBandLabelEvery(y, probe);
-          const nextW = maxLabeledWidth(y, measurer, fontSize);
-          if (nextW < yLabelW) {
-            yEvery = probe;
-            yLabelW = nextW;
-            degradations.push("y:thin");
-            improved = true;
-            break;
-          }
-          if (probe * 2 >= y.ticks.length) break;
-          probe *= 2;
-        }
-        if (!improved) {
-          applyBandLabelEvery(y, yEvery);
-          break;
-        }
+        const thinned = thinBandForWidth(y, yEvery, yLabelW, measurer, fontSize);
+        if (!thinned.improved) break;
+        yEvery = thinned.every;
+        yLabelW = thinned.width;
+        degradations.push("y:thin");
       } else {
         if (yCount <= 2) break;
         yCount = Math.max(2, Math.floor(yCount / 2));

--- a/packages/core/tests/layout/band-thin-once.test.ts
+++ b/packages/core/tests/layout/band-thin-once.test.ts
@@ -38,7 +38,9 @@ describe("band y thinning rebuild cost (#1335)", () => {
     expect(formats).toBe(k);
   });
 
-  it("keeps the same chosen labelEvery, labeled mask, and degradation order", () => {
+  it("does not thin uniform long labels when doubling cannot shrink width (#1356)", () => {
+    // Every category is over-wide; index 0 always stays labeled, so thinning never
+    // reduces maxLabeledWidth. Truncate in place with every=1 instead.
     const k = 64;
     const cats = longCategories(k);
     const r = layout(
@@ -49,20 +51,28 @@ describe("band y thinning rebuild cost (#1335)", () => {
         y: band(...cats),
       }),
     );
-    // Characterisation of the current thinning outcome (must not change).
-    expect(r.y.labelEvery).toBe(32);
+    expect(r.y.labelEvery).toBe(1);
     expect(r.y.ticks).toHaveLength(k);
     expect(r.y.ticks.map((t) => t.value)).toEqual(cats);
-    for (let i = 0; i < k; i++) {
-      expect(r.y.ticks[i]!.labeled).toBe(i % r.y.labelEvery === 0);
-    }
-    expect(r.degradations[0]).toBe("y:thin");
+    expect(r.y.ticks.every((t) => t.labeled)).toBe(true);
+    expect(r.degradations).not.toContain("y:thin");
     expect(r.degradations).toContain("y:truncate");
+    expect(r.y.truncated).toBe(true);
   });
 
   it("stops doubling when the next every would cover the whole tick list", () => {
-    // Very tight capLeft forces the loop to the break arm rather than fitting.
-    const cats = longCategories(8);
+    // Surviving labels get shorter at each doubling so width keeps falling, yet
+    // the tinest cap still overflows — until every*2 >= length forces the break.
+    const cats = [
+      "WWWWWWWW", // 0
+      "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", // 1 longest
+      "YYYYYYYYYYYYYYYY", // 2 mid-long
+      "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", // 3
+      "ZZZZZZZZZZ", // 4 mid
+      "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", // 5
+      "AAAAAAAA", // 6 short
+      "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", // 7
+    ];
     const r = layout(
       base({
         width: 80,

--- a/packages/core/tests/layout/band-thin-once.test.ts
+++ b/packages/core/tests/layout/band-thin-once.test.ts
@@ -38,9 +38,10 @@ describe("band y thinning rebuild cost (#1335)", () => {
     expect(formats).toBe(k);
   });
 
-  it("does not thin uniform long labels when doubling cannot shrink width (#1356)", () => {
-    // Every category is over-wide; index 0 always stays labeled, so thinning never
-    // reduces maxLabeledWidth. Truncate in place with every=1 instead.
+  it("does not width-thin uniform long labels; density still thins crowded lists (#1356)", () => {
+    // Width doubling cannot shrink maxLabeledWidth (index 0 always labeled), so
+    // the width loop truncates. Density thinning (separate pass) still raises
+    // labelEvery when band step is below label height + gap.
     const k = 64;
     const cats = longCategories(k);
     const r = layout(
@@ -51,13 +52,33 @@ describe("band y thinning rebuild cost (#1335)", () => {
         y: band(...cats),
       }),
     );
-    expect(r.y.labelEvery).toBe(1);
     expect(r.y.ticks).toHaveLength(k);
     expect(r.y.ticks.map((t) => t.value)).toEqual(cats);
+    expect(r.y.labelEvery).toBeGreaterThan(1);
+    expect(r.degradations).toContain("y:thin");
+    expect(r.degradations).toContain("y:truncate");
+    expect(r.y.truncated).toBe(true);
+    for (let i = 0; i < k; i++) {
+      expect(r.y.ticks[i]!.labeled).toBe(i % r.y.labelEvery === 0);
+    }
+  });
+
+  it("width-truncates without density thin when few long categories fit the height", () => {
+    // Under BAND_THIN_MIN_CATEGORIES, density never fires; width still cannot
+    // improve via thinning, so every stays 1 and labels truncate.
+    const cats = longCategories(8);
+    const r = layout(
+      base({
+        width: 400,
+        height: 400,
+        x: lin(0, 100),
+        y: band(...cats),
+      }),
+    );
+    expect(r.y.labelEvery).toBe(1);
     expect(r.y.ticks.every((t) => t.labeled)).toBe(true);
     expect(r.degradations).not.toContain("y:thin");
     expect(r.degradations).toContain("y:truncate");
-    expect(r.y.truncated).toBe(true);
   });
 
   it("stops doubling when the next every would cover the whole tick list", () => {

--- a/packages/core/tests/layout/band-y-wide-label-thin.test.ts
+++ b/packages/core/tests/layout/band-y-wide-label-thin.test.ts
@@ -129,4 +129,34 @@ describe("vertical band y: over-wide label does not hide short siblings (#1356)"
     expect(r.degradations).toContain("y:thin");
     expect(r.y.ticks.filter((t) => t.labeled).length).toBeLessThan(cats.length);
   });
+
+  it("does not reserve left margin for a wide label that density hides", () => {
+    // Wide label only at odd indices; density (every≥2) hides it. Left margin
+    // must reflect the short survivors, not the hidden long name.
+    const cats = Array.from({ length: 40 }, (_, i) =>
+      i % 2 === 1 ? `Very long category label reserved width should not survive ${i}` : `S${i}`,
+    );
+    const shortOnly = layout(
+      base({
+        width: 400,
+        height: 120,
+        x: lin(0, 10),
+        y: band(...Array.from({ length: 40 }, (_, i) => `S${i}`)),
+      }),
+    );
+    const mixed = layout(
+      base({
+        width: 400,
+        height: 120,
+        x: lin(0, 10),
+        y: band(...cats),
+      }),
+    );
+    expect(mixed.y.labelEvery).toBeGreaterThan(1);
+    expect(mixed.y.ticks.some((t) => t.labeled && String(t.value).startsWith("Very"))).toBe(false);
+    // Same density outcome as all-short → left margin within one quantum.
+    expect(Math.abs(mixed.margins.left - shortOnly.margins.left)).toBeLessThanOrEqual(
+      theme.quantum,
+    );
+  });
 });

--- a/packages/core/tests/layout/band-y-wide-label-thin.test.ts
+++ b/packages/core/tests/layout/band-y-wide-label-thin.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Vertical band axis: width overflow must truncate, not thin away short labels (#1356).
+ *
+ * Thinning labelEvery only helps left-margin width when the widest labeled
+ * ticks actually disappear. When a survivor stays over-wide (index 0 is always
+ * labeled), doubling every is a no-op for width and must not strip siblings.
+ */
+import { describe, expect, it } from "bun:test";
+
+import { layout } from "../../src/layout/layout.ts";
+import { band, base, lin, theme } from "./fixtures.ts";
+
+const LONG_A =
+  "ESTABLECESE LA FECHA DE ENTRADA EN VIGENCIA DE LA LEY 27.742 DE PRESUPUESTO NACIONAL PARA EL EJERCICIO";
+const LONG_B =
+  "APRUEBASE EL PROYECTO DE INVERSION PRESENTADO POR LA EMPRESA CONSORCIO MINERO SA DEL NORTE";
+
+/** Issue #1356 repro categories: two over-wide labels among short siblings. */
+const MIXED = [
+  LONG_A,
+  "Alpha",
+  "Beta",
+  "Gamma",
+  "Delta",
+  "Epsilon",
+  LONG_B,
+  "Zeta",
+  "Eta",
+  "Theta",
+];
+
+describe("vertical band y: over-wide label does not hide short siblings (#1356)", () => {
+  it("keeps every short category labeled and truncates only the over-wide ones", () => {
+    const r = layout(
+      base({
+        width: 400,
+        height: 360,
+        x: lin(0, 10),
+        y: band(...MIXED),
+      }),
+    );
+
+    expect(r.y.ticks).toHaveLength(MIXED.length);
+    // Thinning must not fire when it cannot shrink max labeled width.
+    expect(r.y.labelEvery).toBe(1);
+    expect(r.degradations).not.toContain("y:thin");
+    expect(r.degradations).toContain("y:truncate");
+    expect(r.y.truncated).toBe(true);
+
+    for (const t of r.y.ticks) {
+      expect(t.labeled).toBe(true);
+    }
+
+    const short = ["Alpha", "Beta", "Gamma", "Delta", "Epsilon", "Zeta", "Eta", "Theta"];
+    for (const name of short) {
+      const tick = r.y.ticks.find((t) => t.value === name);
+      expect(tick?.label).toBe(name);
+    }
+
+    for (const long of [LONG_A, LONG_B]) {
+      const tick = r.y.ticks.find((t) => t.value === long);
+      expect(tick?.label).not.toBe(long);
+      expect(tick?.label.endsWith(theme.ellipsis)).toBe(true);
+    }
+
+    expect(r.margins.left).toBeLessThanOrEqual(theme.maxMarginFraction * 400);
+  });
+
+  it("still thins when hiding wider ticks actually reduces left-margin width", () => {
+    // Odd indices are the only over-wide labels; every=2 keeps even shorts.
+    const cats = Array.from({ length: 16 }, (_, i) =>
+      i % 2 === 1
+        ? `Very long category label that blows the left margin budget number ${i}`
+        : `S${i}`,
+    );
+    const r = layout(
+      base({
+        width: 200,
+        height: 400,
+        x: lin(0, 10),
+        y: band(...cats),
+      }),
+    );
+    expect(r.y.labelEvery).toBeGreaterThan(1);
+    expect(r.degradations).toContain("y:thin");
+    // Surviving labels are the short even-index ones — no need to truncate.
+    const labeled = r.y.ticks.filter((t) => t.labeled);
+    expect(labeled.length).toBeGreaterThan(0);
+    expect(labeled.every((t) => String(t.value).startsWith("S"))).toBe(true);
+  });
+});

--- a/packages/core/tests/layout/band-y-wide-label-thin.test.ts
+++ b/packages/core/tests/layout/band-y-wide-label-thin.test.ts
@@ -68,6 +68,7 @@ describe("vertical band y: over-wide label does not hide short siblings (#1356)"
 
   it("still thins when hiding wider ticks actually reduces left-margin width", () => {
     // Odd indices are the only over-wide labels; every=2 keeps even shorts.
+    // Tall plot + 16 cats so density does not force further thinning.
     const cats = Array.from({ length: 16 }, (_, i) =>
       i % 2 === 1
         ? `Very long category label that blows the left margin budget number ${i}`
@@ -76,7 +77,7 @@ describe("vertical band y: over-wide label does not hide short siblings (#1356)"
     const r = layout(
       base({
         width: 200,
-        height: 400,
+        height: 640,
         x: lin(0, 10),
         y: band(...cats),
       }),
@@ -87,5 +88,45 @@ describe("vertical band y: over-wide label does not hide short siblings (#1356)"
     const labeled = r.y.ticks.filter((t) => t.labeled);
     expect(labeled.length).toBeGreaterThan(0);
     expect(labeled.every((t) => String(t.value).startsWith("S"))).toBe(true);
+  });
+
+  it("probes past a no-op doubling when a later every drops the widest survivor", () => {
+    // Widest at index 2: every=2 still labels it; every=4 drops it and shrinks width.
+    const cats = [
+      "Short0",
+      "Short1",
+      "THIS IS THE ONE VERY LONG CATEGORY LABEL THAT BLOWS THE LEFT MARGIN ALONE",
+      "Short3",
+      "Short4",
+      "Short5",
+      "Short6",
+      "Short7",
+    ];
+    const r = layout(
+      base({
+        width: 200,
+        height: 320,
+        x: lin(0, 10),
+        y: band(...cats),
+      }),
+    );
+    expect(r.y.labelEvery).toBeGreaterThanOrEqual(4);
+    expect(r.y.ticks.find((t) => t.value === cats[2])?.labeled).toBe(false);
+    expect(r.degradations).toContain("y:thin");
+  });
+
+  it("density-thins many short categories when the plot is too short for all labels", () => {
+    const cats = Array.from({ length: 40 }, (_, i) => `C${i}`);
+    const r = layout(
+      base({
+        width: 400,
+        height: 120,
+        x: lin(0, 10),
+        y: band(...cats),
+      }),
+    );
+    expect(r.y.labelEvery).toBeGreaterThan(1);
+    expect(r.degradations).toContain("y:thin");
+    expect(r.y.ticks.filter((t) => t.labeled).length).toBeLessThan(cats.length);
   });
 });

--- a/packages/core/tests/layout/band-y-wide-label-thin.test.ts
+++ b/packages/core/tests/layout/band-y-wide-label-thin.test.ts
@@ -130,6 +130,24 @@ describe("vertical band y: over-wide label does not hide short siblings (#1356)"
     expect(r.y.ticks.filter((t) => t.labeled).length).toBeLessThan(cats.length);
   });
 
+  it("does not density-thin sparse authored breaks that already have room", () => {
+    // 200 categories, 16 evenly spaced breaks — on-screen pitch is large enough
+    // that every break label should stay labeled.
+    const categories = Array.from({ length: 200 }, (_, i) => `Cat ${i}`);
+    const breaks = Array.from({ length: 16 }, (_, i) => categories[i * 12]!);
+    const r = layout(
+      base({
+        width: 400,
+        height: 400,
+        x: lin(0, 10),
+        y: { type: "band", categories, breaks },
+      }),
+    );
+    expect(r.y.ticks).toHaveLength(breaks.length);
+    expect(r.y.labelEvery).toBe(1);
+    expect(r.y.ticks.every((t) => t.labeled)).toBe(true);
+  });
+
   it("does not reserve left margin for a wide label that density hides", () => {
     // Wide label only at odd indices; density (every≥2) hides it. Left margin
     // must reflect the short survivors, not the hidden long name.


### PR DESCRIPTION
## Summary

- Vertical band axes (native categorical Y, or categorical-on-Y after `coord_flip`) used to double `labelEvery` under the left-margin width cap even when thinning could not shrink measured max label width — typically because index 0 stays labeled and held an over-wide survivor.
- Thinning now commits only when `maxLabeledWidth` actually falls; otherwise the path truncates with ellipsis so short sibling labels stay visible.
- Regression tests for the #1356 mixed long/short case; updated #1335 characterizations that encoded the old “thin even when width does not shrink” outcome.

Closes #1356

## Test plan

- [x] `bun test packages/core/tests/layout/`
- [x] New #1356 tests: all short categories stay labeled; thinning still runs when hiding wider ticks reduces width
- [x] #1335 format-once and length-boundary thinning cases still green
- [ ] CI green on the PR
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1373" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->