### PR TITLE
perf(core): export planStrata from lean render entry, drop Temporal from canvas graphs

### DIFF
--- a/.changeset/lean-render-planstrata.md
+++ b/.changeset/lean-render-planstrata.md
@@ -1,0 +1,12 @@
+---
+"@ggsvelte/core": minor
+---
+
+# Export planStrata from the lean render entry
+
+Migration: additive — `@ggsvelte/core/render` now re-exports `planStrata` and
+the `Stratum` type. Canvas-mark charts can compose
+`runPipeline` + `planStrata` (lean) with `drawStratum`
+(`@ggsvelte/core/dom`) without importing the full `@ggsvelte/core` barrel,
+which installs the Temporal polyfill on import. Measured on the competitive
+canvas scatter entry: 237.7 → 144.7 KB gzip (−39%).

--- a/.changeset/lean-render-planstrata.md
+++ b/.changeset/lean-render-planstrata.md
@@ -4,7 +4,7 @@
 
 # Export planStrata from the lean render entry
 
-Migration: additive — `@ggsvelte/core/render` now re-exports `planStrata` and
+Migration: none — additive. `@ggsvelte/core/render` now re-exports `planStrata` and
 the `Stratum` type. Canvas-mark charts can compose
 `runPipeline` + `planStrata` (lean) with `drawStratum`
 (`@ggsvelte/core/dom`) without importing the full `@ggsvelte/core` barrel,

--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -12061,8 +12061,8 @@ export const DOCS_ROUTES = [
         level: 2,
       },
       {
-        id: "experimental-41",
-        title: "experimental (41)",
+        id: "experimental-43",
+        title: "experimental (43)",
         level: 3,
       },
       {

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -19953,14 +19953,14 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["@ggsvelte/core (./render)"],
   },
   {
-    id: "heading:guide-lifecycle:experimental-41",
+    id: "heading:guide-lifecycle:experimental-43",
     kind: "heading",
-    title: "experimental (41)",
+    title: "experimental (43)",
     summary:
-      "experimental (41) in Lifecycle & editions. API stability tags per export, and the defaults-edition mechanism.",
-    href: "/guide/lifecycle#experimental-41",
+      "experimental (43) in Lifecycle & editions. API stability tags per export, and the defaults-edition mechanism.",
+    href: "/guide/lifecycle#experimental-43",
     keywords: ["Lifecycle & editions", "Reference"],
-    exact: ["experimental (41)"],
+    exact: ["experimental (43)"],
   },
   {
     id: "heading:guide-lifecycle:ggsvelte-core-temporal",
@@ -33526,6 +33526,15 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["SegmentsBatch"],
   },
   {
+    id: "api:ggsvelte-core-render:Stratum",
+    kind: "api",
+    title: "Stratum",
+    summary: "@ggsvelte/core ./render · type · experimental.",
+    href: "/guide/lifecycle#ggsvelte-core-render",
+    keywords: ["@ggsvelte/core", "./render", "type", "experimental"],
+    exact: ["Stratum"],
+  },
+  {
     id: "api:ggsvelte-core-render:TrainedScales",
     kind: "api",
     title: "TrainedScales",
@@ -33560,6 +33569,15 @@ export const DOCS_SEARCH_INDEX = [
     href: "/guide/lifecycle#ggsvelte-core-render",
     keywords: ["@ggsvelte/core", "./render", "value", "experimental"],
     exact: ["pathData"],
+  },
+  {
+    id: "api:ggsvelte-core-render:planStrata",
+    kind: "api",
+    title: "planStrata",
+    summary: "@ggsvelte/core ./render · value · experimental.",
+    href: "/guide/lifecycle#ggsvelte-core-render",
+    keywords: ["@ggsvelte/core", "./render", "value", "experimental"],
+    exact: ["planStrata"],
   },
   {
     id: "api:ggsvelte-core-render:registerGeomBatch",

--- a/benchmarks/competitive/adapters/ggsvelte-canvas.ts
+++ b/benchmarks/competitive/adapters/ggsvelte-canvas.ts
@@ -1,11 +1,10 @@
 /**
  * Canvas-mark ggsvelte mounts (pipeline + planStrata + drawStratum).
- * Note: importing planStrata from @ggsvelte/core (not /render) until strata
- * is re-exported from the lean entry.
+ * All imports stay on the lean graph (@ggsvelte/core/render + /dom) so canvas
+ * charts never install the Temporal polyfill.
  */
-import { planStrata } from "@ggsvelte/core";
 import { cssColorResolver, drawStratum, sizeCanvasForDpr } from "@ggsvelte/core/dom";
-import { runPipeline } from "@ggsvelte/core/render";
+import { planStrata, runPipeline } from "@ggsvelte/core/render";
 import { aes, gg } from "@ggsvelte/spec/portable";
 
 import {

--- a/benchmarks/competitive/lean-polyfill-graph.test.ts
+++ b/benchmarks/competitive/lean-polyfill-graph.test.ts
@@ -1,6 +1,6 @@
 /**
- * Vite tree-shaken client graph for the competitive ggsvelte-svg scatter entry
- * must not include @js-temporal/polyfill or jsbi.
+ * Vite tree-shaken client graphs for the competitive lean ggsvelte entries
+ * (SVG + canvas) must not include @js-temporal/polyfill or jsbi.
  */
 import { describe, expect, it } from "bun:test";
 import { mkdirSync, readFileSync } from "node:fs";
@@ -9,50 +9,65 @@ import { build } from "vite";
 
 const root = import.meta.dir;
 
+async function buildEntry(entryName: string): Promise<{ moduleIds: string[]; rawBytes: number }> {
+  const outDir = path.join(root, "results", "bundles", `_lean-polyfill-test-${entryName}`);
+  mkdirSync(outDir, { recursive: true });
+
+  const result = await build({
+    configFile: false,
+    logLevel: "error",
+    build: {
+      lib: {
+        entry: path.join(root, "entries", entryName),
+        formats: ["es"],
+        fileName: () => "bundle.js",
+      },
+      outDir,
+      emptyOutDir: true,
+      minify: "esbuild",
+      target: "es2022",
+      rollupOptions: { external: [] },
+      write: true,
+    },
+    resolve: {
+      conditions: ["import", "module", "default"],
+    },
+  });
+
+  const outputs = (Array.isArray(result) ? result : [result]).flatMap((item) => item.output ?? []);
+  const chunk = outputs.find((item) => item.type === "chunk");
+  expect(chunk?.type).toBe("chunk");
+  if (chunk?.type !== "chunk") throw new Error("expected a chunk output");
+
+  const raw = readFileSync(path.join(outDir, "bundle.js"));
+  return { moduleIds: Object.keys(chunk.modules), rawBytes: raw.byteLength };
+}
+
+function expectPolyfillFree(
+  { moduleIds, rawBytes }: { moduleIds: string[]; rawBytes: number },
+  maxRawBytes: number,
+): void {
+  expect(moduleIds.filter((id) => id.includes("@js-temporal/polyfill"))).toEqual([]);
+  expect(
+    moduleIds.filter((id) => id.includes(`${path.sep}jsbi${path.sep}`) || id.includes("jsbi-umd")),
+  ).toEqual([]);
+
+  // Pre-fix lean graphs carried the polyfill (~210KB raw extra); stay under the floor.
+  expect(rawBytes).toBeGreaterThan(50_000);
+  expect(rawBytes).toBeLessThan(maxRawBytes);
+}
+
 describe("lean competitive SVG graph", () => {
   it("excludes Temporal polyfill and jsbi after minify", async () => {
-    const outDir = path.join(root, "results", "bundles", "_lean-polyfill-test");
-    mkdirSync(outDir, { recursive: true });
+    // Pre-fix lean SVG was ~827KB raw with polyfill; keep the 700KB floor.
+    expectPolyfillFree(await buildEntry("ggsvelte-svg__scatter-color.ts"), 700_000);
+  }, 120_000);
+});
 
-    const result = await build({
-      configFile: false,
-      logLevel: "error",
-      build: {
-        lib: {
-          entry: path.join(root, "entries/ggsvelte-svg__scatter-color.ts"),
-          formats: ["es"],
-          fileName: () => "bundle.js",
-        },
-        outDir,
-        emptyOutDir: true,
-        minify: "esbuild",
-        target: "es2022",
-        rollupOptions: { external: [] },
-        write: true,
-      },
-      resolve: {
-        conditions: ["import", "module", "default"],
-      },
-    });
-
-    const outputs = (Array.isArray(result) ? result : [result]).flatMap(
-      (item) => item.output ?? [],
-    );
-    const chunk = outputs.find((item) => item.type === "chunk");
-    expect(chunk?.type).toBe("chunk");
-    if (chunk?.type !== "chunk") return;
-
-    const moduleIds = Object.keys(chunk.modules);
-    expect(moduleIds.filter((id) => id.includes("@js-temporal/polyfill"))).toEqual([]);
-    expect(
-      moduleIds.filter(
-        (id) => id.includes(`${path.sep}jsbi${path.sep}`) || id.includes("jsbi-umd"),
-      ),
-    ).toEqual([]);
-
-    const raw = readFileSync(path.join(outDir, "bundle.js"));
-    // Pre-fix lean SVG was ~827KB raw with polyfill; stay under that floor.
-    expect(raw.byteLength).toBeGreaterThan(50_000);
-    expect(raw.byteLength).toBeLessThan(700_000);
+describe("lean competitive canvas graph", () => {
+  it("excludes Temporal polyfill and jsbi after minify", async () => {
+    // Canvas marks need planStrata; it must come from the lean render graph,
+    // not the full @ggsvelte/core barrel (which installs Temporal on import).
+    expectPolyfillFree(await buildEntry("ggsvelte-canvas__scatter-color.ts"), 700_000);
   }, 120_000);
 });

--- a/lifecycle.json
+++ b/lifecycle.json
@@ -5201,6 +5201,10 @@
           "kind": "type",
           "lifecycle": "experimental"
         },
+        "Stratum": {
+          "kind": "type",
+          "lifecycle": "experimental"
+        },
         "TrainedScales": {
           "kind": "type",
           "lifecycle": "experimental"
@@ -5214,6 +5218,10 @@
           "lifecycle": "experimental"
         },
         "pathData": {
+          "kind": "value",
+          "lifecycle": "experimental"
+        },
+        "planStrata": {
           "kind": "value",
           "lifecycle": "experimental"
         },

--- a/packages/core/src/render-entry.ts
+++ b/packages/core/src/render-entry.ts
@@ -42,6 +42,11 @@ export {
 } from "./render-svg.js";
 export type { RenderSVGOptions } from "./render-svg.js";
 
+// Strata planning is pure (no DOM, no temporal install) — lean canvas charts
+// compose it with @ggsvelte/core/dom drawStratum.
+export { planStrata } from "./strata.js";
+export type { Stratum } from "./strata.js";
+
 export type {
   GeometryBatch,
   GlyphsBatch,


### PR DESCRIPTION
## Problem

Canvas-mark charts compose `runPipeline` (lean `@ggsvelte/core/render`) with `planStrata` — but `planStrata` was only exported from the full `@ggsvelte/core` barrel, whose `install-temporal.js` side effect pulls `@js-temporal/polyfill` + `jsbi` (**~213 KB raw / ~93 KB gzip**) into every canvas client bundle. The competitive canvas adapter even carried a TODO comment about this.

Follow-up to #1383 (which fixed the SVG lean graph); canvas was still leaking.

## Change

- `@ggsvelte/core/render` re-exports `planStrata` + the `Stratum` type. `strata.ts` is pure (no DOM, no temporal install), so this costs the lean graph nothing.
- Competitive canvas adapter switches `planStrata` to the lean import.
- The lean-polyfill Vite tree-shake gate (`benchmarks/competitive/lean-polyfill-graph.test.ts`) gains a canvas-entry case (TDD: failed before the fix, passes after).

## Measured

Vite minify + gzip -9, competitive entries:

| entry | before | after |
|---|---|---|
| ggsvelte-canvas (all scenarios) | 237.7 KB gzip | **144.7 KB gzip (−39%)** |
| ggsvelte-svg (unchanged) | 152 KB | 152 KB |
| ggsvelte-full (unchanged, full barrel by design) | 335.6 KB | 335.6 KB |

## Verification

- `bun test benchmarks/competitive/lean-polyfill-graph.test.ts` — canvas case red before, green after
- `bun run check`, `bun run lint`, `bun run knip`, `bun run fmt:check` clean
- `bun run test` — 4352 pass / 0 fail
- `lifecycle.json`, docs routes/search projections regenerated

Note: one pre-existing worktree-local test failure (`scripts/example-interaction-api.test.ts` ENOENT on a stale `examples/node_modules/.bin/ggsvelte-render` symlink from an old install) was repaired locally by removing the stale symlink; unrelated to this change and not committed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1392" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->