### PR TITLE
perf(core): hoist source-backed candidate row locate once per mark

### DIFF
--- a/.changeset/candidate-locate-once.md
+++ b/.changeset/candidate-locate-once.md
@@ -1,0 +1,9 @@
+---
+"@ggsvelte/core": patch
+---
+
+# Hoist source-backed candidate row locate once per mark
+
+Migration: none — candidate datum fields stay byte-identical; only repeated
+`SourceRegistry.locate` work for the same global row is removed from the
+source-backed datum resolver.

--- a/packages/core/src/pipeline/build-candidates.ts
+++ b/packages/core/src/pipeline/build-candidates.ts
@@ -38,9 +38,11 @@ function createRawCandidateDatumResolver(
   // layer, and — where it happened not to throw — indexed a plot-length array
   // with a global row id, silently collapsing those rows into one group.
   const groupsByLayer = new Map<number, WeakMap<ColumnTable, readonly number[]>>();
-  const groupFor = (layerIndex: number, sourceRow: number): number => {
+  const groupFor = (
+    layerIndex: number,
+    located: { table: ColumnTable; localRow: number } | null,
+  ): number => {
     const binding = bindings[layerIndex];
-    const located = sources.locate(sourceRow);
     // Group 0 is the single-group default, which is what a primitive with no
     // locatable source row (annotations, synthesized marks) should carry.
     if (binding === undefined || located === null) return 0;
@@ -60,16 +62,16 @@ function createRawCandidateDatumResolver(
     const binding = bindings[facts.layerIndex];
     const sourceRow = facts.rowIndex;
     if (binding === undefined || sourceRow === null) return {};
-    // Global row id -> the table that owns it: a layer with its own DataRef
-    // has fields the plot table does not (#589).
+    // One locate per mark (#1308): value() and groupFor close over the same
+    // row ownership. Colour/fill ranks stay lazy thunks but re-use `located`.
+    const located = sources.locate(sourceRow);
     const value = (field: string | null): CellValue => {
       if (field === null) return null;
-      const located = sources.locate(sourceRow);
       return located === null ? null : located.table.column(field)[located.localRow]!;
     };
     const styleValue = (style: LayerBinding["size"]): CellValue =>
       style.field === null ? (style.scaledConstant ?? style.constant) : value(style.field);
-    const group = groupFor(facts.layerIndex, sourceRow);
+    const group = groupFor(facts.layerIndex, located);
     const colorRank = ordinalColorRank(color, binding.color.field, () =>
       value(binding.color.field),
     );

--- a/packages/core/tests/candidate-construction/source-backed-locate-once.test.ts
+++ b/packages/core/tests/candidate-construction/source-backed-locate-once.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Hoist source-backed candidate row locate once per mark (issue #1308).
+ *
+ * Seams:
+ * - SourceRegistry.locate call volume while materializing candidates
+ * - Candidate datum fields (x/y, style channels, seriesId/seriesRank)
+ *
+ * Source-backed resolvers used to re-locate the same global row for groupFor
+ * and every mapped field read (up to ~10 times per mark). One locate per mark
+ * is enough; colour/fill ranks keep null-checked lazy reads over the hoisted
+ * located row.
+ */
+import { describe, expect, it, spyOn } from "bun:test";
+
+import { aes, gg } from "@ggsvelte/spec";
+
+import { runPipeline } from "../../src/pipeline.ts";
+import { SourceRegistry } from "../../src/pipeline/source-registry.ts";
+import { size } from "./fixtures.ts";
+
+const ROW_COUNT = 12;
+
+function multiMappedPointValues() {
+  return Array.from({ length: ROW_COUNT }, (_, i) => ({
+    x: i,
+    y: i * 2,
+    size: 1 + (i % 5),
+    alpha: 0.2 + 0.1 * (i % 4),
+    color: `c${i % 3}`,
+    fill: `f${i % 2}`,
+  }));
+}
+
+function countLocateCalls(fn: () => void): number {
+  const desc = Object.getOwnPropertyDescriptor(SourceRegistry.prototype, "locate");
+  if (desc?.value === undefined) {
+    throw new Error("SourceRegistry.prototype.locate is not a data property");
+  }
+  const impl = desc.value as (
+    this: SourceRegistry,
+    globalIndex: number,
+  ) => { table: unknown; localRow: number } | null;
+  let calls = 0;
+  const spy = spyOn(SourceRegistry.prototype, "locate").mockImplementation(function (
+    this: SourceRegistry,
+    globalIndex: number,
+  ) {
+    calls += 1;
+    return impl.call(this, globalIndex);
+  });
+  try {
+    fn();
+    return calls;
+  } finally {
+    spy.mockRestore();
+  }
+}
+
+describe("source-backed candidate locate once (#1308)", () => {
+  it("keeps mapped datum fields identical after a single locate per mark", () => {
+    const values = multiMappedPointValues();
+    const model = runPipeline(
+      gg(
+        values,
+        aes({
+          x: "x",
+          y: "y",
+          size: "size",
+          alpha: "alpha",
+          color: "color",
+          fill: "fill",
+        }),
+      )
+        .geomPoint()
+        .spec(),
+      size,
+    );
+
+    expect(model.candidates.size).toBe(ROW_COUNT);
+    for (let i = 0; i < ROW_COUNT; i++) {
+      const candidate = model.candidates.candidate(i);
+      expect(candidate).not.toBeNull();
+      const row = values[i]!;
+      expect(candidate!.xValue).toBe(row.x);
+      expect(candidate!.yValue).toBe(row.y);
+      expect(candidate!.sizeValue).toBe(row.size);
+      expect(candidate!.alphaValue).toBe(row.alpha);
+      expect(candidate!.sourceOrder).toBe(i);
+      // Discrete colour/fill ranks are non-negative ordinal assignment ranks.
+      expect(candidate!.seriesRank).toBeGreaterThanOrEqual(0);
+      expect(candidate!.seriesId).toBeGreaterThanOrEqual(0);
+    }
+
+    // Colour categories c0,c1,c2 first-seen → ranks 0,1,2 for the first three
+    // rows (same colour field drives seriesRank when ordinal colour applies).
+    expect(model.candidates.candidate(0)!.seriesRank).toBe(0);
+    expect(model.candidates.candidate(1)!.seriesRank).toBe(1);
+    expect(model.candidates.candidate(2)!.seriesRank).toBe(2);
+    expect(model.candidates.candidate(3)!.seriesRank).toBe(0);
+  });
+
+  it("locates each source row at most once while materializing candidates", () => {
+    const values = multiMappedPointValues();
+    const model = runPipeline(
+      gg(
+        values,
+        aes({
+          x: "x",
+          y: "y",
+          size: "size",
+          alpha: "alpha",
+          color: "color",
+          fill: "fill",
+        }),
+      )
+        .geomPoint()
+        .spec(),
+      size,
+    );
+
+    const locateCalls = countLocateCalls(() => {
+      // Deferred store: first query builds indexes and resolves every datum.
+      for (let i = 0; i < model.candidates.size; i++) {
+        model.candidates.candidate(i);
+      }
+    });
+
+    // One locate per mark — not one per field + groupFor (was ~7× here).
+    expect(locateCalls).toBe(model.candidates.size);
+    expect(locateCalls).toBe(ROW_COUNT);
+  });
+});


### PR DESCRIPTION
## Summary

- Source-backed candidate datum resolution was re-running `SourceRegistry.locate` for `groupFor` and every mapped field read (up to ~10 times per mark).
- Hoist one locate per mark and close `value()` / `groupFor` over it; colour/fill ranks stay lazy thunks over the same null-checked row.
- Tests pin datum field identity and locate call count = candidate count.

Fixes #1308

## Test plan

- [x] `bun test packages/core/tests/candidate-construction/source-backed-locate-once.test.ts`
- [x] Related candidate suites: `candidates-per-layer-data`, `pipeline-build`
- [ ] CI green on this PR
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1388" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->