### PR TITLE
fix(core): index guide plans by aesthetic once (#1310)

### DIFF
--- a/.changeset/guide-plan-ids-by-aesthetic.md
+++ b/.changeset/guide-plan-ids-by-aesthetic.md
@@ -1,0 +1,9 @@
+---
+"@ggsvelte/core": patch
+---
+
+# Index guide plans by aesthetic once when assembling the render model
+
+Migration: none — same guidePlanIds assignment and plan-list order on every scale decision.
+
+Pre-bucket plan ids by aesthetic so each decision indexes the bucket instead of rescanning the full guide plan list (O(D×P) → O(P+D)).

--- a/packages/core/src/pipeline/assemble-render-model.ts
+++ b/packages/core/src/pipeline/assemble-render-model.ts
@@ -228,6 +228,27 @@ function bandLabelAdvisories(guidePlans: AssembleRenderModelInput["guidePlans"])
   return out;
 }
 
+/**
+ * One plan-list pass buckets guide plan ids by aesthetic so each scale decision
+ * indexes rather than rescanning the full plan list (#1310). Append order
+ * matches guidePlans order — that order is user-visible through guide assignment.
+ */
+function guidePlanIdsByAesthetic(
+  guidePlans: AssembleRenderModelInput["guidePlans"],
+): ReadonlyMap<"x" | "y", readonly string[]> {
+  const buckets: { x: string[]; y: string[] } = { x: [], y: [] };
+  for (const plan of guidePlans) {
+    if (plan.aesthetic === "x" || plan.aesthetic === "y") {
+      buckets[plan.aesthetic].push(plan.id);
+    }
+  }
+  // Freeze so decisions that share an aesthetic cannot mutate each other's list.
+  return new Map<"x" | "y", readonly string[]>([
+    ["x", Object.freeze(buckets.x)],
+    ["y", Object.freeze(buckets.y)],
+  ]);
+}
+
 export function assembleRenderModel(input: AssembleRenderModelInput): RenderModel {
   const { scene, candidates } = input;
   const scales = buildRenderModelScales(input);
@@ -239,6 +260,7 @@ export function assembleRenderModel(input: AssembleRenderModelInput): RenderMode
   });
   const advisories = [...input.advisories, ...bandLabelAdvisories(input.guidePlans)];
   const diagnostics = dedupeRenderModelDiagnostics(input.warnings, advisories);
+  const planIdsByAesthetic = guidePlanIdsByAesthetic(input.guidePlans);
 
   return {
     scene,
@@ -253,9 +275,7 @@ export function assembleRenderModel(input: AssembleRenderModelInput): RenderMode
     scaleDecisions: input.scaleDecisions.map((decision) => ({
       ...decision,
       domain: decision.aesthetic === "x" ? [...input.xScale.domain] : [...input.yScale.domain],
-      guidePlanIds: input.guidePlans
-        .filter((plan) => plan.aesthetic === decision.aesthetic)
-        .map((plan) => plan.id),
+      guidePlanIds: planIdsByAesthetic.get(decision.aesthetic) ?? [],
     })),
     guidePlans: input.guidePlans,
     coordProjectors: input.coordProjectors,

--- a/packages/core/tests/pipeline-assemble-model.test.ts
+++ b/packages/core/tests/pipeline-assemble-model.test.ts
@@ -7,9 +7,30 @@ import { aes, gg } from "@ggsvelte/spec";
 
 import { runPipeline } from "../src/pipeline.ts";
 import { computeEffectiveDomains } from "../src/pipeline/compute-domains.ts";
+import type { RenderModel } from "../src/pipeline/types.ts";
 import { trainContinuous } from "../src/scales/train.ts";
 
 const size = { width: 640, height: 400 };
+
+/** Plan-list order of ids for an aesthetic — the #1310 assignment contract. */
+function expectedGuidePlanIds(model: RenderModel, aesthetic: "x" | "y"): string[] {
+  return model.guidePlans.filter((plan) => plan.aesthetic === aesthetic).map((plan) => plan.id);
+}
+
+const temporalFacetRows = [
+  { year: "1835", value: 1, r: "a", c: "1" },
+  { year: "1900", value: 2, r: "a", c: "1" },
+  { year: "2026", value: 3, r: "a", c: "1" },
+  { year: "1835", value: 4, r: "b", c: "1" },
+  { year: "1900", value: 5, r: "b", c: "1" },
+  { year: "2026", value: 6, r: "b", c: "1" },
+  { year: "1835", value: 7, r: "a", c: "2" },
+  { year: "1900", value: 8, r: "a", c: "2" },
+  { year: "2026", value: 9, r: "a", c: "2" },
+  { year: "1835", value: 10, r: "b", c: "2" },
+  { year: "1900", value: 11, r: "b", c: "2" },
+  { year: "2026", value: 12, r: "b", c: "2" },
+];
 
 describe("computeEffectiveDomains", () => {
   it("freezes x/y and per-panel domain snapshots", () => {
@@ -63,5 +84,57 @@ describe("assembleRenderModel via runPipeline", () => {
     );
     expect(model.domains.effective.x.length).toBeGreaterThan(0);
     expect(model.domains.baseline.x.length).toBeGreaterThan(0);
+  });
+
+  // #1310: scale decisions index guide plans by aesthetic without a D×P rescan.
+  // Contract: each decision's guidePlanIds is the plan-list-order ids for that aesthetic.
+  describe("scaleDecision.guidePlanIds (#1310)", () => {
+    it("assigns single-panel plan ids in guidePlans order", () => {
+      const model = runPipeline(
+        gg(temporalFacetRows, aes({ x: "year", y: "value" }))
+          .geomLine()
+          .spec(),
+        size,
+      );
+      expect(model.scaleDecisions.length).toBeGreaterThan(0);
+      for (const decision of model.scaleDecisions) {
+        expect(decision.guidePlanIds).toEqual(expectedGuidePlanIds(model, decision.aesthetic));
+      }
+      expect(model.scaleDecisions[0]?.guidePlanIds).toEqual(["axis:x:panel:0"]);
+    });
+
+    it("assigns wrap-facet plan ids in guidePlans order", () => {
+      const model = runPipeline(
+        gg(temporalFacetRows, aes({ x: "year", y: "value" }))
+          .geomLine()
+          .facet({ wrap: "r" })
+          .spec(),
+        size,
+      );
+      expect(model.scene.panels.length).toBe(2);
+      expect(model.scaleDecisions.length).toBeGreaterThan(0);
+      for (const decision of model.scaleDecisions) {
+        expect(decision.guidePlanIds).toEqual(expectedGuidePlanIds(model, decision.aesthetic));
+      }
+      // Shared y on panel 0 only; x on both panels (plan-list order).
+      expect(model.scaleDecisions[0]?.guidePlanIds).toEqual(["axis:x:panel:0", "axis:x:panel:1"]);
+    });
+
+    it("assigns grid-facet plan ids in guidePlans order", () => {
+      const model = runPipeline(
+        gg(temporalFacetRows, aes({ x: "year", y: "value" }))
+          .geomLine()
+          .facet({ rows: "r", cols: "c" })
+          .spec(),
+        size,
+      );
+      expect(model.scene.panels.length).toBe(4);
+      expect(model.scaleDecisions.length).toBeGreaterThan(0);
+      for (const decision of model.scaleDecisions) {
+        expect(decision.guidePlanIds).toEqual(expectedGuidePlanIds(model, decision.aesthetic));
+      }
+      // Outer-axis sharing: only bottom-row panels carry an x guide.
+      expect(model.scaleDecisions[0]?.guidePlanIds).toEqual(["axis:x:panel:2", "axis:x:panel:3"]);
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Pre-bucket guide plan ids by aesthetic in `assembleRenderModel` so each scale decision indexes a frozen list instead of filtering the full plan list (O(D×P) → O(P+D)).
- Plan-list order within an aesthetic is preserved (user-visible through guide assignment).
- Characterization tests lock guidePlanIds for single-panel, wrap, and grid facets.

Fixes #1310

## Test plan

- [x] `bun test packages/core/tests/pipeline-assemble-model.test.ts`
- [x] `bun test packages/core/tests/pipeline-temporal/guides.test.ts`
- [x] `bun test packages/core/tests/layout/band-domain-share.test.ts`
- [ ] CI green

## Review

Pre-Landing Review: No issues found.

Scope Check: CLEAN
Intent: Index guide plans by aesthetic once (#1310)
Delivered: Map pre-pass + characterization tests + patch changeset
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1378" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->