### PR TITLE
fix(core): index batch semantics for unknown-value warnings (#1311)

### DIFF
--- a/.changeset/indexed-semantic-unknown-warn.md
+++ b/.changeset/indexed-semantic-unknown-warn.md
@@ -1,0 +1,10 @@
+---
+"@ggsvelte/core": patch
+---
+
+# Index batch semantics when counting unknown scale values
+
+Binned color and sequential/binned numeric style scales count unknown training
+values from the batch-parsed `view.semantic` array instead of re-deriving each
+row via `semanticOf` (which re-paid encodeKey lookup or single-row parseColumn
+on temporal misses). Warning counts stay the same.

--- a/packages/core/src/pipeline/scale-color-binned.ts
+++ b/packages/core/src/pipeline/scale-color-binned.ts
@@ -165,16 +165,18 @@ export function resolveBinnedColorScale(input: {
       return semantic === undefined ? unknownValue : semanticColorOf(semantic);
     },
   });
-  warnUnknownColors(
-    name,
-    values.filter((value) => {
-      if (value === null) return false;
-      const semantic = view.semanticOf(value);
-      if (semantic === undefined) return true;
-      return transformedOf(semantic) === undefined;
-    }).length,
-    warnings,
-  );
+  // Index the batch semantic array (same alignment as sequential-train). Do not
+  // re-derive rows via semanticOf — that re-pays encodeKey/Map lookup or a
+  // single-row parseColumn on temporal misses the batch already recorded.
+  let unknownCount = 0;
+  for (let index = 0; index < values.length; index++) {
+    if (values[index] === null) continue;
+    const semantic = view.semantic[index]!;
+    if (!Number.isFinite(semantic) || transformedOf(semantic) === undefined) {
+      unknownCount++;
+    }
+  }
+  warnUnknownColors(name, unknownCount, warnings);
   const formatStep = minAdjacentWidth(breaks);
   const formatter = resolveBinnedLegendFormat({
     domain,

--- a/packages/core/src/pipeline/scale-style-numeric-sequential.ts
+++ b/packages/core/src/pipeline/scale-style-numeric-sequential.ts
@@ -158,12 +158,15 @@ export function numericSequentialResolution(input: {
     }
     return numericMappedValue(aesthetic, t, range, config?.sizeUnit);
   };
+  // Index the batch semantic array (index-aligned when values is non-empty;
+  // empty values skip this loop). Avoid semanticOf on the warn path so temporal
+  // misses do not re-call parseColumn one row at a time.
   let unknownCount = 0;
-  for (const value of values) {
-    if (value === null) continue;
-    const semantic = view.semanticOf(value);
+  for (let index = 0; index < values.length; index++) {
+    if (values[index] === null) continue;
+    const semantic = view.semantic[index]!;
     if (
-      semantic === undefined ||
+      !Number.isFinite(semantic) ||
       (config?.oob !== "squish" && (semantic < low || semantic > high))
     ) {
       unknownCount++;

--- a/packages/core/tests/pipeline-color-scales/binned.test.ts
+++ b/packages/core/tests/pipeline-color-scales/binned.test.ts
@@ -129,4 +129,61 @@ describe("binned color scales", () => {
       }),
     );
   });
+
+  // #1311: warn path must count from the batch semantic array (index-aligned),
+  // not re-parse each row via semanticOf. These cases lock the observable counts.
+  it("counts unknown binned colors for null, unparseable, and out-of-domain values (#1311)", () => {
+    const model = runPipeline(
+      pointSpec([5, null, 50, "nope", 1500, Number.POSITIVE_INFINITY, -10], {
+        type: "binned",
+        breaks: [1, 10, 100, 1000],
+        range: ["#111", "#777", "#eee"],
+      }),
+      size,
+    );
+    // null → NA (separate warning); "nope", Infinity, 1500, -10 → unknown.
+    expect(model.warnings.filter((warning) => warning.code === "color-na-values")).toEqual([
+      { code: "color-na-values", message: "1 color value(s) use the NA color." },
+    ]);
+    expect(model.warnings.filter((warning) => warning.code === "color-unknown-values")).toEqual([
+      { code: "color-unknown-values", message: "4 color value(s) use the unknown color." },
+    ]);
+  });
+
+  it("counts unknown binned colors when the transform rejects semantic values (#1311)", () => {
+    const model = runPipeline(
+      pointSpec([1, 0, 10, -5, 100], {
+        type: "binned",
+        transform: "log10",
+        breaks: [1, 10, 100],
+        range: ["#111", "#eee"],
+      }),
+      size,
+    );
+    // 0 and -5 are invalid for log10; in-domain values stay known.
+    expect(model.warnings.filter((warning) => warning.code === "color-unknown-values")).toEqual([
+      { code: "color-unknown-values", message: "2 color value(s) use the unknown color." },
+    ]);
+  });
+
+  it("counts unknown temporal binned colors without treating null as unknown (#1311)", () => {
+    const model = runPipeline(
+      pointSpec(["2024-01-01", null, "not-a-date", "2024-06-01", "2024-12-31"], {
+        type: "binned",
+        temporalKind: "date",
+        parse: "iso",
+        parseFailure: "censor",
+        breaks: ["2024-01-01", "2024-07-01", "2024-12-31"],
+        range: ["#111", "#eee"],
+      }),
+      size,
+    );
+    expect(model.warnings.some((warning) => warning.code === "color-temporal-censored")).toBe(true);
+    expect(model.warnings.filter((warning) => warning.code === "color-na-values")).toEqual([
+      { code: "color-na-values", message: "1 color value(s) use the NA color." },
+    ]);
+    expect(model.warnings.filter((warning) => warning.code === "color-unknown-values")).toEqual([
+      { code: "color-unknown-values", message: "1 color value(s) use the unknown color." },
+    ]);
+  });
 });

--- a/packages/core/tests/pipeline-style-families/scale-policy.test.ts
+++ b/packages/core/tests/pipeline-style-families/scale-policy.test.ts
@@ -172,6 +172,77 @@ describe("style scale policy and validation", () => {
     expect(model.warnings.some((warning) => warning.code === "style-unknown-values")).toBe(false);
   });
 
+  // #1311: sequential style warn path must index the batch semantic array.
+  it("counts unknown sequential style values for null, unparseable, and OOB (#1311)", () => {
+    const model = runPipeline(
+      fromAny({
+        data: {
+          values: [
+            { x: 1, y: 1, amount: 10 },
+            { x: 2, y: 2, amount: null },
+            { x: 3, y: 3, amount: "nope" },
+            { x: 4, y: 4, amount: 200 },
+            { x: 5, y: 5, amount: Number.POSITIVE_INFINITY },
+          ],
+        },
+        aes: { x: { field: "x" }, y: { field: "y" }, size: { field: "amount" } },
+        layers: [{ geom: "point" }],
+        scales: {
+          size: {
+            type: "sequential",
+            domain: [0, 100],
+            range: [2, 10],
+            naValue: 1,
+            unknownValue: 99,
+          },
+        },
+      }),
+      viewport,
+    );
+    // null → NA; "nope", 200 (OOB), Infinity → unknown.
+    expect(model.warnings.filter((warning) => warning.code === "style-na-values")).toEqual([
+      { code: "style-na-values", message: "1 size value(s) use the NA style." },
+    ]);
+    expect(model.warnings.filter((warning) => warning.code === "style-unknown-values")).toEqual([
+      { code: "style-unknown-values", message: "3 size value(s) use the unknown style." },
+    ]);
+  });
+
+  it("counts unknown binned style values without counting null as unknown (#1311)", () => {
+    const model = runPipeline(
+      fromAny({
+        data: {
+          values: [
+            { x: 1, y: 1, amount: 2 },
+            { x: 2, y: 2, amount: null },
+            { x: 3, y: 3, amount: "nope" },
+            { x: 4, y: 4, amount: 50 },
+            { x: 5, y: 5, amount: 150 },
+          ],
+        },
+        aes: { x: { field: "x" }, y: { field: "y" }, size: { field: "amount" } },
+        layers: [{ geom: "point" }],
+        scales: {
+          size: {
+            type: "binned",
+            breaks: [0, 10, 100],
+            range: [2, 10],
+            naValue: 1,
+            unknownValue: 99,
+          },
+        },
+      }),
+      viewport,
+    );
+    // null → NA; "nope" and 150 (above last break) → unknown; 2 and 50 in bins.
+    expect(model.warnings.filter((warning) => warning.code === "style-na-values")).toEqual([
+      { code: "style-na-values", message: "1 size value(s) use the NA style." },
+    ]);
+    expect(model.warnings.filter((warning) => warning.code === "style-unknown-values")).toEqual([
+      { code: "style-unknown-values", message: "2 size value(s) use the unknown style." },
+    ]);
+  });
+
   it("cycles finite shapes past the palette when onExhaust is cycle", () => {
     const model = runPipeline(
       fromAny({


### PR DESCRIPTION
## Summary

- **Fixes #1311.** Binned color and sequential/binned numeric style scales already batch-parse training values into `view.semantic`. The unknown-value warn path re-derived each row via `semanticOf`, re-paying encodeKey/Map lookup and single-row `parseColumn` on temporal misses.
- Count unknowns with an indexed loop over `view.semantic`, matching the sequential color train path (`scale-color-sequential-train.ts`).
- Characterization tests lock warning counts for null, unparseable, OOB, transform-invalid, and temporal-censor cases.

## Test plan

- [x] `bun test tests/pipeline-color-scales/binned.test.ts tests/pipeline-style-families/scale-policy.test.ts` (incl. new #1311 cases)
- [ ] CI green on this PR
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1385" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->