### PR TITLE
perf(core): hoist aggregate lineage x-key views once per frame

### DIFF
--- a/.changeset/identity-xkey-hoist.md
+++ b/.changeset/identity-xkey-hoist.md
@@ -1,0 +1,8 @@
+---
+"@ggsvelte/core": patch
+---
+
+# Hoist candidate identity x-key column views once per frame
+
+Migration: none — group×x bucket keys and lineage membership stay byte-identical;
+only per-row conversion/parsed/position column work is removed from the identity index loop.

--- a/packages/core/src/pipeline/candidate-construction/identity-buckets.ts
+++ b/packages/core/src/pipeline/candidate-construction/identity-buckets.ts
@@ -1,11 +1,58 @@
 import { bandKey } from "../../scales/train.js";
+import type { CellValue } from "../../table.js";
 import { ColumnTable } from "../../table.js";
 import { binIndexOf } from "../../stats/bin-breaks.js";
-import { assignBinId } from "../binned-scale.js";
+import { assignBinId, type BinnedBoundaries } from "../binned-scale.js";
 import { shouldAggregateOnSemanticTemporalX } from "../frame-stats-shared.js";
 import { positionColumn, xConversionOf } from "../temporal-position.js";
 import type { FinalizedLayerFrame, LayerBinding } from "../types.js";
 import { globalSourceRowForInputRow } from "../source-row-lineage.js";
+
+/**
+ * Loop-invariant column views for group×x lineage keys (#1307).
+ * Resolve once per frame; index each input row without re-deriving columns.
+ */
+export type AggregateLineageXView =
+  | {
+      readonly kind: "binned";
+      readonly transformed: Float64Array;
+      readonly xBinning: BinnedBoundaries;
+    }
+  | { readonly kind: "semantic"; readonly semantic: Float64Array; readonly valid: Uint8Array }
+  | { readonly kind: "raw"; readonly column: readonly CellValue[] };
+
+/** Resolve conversion/parsed/position columns once for a frame's x field. */
+export function resolveAggregateLineageXView(
+  table: ColumnTable,
+  field: string,
+  binding: LayerBinding,
+): AggregateLineageXView {
+  // Only count aggregates on bin ids (frame.bin.xId). Summary/boxplot still
+  // aggregate on actual x values even when a binned scale is attached.
+  if (binding.xBinning !== undefined && (binding.layer.stat ?? "identity") === "count") {
+    return {
+      kind: "binned",
+      transformed: positionColumn(table, field, xConversionOf(binding), binding.xTransform),
+      xBinning: binding.xBinning,
+    };
+  }
+  const conversion = xConversionOf(binding);
+  const parsed = table.parsed(field, conversion.sourceParser, conversion.options);
+  if (shouldAggregateOnSemanticTemporalX(binding, parsed.decision.status)) {
+    return { kind: "semantic", semantic: parsed.semantic, valid: parsed.valid };
+  }
+  return { kind: "raw", column: table.column(field) };
+}
+
+function aggregateLineageXKeyFromView(view: AggregateLineageXView, localRow: number): string {
+  if (view.kind === "binned") {
+    return bandKey(assignBinId(view.transformed[localRow]!, view.xBinning));
+  }
+  if (view.kind === "semantic") {
+    return bandKey(view.valid[localRow] === 1 ? view.semantic[localRow] : null);
+  }
+  return bandKey(view.column[localRow]);
+}
 
 /** Key used for count/summary/boxplot group×x lineage buckets (matches frame xValues). */
 export function aggregateLineageXKey(
@@ -13,19 +60,12 @@ export function aggregateLineageXKey(
   field: string,
   localRow: number,
   binding: LayerBinding,
+  view?: AggregateLineageXView,
 ): string {
-  // Only count aggregates on bin ids (frame.bin.xId). Summary/boxplot still
-  // aggregate on actual x values even when a binned scale is attached.
-  if (binding.xBinning !== undefined && (binding.layer.stat ?? "identity") === "count") {
-    const transformed = positionColumn(table, field, xConversionOf(binding), binding.xTransform);
-    return bandKey(assignBinId(transformed[localRow]!, binding.xBinning));
-  }
-  const conversion = xConversionOf(binding);
-  const parsed = table.parsed(field, conversion.sourceParser, conversion.options);
-  if (shouldAggregateOnSemanticTemporalX(binding, parsed.decision.status)) {
-    return bandKey(parsed.valid[localRow] === 1 ? parsed.semantic[localRow] : null);
-  }
-  return bandKey(table.column(field)[localRow]);
+  return aggregateLineageXKeyFromView(
+    view ?? resolveAggregateLineageXView(table, field, binding),
+    localRow,
+  );
 }
 
 export function appendSourceRowByGroupX(input: {

--- a/packages/core/src/pipeline/candidate-construction/identity-index.ts
+++ b/packages/core/src/pipeline/candidate-construction/identity-index.ts
@@ -7,6 +7,7 @@ import {
   appendSourceRowByGroupKey,
   appendSourceRowByGroupX,
   buildBinLineageBuckets,
+  resolveAggregateLineageXView,
 } from "./identity-buckets.js";
 import { globalSourceRowForInputRow } from "../source-row-lineage.js";
 
@@ -81,12 +82,17 @@ export function buildCandidateIdentityIndex(
               frame.binding.xTransform,
             )
           : null;
+      // Resolve conversion/parsed/position columns once per frame (#1307).
+      const lineageXView =
+        bucketByX && xField !== null
+          ? resolveAggregateLineageXView(frame.table, xField, frame.binding)
+          : null;
       for (let localRow = 0; localRow < inputGroups.length; localRow++) {
         const group = inputGroups[localRow]!;
         const sourceRow = globalSourceRowForInputRow(frame, localRow);
         const key = `${frameKey}:${group}`;
         appendSourceRowByGroupKey(sourceRowsByGroup, key, sourceRow);
-        if (bucketByX && xField !== null) {
+        if (lineageXView !== null && xField !== null) {
           // Summary/boxplot: only finite y belongs in the final represented
           // membership. Always create the group×x key (include=false) so an
           // all-non-finite bucket is an empty frozen array, not a map miss.
@@ -96,7 +102,7 @@ export function buildCandidateIdentityIndex(
             panelIndex,
             layerIndex,
             group,
-            xKey: aggregateLineageXKey(frame.table, xField, localRow, frame.binding),
+            xKey: aggregateLineageXKey(frame.table, xField, localRow, frame.binding, lineageXView),
             sourceRow,
             include: includeInX,
           });

--- a/packages/core/tests/candidate-construction/aggregate-lineage-xkey-hoist.test.ts
+++ b/packages/core/tests/candidate-construction/aggregate-lineage-xkey-hoist.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Hoist aggregate lineage x key views once per frame (issue #1307).
+ *
+ * Seams:
+ * - resolveAggregateLineageXView + aggregateLineageXKey (byte-identical keys)
+ * - buildCandidateIdentityIndex (column/parsed derivations O(frames), not O(rows))
+ */
+import { describe, expect, it, spyOn } from "bun:test";
+
+import { aes, gg } from "@ggsvelte/spec";
+
+import { ColumnTable } from "../../src/table.ts";
+import { size, countColumnReads } from "./fixtures.ts";
+
+const ROW_COUNT = 40;
+
+describe("aggregate lineage x-key hoist (#1307)", () => {
+  it("keeps raw count group×x keys byte-identical after hoist", async () => {
+    const { preparePanels } = await import("../../src/pipeline/prepare-panels.ts");
+    const { buildCandidateIdentityIndex } =
+      await import("../../src/pipeline/candidate-construction/identity-index.ts");
+    const { aggregateLineageXKey, resolveAggregateLineageXView } =
+      await import("../../src/pipeline/candidate-construction/identity-buckets.ts");
+    const { bandKey } = await import("../../src/scales/train.ts");
+    const { normalize } = await import("@ggsvelte/spec");
+
+    const values = Array.from({ length: ROW_COUNT }, (_, i) => ({
+      x: (i % 5) + 1,
+    }));
+    const prepared = preparePanels(
+      normalize(
+        gg(values, aes({ x: "x" }))
+          .geomBar()
+          .spec(),
+      ),
+      size,
+      [],
+      [],
+    );
+    const frame = prepared.panelFrames[0]![0]!;
+    const field = frame.binding.xField!;
+    const view = resolveAggregateLineageXView(frame.table, field, frame.binding);
+
+    for (let localRow = 0; localRow < frame.inputGroups.length; localRow++) {
+      expect(aggregateLineageXKey(frame.table, field, localRow, frame.binding, view)).toBe(
+        aggregateLineageXKey(frame.table, field, localRow, frame.binding),
+      );
+    }
+
+    const index = buildCandidateIdentityIndex(prepared.panelFrames, prepared.facetPanels);
+    for (let level = 1; level <= 5; level++) {
+      const key = `0:0:0:${bandKey(level)}`;
+      const expected = values.map((row, i) => (row.x === level ? i : -1)).filter((i) => i >= 0);
+      expect(index.sourceRowsByGroupX.get(key)).toEqual(expected);
+    }
+  });
+
+  it("keeps temporal summary group×x keys byte-identical after hoist", async () => {
+    const { preparePanels } = await import("../../src/pipeline/prepare-panels.ts");
+    const { buildCandidateIdentityIndex } =
+      await import("../../src/pipeline/candidate-construction/identity-index.ts");
+    const { aggregateLineageXKey, resolveAggregateLineageXView } =
+      await import("../../src/pipeline/candidate-construction/identity-buckets.ts");
+    const { bandKey } = await import("../../src/scales/train.ts");
+    const { normalize } = await import("@ggsvelte/spec");
+
+    const values = [
+      { when: "1/2/2025", value: 1 },
+      { when: "01/02/2025", value: 3 },
+      { when: "02/02/2025", value: 5 },
+      { when: "03/02/2025", value: 7 },
+    ];
+    const prepared = preparePanels(
+      normalize(
+        gg(values, aes({ x: "when", y: "value" }))
+          .geomErrorbar({ stat: "summary" })
+          .scaleXDate({ parse: "dmy", nice: false })
+          .spec(),
+      ),
+      size,
+      [],
+      [],
+    );
+    const frame = prepared.panelFrames[0]![0]!;
+    const field = frame.binding.xField!;
+    const view = resolveAggregateLineageXView(frame.table, field, frame.binding);
+
+    for (let localRow = 0; localRow < frame.inputGroups.length; localRow++) {
+      expect(aggregateLineageXKey(frame.table, field, localRow, frame.binding, view)).toBe(
+        aggregateLineageXKey(frame.table, field, localRow, frame.binding),
+      );
+    }
+
+    const index = buildCandidateIdentityIndex(prepared.panelFrames, prepared.facetPanels);
+    const day1 = bandKey(Date.UTC(2025, 1, 1));
+    const day2 = bandKey(Date.UTC(2025, 1, 2));
+    const day3 = bandKey(Date.UTC(2025, 1, 3));
+    expect(index.sourceRowsByGroupX.get(`0:0:0:${day1}`)).toEqual([0, 1]);
+    expect(index.sourceRowsByGroupX.get(`0:0:0:${day2}`)).toEqual([2]);
+    expect(index.sourceRowsByGroupX.get(`0:0:0:${day3}`)).toEqual([3]);
+  });
+
+  it("keeps binned count group×x keys byte-identical after hoist", async () => {
+    const { preparePanels } = await import("../../src/pipeline/prepare-panels.ts");
+    const { buildCandidateIdentityIndex } =
+      await import("../../src/pipeline/candidate-construction/identity-index.ts");
+    const { aggregateLineageXKey, resolveAggregateLineageXView } =
+      await import("../../src/pipeline/candidate-construction/identity-buckets.ts");
+    const { normalize } = await import("@ggsvelte/spec");
+
+    const values = Array.from({ length: 12 }, (_, i) => ({ x: i }));
+    const prepared = preparePanels(
+      normalize({
+        data: { values },
+        layers: [{ geom: "bar", aes: { x: { field: "x" } }, stat: "count" }],
+        scales: { x: { type: "binned", breaks: [0, 4, 8, 12] } },
+      }),
+      size,
+      [],
+      [],
+    );
+    const frame = prepared.panelFrames[0]![0]!;
+    expect(frame.binding.xBinning).toBeDefined();
+    const field = frame.binding.xField!;
+    const view = resolveAggregateLineageXView(frame.table, field, frame.binding);
+
+    for (let localRow = 0; localRow < frame.inputGroups.length; localRow++) {
+      expect(aggregateLineageXKey(frame.table, field, localRow, frame.binding, view)).toBe(
+        aggregateLineageXKey(frame.table, field, localRow, frame.binding),
+      );
+    }
+
+    const index = buildCandidateIdentityIndex(prepared.panelFrames, prepared.facetPanels);
+    expect(index.sourceRowsByGroupX.size).toBeGreaterThan(0);
+    // Every input row lands in some group×x bucket (no silent key drift).
+    const covered = new Set<number>();
+    for (const rows of index.sourceRowsByGroupX.values()) {
+      for (const row of rows) covered.add(row);
+    }
+    expect([...covered].toSorted((a, b) => a - b)).toEqual(
+      Array.from({ length: values.length }, (_, i) => i),
+    );
+  });
+
+  it("reads the raw x column once per frame while building the identity index", async () => {
+    const { preparePanels } = await import("../../src/pipeline/prepare-panels.ts");
+    const { buildCandidateIdentityIndex } =
+      await import("../../src/pipeline/candidate-construction/identity-index.ts");
+    const { normalize } = await import("@ggsvelte/spec");
+
+    const values = Array.from({ length: ROW_COUNT }, (_, i) => ({ x: (i % 5) + 1 }));
+    const prepared = preparePanels(
+      normalize(
+        gg(values, aes({ x: "x" }))
+          .geomBar()
+          .spec(),
+      ),
+      size,
+      [],
+      [],
+    );
+
+    const reads = countColumnReads("x", () => {
+      buildCandidateIdentityIndex(prepared.panelFrames, prepared.facetPanels);
+    });
+    // Hoisted view: one column() for the frame, not one per input row.
+    expect(reads).toBeLessThanOrEqual(1);
+    expect(reads).toBeGreaterThan(0);
+  });
+
+  it("parses the temporal x column once per frame while building the identity index", async () => {
+    const { preparePanels } = await import("../../src/pipeline/prepare-panels.ts");
+    const { buildCandidateIdentityIndex } =
+      await import("../../src/pipeline/candidate-construction/identity-index.ts");
+    const { normalize } = await import("@ggsvelte/spec");
+
+    const values = Array.from({ length: ROW_COUNT }, (_, i) => ({
+      when: `${String((i % 28) + 1).padStart(2, "0")}/02/2025`,
+      value: i,
+    }));
+    const prepared = preparePanels(
+      normalize(
+        gg(values, aes({ x: "when", y: "value" }))
+          .geomErrorbar({ stat: "summary" })
+          .scaleXDate({ parse: "dmy", nice: false })
+          .spec(),
+      ),
+      size,
+      [],
+      [],
+    );
+
+    const desc = Object.getOwnPropertyDescriptor(ColumnTable.prototype, "parsed");
+    if (desc?.value === undefined) {
+      throw new Error("ColumnTable.prototype.parsed is not a data property");
+    }
+    const impl = desc.value as (
+      this: ColumnTable,
+      name: string,
+      parser?: unknown,
+      options?: unknown,
+    ) => unknown;
+    let parsedCalls = 0;
+    const spy = spyOn(ColumnTable.prototype, "parsed").mockImplementation(function (
+      this: ColumnTable,
+      name: string,
+      parser?: unknown,
+      options?: unknown,
+    ) {
+      if (name === "when") parsedCalls += 1;
+      return impl.call(this, name, parser, options);
+    });
+    try {
+      buildCandidateIdentityIndex(prepared.panelFrames, prepared.facetPanels);
+    } finally {
+      spy.mockRestore();
+    }
+    // Semantic temporal arm: one parsed() for the frame, not one per row.
+    expect(parsedCalls).toBeLessThanOrEqual(1);
+    expect(parsedCalls).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Resolve conversion/parsed/position column views for group×x lineage keys once per frame instead of once per input row (`aggregateLineageXKey` / `buildCandidateIdentityIndex`).
- Keys stay byte-identical across raw count, temporal summary, and binned count paths; column/`parsed` work is bounded at one call per frame during index build.

Fixes #1307

## Test plan

- [x] New hoist characterization suite (key parity + once-per-frame column/`parsed` bounds)
- [x] Existing aggregate-lineage and candidate-construction suites green
- [x] oxlint + pre-commit format/lint
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1387" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->