### PR TITLE
perf(svelte): skip row builds on keyed pin rebind miss (#1318)

### DIFF
--- a/packages/svelte/src/lib/inspection/coordinator.ts
+++ b/packages/svelte/src/lib/inspection/coordinator.ts
@@ -249,12 +249,16 @@ export function createInspectionCoordinator<
     return logicalIdentity === prior.seedLogicalIdentity;
   };
 
-  /** Keyed pin match: layer + non-null row whose key equals the pinned key. */
+  /**
+   * Keyed pin match: layer + non-null row whose key equals the pinned key.
+   * Key first — `model.row` allocates a full Record (O(F)). Identity-change
+   * full-scans must not pay that for every candidate in the layer (#1318).
+   */
   const keyedPinMatch = (model: RenderModel, prior: Slot, candidate: CandidateFacts): boolean => {
     if (candidate.layerIndex !== prior.layerIndex || candidate.rowIndex === null) return false;
-    // Both gates stay: keyed rebind needs a live row AND a matching key.
-    const row = model.row(candidate.rowIndex);
-    return row !== null && keyAt(candidate.rowIndex) === prior.seedKey;
+    if (keyAt(candidate.rowIndex) !== prior.seedKey) return false;
+    // Live-row gate stays: key bag can outlive a dropped source index.
+    return model.row(candidate.rowIndex) !== null;
   };
 
   /**

--- a/packages/svelte/tests/inspection/coordinator.test.ts
+++ b/packages/svelte/tests/inspection/coordinator.test.ts
@@ -555,6 +555,58 @@ describe("inspection coordinator", () => {
     first.dispose();
     resized.dispose();
   });
+  it("keyed identity-change rebind does not build a row per candidate (#1318)", () => {
+    // Identity-epoch change skips the seedId fast path and full-scans. keyedPinMatch
+    // used to call model.row for every layer candidate (O(C·F) allocations). Row
+    // builds must stay O(matches + materialize), not O(C).
+    const count = 400;
+    const data = Array.from({ length: count }, (_, index) => ({
+      id: `r${index}`,
+      x: index,
+      y: (index % 11) + 1,
+    }));
+    const makeModel = () =>
+      runPipeline(
+        gg(data, aes({ x: "x", y: "y" }))
+          .geomPoint()
+          .spec(),
+        { width: 400, height: 300 },
+      );
+    const first = makeModel();
+    const next = makeModel();
+    expect(next.candidates.size).toBe(count);
+
+    const coordinator = createInspectionCoordinator(idKeys(data));
+    coordinator.resolve({
+      model: first,
+      seed: first.candidates.candidate(0)!,
+      mode: "exact",
+      state: "pinned",
+      source: "pointer",
+      identityEpoch: 1,
+      layoutEpoch: 1,
+    });
+
+    const originalRow = next.row.bind(next);
+    let rowReads = 0;
+    vi.spyOn(next, "row").mockImplementation((index: number) => {
+      rowReads++;
+      return originalRow(index);
+    });
+    const reconciled = coordinator.reconcilePinned({
+      model: next,
+      identityEpoch: 2,
+      layoutEpoch: 2,
+    });
+    expect(reconciled).not.toBeNull();
+    expect(reconciled!.snapshot.focus.key).toBe("r0");
+    // Full-scan keyed match must not allocate a row for every candidate. Materialize
+    // still reads focus (+ members); a pre-fix pass is ~C (+ materialize) row reads.
+    expect(rowReads).toBeLessThan(40);
+    expect(rowReads).toBeLessThan(count / 5);
+    first.dispose();
+    next.dispose();
+  });
   it("rejects keyed seedId fast path when primitive role no longer matches", () => {
     const data = [{ id: "a", x: 1, y: 2, ymin: 1, ymax: 3 }];
     const points = runPipeline(


### PR DESCRIPTION
## Summary

- **Fixes #1318:** identity-change keyed pin rebind no longer calls `model.row` for every candidate in the layer.
- `keyedPinMatch` checks `keyAt` first; `model.row` (full Record alloc, O(F)) runs only when the key matches.
- Live-row gate kept so a key bag entry cannot pin a dropped source index.
- Characterization test spies `model.row` on a 400-candidate identity-epoch rebind and bounds row reads independent of candidate count.

## Test plan

- [x] `bunx vitest run --project chromium tests/inspection/coordinator.test.ts` (16/16)
- [x] RED: new test failed before the match reorder
- [x] GREEN: same test + existing multi-match / keyed rebind cases pass after the fix
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1379" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->