### PR TITLE
perf(spec): hoist timezone validation off the per-row path

### DIFF
--- a/.changeset/timezone-validation-hoist.md
+++ b/.changeset/timezone-validation-hoist.md
@@ -1,0 +1,12 @@
+---
+"@ggsvelte/spec": patch
+---
+
+# Hoist timezone validation off the per-row parse path
+
+Migration: none — same parse results and failure messages; fewer allocations
+when a column shares one timezone option.
+
+`timezoneValidationFailure` uses a module-level UTC-alias Set and caches the
+full `TemporalParseResult` (or null) so repeated checks for the same zone do
+not rebuild the alias array or re-allocate invalid-zone failures.

--- a/packages/spec/src/temporal-parse-core.ts
+++ b/packages/spec/src/temporal-parse-core.ts
@@ -191,18 +191,23 @@ export function temporalImplementation(): typeof PolyfillTemporal {
   return nativeTemporal ?? PolyfillTemporal;
 }
 
-const TIMEZONE_VALIDITY_CACHE = new Map<string, boolean>();
+/** Allocation-free UTC aliases — same three names as partsToEpoch. */
+const UTC_TIMEZONE_ALIASES = new Set(["UTC", "Etc/UTC", "Z"]);
+
+/**
+ * null = valid zone; TemporalParseResult = memoized failure for invalid zones.
+ * Avoids per-row array allocation on the alias check and per-row failure objects
+ * when the same invalid zone is checked across a column parse.
+ */
+const TIMEZONE_VALIDITY_CACHE = new Map<string, TemporalParseResult | null>();
 
 export function timezoneValidationFailure(
   timezone: string | undefined,
 ): TemporalParseResult | null {
-  if (timezone === undefined || ["UTC", "Etc/UTC", "Z"].includes(timezone)) return null;
+  if (timezone === undefined || UTC_TIMEZONE_ALIASES.has(timezone)) return null;
   const cached = TIMEZONE_VALIDITY_CACHE.get(timezone);
-  if (cached !== undefined) {
-    return cached
-      ? null
-      : temporalParseFailure(`invalid or unsupported timezone ${JSON.stringify(timezone)}`);
-  }
+  if (cached !== undefined) return cached;
+
   let valid = true;
   try {
     const Temporal = temporalImplementation();
@@ -220,10 +225,11 @@ export function timezoneValidationFailure(
     const oldest = TIMEZONE_VALIDITY_CACHE.keys().next().value;
     if (oldest !== undefined) TIMEZONE_VALIDITY_CACHE.delete(oldest);
   }
-  TIMEZONE_VALIDITY_CACHE.set(timezone, valid);
-  return valid
+  const result = valid
     ? null
     : temporalParseFailure(`invalid or unsupported timezone ${JSON.stringify(timezone)}`);
+  TIMEZONE_VALIDITY_CACHE.set(timezone, result);
+  return result;
 }
 
 export function partsToEpoch(
@@ -247,7 +253,7 @@ export function partsToEpoch(
   // Calendar dates are timezone-free values. Keep them on UTC calendar
   // boundaries so ticks preserve their represented date.
   const timezone = kind === "date" || kind === "time" ? "UTC" : (options.timezone ?? "UTC");
-  if (timezone === "UTC" || timezone === "Etc/UTC" || timezone === "Z") {
+  if (UTC_TIMEZONE_ALIASES.has(timezone)) {
     const epochMs = utcEpoch(parts);
     return Number.isFinite(epochMs)
       ? { ok: true, epochMs, kind: "date", precision: "date" }

--- a/packages/spec/tests/temporal-parse.test.ts
+++ b/packages/spec/tests/temporal-parse.test.ts
@@ -5,6 +5,7 @@
  */
 import { describe, expect, it } from "bun:test";
 
+import { timezoneValidationFailure } from "../src/temporal-parse-core.ts";
 import { parseTemporal, parseTemporalColumn } from "../src/temporal.ts";
 
 describe("strict temporal parsing", () => {
@@ -183,5 +184,43 @@ describe("strict temporal parsing", () => {
       Date.parse("2024-03-10T06:30:00.000Z"),
       Date.parse("2024-03-10T07:30:00.000Z"),
     ]);
+  });
+});
+
+describe("timezoneValidationFailure (hot-path cache)", () => {
+  it("treats undefined and UTC aliases as valid without a failure object", () => {
+    expect(timezoneValidationFailure(undefined)).toBeNull();
+    expect(timezoneValidationFailure("UTC")).toBeNull();
+    expect(timezoneValidationFailure("Etc/UTC")).toBeNull();
+    expect(timezoneValidationFailure("Z")).toBeNull();
+  });
+
+  it("accepts a real IANA zone and rejects an unknown one with a stable message", () => {
+    expect(timezoneValidationFailure("America/New_York")).toBeNull();
+    const failure = timezoneValidationFailure("Not/A_Zone");
+    expect(failure).toMatchObject({
+      ok: false,
+      reason: 'invalid or unsupported timezone "Not/A_Zone"',
+    });
+  });
+
+  it("returns the same failure object on repeated invalid-zone checks (no per-row alloc)", () => {
+    const first = timezoneValidationFailure("Not/A_Zone");
+    const second = timezoneValidationFailure("Not/A_Zone");
+    expect(first).not.toBeNull();
+    expect(second).toBe(first);
+  });
+
+  it("keeps parseTemporal results aligned with the validator for aliases and invalid zones", () => {
+    for (const timezone of ["UTC", "Etc/UTC", "Z"] as const) {
+      expect(parseTemporal("2024-01-01", "iso", { timezone })).toMatchObject({ ok: true });
+    }
+    const once = parseTemporal("2024-01-01", "iso", { timezone: "Not/A_Zone" });
+    const twice = parseTemporal("2024-01-01", "iso", { timezone: "Not/A_Zone" });
+    expect(once).toMatchObject({
+      ok: false,
+      reason: 'invalid or unsupported timezone "Not/A_Zone"',
+    });
+    expect(twice).toBe(once);
   });
 });

--- a/packages/spec/tests/temporal-parse.test.ts
+++ b/packages/spec/tests/temporal-parse.test.ts
@@ -189,7 +189,7 @@ describe("strict temporal parsing", () => {
 
 describe("timezoneValidationFailure (hot-path cache)", () => {
   it("treats undefined and UTC aliases as valid without a failure object", () => {
-    expect(timezoneValidationFailure(undefined)).toBeNull();
+    expect(timezoneValidationFailure()).toBeNull();
     expect(timezoneValidationFailure("UTC")).toBeNull();
     expect(timezoneValidationFailure("Etc/UTC")).toBeNull();
     expect(timezoneValidationFailure("Z")).toBeNull();


### PR DESCRIPTION
Fixes #1320

## What

`timezoneValidationFailure` runs as the first step of every `parseTemporal`
call. With an explicit timezone, each row allocated a fresh `["UTC", "Etc/UTC", "Z"]`
array for `.includes`, and invalid zones re-built a failure object (and re-ran
`JSON.stringify`) even after the boolean cache hit.

## How

- Module-level `UTC_TIMEZONE_ALIASES` Set (shared with `partsToEpoch`)
- Cache `TemporalParseResult | null` instead of a boolean so the invalid branch
  returns a memoized object

## Tests

`packages/spec/tests/temporal-parse.test.ts`:

- Alias / valid / invalid message stability
- Same failure object identity on repeated invalid-zone checks
- `parseTemporal` reuses that identity for a column of bad zones

Related temporal suite green locally (39 tests across 5 files).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1377" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->