### PR TITLE
perf(svelte): snapshot layer data once per assemble

### DIFF
--- a/.changeset/assemble-single-layer-snapshot.md
+++ b/.changeset/assemble-single-layer-snapshot.md
@@ -1,0 +1,12 @@
+---
+"@ggsvelte/svelte": patch
+---
+
+# Assemble snapshots each layer once, not twice
+
+Migration: none — same assembled PortableSpec and mutation isolation; one less
+O(rows×cols) deep copy per layer with inline data on every assemble.
+
+`assemblePortableSpec` already snapshots layers before folding non-mark
+grammar children. `materializeAndNormalize` no longer re-snapshots them before
+Date→ISO materialization.

--- a/packages/svelte/src/lib/assembly/assemble.ts
+++ b/packages/svelte/src/lib/assembly/assemble.ts
@@ -131,9 +131,12 @@ function snapshotLayerInput(layer: LayerInput): LayerInput {
 /**
  * Materialize authoring data (Date → ISO) then normalize — TypeBox validate
  * stays on builder.spec() / validate(), not the GGPlot assemble path.
+ *
+ * Layers are already snapshotted in `assemblePortableSpec` before fold; do not
+ * re-snapshot here (#1327). `foldPlotLayer` never mutates mark layer data.
  */
 function materializeAndNormalize(draft: AssembleDraft): PortableSpec {
-  const layers = draft.layers.map(snapshotLayerInput);
+  const layers = draft.layers;
   const authoringData =
     draft.data === undefined ? undefined : toAuthoringDataRef(draft.data as DataInput);
   const calendarFields = calendarDateFields({
@@ -143,7 +146,7 @@ function materializeAndNormalize(draft: AssembleDraft): PortableSpec {
   });
   const portableLayers: LayerInput[] = layers.map((layer) => {
     if (layer.data === undefined) return layer;
-    // layerFrom/snapshot stores AuthoringDataRef; portable ISO conversion here.
+    // assemblePortableSpec stores AuthoringDataRef; portable ISO conversion here.
     const data = toDataRef(layer.data, calendarFields);
     return { ...layer, data };
   });

--- a/packages/svelte/tests/assembly/assemble.test.ts
+++ b/packages/svelte/tests/assembly/assemble.test.ts
@@ -358,6 +358,32 @@ describe("assemblePortableSpec", () => {
     expect(assembled!.data).toBeUndefined();
   });
 
+  it("rebuilds each layer row once for snapshot plus once for portable materialize (#1327)", () => {
+    // snapshotRows and portableRows each call Object.entries once per row.
+    // A second snapshot in materializeAndNormalize would add another R entries.
+    const layerRows = Array.from({ length: 20 }, (_, i) => ({ x: i, y: i }));
+    let entries = 0;
+    const original = Object.entries;
+    Object.entries = ((value: object) => {
+      entries += 1;
+      return original(value);
+    }) as typeof Object.entries;
+    try {
+      const assembled = assemblePortableSpec({
+        aes: { x: "x", y: "y" },
+        layers: [{ geom: "point", data: layerRows }],
+      });
+      expect(assembled).not.toBeNull();
+      expect(assembled!.layers[0]?.data).toEqual({
+        values: layerRows,
+      });
+    } finally {
+      Object.entries = original;
+    }
+    // 20 snapshot + 20 portable materialize — not 40 snapshot + 20 portable.
+    expect(entries).toBe(40);
+  });
+
   it("materializes Date cells in per-layer data to portable ISO strings", () => {
     const day = new Date("2020-06-01T00:00:00.000Z");
     const assembled = assemblePortableSpec({


### PR DESCRIPTION
Fixes #1327

## What

`assemblePortableSpec` snapshotted every layer, then `materializeAndNormalize`
snapshotted them again before portable Date→ISO conversion. On a 100k-row
inline layer that is a full extra O(R×C) deep copy on every prop-driven
reassemble (`assembled` is `$derived`).

Sibling of #1280 (builder geom sugar); different call site.

## How

Drop the re-snapshot in `materializeAndNormalize`. Layers are already
snapshotted at draft construction; `foldPlotLayer` only folds non-mark
grammar (theme/coord/facet/…) and never mutates mark layer data. Plot-level
`data` still snapshots once at materialize time (it was never double-copied).

## Tests

`packages/svelte/tests/assembly/assemble.test.ts`:

- Counts `Object.entries` over 20 layer rows: 40 = one snapshot + one
  portable materialize (was 60 with the second snapshot)
- Existing mutation-isolation tests for plot and layer data remain green

Full assemble suite: 111 pass across chromium/firefox/webkit.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1375" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->