### PR TITLE
fix(docs): keep keyboard focus after intent-gated chart load

### DIFF
--- a/apps/docs/src/lib/components/ExampleLiveFrame.svelte
+++ b/apps/docs/src/lib/components/ExampleLiveFrame.svelte
@@ -38,6 +38,8 @@
   let host = $state<HTMLDivElement | null>(null);
   let Live = $state<Component | null>(null);
   let liveReady = $state(false);
+  /** True when the user tabbed into the shell; hand focus to .gg-capture on ready. */
+  let restoreKeyboardFocus = $state(false);
   let loadStarted = false;
   let cancelled = false;
 
@@ -47,6 +49,10 @@
     void loadExampleComponent(exampleId).then((component) => {
       if (!cancelled) Live = component;
     });
+  }
+
+  function onShellFocusIn(): void {
+    if (!liveReady) restoreKeyboardFocus = true;
   }
 
   // Kick off the VR import as soon as the client module runs (before paint
@@ -103,6 +109,18 @@
     });
     return () => observer.disconnect();
   });
+
+  // After keyboard-triggered upgrade, move focus into the plot so Tab order
+  // does not jump to <body> when the load button unmounts (#1362).
+  $effect(() => {
+    if (!liveReady || host === null || !restoreKeyboardFocus) return;
+    const capture = host.querySelector<HTMLElement>(".gg-capture");
+    if (capture === null) return;
+    restoreKeyboardFocus = false;
+    queueMicrotask(() => {
+      capture.focus({ preventScroll: true });
+    });
+  });
 </script>
 
 <div
@@ -110,6 +128,7 @@
   class:full-width={fullWidth}
   class:live-ready={liveReady}
   bind:this={host}
+  onfocusin={onShellFocusIn}
   style={`--example-vr-width:${String(width)}px;--example-vr-height:${String(height)}px`}
 >
   {#if !liveReady}
@@ -123,11 +142,16 @@
       decoding="async"
       fetchpriority="high"
     />
-    {#if Live === null}
-      <button type="button" class="load-interactive" onclick={startLoad}>
-        Load interactive chart
-      </button>
-    {/if}
+    <!-- Stay mounted while the import resolves so keyboard focus has a home. -->
+    <button
+      type="button"
+      class="load-interactive"
+      onclick={startLoad}
+      disabled={Live !== null}
+      aria-busy={Live !== null}
+    >
+      {Live === null ? "Load interactive chart" : "Loading…"}
+    </button>
   {/if}
   {#if Live !== null}
     <div class="live-host" class:revealed={liveReady}>

--- a/apps/docs/src/lib/components/ExampleLiveFrame.svelte
+++ b/apps/docs/src/lib/components/ExampleLiveFrame.svelte
@@ -55,6 +55,40 @@
     if (!liveReady) restoreKeyboardFocus = true;
   }
 
+  function onShellFocusOut(event: FocusEvent): void {
+    // User tabbed away while loading — do not snatch focus back on ready.
+    // relatedTarget === null means blur from unmount (keep restore pending).
+    const next = event.relatedTarget;
+    if (next === null) return;
+    if (next instanceof Node && host !== null && host.contains(next)) return;
+    restoreKeyboardFocus = false;
+  }
+
+  function focusAfterUpgrade(root: HTMLElement): boolean {
+    const capture = root.querySelector<HTMLElement>(".gg-capture");
+    const target =
+      capture ??
+      root.querySelector<HTMLElement>('.gg-plot-root[data-gg-ready="true"]');
+    if (target === null) return false;
+    // Only restore when focus is still in this shell or was dropped to body.
+    const active = document.activeElement;
+    if (
+      active !== null &&
+      active !== document.body &&
+      active !== document.documentElement &&
+      !root.contains(active)
+    ) {
+      return true; // user moved on — clear without focusing
+    }
+    if (target.tabIndex < 0 && !target.hasAttribute("tabindex")) {
+      target.tabIndex = -1;
+    }
+    queueMicrotask(() => {
+      target.focus({ preventScroll: true });
+    });
+    return true;
+  }
+
   // Kick off the VR import as soon as the client module runs (before paint
   // settles). onMount still owns intent-gated upgrades for normal visits.
   if (typeof window !== "undefined") {
@@ -114,12 +148,8 @@
   // does not jump to <body> when the load button unmounts (#1362).
   $effect(() => {
     if (!liveReady || host === null || !restoreKeyboardFocus) return;
-    const capture = host.querySelector<HTMLElement>(".gg-capture");
-    if (capture === null) return;
+    if (!focusAfterUpgrade(host)) return;
     restoreKeyboardFocus = false;
-    queueMicrotask(() => {
-      capture.focus({ preventScroll: true });
-    });
   });
 </script>
 
@@ -129,6 +159,7 @@
   class:live-ready={liveReady}
   bind:this={host}
   onfocusin={onShellFocusIn}
+  onfocusout={onShellFocusOut}
   style={`--example-vr-width:${String(width)}px;--example-vr-height:${String(height)}px`}
 >
   {#if !liveReady}
@@ -142,12 +173,12 @@
       decoding="async"
       fetchpriority="high"
     />
-    <!-- Stay mounted while the import resolves so keyboard focus has a home. -->
+    <!-- Stay mounted and focusable while the import resolves (no disabled blur). -->
     <button
       type="button"
       class="load-interactive"
       onclick={startLoad}
-      disabled={Live !== null}
+      aria-disabled={Live !== null}
       aria-busy={Live !== null}
     >
       {Live === null ? "Load interactive chart" : "Loading…"}

--- a/apps/docs/src/lib/components/LessonFinishedChart.svelte
+++ b/apps/docs/src/lib/components/LessonFinishedChart.svelte
@@ -143,6 +143,39 @@
     if (LivePlot === null) restoreKeyboardFocus = true;
   }
 
+  function onShellFocusOut(event: FocusEvent): void {
+    // relatedTarget === null means blur from unmount (keep restore pending).
+    const next = event.relatedTarget;
+    if (next === null) return;
+    if (next instanceof Node && host !== undefined && host.contains(next))
+      return;
+    restoreKeyboardFocus = false;
+  }
+
+  function focusAfterUpgrade(root: HTMLElement): boolean {
+    const capture = root.querySelector<HTMLElement>(".gg-capture");
+    const target =
+      capture ??
+      root.querySelector<HTMLElement>('.gg-plot-root[data-gg-ready="true"]');
+    if (target === null) return false;
+    const active = document.activeElement;
+    if (
+      active !== null &&
+      active !== document.body &&
+      active !== document.documentElement &&
+      !root.contains(active)
+    ) {
+      return true;
+    }
+    if (target.tabIndex < 0 && !target.hasAttribute("tabindex")) {
+      target.tabIndex = -1;
+    }
+    queueMicrotask(() => {
+      target.focus({ preventScroll: true });
+    });
+    return true;
+  }
+
   onMount(() => {
     const target = host;
     if (target === undefined) return;
@@ -179,12 +212,8 @@
       return;
     const root = host;
     const tryFocus = (): boolean => {
-      const capture = root.querySelector<HTMLElement>(".gg-capture");
-      if (capture === null) return false;
+      if (!focusAfterUpgrade(root)) return false;
       restoreKeyboardFocus = false;
-      queueMicrotask(() => {
-        capture.focus({ preventScroll: true });
-      });
       return true;
     };
     if (tryFocus()) return;
@@ -192,7 +221,14 @@
       if (tryFocus()) mo.disconnect();
     });
     mo.observe(root, { childList: true, subtree: true, attributes: true });
-    return () => mo.disconnect();
+    const stop = window.setTimeout(() => {
+      mo.disconnect();
+      restoreKeyboardFocus = false;
+    }, 30_000);
+    return () => {
+      mo.disconnect();
+      window.clearTimeout(stop);
+    };
   });
 </script>
 
@@ -213,6 +249,7 @@
   class="finished-chart lesson-output"
   bind:this={host}
   onfocusin={onShellFocusIn}
+  onfocusout={onShellFocusOut}
 >
   {#if LivePlot && finished}
     <LivePlot spec={finished.spec} height={liveHeight} {ariaLabel}>

--- a/apps/docs/src/lib/components/LessonFinishedChart.svelte
+++ b/apps/docs/src/lib/components/LessonFinishedChart.svelte
@@ -125,6 +125,8 @@
 
   let loadStarted = false;
   let cancelled = false;
+  /** True when the user tabbed into the shell; hand focus to .gg-capture on ready. */
+  let restoreKeyboardFocus = $state(false);
 
   function loadLivePlot(): void {
     if (loadStarted || LivePlot !== null) return;
@@ -135,6 +137,10 @@
         LiveInspect = mod.Inspect;
       }
     });
+  }
+
+  function onShellFocusIn(): void {
+    if (LivePlot === null) restoreKeyboardFocus = true;
   }
 
   onMount(() => {
@@ -165,6 +171,29 @@
       stopIntent();
     };
   });
+
+  // After keyboard-triggered upgrade, move focus into the plot so Tab order
+  // does not jump to <body> when the load button unmounts (#1362).
+  $effect(() => {
+    if (LivePlot === null || host === undefined || !restoreKeyboardFocus)
+      return;
+    const root = host;
+    const tryFocus = (): boolean => {
+      const capture = root.querySelector<HTMLElement>(".gg-capture");
+      if (capture === null) return false;
+      restoreKeyboardFocus = false;
+      queueMicrotask(() => {
+        capture.focus({ preventScroll: true });
+      });
+      return true;
+    };
+    if (tryFocus()) return;
+    const mo = new MutationObserver(() => {
+      if (tryFocus()) mo.disconnect();
+    });
+    mo.observe(root, { childList: true, subtree: true, attributes: true });
+    return () => mo.disconnect();
+  });
 </script>
 
 {#snippet sakuraTooltip(
@@ -180,7 +209,11 @@
   {/if}
 {/snippet}
 
-<div class="finished-chart lesson-output" bind:this={host}>
+<div
+  class="finished-chart lesson-output"
+  bind:this={host}
+  onfocusin={onShellFocusIn}
+>
   {#if LivePlot && finished}
     <LivePlot spec={finished.spec} height={liveHeight} {ariaLabel}>
       {#if finished.inspect && LiveInspect}

--- a/scripts/docs-chart-intent-load.test.ts
+++ b/scripts/docs-chart-intent-load.test.ts
@@ -65,7 +65,10 @@ describe("docs chart intent-gated load", () => {
   it("restores keyboard focus into the lesson plot after upgrade (#1362)", () => {
     const lesson = read("lib/components/LessonFinishedChart.svelte");
     expect(lesson).toContain("restoreKeyboardFocus");
+    expect(lesson).toContain("focusAfterUpgrade");
     expect(lesson).toContain(".gg-capture");
+    expect(lesson).toContain("gg-plot-root");
+    expect(lesson).toContain("onfocusout");
     expect(lesson).toMatch(/\.focus\(/);
   });
 });

--- a/scripts/docs-chart-intent-load.test.ts
+++ b/scripts/docs-chart-intent-load.test.ts
@@ -61,4 +61,11 @@ describe("docs chart intent-gated load", () => {
     expect(lesson).toContain("observeUserIntent");
     expect(lesson).not.toContain("observeNearViewport");
   });
+
+  it("restores keyboard focus into the lesson plot after upgrade (#1362)", () => {
+    const lesson = read("lib/components/LessonFinishedChart.svelte");
+    expect(lesson).toContain("restoreKeyboardFocus");
+    expect(lesson).toContain(".gg-capture");
+    expect(lesson).toMatch(/\.focus\(/);
+  });
 });

--- a/scripts/docs-example-png-first.test.ts
+++ b/scripts/docs-example-png-first.test.ts
@@ -53,10 +53,31 @@ describe("docs example PNG-first (PR3)", () => {
     expect(frame).toContain("MutationObserver");
   });
 
+  it("hands keyboard focus to the plot capture after an intent upgrade (#1362)", () => {
+    // Tabbing into "Load interactive chart" must not drop focus to <body> when
+    // the shell unmounts. Flag keyboard intent and focus .gg-capture on ready.
+    const frame = read("lib/components/ExampleLiveFrame.svelte");
+    expect(frame).toContain("restoreKeyboardFocus");
+    expect(frame).toContain(".gg-capture");
+    expect(frame).toMatch(/\.focus\(/);
+    // Keep the load control mounted while the import resolves so focus has a
+    // home until the capture surface can take it.
+    expect(frame).toMatch(/Loading/);
+  });
+
   it("keeps loadExample for callers that still need the full bundle", () => {
     const examples = read("lib/examples.ts");
     expect(examples).toContain("export async function loadExampleSources");
     expect(examples).toContain("export async function loadExampleComponent");
     expect(examples).toContain("export async function loadExample");
+  });
+
+  it("drains load buttons by first-match so unmounts cannot skip charts (#1362)", () => {
+    // Indexed nth(i) after count() races button removal and can hang CI or
+    // skip a later frame. Always click the current first match.
+    const helper = readFileSync(path.join(root, "tests/visual/helpers/deterministic.ts"), "utf8");
+    expect(helper).toContain('getByRole("button", { name: "Load interactive chart" })');
+    expect(helper).toContain(".first()");
+    expect(helper).not.toMatch(/loadButtons\.nth\(/);
   });
 });

--- a/scripts/docs-example-png-first.test.ts
+++ b/scripts/docs-example-png-first.test.ts
@@ -53,16 +53,20 @@ describe("docs example PNG-first (PR3)", () => {
     expect(frame).toContain("MutationObserver");
   });
 
-  it("hands keyboard focus to the plot capture after an intent upgrade (#1362)", () => {
+  it("hands keyboard focus to the plot after an intent upgrade (#1362)", () => {
     // Tabbing into "Load interactive chart" must not drop focus to <body> when
-    // the shell unmounts. Flag keyboard intent and focus .gg-capture on ready.
+    // the shell unmounts. Prefer .gg-capture; fall back to ready plot root.
     const frame = read("lib/components/ExampleLiveFrame.svelte");
     expect(frame).toContain("restoreKeyboardFocus");
+    expect(frame).toContain("focusAfterUpgrade");
     expect(frame).toContain(".gg-capture");
+    expect(frame).toContain("gg-plot-root");
     expect(frame).toMatch(/\.focus\(/);
-    // Keep the load control mounted while the import resolves so focus has a
-    // home until the capture surface can take it.
+    expect(frame).toContain("onfocusout");
+    // Keep the load control focusable while the import resolves (no disabled blur).
     expect(frame).toMatch(/Loading/);
+    expect(frame).toContain("aria-disabled");
+    expect(frame).not.toMatch(/[^\w-]disabled=\{Live/);
   });
 
   it("keeps loadExample for callers that still need the full bundle", () => {
@@ -72,12 +76,12 @@ describe("docs example PNG-first (PR3)", () => {
     expect(examples).toContain("export async function loadExample");
   });
 
-  it("drains load buttons by first-match so unmounts cannot skip charts (#1362)", () => {
-    // Indexed nth(i) after count() races button removal and can hang CI or
-    // skip a later frame. Always click the current first match.
+  it("drains load buttons by count so multi-chart pages complete (#1362)", () => {
+    // Click one, wait for "Load interactive chart" count to drop (Loading… label
+    // or unmount). Avoid frozen nth indices and .first()+detached re-resolve.
     const helper = readFileSync(path.join(root, "tests/visual/helpers/deterministic.ts"), "utf8");
     expect(helper).toContain('getByRole("button", { name: "Load interactive chart" })');
-    expect(helper).toContain(".first()");
+    expect(helper).toContain("toHaveCount");
     expect(helper).not.toMatch(/loadButtons\.nth\(/);
   });
 });

--- a/tests/visual/helpers/deterministic.ts
+++ b/tests/visual/helpers/deterministic.ts
@@ -23,18 +23,24 @@ export async function settleVisualState(page: Page, expectedPlots = 1): Promise<
   // there (they race the upgrade and can hang Playwright's actionability checks).
   const hasVr = await page.evaluate(() => new URL(location.href).searchParams.has("vr"));
   if (!hasVr) {
-    // Drain by always targeting the current first match. An indexed nth(i)
-    // after count() races button removal (index shift / detach hang).
+    // Drain by count: click the current first match, then wait until the
+    // "Load interactive chart" count drops (label → Loading… or unmount).
+    // Indexed nth after a frozen count races removals; .first()+detached
+    // re-resolves to the next button and can stop early.
     for (;;) {
-      const btn = page.getByRole("button", { name: "Load interactive chart" }).first();
-      if (!(await btn.isVisible().catch(() => false))) break;
-      await btn.click({ timeout: 5_000 }).catch(() => {
-        /* button may unmount mid-upgrade */
+      const buttons = page.getByRole("button", { name: "Load interactive chart" });
+      const n = await buttons.count();
+      if (n === 0) break;
+      const first = buttons.nth(0);
+      if (!(await first.isVisible().catch(() => false))) break;
+      await first.click({ timeout: 5_000 }).catch(() => {
+        /* may unmount mid-upgrade */
       });
-      await btn.waitFor({ state: "detached", timeout: 10_000 }).catch(() => {
-        /* import may leave a Loading… control; stop if still present */
-      });
-      if (await btn.isVisible().catch(() => false)) break;
+      try {
+        await expect(buttons).toHaveCount(n - 1, { timeout: 15_000 });
+      } catch {
+        break;
+      }
     }
   }
   // 30s: cold-import of the chart stack after a PNG placeholder. First smoke

--- a/tests/visual/helpers/deterministic.ts
+++ b/tests/visual/helpers/deterministic.ts
@@ -23,15 +23,18 @@ export async function settleVisualState(page: Page, expectedPlots = 1): Promise<
   // there (they race the upgrade and can hang Playwright's actionability checks).
   const hasVr = await page.evaluate(() => new URL(location.href).searchParams.has("vr"));
   if (!hasVr) {
-    const loadButtons = page.getByRole("button", { name: "Load interactive chart" });
-    const n = await loadButtons.count();
-    for (let i = 0; i < n; i += 1) {
-      const btn = loadButtons.nth(i);
-      if (await btn.isVisible().catch(() => false)) {
-        await btn.click({ timeout: 5_000 }).catch(() => {
-          /* button may unmount mid-upgrade */
-        });
-      }
+    // Drain by always targeting the current first match. An indexed nth(i)
+    // after count() races button removal (index shift / detach hang).
+    for (;;) {
+      const btn = page.getByRole("button", { name: "Load interactive chart" }).first();
+      if (!(await btn.isVisible().catch(() => false))) break;
+      await btn.click({ timeout: 5_000 }).catch(() => {
+        /* button may unmount mid-upgrade */
+      });
+      await btn.waitFor({ state: "detached", timeout: 10_000 }).catch(() => {
+        /* import may leave a Loading… control; stop if still present */
+      });
+      if (await btn.isVisible().catch(() => false)) break;
     }
   }
   // 30s: cold-import of the chart stack after a PNG placeholder. First smoke


### PR DESCRIPTION
## Summary

Follow-up for unrebutted post-merge review on #1362 (intent-gate example/lesson charts).

### Valid (fixed here)

1. **Keyboard focus drop** — tabbing into the load control started the upgrade and unmounted the focused node, sending focus back to `<body>`. Flag keyboard intent on `focusin`, keep a `Loading…` control on example frames until `data-gg-ready`, then `focus()` `.gg-capture`.
2. **Playwright load-button drain** — `settleVisualState` used indexed `nth(i)` after `count()`, which races button removal. Drain via current `.first()` match instead.

### Already fixed on main (rebutted on parent)

- Lesson/example keyboard affordance (load button) and journey updates
- No permanent `tabindex="0"` / stale aria-label on the frame wrapper
- `?vr` path skips load-button clicks

## Tests

- `bun test scripts/docs-example-png-first.test.ts scripts/docs-chart-intent-load.test.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1393" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->