### PR TITLE
perf(core): hoist per-iteration invariants in stats and frame helpers (#1312)

### DIFF
--- a/.changeset/hoist-stats-frame-invariants.md
+++ b/.changeset/hoist-stats-frame-invariants.md
@@ -1,0 +1,9 @@
+---
+"@ggsvelte/core": patch
+---
+
+# Hoist per-iteration invariants in stats and frame helpers
+
+Migration: none — identical stat output and facet panel order.
+
+Hoist `Object.keys` / column resolution / encode-band keys above hot loops, store hex-bin cell coords at insert time, and drop the redundant all-true contour mask (#1312).

--- a/packages/core/src/pipeline/facets-helpers.ts
+++ b/packages/core/src/pipeline/facets-helpers.ts
@@ -128,14 +128,30 @@ export function facetValues(
       if (!numericByKey.has(key)) numericByKey.set(key, semantic[index]!);
     }
   }
-  values.sort((a, b) => {
-    if (a === null) return b === null ? 0 : 1;
-    if (b === null) return -1;
-    if (numeric) return numericByKey.get(encodeKey(a))! - numericByKey.get(encodeKey(b))!;
-    const ka = bandKey(a);
-    const kb = bandKey(b);
-    if (ka === kb) return encodeKey(a).localeCompare(encodeKey(b), "en");
-    return ka < kb ? -1 : ka > kb ? 1 : 0;
+  // Decorate-sort-undecorate: precompute all three comparator keys once so
+  // the O(k log k) sort never re-encodes or re-bandKeys a level (#1312).
+  type Decorated = {
+    value: CellValue;
+    enc: string;
+    band: string;
+    num: number;
+  };
+  const decorated: Decorated[] = values.map((value) => {
+    const enc = encodeKey(value);
+    return {
+      value,
+      enc,
+      // bandKey is only used for non-null nominal tiers; nulls sort last.
+      band: value === null ? "" : bandKey(value),
+      num: numeric ? (numericByKey.get(enc) ?? NaN) : 0,
+    };
   });
-  return values;
+  decorated.sort((a, b) => {
+    if (a.value === null) return b.value === null ? 0 : 1;
+    if (b.value === null) return -1;
+    if (numeric) return a.num - b.num;
+    if (a.band === b.band) return a.enc.localeCompare(b.enc, "en");
+    return a.band < b.band ? -1 : a.band > b.band ? 1 : 0;
+  });
+  return decorated.map((d) => d.value);
 }

--- a/packages/core/src/pipeline/facets-helpers.ts
+++ b/packages/core/src/pipeline/facets-helpers.ts
@@ -141,8 +141,10 @@ export function facetValues(
     return {
       value,
       enc,
-      // bandKey is only used for non-null nominal tiers; nulls sort last.
-      band: value === null ? "" : bandKey(value),
+      // bandKey only on the nominal tier (matches pre-hoist short-circuit).
+      // Numeric/temporal never read `band`; calling bandKey on Invalid Date
+      // would throw via toISOString (Devin #1386).
+      band: numeric || value === null ? "" : bandKey(value),
       num: numeric ? (numericByKey.get(enc) ?? NaN) : 0,
     };
   });

--- a/packages/core/src/pipeline/frame-edge-expand.ts
+++ b/packages/core/src/pipeline/frame-edge-expand.ts
@@ -3,6 +3,7 @@
  * sees xmin/xmax/ymin/ymax. Band tile leaves edges null (centers train).
  */
 import { resolution as resolutionOf } from "../stats/numeric.js";
+import type { CellValue } from "../table.js";
 
 import { positionFieldType } from "./temporal-position.js";
 import type { LayerFrame, PipelineWarning } from "./types.js";
@@ -11,15 +12,14 @@ import { PipelineError } from "./types.js";
 const RASTER_SPACING_EPS = Math.sqrt(Number.EPSILON);
 
 function sizeAt(
-  frame: LayerFrame,
-  field: string | null,
+  sizeColumn: readonly CellValue[] | null,
   param: number | undefined,
   defaultSize: number,
   row: number,
 ): number {
-  if (field !== null) {
+  if (sizeColumn !== null) {
     // Panel-local table after faceting — index by frame row, not source id.
-    const raw = frame.table.column(field)[row]!;
+    const raw = sizeColumn[row]!;
     const n = typeof raw === "number" ? raw : Number(raw);
     return Number.isFinite(n) ? n : NaN;
   }
@@ -89,12 +89,17 @@ export function expandEdgeFrame(frame: LayerFrame, warnings: PipelineWarning[]):
     const params = frame.binding.layer.params ?? {};
     const defW = defaultResolution(frame.xNumeric);
     const defH = defaultResolution(frame.yNumeric);
+    // Resolve size columns once — field names are invariant for the frame.
+    const widthCol =
+      frame.binding.widthField === null ? null : frame.table.column(frame.binding.widthField);
+    const heightCol =
+      frame.binding.heightField === null ? null : frame.table.column(frame.binding.heightField);
     if (xType !== "nominal") {
       const left = new Float64Array(frame.n);
       const right = new Float64Array(frame.n);
       for (let row = 0; row < frame.n; row++) {
         const cx = frame.xNumeric[row]!;
-        const w = sizeAt(frame, frame.binding.widthField, params.width, defW, row);
+        const w = sizeAt(widthCol, params.width, defW, row);
         if (!Number.isFinite(cx) || !(w > 0) || !Number.isFinite(w)) {
           left[row] = NaN;
           right[row] = NaN;
@@ -111,7 +116,7 @@ export function expandEdgeFrame(frame: LayerFrame, warnings: PipelineWarning[]):
       const top = new Float64Array(frame.n);
       for (let row = 0; row < frame.n; row++) {
         const cy = frame.yNumeric[row]!;
-        const h = sizeAt(frame, frame.binding.heightField, params.height, defH, row);
+        const h = sizeAt(heightCol, params.height, defH, row);
         if (!Number.isFinite(cy) || !(h > 0) || !Number.isFinite(h)) {
           bottom[row] = NaN;
           top[row] = NaN;

--- a/packages/core/src/pipeline/frame-stats-bindot.ts
+++ b/packages/core/src/pipeline/frame-stats-bindot.ts
@@ -46,12 +46,13 @@ export function buildBindotFrame(
   const col = columnOf(result, null);
 
   // Per-observation aesthetics from source rows (not group-constant only).
+  // Resolve columns once — field names are invariant for the binding.
   const colorField = binding.color.field;
   const fillField = binding.fill.field;
-  const colorValues =
-    colorField === null ? null : result.sourceRows.map((row) => table.column(colorField)[row]!);
-  const fillValues =
-    fillField === null ? null : result.sourceRows.map((row) => table.column(fillField)[row]!);
+  const colorCol = colorField === null ? null : table.column(colorField);
+  const fillCol = fillField === null ? null : table.column(fillField);
+  const colorValues = colorCol === null ? null : result.sourceRows.map((row) => colorCol[row]!);
+  const fillValues = fillCol === null ? null : result.sourceRows.map((row) => fillCol[row]!);
 
   return statLayerFrame({
     binding,

--- a/packages/core/src/stats/align.ts
+++ b/packages/core/src/stats/align.ts
@@ -117,7 +117,8 @@ export function statAlign(input: StatAlignInput): StatAlignResult {
   const outG: number[] = [];
   const outRow: number[] = [];
   const carriedOut: Record<string, CellValue[]> = {};
-  for (const key of Object.keys(carried)) carriedOut[key] = [];
+  const carriedKeys = Object.keys(carried);
+  for (const key of carriedKeys) carriedOut[key] = [];
 
   const groupIds = [...byGroup.keys()].toSorted((a, b) => a - b);
   for (const g of groupIds) {
@@ -152,7 +153,7 @@ export function statAlign(input: StatAlignInput): StatAlignResult {
       outY.push(yq);
       outG.push(g);
       outRow.push(cursor < n && xs[cursor] === xq ? series.rows[cursor]! : -1);
-      for (const key of Object.keys(carriedOut)) {
+      for (const key of carriedKeys) {
         carriedOut[key]!.push(carried[key]![rep]!);
       }
     }

--- a/packages/core/src/stats/bin-hex.ts
+++ b/packages/core/src/stats/bin-hex.ts
@@ -140,12 +140,15 @@ function hexBinKey(gs: number, q: number, r: number): string {
   return `${gs}:${q}:${r}`;
 }
 
+/** Occupied (or lattice-filled) hex cell with coords stored at insert time. */
+type HexCell = { gs: number; q: number; r: number; count: number };
+
 /**
  * Materialize zero-count axial cells whose centres sit in a one-hex pad of the
  * unit square, for every group slot. Extracted so `statBinHex` stays under the
  * max nesting depth for type-aware lint.
  */
-function fillEmptyLatticeCells(counts: Map<string, number>, groupCount: number, s: number): void {
+function fillEmptyLatticeCells(counts: Map<string, HexCell>, groupCount: number, s: number): void {
   const pad = Math.max(Math.sqrt(3) * s, 2 * s);
   const sampleCorners: Array<readonly [number, number]> = [
     [0, 0],
@@ -180,7 +183,7 @@ function fillEmptyLatticeCells(counts: Map<string, number>, groupCount: number, 
         const { x: ux, y: uy } = axialToPixel(q, r, s);
         if (ux < -pad || ux > 1 + pad || uy < -pad || uy > 1 + pad) continue;
         const key = hexBinKey(gs, q, r);
-        if (!counts.has(key)) counts.set(key, 0);
+        if (!counts.has(key)) counts.set(key, { gs, q, r, count: 0 });
       }
     }
   }
@@ -234,8 +237,9 @@ export function statBinHex(input: BinHexStatInput): BinHexStatResult {
     }
   }
 
-  // Key: groupSlot | q | r  → count
-  const counts = new Map<string, number>();
+  // Key: groupSlot | q | r  → cell (coords stored at insert so collect never
+  // re-parses the composite string key).
+  const counts = new Map<string, HexCell>();
   let dropped = 0;
 
   for (let i = 0; i < nIn; i++) {
@@ -255,7 +259,9 @@ export function statBinHex(input: BinHexStatInput): BinHexStatResult {
     if (weights !== null && weights !== undefined) {
       w = Number.isFinite(weights[i]!) ? weights[i]! : 0;
     }
-    counts.set(key, (counts.get(key) ?? 0) + w);
+    const existing = counts.get(key);
+    if (existing === undefined) counts.set(key, { gs, q, r, count: w });
+    else existing.count += w;
   }
 
   // drop:false — materialize the full axial lattice over the unit square so
@@ -265,18 +271,11 @@ export function statBinHex(input: BinHexStatInput): BinHexStatResult {
     fillEmptyLatticeCells(counts, groupOrder.length, s);
   }
 
-  // Collect cells.
-  type Cell = { gs: number; q: number; r: number; count: number };
-  const cells: Cell[] = [];
-  for (const [key, count] of counts) {
-    if (drop && count === 0) continue;
-    const [gsStr, qStr, rStr] = key.split(":");
-    cells.push({
-      gs: Number(gsStr),
-      q: Number(qStr),
-      r: Number(rStr),
-      count,
-    });
+  // Collect cells (coords already known — no key.split / Number re-parse).
+  const cells: HexCell[] = [];
+  for (const cell of counts.values()) {
+    if (drop && cell.count === 0) continue;
+    cells.push(cell);
   }
   if (cells.length === 0) return empty(dropped);
 

--- a/packages/core/src/stats/connect.ts
+++ b/packages/core/src/stats/connect.ts
@@ -105,7 +105,8 @@ export function statConnect(input: StatConnectInput): StatConnectResult {
   const outY: number[] = [];
   const outG: number[] = [];
   const carriedOut: Record<string, CellValue[]> = {};
-  for (const key of Object.keys(carried)) carriedOut[key] = [];
+  const carriedKeys = Object.keys(carried);
+  for (const key of carriedKeys) carriedOut[key] = [];
 
   // Preserve first-seen group order (stable with input traversal).
   for (const g of byGroup.keys()) {
@@ -119,7 +120,7 @@ export function statConnect(input: StatConnectInput): StatConnectResult {
     if (rows.length === 0) continue;
 
     const pushCarried = (sourceRow: number) => {
-      for (const key of Object.keys(carriedOut)) {
+      for (const key of carriedKeys) {
         carriedOut[key]!.push(carried[key]![sourceRow]!);
       }
     };

--- a/packages/core/src/stats/contour.ts
+++ b/packages/core/src/stats/contour.ts
@@ -43,10 +43,10 @@ export interface ContourStatResult {
 
 type Pt = { x: number; y: number };
 
-function uniqueSorted(values: Float64Array, finiteMask: boolean[]): number[] {
+function uniqueSorted(values: Float64Array): number[] {
+  // Number.isFinite already drops non-finite samples; no separate mask needed.
   const set = new Set<number>();
   for (let i = 0; i < values.length; i++) {
-    if (finiteMask[i] !== true) continue;
     const v = values[i]!;
     if (Number.isFinite(v)) set.add(v);
   }
@@ -356,12 +356,11 @@ export function statContour(input: ContourStatInput): ContourStatResult {
 
   for (const g of groupOrder) {
     const rows = groupRows.get(g)!;
-    const mask = rows.map(() => true);
     const gx = Float64Array.from(rows, (r) => x[r]!);
     const gy = Float64Array.from(rows, (r) => y[r]!);
     const gz = Float64Array.from(rows, (r) => z[r]!);
-    const xs = uniqueSorted(gx, mask);
-    const ys = uniqueSorted(gy, mask);
+    const xs = uniqueSorted(gx);
+    const ys = uniqueSorted(gy);
     if (xs.length < 2 || ys.length < 2) {
       droppedGroups++;
       continue;

--- a/packages/core/src/stats/ellipse.ts
+++ b/packages/core/src/stats/ellipse.ts
@@ -180,7 +180,8 @@ export function statEllipse(input: StatEllipseInput): StatEllipseResult {
   const outY: number[] = [];
   const outG: number[] = [];
   const carriedOut: Record<string, import("../table.js").CellValue[]> = {};
-  for (const key of Object.keys(carried)) carriedOut[key] = [];
+  const carriedKeys = Object.keys(carried);
+  for (const key of carriedKeys) carriedOut[key] = [];
 
   let droppedGroups = 0;
   const groupIds = [...byGroup.keys()].toSorted((a, b) => a - b);
@@ -200,7 +201,7 @@ export function statEllipse(input: StatEllipseInput): StatEllipseResult {
       outX.push(ring.x[i]!);
       outY.push(ring.y[i]!);
       outG.push(g);
-      for (const key of Object.keys(carriedOut)) {
+      for (const key of carriedKeys) {
         carriedOut[key]!.push(carried[key]![rep]!);
       }
     }

--- a/packages/core/src/stats/quantile.ts
+++ b/packages/core/src/stats/quantile.ts
@@ -240,7 +240,8 @@ export function statQuantile(input: StatQuantileInput): StatQuantileResult {
   const outG: number[] = [];
   const outQ: number[] = [];
   const carriedOut: Record<string, CellValue[]> = {};
-  for (const key of Object.keys(carried)) carriedOut[key] = [];
+  const carriedKeys = Object.keys(carried);
+  for (const key of carriedKeys) carriedOut[key] = [];
 
   let seriesId = 0;
   let droppedGroups = 0;
@@ -279,7 +280,7 @@ export function statQuantile(input: StatQuantileInput): StatQuantileResult {
         outY.push(fit.intercept + fit.slope * x0);
         outG.push(seriesId);
         outQ.push(tau);
-        for (const key of Object.keys(carriedOut)) {
+        for (const key of carriedKeys) {
           carriedOut[key]!.push(carried[key]![rep]!);
         }
       }

--- a/packages/core/tests/pipeline-facets-unit.test.ts
+++ b/packages/core/tests/pipeline-facets-unit.test.ts
@@ -14,6 +14,7 @@ import { encodeKey } from "../src/scales/state.ts";
 import { PipelineError } from "../src/pipeline.ts";
 import { resolveFacet, SINGLE_PANEL } from "../src/pipeline/facets.ts";
 import { assertFacetForm, facetFreeFlags } from "../src/pipeline/facets-form.ts";
+import { facetValues } from "../src/pipeline/facets-helpers.ts";
 import { partitionByField, partitionByFields } from "../src/pipeline/facets-tokens.ts";
 import { ColumnTable } from "../src/table.ts";
 
@@ -155,6 +156,32 @@ describe("resolveFacet — grid", () => {
       expect(e).toBeInstanceOf(PipelineError);
       expect((e as PipelineError).code).toBe("facet-form-missing");
     }
+  });
+});
+
+describe("facetValues — decorate-sort (#1312)", () => {
+  it("orders temporal levels by semantic time (numeric tier, no bandKey)", () => {
+    // Temporal columns take the numeric sort tier; bandKey is only for nominal.
+    // The decorate step must not call bandKey on this path — Invalid Date would
+    // throw via toISOString (Devin on #1386).
+    const t = ColumnTable.fromRows([
+      { d: "2020-01-03", x: 1 },
+      { d: "2020-01-01", x: 2 },
+      { d: "2020-01-02", x: 3 },
+    ]);
+    expect(t.fieldType("d")).toBe("temporal");
+    expect(facetValues(t, "d")).toEqual(["2020-01-01", "2020-01-02", "2020-01-03"]);
+  });
+
+  it("orders quantitative levels ascending with null last", () => {
+    const t = ColumnTable.fromRows([
+      { n: 3, x: 1 },
+      { n: 1, x: 2 },
+      { n: null, x: 3 },
+      { n: 2, x: 4 },
+    ]);
+    expect(t.fieldType("n")).not.toBe("nominal");
+    expect(facetValues(t, "n")).toEqual([1, 2, 3, null]);
   });
 });
 


### PR DESCRIPTION
## Summary

- Hoist loop-invariant `Object.keys(carried)` above the emit loops in `statConnect`, `statAlign`, `statQuantile`, and `statEllipse` (matches the rest of `packages/core/src/stats`).
- Resolve size / color / fill columns once in `expandEdgeFrame` and `buildBindotFrame` instead of per row.
- Decorate-sort-undecorate in `facetValues` so encode/band/numeric keys are computed once per level.
- Store hex-bin cell coords at insert time (no `key.split` / `Number` re-parse per occupied cell).
- Drop the all-true contour mask; `uniqueSorted` already gates on `Number.isFinite`.

Closes #1312.

## Test plan

- [x] `bun test` on connect/align/quantile/ellipse/bin-hex/contour/bindot unit + pipeline-m2 + facets + tile/hex geometry (380 tests green)
- [ ] CI green on the PR
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1386" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->