### PR TITLE
perf(svelte): drop repeated per-row work on render/interaction paths (#1329)

### DIFF
--- a/.changeset/perf-repeated-per-row-1329.md
+++ b/.changeset/perf-repeated-per-row-1329.md
@@ -1,0 +1,9 @@
+---
+"@ggsvelte/svelte": patch
+---
+
+# Drop repeated per-row work on render and interaction paths
+
+Migration: none — same legend keys, pin rebind, a11y totals, mark labels, and identity epochs.
+
+Hoists work that used to re-run over data-scaled collections: lineage-level legend visit keys, precomputed inspection batch roles, index-only keyed pin match, one a11y primitive scan when the table is open, unique mark-label fields closed over the model, and join-built data identity tokens.

--- a/packages/svelte/src/lib/a11y/CanvasA11y.svelte
+++ b/packages/svelte/src/lib/a11y/CanvasA11y.svelte
@@ -21,11 +21,10 @@
     onToggle: () => void;
   } = $props();
 
-  // Closed: O(P) distinct-index count only (aria-label). Open: full sort +
-  // row materialisation for the capped table. Avoids O(R log R) + model.row
-  // work on every model update while the table stays closed.
-  const total = $derived(a11yMarkCount(batches));
+  // Closed: O(P) distinct-index count only (aria-label). Open: one full table
+  // build — reuse `table.total` so the primitive scan is not paid twice (#1329).
   const table = $derived(open ? a11yRows(model, batches) : null);
+  const total = $derived(table === null ? a11yMarkCount(batches) : table.total);
   const ariaLabel = $derived(
     `${sceneLabelText} — ${String(total)} canvas-rendered marks. Canvas marks are not individually focusable; use the data table.`,
   );

--- a/packages/svelte/src/lib/assembly/labels.ts
+++ b/packages/svelte/src/lib/assembly/labels.ts
@@ -46,20 +46,43 @@ export function zoomAnnouncement(domains: ReadonlyZoomDomains | null): string {
   return domains === null ? "Zoom reset." : "Zoom complete.";
 }
 
+/**
+ * Unique mapped field names across layers (first-seen order).
+ * Hosts that label many marks should call once per model and close over the
+ * result — `markLabel` / `datumLabel` recompute it per call (#1329).
+ */
+export function uniqueMappedFields(model: RenderModel): readonly string[] {
+  const seen = new Set<string>();
+  const fields: string[] = [];
+  for (const layer of model.layerFields) {
+    if (layer === undefined) continue;
+    for (const mapped of layer) {
+      if (seen.has(mapped.field)) continue;
+      seen.add(mapped.field);
+      fields.push(mapped.field);
+    }
+  }
+  return fields;
+}
+
+/** Label parts from a precomputed unique field list and a row record. */
+export function labelFromFields(
+  fields: readonly string[],
+  values: Record<string, CellValue>,
+  emptyFallback: string,
+): string {
+  if (fields.length === 0) return emptyFallback;
+  const parts: string[] = [];
+  for (const field of fields) parts.push(`${field} ${String(values[field] ?? "")}`);
+  return parts.join(", ");
+}
+
 /** Accessible per-mark label from the layer's mapped fields. */
 export function markLabel(model: RenderModel | null, row: number): string {
   if (model === null) return `data point ${row + 1}`;
   const values = model.row(row);
   if (values === null) return `data point ${row + 1}`;
-  const fields = model.layerFields.flat();
-  const seen = new Set<string>();
-  const parts: string[] = [];
-  for (const f of fields) {
-    if (seen.has(f.field)) continue;
-    seen.add(f.field);
-    parts.push(`${f.field} ${String(values[f.field] ?? "")}`);
-  }
-  return parts.join(", ") || `data point ${row + 1}`;
+  return labelFromFields(uniqueMappedFields(model), values, `data point ${row + 1}`);
 }
 
 export function datumLabel(
@@ -67,15 +90,8 @@ export function datumLabel(
   values: Record<string, CellValue> | null,
 ): string {
   if (values === null) return "No active datum";
-  const fields = model?.layerFields.flat() ?? [];
-  const seen = new Set<string>();
-  const parts: string[] = [];
-  for (const field of fields) {
-    if (seen.has(field.field)) continue;
-    seen.add(field.field);
-    parts.push(`${field.field} ${String(values[field.field] ?? "")}`);
-  }
-  return parts.join(", ") || "Active datum";
+  if (model === null) return labelFromFields([], values, "Active datum");
+  return labelFromFields(uniqueMappedFields(model), values, "Active datum");
 }
 
 export function inspectionLiveText(

--- a/packages/svelte/src/lib/chrome/chrome-state.svelte.ts
+++ b/packages/svelte/src/lib/chrome/chrome-state.svelte.ts
@@ -29,7 +29,12 @@ import {
   zoomSupportsChannel,
 } from "../interaction/capability.js";
 import type { ContinuousZoomDomains } from "../scene/geometry.js";
-import { datumLabel as datumLabelFor, markLabel as markLabelFor } from "../assembly/labels.js";
+import {
+  datumLabel as datumLabelFor,
+  labelFromFields,
+  markLabel as markLabelFor,
+  uniqueMappedFields,
+} from "../assembly/labels.js";
 import { isContainerWidthProp, plotRootInlineStyle } from "../assembly/layout.js";
 import { themeTokensToCss } from "./theme-css.js";
 
@@ -208,10 +213,18 @@ export function createPlotChromeState(deps: PlotChromeStateDeps): PlotChromeStat
     }),
   );
 
-  // Stable SceneView callback identity when model is unchanged.
+  // Stable SceneView callback identity when model is unchanged. Unique field
+  // list is built once per model so per-mark labels do not re-flatten
+  // layerFields (#1329).
   const markLabel = $derived.by(() => {
     const model = deps.model();
-    return (row: number) => markLabelFor(model, row);
+    if (model === null) return (row: number) => markLabelFor(null, row);
+    const fields = uniqueMappedFields(model);
+    return (row: number) => {
+      const values = model.row(row);
+      if (values === null) return `data point ${row + 1}`;
+      return labelFromFields(fields, values, `data point ${row + 1}`);
+    };
   });
 
   function datumLabel(values: Record<string, CellValue> | null): string {

--- a/packages/svelte/src/lib/inspection/coordinator.ts
+++ b/packages/svelte/src/lib/inspection/coordinator.ts
@@ -78,19 +78,40 @@ function rowCellPayload(row: Record<string, CellValue>): string {
   return parts.join(",");
 }
 
-/** Stable role within one layer's batches of the same geometry kind. Absolute
- * scene batch indices can shift when unrelated layers change, while this role
- * still distinguishes composite pieces such as a smooth ribbon/line or a
- * boxplot's whisker/median segments. */
-function candidateBatchRole(model: RenderModel, candidate: CandidateFacts): string {
-  let ordinal = 0;
-  for (let index = 0; index <= candidate.batchIndex; index++) {
-    const batch = model.scene.batches[index];
-    if (batch?.layerIndex !== candidate.layerIndex || batch.kind !== candidate.kind) continue;
-    if (index === candidate.batchIndex) return `${candidate.kind}:${ordinal}`;
-    ordinal++;
+/**
+ * Per-batch role token within one layer's batches of the same geometry kind.
+ * Absolute scene batch indices can shift when unrelated layers change; the
+ * role still distinguishes composite pieces (smooth ribbon/line, boxplot
+ * whisker/median). Built once per model — O(B) prep, O(1) lookup (#1329).
+ */
+function buildBatchRoles(model: RenderModel): readonly string[] {
+  const batches = model.scene.batches;
+  const roles: string[] = [];
+  const ordinalByLayerKind = new Map<string, number>();
+  for (let index = 0; index < batches.length; index++) {
+    const batch = batches[index]!;
+    const layerKind = `${String(batch.layerIndex)}\0${batch.kind}`;
+    const ordinal = ordinalByLayerKind.get(layerKind) ?? 0;
+    roles.push(`${batch.kind}:${ordinal}`);
+    ordinalByLayerKind.set(layerKind, ordinal + 1);
   }
-  return `${candidate.kind}:missing`;
+  return roles;
+}
+
+/** O(1) role for a candidate against a precomputed per-model role table. */
+function candidateBatchRole(
+  model: RenderModel,
+  candidate: CandidateFacts,
+  roles: readonly string[],
+): string {
+  const batch = model.scene.batches[candidate.batchIndex];
+  if (
+    batch === undefined ||
+    batch.layerIndex !== candidate.layerIndex ||
+    batch.kind !== candidate.kind
+  )
+    return `${candidate.kind}:missing`;
+  return roles[candidate.batchIndex] ?? `${candidate.kind}:missing`;
 }
 
 /**
@@ -122,6 +143,15 @@ export function createInspectionCoordinator<
   let lastSemanticFingerprint: string | null = null;
   let lastPresentationIdentity: string | null = null;
   let lastSlot: "transient" | "pinned" | null = null;
+  /** Last model whose batch-role table is cached (identity compare). */
+  let batchRoleModel: RenderModel | null = null;
+  let batchRoles: readonly string[] = [];
+  const rolesFor = (model: RenderModel): readonly string[] => {
+    if (batchRoleModel === model) return batchRoles;
+    batchRoles = buildBatchRoles(model);
+    batchRoleModel = model;
+    return batchRoles;
+  };
   const symbolIds = new Map<symbol, number>();
   const epochIds = new Map<symbol, number>();
   const epochToken = (value: PropertyKey): string => {
@@ -223,7 +253,7 @@ export function createInspectionCoordinator<
       seedKey: focusKey,
       seedRow: input.seed.rowIndex,
       seedKind: input.seed.kind,
-      seedBatchRole: candidateBatchRole(input.model, input.seed),
+      seedBatchRole: candidateBatchRole(input.model, input.seed, rolesFor(input.model)),
       seedPrimitiveIndex: input.seed.primitiveIndex,
       seedLogicalIdentity: `${axisToken(input.seed.xToken)}|${axisToken(input.seed.yToken)}|${input.model.lineage.keys(input.seed.lineage).join(",")}`,
       layerIndex: input.seed.layerIndex,
@@ -239,12 +269,17 @@ export function createInspectionCoordinator<
   };
 
   /** Keyless pin match: cheap filters then O(L) logical identity (#229). */
-  const keylessPinMatch = (model: RenderModel, prior: Slot, candidate: CandidateFacts): boolean => {
+  const keylessPinMatch = (
+    model: RenderModel,
+    prior: Slot,
+    candidate: CandidateFacts,
+    roles: readonly string[],
+  ): boolean => {
     if (candidate.layerIndex !== prior.layerIndex) return false;
     if (candidate.rowIndex !== prior.seedRow) return false;
     if (candidate.kind !== prior.seedKind) return false;
     if (candidate.primitiveIndex !== prior.seedPrimitiveIndex) return false;
-    if (candidateBatchRole(model, candidate) !== prior.seedBatchRole) return false;
+    if (candidateBatchRole(model, candidate, roles) !== prior.seedBatchRole) return false;
     const logicalIdentity = `${axisToken(candidate.xToken)}|${axisToken(candidate.yToken)}|${model.lineage.keys(candidate.lineage).join(",")}`;
     return logicalIdentity === prior.seedLogicalIdentity;
   };
@@ -252,12 +287,12 @@ export function createInspectionCoordinator<
   /**
    * Keyed pin match: layer + non-null row whose key equals the pinned key.
    * Key first — `model.row` allocates a full Record (O(F)). Identity-change
-   * full-scans must not pay that for every candidate in the layer (#1318).
+   * full-scans must not pay that for every candidate in the layer (#1318 /
+   * #1329). Live-row gate stays: key bag can outlive a dropped source index.
    */
   const keyedPinMatch = (model: RenderModel, prior: Slot, candidate: CandidateFacts): boolean => {
     if (candidate.layerIndex !== prior.layerIndex || candidate.rowIndex === null) return false;
     if (keyAt(candidate.rowIndex) !== prior.seedKey) return false;
-    // Live-row gate stays: key bag can outlive a dropped source index.
     return model.row(candidate.rowIndex) !== null;
   };
 
@@ -267,11 +302,16 @@ export function createInspectionCoordinator<
    * is not always pure layout — layer-prop swaps can keep the identity token
    * while changing primitives that reuse an id (Codex #272 P2).
    */
-  const keyedPinRoleMatch = (model: RenderModel, prior: Slot, candidate: CandidateFacts): boolean =>
+  const keyedPinRoleMatch = (
+    model: RenderModel,
+    prior: Slot,
+    candidate: CandidateFacts,
+    roles: readonly string[],
+  ): boolean =>
     keyedPinMatch(model, prior, candidate) &&
     candidate.kind === prior.seedKind &&
     candidate.primitiveIndex === prior.seedPrimitiveIndex &&
-    candidateBatchRole(model, candidate) === prior.seedBatchRole;
+    candidateBatchRole(model, candidate, roles) === prior.seedBatchRole;
 
   const reconcilePinned = (
     input: Readonly<{
@@ -285,6 +325,7 @@ export function createInspectionCoordinator<
     const prior = pinned;
     if (prior === null) return null;
     let seed: CandidateFacts | null = null;
+    const roles = rolesFor(input.model);
     // Same identityEpoch: O(1) seedId revalidation when id + role still match.
     // Keyed path requires kind/batch/primitive (not only layer+key) so geom
     // swaps that reuse seedId cannot pin the wrong primitive. Fall through to
@@ -294,8 +335,8 @@ export function createInspectionCoordinator<
       const preferred = input.model.candidates.candidate(prior.seedId);
       if (preferred !== null) {
         if (prior.seedKey === null) {
-          if (keylessPinMatch(input.model, prior, preferred)) seed = preferred;
-        } else if (keyedPinRoleMatch(input.model, prior, preferred)) {
+          if (keylessPinMatch(input.model, prior, preferred, roles)) seed = preferred;
+        } else if (keyedPinRoleMatch(input.model, prior, preferred, roles)) {
           seed = preferred;
         }
       }
@@ -314,7 +355,7 @@ export function createInspectionCoordinator<
       for (let id = 0; id < input.model.candidates.size; id++) {
         const candidate = input.model.candidates.candidate(id);
         if (candidate === null) continue;
-        if (!keylessPinMatch(input.model, prior, candidate)) continue;
+        if (!keylessPinMatch(input.model, prior, candidate, roles)) continue;
         matches.push(candidate);
       }
       seed = matches.length === 1 ? matches[0]! : null;
@@ -333,7 +374,7 @@ export function createInspectionCoordinator<
           const sameRole = matches.filter(
             (candidate) =>
               candidate.kind === prior.seedKind &&
-              candidateBatchRole(input.model, candidate) === prior.seedBatchRole &&
+              candidateBatchRole(input.model, candidate, roles) === prior.seedBatchRole &&
               candidate.primitiveIndex === prior.seedPrimitiveIndex,
           );
           seed = sameRole.length === 1 ? sameRole[0]! : null;
@@ -379,6 +420,8 @@ export function createInspectionCoordinator<
       lastSemanticFingerprint = null;
       lastPresentationIdentity = null;
       lastSlot = null;
+      batchRoleModel = null;
+      batchRoles = [];
       symbolIds.clear();
       epochIds.clear();
     },

--- a/packages/svelte/src/lib/legend/entry-key-index.ts
+++ b/packages/svelte/src/lib/legend/entry-key-index.ts
@@ -72,7 +72,9 @@ export type LegendKeyIndexAdapter = {
  *   channel (scaled constant aes) and match the constant against entries.
  * - Row membership = lineage row indexes (insertion order) then candidate
  *   rowIndex if not already present.
- * - Visit key is scale:layerIndex:field|const:rowIndex (dedupe repeated candidates).
+ * - Visit key is scale:layerIndex:aesthetic:field|const:lineageId (one expand
+ *   of the shared bag per lineage; candidate-local rowIndex outside the bag is
+ *   a separate one-shot). Drops per-row visited probes across smooth grids.
  * - Skip null rows (field path) / null keys; constant path only needs keys.
  * - Match entry values via pre-built token→index maps (NaN, Date, -0/0);
  *   O(E) prep + O(1) per row, not findIndex.
@@ -193,35 +195,12 @@ export function buildLegendEntryKeyIndex(
     return byChannel.get(scale);
   };
 
-  const visited = new Set<string>();
-  const indexAestheticRows = (input: {
-    sceneLegend: Extract<SceneLegend, { type: "discrete" }>;
-    candidate: LegendKeyCandidate;
-    aesthetic: string;
-    rowIndexes: () => Iterable<number>;
-  }): void => {
-    const { sceneLegend, candidate, aesthetic, rowIndexes } = input;
-    const field = fieldFor(candidate.layerIndex, aesthetic);
-    const scaledConstant =
-      field === undefined
-        ? adapter.layerScaledConstant?.(candidate.layerIndex, aesthetic)
-        : undefined;
-    if (field === undefined && scaledConstant === undefined) return;
-    const entryByToken = entryLookupByLegend.get(sceneLegend)!;
-    for (const rowIndex of rowIndexes()) {
-      const visitField = field ?? `const:${String(scaledConstant)}`;
-      const visit = `${sceneLegend.scale}:${String(candidate.layerIndex)}:${aesthetic}:${visitField}:${String(rowIndex)}`;
-      if (visited.has(visit)) continue;
-      visited.add(visit);
-      const key = adapter.semanticKey(rowIndex);
-      if (key === null || key === undefined) continue;
-      const matched = resolveLegendMatchValue(adapter, field, scaledConstant, rowIndex);
-      if (matched.skip) continue;
-      const entryIndex = entryByToken.get(legendValueToken(matched.value));
-      if (entryIndex === undefined) continue;
-      index.get(legendIdentityKey({ scale: sceneLegend.scale, entryIndex }))?.push(key);
-    }
-  };
+  // Visit key is scale:layer:aesthetic:field|const:lineageId — one expand of
+  // the shared bag per lineage (smooth eval grids ~80 vertices), not per row
+  // per candidate (#1329). Candidate-local rowIndex outside the bag is a
+  // separate one-shot visit.
+  const visitedLineages = new Set<string>();
+  const visitedExtraRows = new Set<string>();
 
   // Lineage membership once per lineage id (smooth shares one bag across
   // the eval grid). Candidates may still append their own rowIndex.
@@ -235,31 +214,59 @@ export function buildLegendEntryKeyIndex(
     return rows;
   };
 
+  const indexRow = (input: {
+    sceneLegend: Extract<SceneLegend, { type: "discrete" }>;
+    field: string | undefined;
+    scaledConstant: unknown;
+    rowIndex: number;
+  }): void => {
+    const { sceneLegend, field, scaledConstant, rowIndex } = input;
+    const key = adapter.semanticKey(rowIndex);
+    if (key === null || key === undefined) return;
+    const matched = resolveLegendMatchValue(adapter, field, scaledConstant, rowIndex);
+    if (matched.skip) return;
+    const entryIndex = entryLookupByLegend.get(sceneLegend)!.get(legendValueToken(matched.value));
+    if (entryIndex === undefined) return;
+    index.get(legendIdentityKey({ scale: sceneLegend.scale, entryIndex }))?.push(key);
+  };
+
+  const indexAesthetic = (input: {
+    sceneLegend: Extract<SceneLegend, { type: "discrete" }>;
+    candidate: LegendKeyCandidate;
+    aesthetic: string;
+    sharedRows: () => Set<number>;
+  }): void => {
+    const { sceneLegend, candidate, aesthetic, sharedRows } = input;
+    const field = fieldFor(candidate.layerIndex, aesthetic);
+    const scaledConstant =
+      field === undefined
+        ? adapter.layerScaledConstant?.(candidate.layerIndex, aesthetic)
+        : undefined;
+    if (field === undefined && scaledConstant === undefined) return;
+    const visitField = field ?? `const:${String(scaledConstant)}`;
+    const lineageVisit = `${sceneLegend.scale}:${String(candidate.layerIndex)}:${aesthetic}:${visitField}:${String(candidate.lineage)}`;
+    if (!visitedLineages.has(lineageVisit)) {
+      visitedLineages.add(lineageVisit);
+      for (const rowIndex of sharedRows())
+        indexRow({ sceneLegend, field, scaledConstant, rowIndex });
+    }
+    if (candidate.rowIndex === null || sharedRows().has(candidate.rowIndex)) return;
+    const extraVisit = `${lineageVisit}:r${String(candidate.rowIndex)}`;
+    if (visitedExtraRows.has(extraVisit)) return;
+    visitedExtraRows.add(extraVisit);
+    indexRow({ sceneLegend, field, scaledConstant, rowIndex: candidate.rowIndex });
+  };
+
   for (const candidate of adapter.candidates()) {
-    let sourceRows: Set<number> | null = null;
-    const rowsForCandidate = (): Set<number> => {
-      if (sourceRows === null) {
-        const shared = lineageRows(candidate.lineage);
-        if (candidate.rowIndex !== null && !shared.has(candidate.rowIndex)) {
-          // Copy only when we must attach a candidate-local row not already
-          // in the shared membership (identity marks). Shared smooth bags
-          // stay one Set for every eval-grid mark.
-          sourceRows = new Set([...shared, candidate.rowIndex]);
-        } else {
-          sourceRows = shared;
-        }
-      }
-      return sourceRows;
+    let shared: Set<number> | null = null;
+    const sharedRows = (): Set<number> => {
+      shared ??= lineageRows(candidate.lineage);
+      return shared;
     };
 
     for (const sceneLegend of discreteLegends) {
       for (const aesthetic of sceneLegend.aesthetics ?? [sceneLegend.scale])
-        indexAestheticRows({
-          sceneLegend,
-          candidate,
-          aesthetic,
-          rowIndexes: rowsForCandidate,
-        });
+        indexAesthetic({ sceneLegend, candidate, aesthetic, sharedRows });
     }
   }
   return new Map(

--- a/packages/svelte/src/lib/runtime/semantic-data-identity.ts
+++ b/packages/svelte/src/lib/runtime/semantic-data-identity.ts
@@ -6,6 +6,20 @@
  */
 
 /**
+ * O(R) order fingerprint for a row array — length + per-row source ids.
+ * Builds via `join` (one final string) rather than `token +=` growth (#1329).
+ */
+function rowRefOrderToken(
+  rows: readonly unknown[],
+  sourceIdentity: (value: unknown) => string,
+): string {
+  if (rows.length === 0) return "v:0";
+  const parts: string[] = [`v:${String(rows.length)}`];
+  for (let index = 0; index < rows.length; index++) parts.push(sourceIdentity(rows[index]));
+  return parts.join(":");
+}
+
+/**
  * O(R) order fingerprint for plot data — row *references* and length, not
  * deep cell values. In-place reverse bumps the token; in-place cell edits on
  * the same row objects do not (hosts should replace rows/arrays for identity).
@@ -17,11 +31,7 @@ export function dataContentOrderToken(
   sourceIdentity: (value: unknown) => string,
 ): string {
   if (data === null || data === undefined) return "null";
-  if (Array.isArray(data)) {
-    let token = `v:${data.length}`;
-    for (let index = 0; index < data.length; index++) token += `:${sourceIdentity(data[index])}`;
-    return token;
-  }
+  if (Array.isArray(data)) return rowRefOrderToken(data, sourceIdentity);
   if (typeof data === "object") {
     const record = data as Record<string, unknown>;
     const fieldKeys = Object.keys(record);
@@ -29,11 +39,7 @@ export function dataContentOrderToken(
     // A bare column map may own a field named `values`/`columns` alongside
     // other arrays and must not short-circuit (Codex P2).
     if (fieldKeys.length === 1 && fieldKeys[0] === "values" && Array.isArray(record["values"])) {
-      const values = record["values"] as unknown[];
-      let token = `v:${values.length}`;
-      for (let index = 0; index < values.length; index++)
-        token += `:${sourceIdentity(values[index])}`;
-      return token;
+      return rowRefOrderToken(record["values"] as unknown[], sourceIdentity);
     }
     if (
       fieldKeys.length === 1 &&

--- a/packages/svelte/tests/a11y/canvas-a11y-component.test.ts
+++ b/packages/svelte/tests/a11y/canvas-a11y-component.test.ts
@@ -115,6 +115,10 @@ describe("CanvasA11y", () => {
     await until(() => view.container.querySelector(".gg-a11y-table") !== null);
     expect(row).toHaveBeenCalled();
     expect(view.container.querySelectorAll(".gg-a11y-table tbody tr").length).toBe(4);
+    // Open path reuses table.total for aria — still 4 marks, one materialise.
+    expect(view.container.querySelector(".gg-canvas-a11y")?.getAttribute("aria-label")).toContain(
+      "4 canvas-rendered marks",
+    );
   });
 
   it("renders field headers and body rows from a11yRows", async () => {

--- a/packages/svelte/tests/assembly/labels.test.ts
+++ b/packages/svelte/tests/assembly/labels.test.ts
@@ -14,10 +14,12 @@ import {
   countLabel,
   datumLabel,
   inspectionLiveText,
+  labelFromFields,
   legendFocusAnnouncement,
   markLabel,
   resolveInteractionLiveText,
   selectionAnnouncement,
+  uniqueMappedFields,
   zoomAnnouncement,
 } from "../../src/lib/assembly/labels.js";
 
@@ -30,6 +32,25 @@ function model(opts: {
     row: (index: number) => opts.rows?.[index] ?? null,
   });
 }
+
+describe("uniqueMappedFields / labelFromFields", () => {
+  it("dedupes field names in first-seen order across layers", () => {
+    const m = model({
+      layerFields: [
+        [{ field: "x" }, { field: "y" }],
+        [{ field: "y" }, { field: "color" }],
+      ],
+    });
+    expect(uniqueMappedFields(m)).toEqual(["x", "y", "color"]);
+  });
+
+  it("formats a closed-over field list without re-walking layerFields", () => {
+    expect(labelFromFields(["x", "color"], { x: 1, color: "red" }, "fallback")).toBe(
+      "x 1, color red",
+    );
+    expect(labelFromFields([], { x: 1 }, "data point 1")).toBe("data point 1");
+  });
+});
 
 describe("markLabel", () => {
   it("falls back when model or row is missing", () => {

--- a/packages/svelte/tests/legend/focus-entry-key-index-pure.test.ts
+++ b/packages/svelte/tests/legend/focus-entry-key-index-pure.test.ts
@@ -508,6 +508,8 @@ describe("buildLegendEntryKeyIndex", () => {
 
   it("expands a shared lineage once across many candidates (smooth eval grid)", () => {
     let lineageKeysCalls = 0;
+    let rowCalls = 0;
+    let semanticKeyCalls = 0;
     const sharedRows = Array.from({ length: 40 }, (_, i) => i);
     const index = buildLegendEntryKeyIndex({
       legends: [discreteFill],
@@ -518,12 +520,46 @@ describe("buildLegendEntryKeyIndex", () => {
         lineageKeysCalls += 1;
         return lineageId === 7 ? sharedRows : [];
       },
-      row: (rowIndex) => ({ channel: rowIndex % 2 === 0 ? "web" : "store" }),
-      semanticKey: (rowIndex) => `k${String(rowIndex)}`,
+      row: (rowIndex) => {
+        rowCalls += 1;
+        return { channel: rowIndex % 2 === 0 ? "web" : "store" };
+      },
+      semanticKey: (rowIndex) => {
+        semanticKeyCalls += 1;
+        return `k${String(rowIndex)}`;
+      },
     });
     expect(lineageKeysCalls).toBe(1);
+    // Lineage-level visit (#1329): one expand for the shared bag, not N×R
+    // probes across the 12 smooth eval-grid candidates.
+    expect(rowCalls).toBe(40);
+    expect(semanticKeyCalls).toBe(40);
     expect(index.get("fill:0")?.length).toBe(20);
     expect(index.get("fill:1")?.length).toBe(20);
+  });
+
+  it("appends a candidate-local row after a lineage already expanded by peers", () => {
+    // First candidates share lineage 1 (rows 0,1); a later identity candidate
+    // adds rowIndex 9 not in the lineage bag — must still index that row once.
+    const index = buildLegendEntryKeyIndex(
+      adapter({
+        candidates: [
+          { layerIndex: 0, lineage: 1, rowIndex: null },
+          { layerIndex: 0, lineage: 1, rowIndex: null },
+          { layerIndex: 0, lineage: 1, rowIndex: 9 },
+        ],
+        fields: { 0: [{ channel: "fill", field: "channel" }] },
+        lineages: { 1: [0, 1] },
+        rows: {
+          0: { channel: "web" },
+          1: { channel: "store" },
+          9: { channel: "web" },
+        },
+        keys: { 0: "a", 1: "b", 9: "extra" },
+      }),
+    );
+    expect(index.get("fill:0")).toEqual(["a", "extra"]);
+    expect(index.get("fill:1")).toEqual(["b"]);
   });
 
   it("does not call lineageKeys when no discrete legend applies to the candidate", () => {


### PR DESCRIPTION
## Summary

Closes #1329. Hoists six data-scaled re-walks found in the first `packages/svelte` complexity audit into per-collection work, with no behaviour change in legend keys, pin rebind, a11y totals, mark labels, or identity epochs.

| Hotspot | Change |
|---|---|
| Legend entry-key index | Visit key is `(scale, layer, aesthetic, field, lineageId)` — one expand of the shared bag per smooth lineage; candidate-local rows are a one-shot |
| Inspection batch role | Precompute role ordinals once per model; O(1) lookup on resolve / pin match |
| Keyed pin rebind | Index-only `keyAt` match — drop `model.row` full-column allocations on the scan |
| Data identity token | Build row-ref order via `join` instead of `token +=` growth |
| Canvas a11y | Open path reuses `table.total` so the primitive scan is not paid twice |
| Mark labels | `uniqueMappedFields` once per model, closed over in chrome-state |

## Test plan

- [x] `packages/svelte` chromium: legend entry-key index, inspection coordinator, labels, a11y component, semantic identity pure/epoch, chrome-state
- [x] Characterisation: shared-lineage smooth grid — `row` / `semanticKey` calls = R, not N×R
- [x] Characterisation: keyed pin identity-epoch rebind bounds `model.row` calls far below candidate count
- [ ] CI green on the PR
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1381" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->