### PR TITLE
fix(core): batch paint-vector calls in geometry emitters (#1309)

### DIFF
--- a/.changeset/paint-vector-batch-emitters.md
+++ b/.changeset/paint-vector-batch-emitters.md
@@ -1,0 +1,9 @@
+---
+"@ggsvelte/core": patch
+---
+
+# Batch paint-vector resolution in geometry emitters
+
+Migration: none — same stroke and fill colours; fewer paint-vector calls and allocations per batch.
+
+Geometry emitters that already accumulate style-row indices now resolve colour once per batch instead of once per item (segments, line subpaths, curves, polygons, ribbons, area/density groups).

--- a/packages/core/src/pipeline/geometry-curve.ts
+++ b/packages/core/src/pipeline/geometry-curve.ts
@@ -73,7 +73,6 @@ export function curveBatch(
   const semanticAnchors = new Uint8Array(totalVerts);
   const semanticIndex = new Uint32Array(totalVerts);
   const pathOffsets = new Uint32Array(sampled.length + 1);
-  const strokes: (string | null)[] = [];
   const styleRows: number[] = [];
 
   let cursor = 0;
@@ -81,7 +80,6 @@ export function curveBatch(
     pathOffsets[s] = cursor;
     const { row, positions: pts, count } = sampled[s]!;
     styleRows.push(row);
-    strokes.push(paintVector(frame, "color", color, [row])[0]!);
     const sourceRow = frame.rowIndex[row]!;
     for (let i = 0; i < count; i++) {
       positions[cursor * 2] = pts[i * 2]!;
@@ -94,6 +92,9 @@ export function curveBatch(
     }
   }
   pathOffsets[sampled.length] = cursor;
+
+  // One paint vector for all kept curve rows (#1309).
+  const strokes = paintVector(frame, "color", color, styleRows);
 
   const paint = layerPaintFromParams(binding.layer.params);
   const strokePaintResolved =

--- a/packages/core/src/pipeline/geometry-paths-area-fill.ts
+++ b/packages/core/src/pipeline/geometry-paths-area-fill.ts
@@ -4,6 +4,15 @@
 import type { LayerFrame, ResolvedColorScale } from "./types.js";
 import { paintVector } from "./geometry-style.js";
 
+/** One paint vector for many group-representative rows (#1309). */
+export function areaGroupFillsOf(
+  frame: LayerFrame,
+  fill: ResolvedColorScale | null,
+  styleRows: ArrayLike<number>,
+): (string | null)[] {
+  return paintVector(frame, "fill", fill, styleRows);
+}
+
 export function areaGroupFillOf(
   frame: LayerFrame,
   fill: ResolvedColorScale | null,
@@ -11,5 +20,5 @@ export function areaGroupFillOf(
 ): string | null {
   const first = rows[0];
   if (first === undefined) return frame.binding.fill.constant;
-  return paintVector(frame, "fill", fill, [first])[0]!;
+  return areaGroupFillsOf(frame, fill, [first])[0]!;
 }

--- a/packages/core/src/pipeline/geometry-paths-area.ts
+++ b/packages/core/src/pipeline/geometry-paths-area.ts
@@ -9,7 +9,7 @@ import type { Frame } from "./geometry-shared.js";
 import { constantStyle, numericStyleVector, type ResolvedStyleScales } from "./geometry-style.js";
 import { bucketByGroup, sortGroupRowsByX, warnSingleObservationGroups } from "./geometry-shared.js";
 import { writeClosedPathGroups } from "./geometry-paths-closed-batch.js";
-import { areaGroupFillOf } from "./geometry-paths-area-fill.js";
+import { areaGroupFillsOf } from "./geometry-paths-area-fill.js";
 
 export function areaBatch(
   frame: LayerFrame,
@@ -32,6 +32,10 @@ export function areaBatch(
       : resolveGradientPaint(paint.fillPaint, binding.index, "fill");
   const glowResolved = paint.glow === null ? undefined : resolveGlow(paint.glow, binding.index);
 
+  // One fill paint vector for all groups (#1309).
+  const styleRows = groupRows.map((rows) => rows[0]!);
+  const fillPaints = areaGroupFillsOf(frame, fill, styleRows);
+
   // Draw later-stacked groups first so the first-seen group paints on top.
   const { positions, rowIndex, closedFrameRows, pathOffsets, fills, strokes } =
     writeClosedPathGroups({
@@ -40,19 +44,14 @@ export function areaBatch(
       groupRows,
       yTop: frame.ymax,
       yBottom: frame.ymin,
-      fillOf: (rows) => areaGroupFillOf(frame, fill, rows) ?? fillPaintResolved?.fallback ?? null,
+      fillOf: (_rows, index) => fillPaints[index] ?? fillPaintResolved?.fallback ?? null,
     });
 
   const params: { alpha?: number } =
     binding.layer.geom === "area" || binding.layer.geom === "density"
       ? (binding.layer.params ?? {})
       : {};
-  const mappedAlphas = numericStyleVector(
-    frame,
-    "alpha",
-    groupRows.map((rows) => rows[0]!),
-    styles,
-  );
+  const mappedAlphas = numericStyleVector(frame, "alpha", styleRows, styles);
   const subpathCount = pathOffsets.length - 1;
   const constantAlpha = constantStyle(binding, params, "alpha", 1);
   // Multi-group closed fills must carry alpha per subpath. SVG group opacity

--- a/packages/core/src/pipeline/geometry-paths-closed-batch.ts
+++ b/packages/core/src/pipeline/geometry-paths-closed-batch.ts
@@ -11,7 +11,7 @@ export function writeClosedPathGroups(input: {
   groupRows: readonly (readonly number[])[];
   yTop: Float64Array;
   yBottom: Float64Array;
-  fillOf: (rows: readonly number[]) => string | null;
+  fillOf: (rows: readonly number[], groupIndex: number) => string | null;
 }): {
   positions: Float32Array;
   rowIndex: Uint32Array;
@@ -44,7 +44,7 @@ export function writeClosedPathGroups(input: {
       yTop,
       yBottom,
     });
-    fills.push(fillOf(rows));
+    fills.push(fillOf(rows, s));
     strokes.push(null);
   }
   pathOffsets[groupRows.length] = cursor;

--- a/packages/core/src/pipeline/geometry-paths-line-write.ts
+++ b/packages/core/src/pipeline/geometry-paths-line-write.ts
@@ -27,7 +27,7 @@ export function writeLineSubpaths(input: {
   const rowIndex = new Uint32Array(total);
   const frameRowIndex = includeFrameRows ? new Uint32Array(total) : undefined;
   const pathOffsets = new Uint32Array(subpaths.length + 1);
-  const strokes: (string | null)[] = [];
+  const styleRows = new Uint32Array(subpaths.length);
   let cursor = 0;
 
   // Continuous multi-series: monomorphic normalize + pixel map (no band/offset branch).
@@ -43,6 +43,7 @@ export function writeLineSubpaths(input: {
     for (let s = 0; s < subpaths.length; s++) {
       pathOffsets[s] = cursor;
       const rows = subpaths[s]!;
+      styleRows[s] = rows[0]!;
       for (let i = 0; i < rows.length; i++) {
         const row = rows[i]!;
         const tx = xScale.normalizeTransformed(xNum[row]!);
@@ -53,12 +54,12 @@ export function writeLineSubpaths(input: {
         if (frameRowIndex !== undefined) frameRowIndex[cursor] = row;
         cursor++;
       }
-      strokes.push(paintVector(frame, "color", color, [rows[0]!])[0]!);
     }
   } else {
     for (let s = 0; s < subpaths.length; s++) {
       pathOffsets[s] = cursor;
       const rows = subpaths[s]!;
+      styleRows[s] = rows[0]!;
       for (const row of rows) {
         const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row);
         const ty = positionOf(fx.yScale, frame.yNumeric, frame.yValues, row);
@@ -68,10 +69,11 @@ export function writeLineSubpaths(input: {
         if (frameRowIndex !== undefined) frameRowIndex[cursor] = row;
         cursor++;
       }
-      strokes.push(paintVector(frame, "color", color, [rows[0]!])[0]!);
     }
   }
   pathOffsets[subpaths.length] = cursor;
+  // One paint vector for all subpath representative rows (#1309).
+  const strokes = paintVector(frame, "color", color, styleRows);
   return {
     positions,
     rowIndex,

--- a/packages/core/src/pipeline/geometry-paths-polygon.ts
+++ b/packages/core/src/pipeline/geometry-paths-polygon.ts
@@ -16,7 +16,7 @@ import {
   paintVector,
   type ResolvedStyleScales,
 } from "./geometry-style.js";
-import { areaGroupFillOf } from "./geometry-paths-area-fill.js";
+import { areaGroupFillsOf } from "./geometry-paths-area-fill.js";
 
 export function polygonBatch(
   frame: LayerFrame,
@@ -42,6 +42,11 @@ export function polygonBatch(
       ? undefined
       : resolveGradientPaint(paint.strokePaint, binding.index, "stroke");
   const glowResolved = paint.glow === null ? undefined : resolveGlow(paint.glow, binding.index);
+
+  // Representative rows first so fill/stroke resolve in one vector each (#1309).
+  const styleRows = groupRows.map((rows) => rows[0]!);
+  const fillPaints = areaGroupFillsOf(frame, fill, styleRows);
+  const strokePaints = paintVector(frame, "color", color, styleRows);
 
   let total = 0;
   for (const rows of groupRows) total += rows.length;
@@ -75,8 +80,8 @@ export function polygonBatch(
       closedFrameRows[cursor] = row;
       cursor++;
     }
-    fills.push(areaGroupFillOf(frame, fill, rows) ?? fillPaintResolved?.fallback ?? null);
-    let stroke = paintVector(frame, "color", color, [rows[0]!])[0]!;
+    fills.push(fillPaints[s] ?? fillPaintResolved?.fallback ?? null);
+    let stroke = strokePaints[s]!;
     if (stroke === null && strokePaintResolved !== undefined) {
       stroke = strokePaintResolved.fallback;
     }
@@ -89,7 +94,6 @@ export function polygonBatch(
     alpha?: number;
     linewidth?: number;
   };
-  const styleRows = groupRows.map((rows) => rows[0]!);
   const linewidths = numericStyleVector(frame, "linewidth", styleRows, styles);
   const alphas = numericStyleVector(frame, "alpha", styleRows, styles);
   const linetypeIndexes = indexedStyleVector(frame, "linetype", styleRows, styles, (value) =>

--- a/packages/core/src/pipeline/geometry-ribbon.ts
+++ b/packages/core/src/pipeline/geometry-ribbon.ts
@@ -22,7 +22,7 @@ import {
   type ResolvedStyleScales,
 } from "./geometry-style.js";
 // paint helpers imported below
-import { areaGroupFillOf } from "./geometry-paths-area-fill.js";
+import { areaGroupFillsOf } from "./geometry-paths-area-fill.js";
 
 type Outline = "both" | "upper" | "lower" | "full";
 type LineCap = "butt" | "round" | "square";
@@ -210,8 +210,8 @@ function writeClosedRuns(input: {
   fx: Frame;
   orientation: "x" | "y";
   runs: readonly RibbonRun[];
-  fillOf: (rows: readonly number[]) => string | null;
-  strokeOf: (rows: readonly number[]) => string | null;
+  fillOf: (runIndex: number) => string | null;
+  strokeOf: (runIndex: number) => string | null;
   strokeWidth: number;
 }): {
   positions: Float32Array;
@@ -265,8 +265,8 @@ function writeClosedRuns(input: {
       closedFrameRows[cursor] = row;
       cursor++;
     }
-    fills.push(fillOf(rows));
-    strokes.push(strokeWidth > 0 ? strokeOf(rows) : null);
+    fills.push(fillOf(s));
+    strokes.push(strokeWidth > 0 ? strokeOf(s) : null);
   }
   pathOffsets[runs.length] = cursor;
   return { positions, rowIndex, closedFrameRows, pathOffsets, fills, strokes };
@@ -278,7 +278,7 @@ function writeOpenEdges(input: {
   orientation: "x" | "y";
   runs: readonly RibbonRun[];
   edge: "upper" | "lower" | "both";
-  strokeOf: (rows: readonly number[]) => string | null;
+  strokeOf: (runIndex: number) => string | null;
 }): {
   positions: Float32Array;
   rowIndex: Uint32Array;
@@ -301,7 +301,8 @@ function writeOpenEdges(input: {
   const strokes: (string | null)[] = [];
   let cursor = 0;
   let sub = 0;
-  for (const run of runs) {
+  for (let r = 0; r < runs.length; r++) {
+    const run = runs[r]!;
     for (const which of edges) {
       pathOffsets[sub] = cursor;
       const bound = which === "upper" ? hi : lo;
@@ -319,7 +320,7 @@ function writeOpenEdges(input: {
         frameRowIndex[cursor] = row;
         cursor++;
       }
-      strokes.push(strokeOf(run.rows));
+      strokes.push(strokeOf(r));
       sub++;
     }
   }
@@ -327,23 +328,9 @@ function writeOpenEdges(input: {
   return { positions, rowIndex, frameRowIndex, pathOffsets, strokes };
 }
 
-function explicitStrokeColor(
-  frame: LayerFrame,
-  color: ResolvedColorScale | null,
-  rows: readonly number[],
-): string | null {
-  const { binding } = frame;
-  // Outline only when color is explicitly supplied (mapped or constant).
-  if (
-    binding.color.field === null &&
-    binding.color.constant === null &&
-    binding.color.scaledConstant === null
-  ) {
-    return null;
-  }
-  const first = rows[0];
-  if (first === undefined) return binding.color.constant;
-  return paintVector(frame, "color", color, [first])[0]!;
+function hasExplicitColorBinding(frame: LayerFrame): boolean {
+  const { color } = frame.binding;
+  return color.field !== null || color.constant !== null || color.scaledConstant !== null;
 }
 
 export function ribbonBatches(
@@ -386,15 +373,23 @@ export function ribbonBatches(
       : resolveGradientPaint(paint.strokePaint, layerIndex, "stroke");
   const glowResolved = paint.glow === null ? undefined : resolveGlow(paint.glow, layerIndex);
 
-  const strokeOf = (rows: readonly number[]) => {
-    const solid = explicitStrokeColor(frame, color, rows);
-    if (solid !== null) return solid;
+  // One fill vector + one stroke vector for all ribbon runs (#1309).
+  const fillPaints = areaGroupFillsOf(frame, fill, styleRows);
+  const solidStrokes = hasExplicitColorBinding(frame)
+    ? paintVector(frame, "color", color, styleRows)
+    : null;
+  const strokeOf = (runIndex: number) => {
+    if (solidStrokes !== null) {
+      const solid = solidStrokes[runIndex]!;
+      if (solid !== null) return solid;
+    }
     // strokePaint supplies a solid fallback so outlines can activate without
     // aes.color (within-mark paint is not a data scale).
     return strokePaintResolved?.fallback ?? null;
   };
   const hasExplicitColor =
-    strokePaintResolved !== undefined || runs.some((run) => strokeOf(run.rows) !== null);
+    strokePaintResolved !== undefined ||
+    (solidStrokes !== null && solidStrokes.some((s) => s !== null));
   const outlineWidth = constantStyle(frame.binding, params, "linewidth", DEFAULT_LINEWIDTH);
 
   const out: PathsBatch[] = [];
@@ -404,10 +399,7 @@ export function ribbonBatches(
     fx,
     orientation,
     runs,
-    fillOf: (rows) => {
-      const solid = areaGroupFillOf(frame, fill, rows);
-      return solid ?? fillPaintResolved?.fallback ?? null;
-    },
+    fillOf: (runIndex) => fillPaints[runIndex] ?? fillPaintResolved?.fallback ?? null,
     strokeOf,
     strokeWidth: fullStroke ? outlineWidth : 0,
   });

--- a/packages/core/src/pipeline/geometry-segments-data.ts
+++ b/packages/core/src/pipeline/geometry-segments-data.ts
@@ -44,9 +44,13 @@ export function emitDataSegments(input: {
     }
     if (buffers.kept > before) {
       styleRows[before] = row;
-      if (wantsColors && color !== null && strokes !== null) {
-        strokes[before] = mappedPaintVector(frame, "color", color, [row])[0]!;
-      }
+    }
+  }
+  // One mapped paint vector for all kept style rows (#1309).
+  if (wantsColors && color !== null && strokes !== null && buffers.kept > 0) {
+    const painted = mappedPaintVector(frame, "color", color, styleRows.subarray(0, buffers.kept));
+    for (let i = 0; i < buffers.kept; i++) {
+      strokes[i] = painted[i]!;
     }
   }
 }

--- a/packages/core/src/pipeline/geometry-violin.ts
+++ b/packages/core/src/pipeline/geometry-violin.ts
@@ -22,7 +22,7 @@ import {
   paintVector,
   type ResolvedStyleScales,
 } from "./geometry-style.js";
-import { areaGroupFillOf } from "./geometry-paths-area-fill.js";
+import { areaGroupFillsOf } from "./geometry-paths-area-fill.js";
 
 function sortRowsByY(rows: number[], y: Float64Array): number[] {
   return rows.toSorted((a, b) => y[a]! - y[b]!);
@@ -110,6 +110,10 @@ export function violinBatch(
   const pathOffsets = new Uint32Array(sortedGroups.length + 1);
   const fills: (string | null)[] = [];
   const strokes: (string | null)[] = [];
+  // One fill/stroke paint vector for all violins (#1309).
+  const styleRows = sortedGroups.map((rows) => rows[0]!);
+  const fillPaints = areaGroupFillsOf(frame, fill, styleRows);
+  const strokePaints = paintVector(frame, "color", color, styleRows);
   let cursor = 0;
 
   for (let s = 0; s < sortedGroups.length; s++) {
@@ -147,8 +151,8 @@ export function violinBatch(
       closedFrameRows[cursor] = row;
       cursor++;
     }
-    fills.push(areaGroupFillOf(frame, fill, rows) ?? fillPaintResolved?.fallback ?? null);
-    let stroke = paintVector(frame, "color", color, [rows[0]!])[0]!;
+    fills.push(fillPaints[s] ?? fillPaintResolved?.fallback ?? null);
+    let stroke = strokePaints[s]!;
     if (stroke === null && strokePaintResolved !== undefined) {
       stroke = strokePaintResolved.fallback;
     }
@@ -156,12 +160,7 @@ export function violinBatch(
   }
   pathOffsets[sortedGroups.length] = cursor;
 
-  const mappedAlphas = numericStyleVector(
-    frame,
-    "alpha",
-    sortedGroups.map((rows) => rows[0]!),
-    styles,
-  );
+  const mappedAlphas = numericStyleVector(frame, "alpha", styleRows, styles);
   const subpathCount = pathOffsets.length - 1;
   const constantAlpha = constantStyle(binding, params, "alpha", 1);
   const alphas =

--- a/packages/core/tests/pipeline/geometry-paint-batch.test.ts
+++ b/packages/core/tests/pipeline/geometry-paint-batch.test.ts
@@ -1,0 +1,307 @@
+/**
+ * #1309 — geometry emitters batch paintVector / mappedPaintVector once per
+ * style vector, not once per item. Colors must match the known palette; call
+ * count is the acceptance seam for pseudo-batching.
+ */
+import { fromAny, fromPartial } from "@total-typescript/shoehorn";
+import { describe, expect, it, spyOn } from "bun:test";
+
+import { trainContinuous } from "../../src/scales/train.ts";
+import { DEFAULT_MISSING_COLOR } from "../../src/scales/engine.ts";
+import { curveBatch } from "../../src/pipeline/geometry-curve.ts";
+import { emitDataSegments } from "../../src/pipeline/geometry-segments-data.ts";
+import {
+  createSegmentEmitters,
+  type SegmentEmitBuffers,
+} from "../../src/pipeline/geometry-segments-emit.ts";
+import { writeLineSubpaths } from "../../src/pipeline/geometry-paths-line-write.ts";
+import { polygonBatch } from "../../src/pipeline/geometry-paths-polygon.ts";
+import { areaGroupFillOf } from "../../src/pipeline/geometry-paths-area-fill.ts";
+import { ribbonBatches } from "../../src/pipeline/geometry-ribbon.ts";
+import * as geometryStyle from "../../src/pipeline/geometry-style.ts";
+import type { Frame } from "../../src/pipeline/geometry-shared.ts";
+import type { LayerFrame, ResolvedColorScale } from "../../src/pipeline/types.ts";
+import type { ResolvedStyleScales } from "../../src/pipeline/geometry-style.ts";
+
+const PALETTE: Record<string, string> = {
+  a: "#ff0000",
+  b: "#00ff00",
+  c: "#0000ff",
+};
+
+function stubScale(map: Record<string, string> = PALETTE): ResolvedColorScale {
+  return fromPartial<ResolvedColorScale>({
+    kind: "ordinal",
+    scale: {
+      colorOf: (value: unknown) =>
+        value === null || value === undefined ? undefined : map[`${value as string | number}`],
+      naValue: DEFAULT_MISSING_COLOR,
+      unknownValue: DEFAULT_MISSING_COLOR,
+    },
+  });
+}
+
+function continuousFx(w = 100, h = 50): Frame {
+  const xScale = trainContinuous([[0, 10]], {}).scale;
+  const yScale = trainContinuous([[0, 10]], {}).scale;
+  return fromPartial<Frame>({
+    innerWidth: w,
+    innerHeight: h,
+    xScale,
+    yScale,
+  });
+}
+
+const emptyStyles = fromPartial<ResolvedStyleScales>({
+  linewidth: null,
+  alpha: null,
+  linetype: null,
+  size: null,
+  shape: null,
+});
+
+function baseBinding(geom: string, extra: Record<string, unknown> = {}) {
+  return {
+    index: 0,
+    layer: { geom, params: {} },
+    color: { field: null, constant: null, scaledConstant: null, statColumn: null },
+    fill: { field: null, constant: null, scaledConstant: null, statColumn: null },
+    linewidth: { field: null, constant: null, scaledConstant: null, statColumn: null },
+    alpha: { field: null, constant: null, scaledConstant: null, statColumn: null },
+    linetype: { field: null, constant: null, scaledConstant: null, statColumn: null },
+    ...extra,
+  };
+}
+
+describe("emitDataSegments paint batch (#1309)", () => {
+  it("resolves mapped strokes once for all kept rows", () => {
+    const n = 4;
+    const frame = fromAny<LayerFrame>({
+      n,
+      xNumeric: Float64Array.of(1, 2, 3, 4),
+      xValues: null,
+      yNumeric: null,
+      yValues: null,
+      rowIndex: Uint32Array.from({ length: n }, (_, i) => i),
+      colorValues: ["a", "b", null, "c"],
+      binding: {
+        ...baseBinding("vline"),
+        ruleForm: "vertical",
+        color: { field: "g", constant: null, scaledConstant: null, statColumn: null },
+      },
+    });
+    const fx = continuousFx();
+    const capacity = n;
+    const buffers: SegmentEmitBuffers = {
+      segments: new Float32Array(capacity * 4),
+      rowIndex: new Uint32Array(capacity),
+      kept: 0,
+      removed: 0,
+    };
+    const strokes = Array.from<string>({ length: capacity });
+    const styleRows = new Uint32Array(capacity);
+    const { pushVertical, pushHorizontal } = createSegmentEmitters({ fx, buffers });
+    const mappedSpy = spyOn(geometryStyle, "mappedPaintVector");
+
+    emitDataSegments({
+      frame,
+      fx,
+      color: stubScale(),
+      wantsColors: true,
+      pushVertical,
+      pushHorizontal,
+      buffers,
+      strokes,
+      styleRows,
+    });
+
+    expect(buffers.kept).toBe(4);
+    expect(mappedSpy).toHaveBeenCalledTimes(1);
+    expect(strokes.slice(0, 4)).toEqual(["#ff0000", "#00ff00", DEFAULT_MISSING_COLOR, "#0000ff"]);
+    mappedSpy.mockRestore();
+  });
+});
+
+describe("writeLineSubpaths paint batch (#1309)", () => {
+  it("resolves one stroke paint vector for all subpaths", () => {
+    const frame = fromAny<LayerFrame>({
+      n: 6,
+      xNumeric: Float64Array.of(0, 1, 2, 0, 1, 2),
+      yNumeric: Float64Array.of(0, 1, 0, 2, 3, 2),
+      xValues: null,
+      yValues: null,
+      rowIndex: Uint32Array.from({ length: 6 }, (_, i) => i),
+      colorValues: ["a", "a", "a", "b", "b", "b"],
+      binding: {
+        ...baseBinding("line"),
+        color: { field: "g", constant: null, scaledConstant: null, statColumn: null },
+      },
+    });
+    const paintSpy = spyOn(geometryStyle, "paintVector");
+    const out = writeLineSubpaths({
+      frame,
+      fx: continuousFx(),
+      color: stubScale(),
+      subpaths: [
+        [0, 1, 2],
+        [3, 4, 5],
+      ],
+    });
+    expect(paintSpy).toHaveBeenCalledTimes(1);
+    expect(out.strokes).toEqual(["#ff0000", "#00ff00"]);
+    paintSpy.mockRestore();
+  });
+
+  it("keeps constant fallback colours when the channel is unmapped", () => {
+    const frame = fromAny<LayerFrame>({
+      n: 4,
+      xNumeric: Float64Array.of(0, 1, 0, 1),
+      yNumeric: Float64Array.of(0, 1, 0, 1),
+      xValues: null,
+      yValues: null,
+      rowIndex: Uint32Array.from({ length: 4 }, (_, i) => i),
+      colorValues: null,
+      binding: {
+        ...baseBinding("line"),
+        color: { field: null, constant: "#112233", scaledConstant: null, statColumn: null },
+      },
+    });
+    const paintSpy = spyOn(geometryStyle, "paintVector");
+    const out = writeLineSubpaths({
+      frame,
+      fx: continuousFx(),
+      color: null,
+      subpaths: [
+        [0, 1],
+        [2, 3],
+      ],
+    });
+    expect(paintSpy).toHaveBeenCalledTimes(1);
+    expect(out.strokes).toEqual(["#112233", "#112233"]);
+    paintSpy.mockRestore();
+  });
+});
+
+describe("curveBatch paint batch (#1309)", () => {
+  it("resolves one stroke paint vector for all kept curves", () => {
+    const frame = fromAny<LayerFrame>({
+      n: 3,
+      xNumeric: Float64Array.of(0, 2, 4),
+      yNumeric: Float64Array.of(0, 1, 2),
+      xend: Float64Array.of(1, 3, 5),
+      yend: Float64Array.of(1, 2, 3),
+      xValues: null,
+      yValues: null,
+      xendValues: null,
+      yendValues: null,
+      rowIndex: Uint32Array.from({ length: 3 }, (_, i) => i),
+      colorValues: ["a", "b", "c"],
+      binding: {
+        ...baseBinding("curve"),
+        color: { field: "g", constant: null, scaledConstant: null, statColumn: null },
+      },
+    });
+    const paintSpy = spyOn(geometryStyle, "paintVector");
+    const batch = curveBatch(frame, continuousFx(), stubScale(), emptyStyles, []);
+    expect(batch).not.toBeNull();
+    expect(paintSpy).toHaveBeenCalledTimes(1);
+    expect(batch!.strokes).toEqual(["#ff0000", "#00ff00", "#0000ff"]);
+    paintSpy.mockRestore();
+  });
+});
+
+describe("polygonBatch paint batch (#1309)", () => {
+  it("resolves fill and stroke paint vectors once across groups", () => {
+    const frame = fromAny<LayerFrame>({
+      n: 6,
+      xNumeric: Float64Array.of(0, 1, 0.5, 2, 3, 2.5),
+      yNumeric: Float64Array.of(0, 0, 1, 0, 0, 1),
+      xValues: null,
+      yValues: null,
+      groups: [0, 0, 0, 1, 1, 1],
+      rowIndex: Uint32Array.from({ length: 6 }, (_, i) => i),
+      colorValues: ["a", "a", "a", "b", "b", "b"],
+      fillValues: ["a", "a", "a", "b", "b", "b"],
+      binding: {
+        ...baseBinding("polygon"),
+        color: { field: "g", constant: null, scaledConstant: null, statColumn: null },
+        fill: { field: "g", constant: null, scaledConstant: null, statColumn: null },
+      },
+    });
+    const paintSpy = spyOn(geometryStyle, "paintVector");
+    const batch = polygonBatch(frame, continuousFx(), stubScale(), stubScale(), emptyStyles, []);
+    expect(batch).not.toBeNull();
+    // One fill vector + one stroke vector (not one call per group).
+    expect(paintSpy).toHaveBeenCalledTimes(2);
+    expect(batch!.fills).toEqual(["#ff0000", "#00ff00"]);
+    expect(batch!.strokes).toEqual(["#ff0000", "#00ff00"]);
+    paintSpy.mockRestore();
+  });
+});
+
+describe("areaGroupFillOf paint batch helper (#1309)", () => {
+  it("areaGroupFillsOf resolves many groups in one paintVector call", async () => {
+    const { areaGroupFillsOf } = await import("../../src/pipeline/geometry-paths-area-fill.ts");
+    const frame = fromAny<LayerFrame>({
+      fillValues: ["a", "b", "c"],
+      binding: {
+        fill: { field: "g", constant: null, scaledConstant: null, statColumn: null },
+      },
+    });
+    const paintSpy = spyOn(geometryStyle, "paintVector");
+    const fills = areaGroupFillsOf(frame, stubScale(), [0, 2, 1]);
+    expect(paintSpy).toHaveBeenCalledTimes(1);
+    expect(fills).toEqual(["#ff0000", "#0000ff", "#00ff00"]);
+    // Single-group helper stays equivalent.
+    expect(areaGroupFillOf(frame, stubScale(), [2])).toBe("#0000ff");
+    paintSpy.mockRestore();
+  });
+
+  it("returns the constant fill when unmapped", async () => {
+    const { areaGroupFillsOf } = await import("../../src/pipeline/geometry-paths-area-fill.ts");
+    const frame = fromAny<LayerFrame>({
+      fillValues: null,
+      binding: {
+        fill: { field: null, constant: "#cde", scaledConstant: null, statColumn: null },
+      },
+    });
+    expect(areaGroupFillsOf(frame, null, [0, 1])).toEqual(["#cde", "#cde"]);
+  });
+});
+
+describe("ribbonBatches paint batch (#1309)", () => {
+  it("resolves fill and stroke paint vectors once across runs", () => {
+    const frame = fromAny<LayerFrame>({
+      n: 6,
+      xNumeric: Float64Array.of(0, 1, 2, 0, 1, 2),
+      yNumeric: Float64Array.of(1, 1, 1, 1, 1, 1),
+      ymin: Float64Array.of(0, 0, 0, 0, 0, 0),
+      ymax: Float64Array.of(1, 2, 1, 2, 3, 2),
+      xValues: null,
+      yValues: null,
+      groups: [0, 0, 0, 1, 1, 1],
+      rowIndex: Uint32Array.from({ length: 6 }, (_, i) => i),
+      colorValues: ["a", "a", "a", "b", "b", "b"],
+      fillValues: ["a", "a", "a", "b", "b", "b"],
+      binding: {
+        ...baseBinding("ribbon"),
+        color: { field: "g", constant: null, scaledConstant: null, statColumn: null },
+        fill: { field: "g", constant: null, scaledConstant: null, statColumn: null },
+        ribbonOrientation: "x",
+      },
+    });
+    const paintSpy = spyOn(geometryStyle, "paintVector");
+    const batches = ribbonBatches(frame, continuousFx(), stubScale(), stubScale(), emptyStyles, []);
+    expect(batches.length).toBeGreaterThan(0);
+    // At most one fill vector + one stroke vector for the styleRows set.
+    const paintCalls = paintSpy.mock.calls.filter(
+      (call) => call[1] === "fill" || call[1] === "color",
+    );
+    expect(paintCalls.length).toBeLessThanOrEqual(2);
+    expect(paintCalls.some((c) => c[1] === "fill")).toBe(true);
+    expect(paintCalls.some((c) => c[1] === "color")).toBe(true);
+    const closed = batches.find((b) => b.closed);
+    expect(closed?.fills).toEqual(["#ff0000", "#00ff00"]);
+    paintSpy.mockRestore();
+  });
+});

--- a/packages/core/tests/pipeline/geometry-paint-batch.test.ts
+++ b/packages/core/tests/pipeline/geometry-paint-batch.test.ts
@@ -300,7 +300,7 @@ describe("ribbonBatches paint batch (#1309)", () => {
     expect(paintCalls.length).toBeLessThanOrEqual(2);
     expect(paintCalls.some((c) => c[1] === "fill")).toBe(true);
     expect(paintCalls.some((c) => c[1] === "color")).toBe(true);
-    const closed = batches.find((b) => b.closed);
+    const closed = batches.find((b) => b.closed === true);
     expect(closed?.fills).toEqual(["#ff0000", "#00ff00"]);
     paintSpy.mockRestore();
   });


### PR DESCRIPTION
## Summary

- Geometry emitters called `paintVector` / `mappedPaintVector` once per item (frame row, subpath, curve, polygon group, ribbon run) even though they already accumulated style-row indices.
- Resolve colour **once per batch** and index the result: segments, line subpaths, curves, polygons, ribbons, area/density groups, and violins.
- Add `areaGroupFillsOf` for multi-group fill resolution; keep `areaGroupFillOf` as a single-group wrapper.
- TDD coverage: one paint call per batch plus known palette colours for mapped, unmapped, and NA cases.

Closes #1309

## Test plan

- [x] `bun test packages/core/tests/pipeline/geometry-paint-batch.test.ts`
- [x] Related geometry suites (polygon, paths-boxplot, style-paint, pipeline-geometry)
- [ ] CI green on the PR
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1384" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->