### PR TITLE
fix(inspect): multi-layer tooltip total and overflow

### DIFF
--- a/.changeset/inspect-multilayer-total-1389.md
+++ b/.changeset/inspect-multilayer-total-1389.md
@@ -1,0 +1,10 @@
+---
+"@ggsvelte/svelte": patch
+---
+
+# Align inspect tooltip Total and overflow with multi-layer groups
+
+Migration: none — `groupTotal` / `groupMemberCount` on axis-mode inspection
+snapshots still mean full-group unique series contributions; they now include
+distinct series from every layer (not only the focus layer) while still
+deduping multi-layer paints of the same source series (line+point, col+text).

--- a/packages/svelte/skills/ggsvelte/references/interactions.md
+++ b/packages/svelte/skills/ggsvelte/references/interactions.md
@@ -133,10 +133,12 @@ does not dump every series:
 2. Up to **7 more** members are chosen by **largest absolute value** at that
    axis position (y when grouping by x, x when grouping by y) — not by stacking
    order — so tiny early series cannot crowd out the large contributors.
-3. A **Total** row sums all numeric contributions in the full group (not just
-   the capped hover window).
+3. A **Total** row sums unique numeric contributions in the full group across
+   layers (not just the capped hover window or the focus layer). Multi-layer
+   paints of the same series (line+point) count once; a thin overlay over a
+   stack still includes every distinct series in the total.
 4. An overflow line (`+N more · pin to inspect all`) appears when the group is
-   larger than eight display members.
+   larger than eight display members (full-group unique count, all layers).
 
 **Pin** the tooltip (click, or keyboard pin) to scroll the full group inside the
 320px panel. **Opt into a full custom listing** with

--- a/packages/svelte/src/lib/inspection/resolver.ts
+++ b/packages/svelte/src/lib/inspection/resolver.ts
@@ -73,18 +73,36 @@ function candidateValueContribution(
 }
 
 /**
+ * Bound column for the value axis on a candidate's layer (y when grouping by
+ * x, x when grouping by y). Distinguishes multi-column overlays (sales vs
+ * target) while leaving line+point on the same field collapsible.
+ */
+function valueFieldName(model: RenderModel, member: CandidateFacts, groupAxis: "x" | "y"): string {
+  const channel = groupAxis === "x" ? "y" : "x";
+  for (const field of model.layerFields[member.layerIndex] ?? []) {
+    if (field.channel === channel) return field.field;
+  }
+  return "";
+}
+
+/**
  * Identity for one stack-total / overflow contribution (#1274 / #1389).
  *
- * Always pairs identity with the numeric contribution so:
- * - line+point / col+text (same row, same value) collapse to one contribution
- * - multi-column layers on the same row (sales col + target line) both count
- * - aggregates (null rowIndex) use layer-local seriesId + value so double-
- *   painted summaries collapse while distinct colliding seriesIds do not
+ * - Source-backed: row + mapped value field. Same field on the same row
+ *   (line+point, col+text) collapses; different fields (sales vs target)
+ *   stay distinct even when the numbers happen to match.
+ * - Aggregates (null rowIndex): seriesId + field + contribution so double-
+ *   painted summaries collapse while distinct values under a colliding
+ *   per-layer series index still count separately.
  */
-function contributionIdentity(member: CandidateFacts, contribution: number | null): string {
+function contributionIdentity(
+  member: CandidateFacts,
+  contribution: number | null,
+  valueField: string,
+): string {
+  if (member.rowIndex !== null) return `r:${member.rowIndex}:f:${valueField}`;
   const valueToken = contribution === null ? "" : String(contribution);
-  if (member.rowIndex !== null) return `r:${member.rowIndex}:v:${valueToken}`;
-  return `s:${member.seriesId}:v:${valueToken}`;
+  return `s:${member.seriesId}:f:${valueField}:v:${valueToken}`;
 }
 
 /**
@@ -96,6 +114,7 @@ function contributionIdentity(member: CandidateFacts, contribution: number | nul
  * (and col+text) double-counting of the same source series.
  */
 function groupMagnitudeTotal(
+  model: RenderModel,
   members: readonly CandidateFacts[],
   groupAxis: "x" | "y",
 ): number | null {
@@ -103,7 +122,11 @@ function groupMagnitudeTotal(
   for (const member of members) {
     const contribution = candidateValueContribution(member, groupAxis);
     if (contribution === null) continue;
-    const key = contributionIdentity(member, contribution);
+    const key = contributionIdentity(
+      member,
+      contribution,
+      valueFieldName(model, member, groupAxis),
+    );
     if (byIdentity.has(key)) continue;
     byIdentity.set(key, contribution);
   }
@@ -118,13 +141,17 @@ function groupMagnitudeTotal(
  * Drives "+N more" after display collapse; must span layers so a thin
  * overlay focus does not hide truncation of a large stack beneath it.
  */
-function groupSeriesCount(members: readonly CandidateFacts[], groupAxis: "x" | "y"): number {
+function groupSeriesCount(
+  model: RenderModel,
+  members: readonly CandidateFacts[],
+  groupAxis: "x" | "y",
+): number {
   const seen = new Set<string>();
   for (const member of members) {
     const contribution = candidateValueContribution(member, groupAxis);
     // Count series even when the value is non-numeric so overflow still
     // reflects listed display rows (Total may be null separately).
-    seen.add(contributionIdentity(member, contribution));
+    seen.add(contributionIdentity(member, contribution, valueFieldName(model, member, groupAxis)));
   }
   return seen.size;
 }
@@ -369,8 +396,8 @@ export function materializeInspection<
     // Full-group series total + count (deduped across layers) — independent of
     // the hover cap so Total and "+N more" stay honest when members were
     // truncated or the focus layer is a thin overlay (#1274 / #1389).
-    groupTotal: groupMagnitudeTotal(completeCandidates, groupAxis),
-    groupMemberCount: groupSeriesCount(completeCandidates, groupAxis),
+    groupTotal: groupMagnitudeTotal(model, completeCandidates, groupAxis),
+    groupMemberCount: groupSeriesCount(model, completeCandidates, groupAxis),
   });
 }
 

--- a/packages/svelte/src/lib/inspection/resolver.ts
+++ b/packages/svelte/src/lib/inspection/resolver.ts
@@ -73,37 +73,58 @@ function candidateValueContribution(
 }
 
 /**
- * Stack total for the default tooltip (#1274).
+ * Identity for one stack-total / overflow contribution (#1274 / #1389).
  *
- * Only candidates on `focusLayerIndex` contribute, one per `seriesId`. That
- * keeps line+point (or col+text) from double-counting, and avoids treating
- * `seriesId` as global across layers (it is a per-layer group index).
+ * - Prefer source `rowIndex` when present so multi-layer paints of the same
+ *   row (line+point, col+text) contribute once.
+ * - When `rowIndex` is null (aggregates / stats), pair layer-local `seriesId`
+ *   with the numeric contribution so double-painted summary series collapse
+ *   while distinct values under a colliding per-layer series index still
+ *   count separately (stack series 0 + overlay series 0 with different y).
+ */
+function contributionIdentity(member: CandidateFacts, contribution: number | null): string {
+  if (member.rowIndex !== null) return `r:${member.rowIndex}`;
+  return `s:${member.seriesId}:v:${contribution === null ? "" : String(contribution)}`;
+}
+
+/**
+ * Stack total for the default tooltip (#1274 / #1389).
+ *
+ * Sums unique series contributions across the full axis group (every layer),
+ * not only the focus layer — so a thin overlay over a high-n stack still
+ * reports a total that matches the listed rows. Dedup prevents line+point
+ * (and col+text) double-counting of the same source series.
  */
 function groupMagnitudeTotal(
   members: readonly CandidateFacts[],
   groupAxis: "x" | "y",
-  focusLayerIndex: number,
 ): number | null {
-  const bySeries = new Map<number, number>();
+  const byIdentity = new Map<string, number>();
   for (const member of members) {
-    if (member.layerIndex !== focusLayerIndex) continue;
-    if (bySeries.has(member.seriesId)) continue;
     const contribution = candidateValueContribution(member, groupAxis);
     if (contribution === null) continue;
-    bySeries.set(member.seriesId, contribution);
+    const key = contributionIdentity(member, contribution);
+    if (byIdentity.has(key)) continue;
+    byIdentity.set(key, contribution);
   }
-  if (bySeries.size === 0) return null;
+  if (byIdentity.size === 0) return null;
   let sum = 0;
-  for (const value of bySeries.values()) sum += value;
+  for (const value of byIdentity.values()) sum += value;
   return sum;
 }
 
-/** Unique series count on the focus layer in the full axis group. */
-function groupSeriesCount(members: readonly CandidateFacts[], focusLayerIndex: number): number {
-  const seen = new Set<number>();
+/**
+ * Unique series-contribution count in the full axis group (#1274 / #1389).
+ * Drives "+N more" after display collapse; must span layers so a thin
+ * overlay focus does not hide truncation of a large stack beneath it.
+ */
+function groupSeriesCount(members: readonly CandidateFacts[], groupAxis: "x" | "y"): number {
+  const seen = new Set<string>();
   for (const member of members) {
-    if (member.layerIndex !== focusLayerIndex) continue;
-    seen.add(member.seriesId);
+    const contribution = candidateValueContribution(member, groupAxis);
+    // Count series even when the value is non-numeric so overflow still
+    // reflects listed display rows (Total may be null separately).
+    seen.add(contributionIdentity(member, contribution));
   }
   return seen.size;
 }
@@ -345,10 +366,11 @@ export function materializeInspection<
     members: Object.freeze(nonempty),
     axisValue: group.axisValue,
     axisLabel: axisLabel(model, mode, group.axisValue),
-    // Focus-layer series total + count — independent of the hover cap so Total
-    // and "+N more" stay honest when members were truncated (#1274).
-    groupTotal: groupMagnitudeTotal(completeCandidates, groupAxis, seed.layerIndex),
-    groupMemberCount: groupSeriesCount(completeCandidates, seed.layerIndex),
+    // Full-group series total + count (deduped across layers) — independent of
+    // the hover cap so Total and "+N more" stay honest when members were
+    // truncated or the focus layer is a thin overlay (#1274 / #1389).
+    groupTotal: groupMagnitudeTotal(completeCandidates, groupAxis),
+    groupMemberCount: groupSeriesCount(completeCandidates, groupAxis),
   });
 }
 

--- a/packages/svelte/src/lib/inspection/resolver.ts
+++ b/packages/svelte/src/lib/inspection/resolver.ts
@@ -75,16 +75,16 @@ function candidateValueContribution(
 /**
  * Identity for one stack-total / overflow contribution (#1274 / #1389).
  *
- * - Prefer source `rowIndex` when present so multi-layer paints of the same
- *   row (line+point, col+text) contribute once.
- * - When `rowIndex` is null (aggregates / stats), pair layer-local `seriesId`
- *   with the numeric contribution so double-painted summary series collapse
- *   while distinct values under a colliding per-layer series index still
- *   count separately (stack series 0 + overlay series 0 with different y).
+ * Always pairs identity with the numeric contribution so:
+ * - line+point / col+text (same row, same value) collapse to one contribution
+ * - multi-column layers on the same row (sales col + target line) both count
+ * - aggregates (null rowIndex) use layer-local seriesId + value so double-
+ *   painted summaries collapse while distinct colliding seriesIds do not
  */
 function contributionIdentity(member: CandidateFacts, contribution: number | null): string {
-  if (member.rowIndex !== null) return `r:${member.rowIndex}`;
-  return `s:${member.seriesId}:v:${contribution === null ? "" : String(contribution)}`;
+  const valueToken = contribution === null ? "" : String(contribution);
+  if (member.rowIndex !== null) return `r:${member.rowIndex}:v:${valueToken}`;
+  return `s:${member.seriesId}:v:${valueToken}`;
 }
 
 /**

--- a/packages/svelte/src/lib/interaction/interaction.ts
+++ b/packages/svelte/src/lib/interaction/interaction.ts
@@ -67,18 +67,19 @@ export type PlotInspectionChange<Row, Key> =
       readonly axisValue: CellValue;
       readonly axisLabel: string;
       /**
-       * Sum of numeric contributions on the value axis for series on the
-       * focus member's layer (y when mode is x, x when mode is y). Used by
+       * Sum of numeric contributions on the value axis for unique series in
+       * the full axis group (y when mode is x, x when mode is y). Used by
        * the default tooltip Total row; independent of the hover member cap
-       * (#1274). One contribution per seriesId on that layer so multi-layer
-       * paints of the same series do not double-count. `null` when none of
-       * those members has a finite numeric contribution.
+       * (#1274 / #1389). Multi-layer paints of the same source series
+       * (line+point, col+text) contribute once; distinct series on other
+       * layers (e.g. a trend over a stack) are included. `null` when no
+       * member has a finite numeric contribution.
        */
       readonly groupTotal: number | null;
       /**
-       * Unique series count on the focus layer in the full axis-group.
-       * Drives the default tooltip "+N more" line when hover rows were
-       * truncated (#1274).
+       * Unique series-contribution count in the full axis group (all layers,
+       * deduped). Drives the default tooltip "+N more" line when hover rows
+       * were truncated (#1274 / #1389).
        */
       readonly groupMemberCount: number;
     });

--- a/packages/svelte/tests/inspection/resolve-snapshot.test.ts
+++ b/packages/svelte/tests/inspection/resolve-snapshot.test.ts
@@ -525,9 +525,12 @@ describe("groupTotal / groupMemberCount multi-layer honesty (#1389)", () => {
   it("counts both columns when two layers map different y fields on the same rows", () => {
     // sales col + target line share rowIndex but read different y fields.
     // Total must be sales+target (25 at Jan), not only the first layer (10).
+    // Equal values (Mar: 12+12) must still count twice — identity is the
+    // mapped field, not the numeric coincidence.
     const data = [
       { id: "jan", x: "Jan", sales: 10, target: 15 },
       { id: "feb", x: "Feb", sales: 20, target: 18 },
+      { id: "mar", x: "Mar", sales: 12, target: 12 },
     ];
     const model = runPipeline(
       gg(data, aes({ x: "x" }))
@@ -536,13 +539,28 @@ describe("groupTotal / groupMemberCount multi-layer honesty (#1389)", () => {
         .spec(),
       { width: 400, height: 300 },
     );
-    const seed = model.candidates.candidate(0)!;
-    expect(seed.xValue).toBe("Jan");
-    const inspection = axisInspection(model, seed);
-    expect(inspection.mode).toBe("x");
-    if (inspection.mode === "x" || inspection.mode === "y") {
-      expect(inspection.groupTotal).toBe(25);
-      expect(inspection.groupMemberCount).toBe(2);
+    const jan = model.candidates.candidate(0)!;
+    expect(jan.xValue).toBe("Jan");
+    const janInspection = axisInspection(model, jan);
+    expect(janInspection.mode).toBe("x");
+    if (janInspection.mode === "x" || janInspection.mode === "y") {
+      expect(janInspection.groupTotal).toBe(25);
+      expect(janInspection.groupMemberCount).toBe(2);
+    }
+
+    let marSeed = model.candidates.candidate(0)!;
+    for (let id = 0; id < model.candidates.size; id++) {
+      const c = model.candidates.candidate(id)!;
+      if (c.xValue === "Mar") {
+        marSeed = c;
+        break;
+      }
+    }
+    const marInspection = axisInspection(model, marSeed);
+    expect(marInspection.mode).toBe("x");
+    if (marInspection.mode === "x" || marInspection.mode === "y") {
+      expect(marInspection.groupTotal).toBe(24);
+      expect(marInspection.groupMemberCount).toBe(2);
     }
     model.dispose();
   });

--- a/packages/svelte/tests/inspection/resolve-snapshot.test.ts
+++ b/packages/svelte/tests/inspection/resolve-snapshot.test.ts
@@ -521,4 +521,29 @@ describe("groupTotal / groupMemberCount multi-layer honesty (#1389)", () => {
     }
     model.dispose();
   });
+
+  it("counts both columns when two layers map different y fields on the same rows", () => {
+    // sales col + target line share rowIndex but read different y fields.
+    // Total must be sales+target (25 at Jan), not only the first layer (10).
+    const data = [
+      { id: "jan", x: "Jan", sales: 10, target: 15 },
+      { id: "feb", x: "Feb", sales: 20, target: 18 },
+    ];
+    const model = runPipeline(
+      gg(data, aes({ x: "x" }))
+        .geomCol({ aes: { y: "sales" } })
+        .geomLine({ aes: { y: "target" } })
+        .spec(),
+      { width: 400, height: 300 },
+    );
+    const seed = model.candidates.candidate(0)!;
+    expect(seed.xValue).toBe("Jan");
+    const inspection = axisInspection(model, seed);
+    expect(inspection.mode).toBe("x");
+    if (inspection.mode === "x" || inspection.mode === "y") {
+      expect(inspection.groupTotal).toBe(25);
+      expect(inspection.groupMemberCount).toBe(2);
+    }
+    model.dispose();
+  });
 });

--- a/packages/svelte/tests/inspection/resolve-snapshot.test.ts
+++ b/packages/svelte/tests/inspection/resolve-snapshot.test.ts
@@ -399,3 +399,126 @@ describe("selectTransientMembers top-k by value (#1274)", () => {
     model.dispose();
   });
 });
+
+describe("groupTotal / groupMemberCount multi-layer honesty (#1389)", () => {
+  function axisInspection(
+    model: ReturnType<typeof runPipeline>,
+    seed: NonNullable<ReturnType<typeof model.candidates.candidate>>,
+  ) {
+    const target = resolvedTarget(model, seed, "x")!;
+    return materializeInspection(
+      {
+        model,
+        seed,
+        mode: "x",
+        state: "transient",
+        source: "pointer",
+      },
+      target,
+      "transient",
+      (index) => (model.row(index) as { id: string } | null)?.id ?? null,
+    );
+  }
+
+  function candidateOnLayer(
+    model: ReturnType<typeof runPipeline>,
+    layerIndex: number,
+  ): NonNullable<ReturnType<typeof model.candidates.candidate>> {
+    for (let id = 0; id < model.candidates.size; id++) {
+      const candidate = model.candidates.candidate(id);
+      if (candidate !== null && candidate.layerIndex === layerIndex) return candidate;
+    }
+    throw new Error(`no candidate on layer ${layerIndex}`);
+  }
+
+  it("does not double-count line+point paints of the same series", () => {
+    const data = [
+      { id: "a1", x: 1, y: 3, series: "a" },
+      { id: "b1", x: 1, y: 7, series: "b" },
+      { id: "a2", x: 2, y: 4, series: "a" },
+      { id: "b2", x: 2, y: 8, series: "b" },
+    ];
+    const model = runPipeline(
+      gg(data, aes({ x: "x", y: "y", color: "series" }))
+        .geomLine()
+        .geomPoint()
+        .spec(),
+      { width: 400, height: 300 },
+    );
+    // Focus either layer at x=1 — total is 3+7 once, not twice.
+    for (const layerIndex of [0, 1]) {
+      const seed = candidateOnLayer(model, layerIndex);
+      // Prefer an x=1 seed when the first layer candidate is elsewhere.
+      let focus = seed;
+      for (let id = 0; id < model.candidates.size; id++) {
+        const c = model.candidates.candidate(id)!;
+        if (c.layerIndex === layerIndex && c.xValue === 1) {
+          focus = c;
+          break;
+        }
+      }
+      const inspection = axisInspection(model, focus);
+      expect(inspection.mode).toBe("x");
+      if (inspection.mode === "x" || inspection.mode === "y") {
+        expect(inspection.groupTotal).toBe(10);
+        expect(inspection.groupMemberCount).toBe(2);
+      }
+    }
+    model.dispose();
+  });
+
+  it("includes every distinct multi-layer series when focus is a thin overlay", () => {
+    // 12-series stacked columns + one-series trend line. Focus the line:
+    // Total and overflow must reflect the full display group (13), not only
+    // the overlay layer (1). Stack sum 1..12 = 78; trend y = 50 → 128.
+    const stackData = Array.from({ length: 12 }, (_, index) => ({
+      id: `s${index}`,
+      x: "A",
+      y: index + 1,
+      series: `s${index}`,
+    }));
+    const trendData = [{ id: "trend", x: "A", y: 50, series: "trend" }];
+    const model = runPipeline(
+      gg(stackData, aes({ x: "x", y: "y", fill: "series" }))
+        .geomCol({ position: "stack" })
+        .geomLine({ data: trendData, aes: { x: "x", y: "y", color: "series" } })
+        .spec(),
+      { width: 400, height: 300 },
+    );
+    const trendSeed = candidateOnLayer(model, 1);
+    const inspection = axisInspection(model, trendSeed);
+    expect(inspection.mode).toBe("x");
+    if (inspection.mode === "x" || inspection.mode === "y") {
+      expect(inspection.groupTotal).toBe(128);
+      expect(inspection.groupMemberCount).toBe(13);
+    }
+    // Transient cap still applies to listed members; overflow signal uses full count.
+    expect(inspection.members.length).toBeLessThanOrEqual(TRANSIENT_MEMBER_LIMIT);
+    model.dispose();
+  });
+
+  it("includes the overlay series when focus is on the stacked layer", () => {
+    const stackData = Array.from({ length: 12 }, (_, index) => ({
+      id: `s${index}`,
+      x: "A",
+      y: index + 1,
+      series: `s${index}`,
+    }));
+    const trendData = [{ id: "trend", x: "A", y: 50, series: "trend" }];
+    const model = runPipeline(
+      gg(stackData, aes({ x: "x", y: "y", fill: "series" }))
+        .geomCol({ position: "stack" })
+        .geomLine({ data: trendData, aes: { x: "x", y: "y", color: "series" } })
+        .spec(),
+      { width: 400, height: 300 },
+    );
+    const stackSeed = candidateOnLayer(model, 0);
+    const inspection = axisInspection(model, stackSeed);
+    expect(inspection.mode).toBe("x");
+    if (inspection.mode === "x" || inspection.mode === "y") {
+      expect(inspection.groupTotal).toBe(128);
+      expect(inspection.groupMemberCount).toBe(13);
+    }
+    model.dispose();
+  });
+});

--- a/skills/ggsvelte/references/interactions.md
+++ b/skills/ggsvelte/references/interactions.md
@@ -133,10 +133,12 @@ does not dump every series:
 2. Up to **7 more** members are chosen by **largest absolute value** at that
    axis position (y when grouping by x, x when grouping by y) — not by stacking
    order — so tiny early series cannot crowd out the large contributors.
-3. A **Total** row sums all numeric contributions in the full group (not just
-   the capped hover window).
+3. A **Total** row sums unique numeric contributions in the full group across
+   layers (not just the capped hover window or the focus layer). Multi-layer
+   paints of the same series (line+point) count once; a thin overlay over a
+   stack still includes every distinct series in the total.
 4. An overflow line (`+N more · pin to inspect all`) appears when the group is
-   larger than eight display members.
+   larger than eight display members (full-group unique count, all layers).
 
 **Pin** the tooltip (click, or keyboard pin) to scroll the full group inside the
 320px panel. **Opt into a full custom listing** with


### PR DESCRIPTION
## Summary

Fixes #1389: when the pointer focuses a thin overlay layer over a high-n stack, `groupTotal` / `groupMemberCount` were scoped to the focus layer only, so the default tooltip Total disagreed with listed rows and `+N more` could be suppressed.

- **Total / overflow** now use unique series contributions across the **full axis group** (all layers)
- **Dedup** prefers source `rowIndex` (line+point, col+text) so multi-layer paints of the same series still count once; aggregates fall back to `seriesId` + contribution value
- Docs and type comments updated to match

## Test plan

- [x] `groupTotal` / `groupMemberCount` multi-layer honesty tests (#1389): line+point no double-count; stack+trend focus overlay and focus stack both yield total 128 / count 13
- [x] Existing high-n single-layer total 210 / count 20 still passes
- [x] Aggregate line+point summary (null rowIndex) total 15 / count 5
- [x] `interaction-hover-tooltip` suite green
- [x] `svelte-check` clean
- [ ] CI green on PR

Closes #1389.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1391" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->