### PR TITLE
fix(release): fetch full history so recovery tags pin correctly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # Full history: stage-github-releases pickaxes the version-introducing
+          # commit per package (recovery tags must not all pin to HEAD).
+          fetch-depth: 0
           persist-credentials: false
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:

--- a/scripts/release-wiring.test.ts
+++ b/scripts/release-wiring.test.ts
@@ -933,4 +933,16 @@ describe("release.yml concurrent-merge race recovery", () => {
     expect(yml).not.toMatch(/secrets\.NPM_TOKEN/);
     expect(yml).not.toMatch(/NPM_TOKEN:\s*\$\{\{/);
   });
+
+  it("checks out full history so recovery release tags resolve to version-introducing commits", () => {
+    // stage-github-releases uses `git log -S` per package version. Default
+    // actions/checkout depth is 1, so the pickaxe always falls back to HEAD and
+    // recovery tags point at unrelated tip work (post-merge review on #1353).
+    const yml = release();
+    const checkoutAt = yml.indexOf("actions/checkout@");
+    expect(checkoutAt).toBeGreaterThan(-1);
+    const nextUses = yml.indexOf("\n      - uses:", checkoutAt + 1);
+    const checkoutBlock = nextUses === -1 ? yml.slice(checkoutAt) : yml.slice(checkoutAt, nextUses);
+    expect(checkoutBlock).toMatch(/fetch-depth:\s*0/);
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up for unrebutted post-merge/pre-merge-async review on #1353.

**Finding:** recovery release tags can attach to the wrong commit because the release job checkout omits `fetch-depth: 0`. `commitForPackageVersion` uses `git log -1 -S` to find the version-introducing commit; with a depth-1 shallow clone that always falls back to HEAD.

## Root cause

`.github/workflows/release.yml` used default checkout depth (1). Other history-dependent workflows already set `fetch-depth: 0`.

## Fix

- Set `fetch-depth: 0` on the release checkout.
- Wiring test locks the invariant.

## Tests

- `bun test scripts/release-wiring.test.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1390" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->