### PR TITLE
refactor(svelte): one interaction context + controller assembly

### DIFF
--- a/.changeset/interaction-context-assembly.md
+++ b/.changeset/interaction-context-assembly.md
@@ -1,0 +1,21 @@
+---
+"@ggsvelte/svelte": patch
+---
+
+<!-- markdownlint-disable MD041 -->
+
+refactor: one interaction context + controller assembly behind the plot engine
+
+Internal only — no public API or behavior change. The five interaction
+controller factories (zoom, selection, interval, surface, inspection) used to
+declare their own 6–19-field dep bags, hand-wired by the plot engine across
+~60 fields with `let surfaceState!` / `let semanticCandidateProjection!` late
+bindings to break the surface ↔ inspection ↔ interval ↔ selection cycles.
+
+A shared `InteractionContext` now carries the common bag (model, config
+slices, handlers, announce, DOM refs, semantic-key service), each factory
+takes `(context, options)` with options holding only controller-specific
+ports, and a single `createInteractionStates` assembly owns the construction
+order and sibling wiring internally. The surface→inspection reducer edge is a
+hoisted concrete instance, so the `surfaceState!` late binding is gone; the
+projection remains the one documented late binding.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -253,26 +253,26 @@ for job markers).
 
 The Svelte package is organized by feature under `packages/svelte/src/lib/`:
 
-| Directory / file        | Role                                                                                                                                      |
-| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `geoms/`                | Declaration-only geom children (`GeomPoint`, …) and the geom factory/registry                                                             |
-| `assembly/`             | Labels, layout helpers, chrome-adjacent pure assembly                                                                                     |
-| `runtime/`              | Runtime paint, announcer, semantic-key services                                                                                           |
-| `scene/`                | SVG scene tree (`SceneView`, `Batch`, axes, legends paint, strata)                                                                        |
-| `a11y/`                 | Canvas-stratum accessibility surface + row materialization                                                                                |
-| `interaction/`          | Tools, reducer, capability, controller                                                                                                    |
-| `surface/`              | Capture surface controller (pointer/keyboard/brush)                                                                                       |
-| `inspection/`           | Tooltip, inspection coordinator/resolver, inspection state                                                                                |
-| `selection/`            | Point-selection state                                                                                                                     |
-| `interval/`             | Interval selection, bounds editor, query                                                                                                  |
-| `zoom/`                 | Brush-zoom state                                                                                                                          |
-| `legend/`               | Legend filter/focus controllers, targets, pure surface helpers                                                                            |
-| `chrome/`               | Tool rail, status chrome, theme CSS, chrome state                                                                                         |
-| `fonts/`                | Packaged font assets (not TypeScript sources)                                                                                             |
-| `GGPlot.svelte`         | Public component shell                                                                                                                    |
-| `plot-engine.svelte.ts` | Controller wiring; owns the construction/effect-order DAG contract (read the file header before reordering factories or effects)          |
-| `plot-props.ts`         | GGPlot's **internal** props contract + engine resolve helpers (`resolveCapabilities`, `widenPlotProps`) — not re-exported from `index.ts` |
-| `index.ts`              | The **only** public package entry                                                                                                         |
+| Directory / file        | Role                                                                                                                                                     |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `geoms/`                | Declaration-only geom children (`GeomPoint`, …) and the geom factory/registry                                                                            |
+| `assembly/`             | Labels, layout helpers, chrome-adjacent pure assembly                                                                                                    |
+| `runtime/`              | Runtime paint, announcer, semantic-key services                                                                                                          |
+| `scene/`                | SVG scene tree (`SceneView`, `Batch`, axes, legends paint, strata)                                                                                       |
+| `a11y/`                 | Canvas-stratum accessibility surface + row materialization                                                                                               |
+| `interaction/`          | Tools, reducer, capability, controller, shared InteractionContext + the interaction-states assembly                                                      |
+| `surface/`              | Capture surface controller (pointer/keyboard/brush)                                                                                                      |
+| `inspection/`           | Tooltip, inspection coordinator/resolver, inspection state                                                                                               |
+| `selection/`            | Point-selection state                                                                                                                                    |
+| `interval/`             | Interval selection, bounds editor, query                                                                                                                 |
+| `zoom/`                 | Brush-zoom state                                                                                                                                         |
+| `legend/`               | Legend filter/focus controllers, targets, pure surface helpers                                                                                           |
+| `chrome/`               | Tool rail, status chrome, theme CSS, chrome state                                                                                                        |
+| `fonts/`                | Packaged font assets (not TypeScript sources)                                                                                                            |
+| `GGPlot.svelte`         | Public component shell                                                                                                                                   |
+| `plot-engine.svelte.ts` | Host wiring: builds the InteractionContext, delegates controller construction to the interaction-states assembly, owns host-level deriveds + diagnostics |
+| `plot-props.ts`         | GGPlot's **internal** props contract + engine resolve helpers (`resolveCapabilities`, `widenPlotProps`) — not re-exported from `index.ts`                |
+| `index.ts`              | The **only** public package entry                                                                                                                        |
 
 ### No per-directory barrels
 

--- a/packages/svelte/src/lib/inspection/inspection-state.svelte.ts
+++ b/packages/svelte/src/lib/inspection/inspection-state.svelte.ts
@@ -19,18 +19,17 @@
  *
  * Scene-reconcile + coordinator disposal effects register inside this factory.
  */
-import type { CandidateFacts, CellValue, RenderModel } from "@ggsvelte/core";
+import type { CandidateFacts, CellValue } from "@ggsvelte/core";
 
 import { panelBoundsFrom, type PanelBounds } from "../scene/geometry.js";
 
 import { createInspectionCoordinator } from "./coordinator.js";
+import type { InteractionContext } from "../interaction/interaction-context.svelte.js";
 import type { createInteractionReducer } from "../interaction/reducer.js";
 import type {
   InteractionSource,
   PlotInspection,
   PlotInspectionChange,
-  PlotInteractionEvent,
-  ResolvedInteractionConfig,
 } from "../interaction/interaction.js";
 import { inspectionLiveText as inspectionLiveTextFor } from "../assembly/labels.js";
 import { plotTooltipDomId } from "../assembly/layout.js";
@@ -68,36 +67,23 @@ import {
 /** Component-held reducer shape — factory-only export from interaction/reducer. */
 type InteractionReducer = ReturnType<typeof createInteractionReducer>;
 
-export type InspectionStateDeps = {
-  model: () => RenderModel | null;
-  /**
-   * Shared interaction reducer. Prefer a concrete instance from the assembly
-   * (constructed before this factory) so inspection does not close over surface.
-   */
-  reducer: InteractionReducer | (() => InteractionReducer);
-  inspectConfig: () => ResolvedInteractionConfig["inspect"];
-  inspectEnabled: () => boolean;
-  dataIdentityEpoch: () => string;
-  /**
-   * Semantic key at row index — closes over the later semantic-key service.
-   * Handler-only (coordinator resolve paths); never invoked at construction.
-   */
-  keyAt: (index: number) => PropertyKey | null;
-  root: () => HTMLDivElement | null;
-  captureSurface: () => HTMLDivElement | null;
-  plotId: () => string;
-  tooltipHovered: () => boolean;
-  clearTooltipHovered: () => void;
-  oninspect: () => ((event: PlotInspection<Record<string, CellValue>>) => void) | undefined;
-  oninteraction: () =>
-    | ((event: PlotInteractionEvent<Record<string, CellValue>>) => void)
-    | undefined;
-  /** Stable sinks over the announcer. */
-  announce: (message: string) => void;
-  clearAnnouncement: () => void;
+/**
+ * Inspection-specific ports beyond the shared InteractionContext. The reducer
+ * is hoisted by the assembly (constructed before this factory) so inspection
+ * does not close over surface.
+ */
+export type InspectionStateOptions = {
+  /** Shared interaction reducer (concrete instance from the assembly). */
+  readonly reducer: InteractionReducer | (() => InteractionReducer);
+  readonly inspectEnabled: () => boolean;
+  readonly dataIdentityEpoch: () => string;
+  readonly plotId: () => string;
+  readonly clearTooltipHovered: () => void;
+  /** Stable sink over the announcer. */
+  readonly clearAnnouncement: () => void;
 };
 
-function resolveReducer(reducer: InspectionStateDeps["reducer"]): InteractionReducer {
+function resolveReducer(reducer: InspectionStateOptions["reducer"]): InteractionReducer {
   return typeof reducer === "function" ? reducer() : reducer;
 }
 
@@ -164,8 +150,11 @@ export type InspectionState = {
  * Construction-order note: deps must not be invoked during construction —
  * construction-read discipline enforced by the armed-getter suite.
  */
-export function createInspectionState(deps: InspectionStateDeps): InspectionState {
-  const reducerOf = (): InteractionReducer => resolveReducer(deps.reducer);
+export function createInspectionState(
+  context: InteractionContext,
+  options: InspectionStateOptions,
+): InspectionState {
+  const reducerOf = (): InteractionReducer => resolveReducer(options.reducer);
   let inspection = $state<PlotInspectionChange<Record<string, CellValue>, PropertyKey> | null>(
     null,
   );
@@ -189,7 +178,7 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
   // construction (armed-getter suite). setInspection is a function
   // declaration (hoisted) so the apply-pending re-entry closes correctly.
   const pointerQueue = createPointerInspectQueue({
-    model: () => deps.model(),
+    model: () => context.model(),
     reducer: () => reducerOf(),
     inspectionState: () => (inspection === null ? "none" : inspection.state),
     setInspection: (candidate, source, state, concreteMode) => {
@@ -202,10 +191,10 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
   // candidate), not a re-hit of focus.anchor geometry (#787). Bounds come
   // from the semantic viewport — no scene.panels.find round-trip.
   const inspectionPanel = $derived.by((): InspectionPanelBounds | null => {
-    if (inspection === null || deps.model() === null) return null;
+    if (inspection === null || context.model() === null) return null;
     const panelId = inspection.panelId;
     if (panelId === null) return null;
-    const viewportPanel = deps.model()!.viewport.panel(panelId);
+    const viewportPanel = context.model()!.viewport.panel(panelId);
     if (viewportPanel === null) return null;
     return { id: viewportPanel.id, ...panelBoundsFrom(viewportPanel.bounds) };
   });
@@ -216,7 +205,7 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
 
   // Coordinator closes over keyAt — handler-only invocation (deferred).
   const inspectionCoordinator = createInspectionCoordinator<Record<string, CellValue>, PropertyKey>(
-    (index) => deps.keyAt(index),
+    (index) => context.keyAt(index),
   );
 
   let reconciledRun = -1;
@@ -227,9 +216,9 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
     state: "transient" | "pinned" = "transient",
     concreteMode?: "exact" | "x" | "y" | "xy",
   ) {
-    const model = deps.model();
+    const model = context.model();
     if (model === null) throw new Error("Cannot resolve inspection without a render model");
-    const requested = deps.inspectConfig()?.mode ?? "auto";
+    const requested = context.inspectConfig()?.mode ?? "auto";
     const mode = resolveInspectionMode({
       concreteMode,
       requested,
@@ -241,13 +230,13 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
       mode,
       state,
       source,
-      identityEpoch: deps.dataIdentityEpoch(),
+      identityEpoch: options.dataIdentityEpoch(),
       layoutEpoch: model.runId,
       completeness: resolveInspectionCompleteness({
         state,
-        hasCustomContent: deps.inspectConfig()?.content !== undefined,
-        hasInspectCallback: deps.oninspect() !== undefined,
-        hasInteractionCallback: deps.oninteraction() !== undefined,
+        hasCustomContent: context.inspectConfig()?.content !== undefined,
+        hasInspectCallback: context.oninspect() !== undefined,
+        hasInteractionCallback: context.oninteraction() !== undefined,
       }),
     });
   }
@@ -264,14 +253,14 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
     });
     if (emit.type === "skip") return;
     if (emit.updateFingerprint !== null) lastInspectionFingerprint = emit.updateFingerprint;
-    deps.oninspect()?.(next);
-    deps.oninteraction()?.(next);
+    context.oninspect()?.(next);
+    context.oninteraction()?.(next);
   }
 
   function inspectionLiveText(
     value: PlotInspectionChange<Record<string, CellValue>, PropertyKey>,
   ): string {
-    return inspectionLiveTextFor(deps.model(), value);
+    return inspectionLiveTextFor(context.model(), value);
   }
 
   function setInspection(
@@ -288,7 +277,7 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
         source,
       })
     )
-      deps.clearAnnouncement();
+      options.clearAnnouncement();
     // Direct applies (keyboard/touch/programmatic) must cancel queued hover /
     // touch-move inspect frames so a pending rAF cannot override the apply
     // (e.g. touch tap after a sub-threshold touch move scheduled inspect).
@@ -300,7 +289,7 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
       hasHit: candidate !== null,
       requestedState: state,
       currentState: inspection === null ? "none" : inspection.state,
-      tooltipHovered: deps.tooltipHovered(),
+      tooltipHovered: context.tooltipHovered(),
     });
     switch (action.type) {
       case "ignore":
@@ -324,7 +313,7 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
           setInspection(null, source);
           return;
         }
-        const runId = deps.model()?.runId ?? 0;
+        const runId = context.model()?.runId ?? 0;
         // Same-candidate dismiss latch (Escape on transient).
         if (
           dismissedCandidateId === resolved.seed.id &&
@@ -375,19 +364,19 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
         inspectionSeed = resolved.seed;
         if (nextState === "transient") inspectionCoordinator.release("pinned");
         if (shouldAnnounceUnpin({ state: nextState, source }))
-          deps.announce(`${inspectionLiveText(resolved.snapshot)}, unpinned`);
+          context.announce(`${inspectionLiveText(resolved.snapshot)}, unpinned`);
         if (resolved.semanticChanged)
           emitInspection(resolved.snapshot, resolved.semanticFingerprint);
         if (
           shouldFocusPinnedInteractiveTooltip({
             state: nextState,
-            contentMode: deps.inspectConfig()?.contentMode,
+            contentMode: context.inspectConfig()?.contentMode,
           })
         )
           queueMicrotask(() =>
-            deps
+            context
               .root()
-              ?.querySelector<HTMLElement>(`#${CSS.escape(plotTooltipDomId(deps.plotId()))}`)
+              ?.querySelector<HTMLElement>(`#${CSS.escape(plotTooltipDomId(options.plotId()))}`)
               ?.focus(),
           );
       }
@@ -420,7 +409,7 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
     // Latch only when dismissing a *transient* inspection (Escape path).
     if (inspection?.state === "transient" && inspectionSeed !== null) {
       dismissedCandidateId = inspectionSeed.id;
-      dismissedRunId = deps.model()?.runId ?? null;
+      dismissedRunId = context.model()?.runId ?? null;
     } else if (inspection?.state === "pinned") {
       clearDismissedLatch();
     }
@@ -429,12 +418,12 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
     if (plan.emitClear) emitInspection({ type: "inspect", phase: "clear", source });
     inspection = null;
     inspectionSeed = null;
-    if (plan.clearTooltipHovered) deps.clearTooltipHovered();
+    if (plan.clearTooltipHovered) options.clearTooltipHovered();
     if (plan.coordinator === "invalidate") inspectionCoordinator.invalidate();
     else inspectionCoordinator.release("pinned");
     // Cross-module clearBrush / returnToInspect: caller applies via
     // applyInspectionDismissSideEffects (surface / transition owner).
-    if (plan.restoreFocus) queueMicrotask(() => deps.captureSurface()?.focus());
+    if (plan.restoreFocus) queueMicrotask(() => context.captureSurface()?.focus());
     return plan;
   }
 
@@ -444,21 +433,21 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
 
   function applyCandidateId(id: number | null): void {
     if (id === null) return;
-    const candidate = deps.model()?.candidates.candidate(id);
+    const candidate = context.model()?.candidates.candidate(id);
     if (candidate === null || candidate === undefined) return;
     activeCandidateId = id;
     setInspection(candidate, "keyboard", "transient");
   }
 
   function navigate(delta: number): void {
-    const store = deps.model()?.candidates;
+    const store = context.model()?.candidates;
     if (store === undefined || store.size === 0) return;
     const direction = delta < 0 ? "previous" : "next";
     applyCandidateId(store.traverse(activeCandidateId, direction, Math.abs(delta)));
   }
 
   function navigateDirection(dx: number, dy: number): void {
-    const store = deps.model()?.candidates;
+    const store = context.model()?.candidates;
     if (store === undefined || store.size === 0) return;
     if (inspection === null || activeCandidateId === null) {
       applyCandidateId(store.traverse(activeCandidateId, "next"));
@@ -469,7 +458,7 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
   }
 
   function cycleCoincident(delta: number): void {
-    const store = deps.model()?.candidates;
+    const store = context.model()?.candidates;
     if (store === undefined || store.size === 0) return;
     if (inspection === null || activeCandidateId === null) {
       applyCandidateId(store.traverse(activeCandidateId, "next"));
@@ -503,9 +492,9 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
   });
 
   $effect(() => {
-    const currentModel = deps.model();
+    const currentModel = context.model();
     const plan = planSceneInspectReconcile({
-      inspectionEnabled: deps.inspectEnabled(),
+      inspectionEnabled: options.inspectEnabled(),
       // Thunk: do not read `inspection` on the same-run skip path so hover
       // updates are not effect dependencies of scene-run reconcile.
       getInspectionState: () => (inspection === null ? "none" : inspection.state),
@@ -516,7 +505,7 @@ export function createInspectionState(deps: InspectionStateDeps): InspectionStat
     // same-run skip does not subscribe to hover inspection updates.
     applySceneInspectReconcile(plan, {
       model: currentModel,
-      dataIdentityEpoch: deps.dataIdentityEpoch,
+      dataIdentityEpoch: options.dataIdentityEpoch,
       clearInspection() {
         inspection = null;
         inspectionSeed = null;

--- a/packages/svelte/src/lib/interaction/interaction-context.svelte.ts
+++ b/packages/svelte/src/lib/interaction/interaction-context.svelte.ts
@@ -1,0 +1,78 @@
+/**
+ * Shared interaction context — the single dep bag threaded through every
+ * interaction controller factory (zoom, selection, interval, surface,
+ * inspection).
+ *
+ * Before this module each factory declared its own 6–19-field deps type and
+ * plot-engine hand-wired ~60 fields, most of them the same model / config /
+ * handler / DOM getters re-typed per controller. One context replaces the
+ * shared bag; per-factory `options` now hold only what is genuinely
+ * controller-specific (sibling ports, host-derived enablement, narrow config
+ * slices).
+ *
+ * Every field is a deferred getter or stable sink: factories must not read
+ * reactive values at construction beyond what their own docs allow. The
+ * assembly (interaction-states.svelte.ts) owns construction order.
+ */
+import type { CellValue, RenderModel } from "@ggsvelte/core";
+import type { CandidateFacts } from "@ggsvelte/core";
+
+import type { PlotInteractionController } from "./controller.svelte.js";
+import type {
+  InteractionTool,
+  PlotInspection,
+  PlotInteractionEvent,
+  PlotInteractionScope,
+  PlotSelection,
+  ResolvedInteractionConfig,
+  ZoomEvent,
+} from "./interaction.js";
+
+/** Shared dep bag for all interaction controller factories. */
+export type InteractionContext = {
+  /** Trained render model; null pre-model (SSR / first effect). */
+  readonly model: () => RenderModel | null;
+  /** Component DOM handles. */
+  readonly root: () => HTMLDivElement | null;
+  readonly captureSurface: () => HTMLDivElement | null;
+  /** External linked controller, when the plot is controller-driven. */
+  readonly interaction: () => PlotInteractionController<PropertyKey> | undefined;
+  readonly resolvedInteractionScope: () => PlotInteractionScope;
+  /** Narrow config slices over the resolved interaction config. */
+  readonly selectConfig: () => ResolvedInteractionConfig["select"];
+  readonly inspectConfig: () => ResolvedInteractionConfig["inspect"];
+  /** Component-held tooltip hover flag (markup handlers write via engine). */
+  readonly tooltipHovered: () => boolean;
+  /** Stable announcer sink. */
+  readonly announce: (message: string) => void;
+  /** Deferred handler getters (handler-only; never construction-time reads). */
+  readonly oninteraction: () =>
+    | ((event: PlotInteractionEvent<Record<string, CellValue>>) => void)
+    | undefined;
+  readonly oninspect: () =>
+    | ((event: PlotInspection<Record<string, CellValue>>) => void)
+    | undefined;
+  readonly onselect: () => ((event: PlotSelection) => void) | undefined;
+  readonly onzoom: () => ((event: ZoomEvent) => void) | undefined;
+  readonly ontoolchange: () => ((tool: InteractionTool) => void) | undefined;
+  /** Durable row identity service (semantic keys). */
+  readonly keyAt: (index: number) => PropertyKey | null;
+  readonly semanticKey: (
+    row: Record<string, CellValue> | null,
+    index: number | null,
+  ) => PropertyKey | null;
+  readonly candidateSemanticKeys: (candidate: CandidateFacts) => PropertyKey[];
+};
+
+/**
+ * Fields the host must supply to build an InteractionContext. Identical in
+ * shape to the context itself — resolveInteractionContext exists so the host
+ * has one explicit seam to widen later (defaults, SSR hatches) without
+ * touching five factories again.
+ */
+export type InteractionContextDeps = InteractionContext;
+
+/** Build the shared interaction context from host-supplied getters. */
+export function resolveInteractionContext(deps: InteractionContextDeps): InteractionContext {
+  return { ...deps };
+}

--- a/packages/svelte/src/lib/interaction/interaction-states.svelte.ts
+++ b/packages/svelte/src/lib/interaction/interaction-states.svelte.ts
@@ -1,0 +1,114 @@
+/**
+ * Interaction controller assembly — one factory that constructs all five
+ * interaction controllers in their topological order and wires the sibling
+ * ports internally.
+ *
+ * Before this module, plot-engine.svelte.ts hand-wired the construction DAG
+ * across ~200 lines, with `let surfaceState!` / `let semanticCandidateProjection!`
+ * late bindings to break the surface ↔ inspection ↔ interval ↔ selection
+ * cycles. Here the order is an implementation detail:
+ *
+ *   zoom → selection → interval → surface → inspection
+ *
+ * The two irreducible ordering constraints:
+ * - surface is constructed before inspection so the shared interaction
+ *   reducer exists as a concrete instance (inspection no longer closes over
+ *   a later surface binding);
+ * - interval / surface receive sibling controllers as handler-only getters
+ *   over the bundle under construction (event-time reads only — every
+ *   controller documents its construction-time reads as context-only).
+ *
+ * Host-derived enablement (availableTools, pointSelectEnabled, surfaceInter-
+ * active) and host-owned slices (dataIdentityEpoch, consumptionCandidates,
+ * clearAnnouncement) arrive via options; everything shared arrives via the
+ * InteractionContext.
+ */
+import type {
+  InspectionState,
+  InspectionStateOptions,
+} from "../inspection/inspection-state.svelte.js";
+import { createInspectionState } from "../inspection/inspection-state.svelte.js";
+import type { IntervalState, IntervalStateOptions } from "../interval/interval-state.svelte.js";
+import { createIntervalState } from "../interval/interval-state.svelte.js";
+import type { SelectionState } from "../selection/selection-state.svelte.js";
+import { createSelectionState } from "../selection/selection-state.svelte.js";
+import type { SurfaceState, SurfaceStateOptions } from "../surface/surface-state.svelte.js";
+import { createSurfaceState } from "../surface/surface-state.svelte.js";
+import type { PlotZoomState, PlotZoomStateOptions } from "../zoom/zoom-state.svelte.js";
+import { createPlotZoomState } from "../zoom/zoom-state.svelte.js";
+import type { InteractionContext } from "./interaction-context.svelte.js";
+
+/** The five interaction controllers, keyed by role. */
+export type InteractionStates = {
+  readonly zoom: PlotZoomState;
+  readonly selection: SelectionState;
+  readonly interval: IntervalState;
+  readonly surface: SurfaceState;
+  readonly inspection: InspectionState;
+};
+
+/**
+ * Host-owned slices the assembly cannot derive from the context. Sibling
+ * ports (reducer, emitSelection, commitZoom, inspection/interval/zoom
+ * getters) are wired internally — hosts never see them.
+ */
+export type InteractionStatesOptions = {
+  readonly zoom: PlotZoomStateOptions;
+  readonly interval: Pick<IntervalStateOptions, "consumptionCandidates">;
+  readonly surface: Pick<
+    SurfaceStateOptions,
+    "toolProp" | "initialTool" | "availableTools" | "pointSelectEnabled" | "surfaceInteractive"
+  >;
+  readonly inspection: Omit<InspectionStateOptions, "reducer">;
+};
+
+/**
+ * Construct all five interaction controllers. Call once during component
+ * init (controllers register $derived/$effect in the calling effect tree).
+ */
+export function createInteractionStates(
+  context: InteractionContext,
+  options: InteractionStatesOptions,
+): InteractionStates {
+  // Sibling ports close over these bindings; assigned in topological order
+  // below and read only at handler time, never during construction.
+  let interval: IntervalState;
+  let inspection: InspectionState;
+
+  const zoom = createPlotZoomState(context, options.zoom);
+  const selection = createSelectionState(context);
+
+  interval = createIntervalState(context, {
+    consumptionCandidates: options.interval.consumptionCandidates,
+    effectiveZoomDomains: () => zoom.effectiveZoomDomains,
+    commitZoom: (domains, source) => {
+      zoom.commitZoom(domains, source);
+    },
+    inspectionPanel: () => inspection.inspectionPanel,
+    emitSelection: (event) => {
+      selection.emitSelection(event);
+    },
+  });
+
+  const surface = createSurfaceState(context, {
+    ...options.surface,
+    inspection: () => inspection,
+    interval: () => interval,
+    zoom: () => zoom,
+    emitSelection: (event) => {
+      selection.emitSelection(event);
+    },
+    togglePointKeys: (keys, source) => {
+      selection.togglePointKeys(keys, source);
+    },
+  });
+
+  inspection = createInspectionState(context, {
+    ...options.inspection,
+    // Concrete reducer — surface is already constructed, so inspection no
+    // longer closes over a later surface binding (was `let surfaceState!`).
+    reducer: surface.reducer,
+  });
+
+  return { zoom, selection, interval, surface, inspection };
+}

--- a/packages/svelte/src/lib/interaction/interaction-states.svelte.ts
+++ b/packages/svelte/src/lib/interaction/interaction-states.svelte.ts
@@ -1,16 +1,29 @@
 /**
- * Interaction controller assembly — one factory that constructs all five
- * interaction controllers in their topological order and wires the sibling
- * ports internally.
+ * Interaction controller assembly — owns construction order and sibling-port
+ * wiring for the five interaction controllers (zoom, selection, interval,
+ * surface, inspection).
  *
  * Before this module, plot-engine.svelte.ts hand-wired the construction DAG
  * across ~200 lines, with `let surfaceState!` / `let semanticCandidateProjection!`
  * late bindings to break the surface ↔ inspection ↔ interval ↔ selection
- * cycles. Here the order is an implementation detail:
+ * cycles.
  *
- *   zoom → selection → interval → surface → inspection
+ * Why two phases
+ * --------------
+ * On SSR the Svelte compiler evaluates `$derived` eagerly at declaration, so
+ * construction order must be the exact topological order of every derived
+ * read — not just handler-time reads. The full DAG interleaves with host
+ * controllers:
  *
- * The two irreducible ordering constraints:
+ *   zoom → legendFilter → runtime → semanticKeys → selection → interval →
+ *   surface → inspection
+ *
+ * Phase 1 (`createInteractionAssembly`) constructs zoom, the only controller
+ * the legend-filter / runtime chain reads. Phase 2 (`complete`) — called by
+ * the host once the runtime and semantic-key service exist — constructs
+ * selection → interval → surface → inspection and wires all sibling ports
+ * internally:
+ *
  * - surface is constructed before inspection so the shared interaction
  *   reducer exists as a concrete instance (inspection no longer closes over
  *   a later surface binding);
@@ -53,7 +66,6 @@ export type InteractionStates = {
  * getters) are wired internally — hosts never see them.
  */
 export type InteractionStatesOptions = {
-  readonly zoom: PlotZoomStateOptions;
   readonly interval: Pick<IntervalStateOptions, "consumptionCandidates">;
   readonly surface: Pick<
     SurfaceStateOptions,
@@ -62,53 +74,75 @@ export type InteractionStatesOptions = {
   readonly inspection: Omit<InspectionStateOptions, "reducer">;
 };
 
+/** Phase-1 result: zoom (consumed by the host's legend-filter / runtime
+ * chain) plus the phase-2 completion hook. */
+export type InteractionAssembly = {
+  readonly zoom: PlotZoomState;
+  /**
+   * Phase 2 — call once the runtime and semantic-key service exist (SSR
+   * evaluates deriveds eagerly at construction, so model-reading controllers
+   * must be constructed after the runtime). Constructs selection → interval
+   * → surface → inspection and returns the full bundle.
+   */
+  complete(options: InteractionStatesOptions): InteractionStates;
+};
+
 /**
- * Construct all five interaction controllers. Call once during component
- * init (controllers register $derived/$effect in the calling effect tree).
+ * Phase 1: construct the zoom controller (model-free at construction) and
+ * return the assembly handle. Call `complete` after the host runtime exists.
+ * Call once during component init (controllers register $derived/$effect in
+ * the calling effect tree).
  */
-export function createInteractionStates(
+export function createInteractionAssembly(
   context: InteractionContext,
-  options: InteractionStatesOptions,
-): InteractionStates {
-  // Sibling ports close over these bindings; assigned in topological order
-  // below and read only at handler time, never during construction.
-  let interval: IntervalState;
-  let inspection: InspectionState;
-
+  options: { readonly zoom: PlotZoomStateOptions },
+): InteractionAssembly {
   const zoom = createPlotZoomState(context, options.zoom);
-  const selection = createSelectionState(context);
 
-  interval = createIntervalState(context, {
-    consumptionCandidates: options.interval.consumptionCandidates,
-    effectiveZoomDomains: () => zoom.effectiveZoomDomains,
-    commitZoom: (domains, source) => {
-      zoom.commitZoom(domains, source);
-    },
-    inspectionPanel: () => inspection.inspectionPanel,
-    emitSelection: (event) => {
-      selection.emitSelection(event);
-    },
-  });
+  return {
+    zoom,
+    complete(phase2: InteractionStatesOptions): InteractionStates {
+      // Sibling ports close over these bindings; assigned in topological
+      // order below and read only at handler time, never during construction.
+      let interval: IntervalState;
+      let inspection: InspectionState;
 
-  const surface = createSurfaceState(context, {
-    ...options.surface,
-    inspection: () => inspection,
-    interval: () => interval,
-    zoom: () => zoom,
-    emitSelection: (event) => {
-      selection.emitSelection(event);
-    },
-    togglePointKeys: (keys, source) => {
-      selection.togglePointKeys(keys, source);
-    },
-  });
+      const selection = createSelectionState(context);
 
-  inspection = createInspectionState(context, {
-    ...options.inspection,
-    // Concrete reducer — surface is already constructed, so inspection no
-    // longer closes over a later surface binding (was `let surfaceState!`).
-    reducer: surface.reducer,
-  });
+      interval = createIntervalState(context, {
+        consumptionCandidates: phase2.interval.consumptionCandidates,
+        effectiveZoomDomains: () => zoom.effectiveZoomDomains,
+        commitZoom: (domains, source) => {
+          zoom.commitZoom(domains, source);
+        },
+        inspectionPanel: () => inspection.inspectionPanel,
+        emitSelection: (event) => {
+          selection.emitSelection(event);
+        },
+      });
 
-  return { zoom, selection, interval, surface, inspection };
+      const surface = createSurfaceState(context, {
+        ...phase2.surface,
+        inspection: () => inspection,
+        interval: () => interval,
+        zoom: () => zoom,
+        emitSelection: (event) => {
+          selection.emitSelection(event);
+        },
+        togglePointKeys: (keys, source) => {
+          selection.togglePointKeys(keys, source);
+        },
+      });
+
+      inspection = createInspectionState(context, {
+        ...phase2.inspection,
+        // Concrete reducer — surface is already constructed, so inspection
+        // no longer closes over a later surface binding (was `let
+        // surfaceState!`).
+        reducer: surface.reducer,
+      });
+
+      return { zoom, selection, interval, surface, inspection };
+    },
+  };
 }

--- a/packages/svelte/src/lib/interaction/interaction-states.svelte.ts
+++ b/packages/svelte/src/lib/interaction/interaction-states.svelte.ts
@@ -52,7 +52,7 @@ import { createPlotZoomState } from "../zoom/zoom-state.svelte.js";
 import type { InteractionContext } from "./interaction-context.svelte.js";
 
 /** The five interaction controllers, keyed by role. */
-export type InteractionStates = {
+type InteractionStates = {
   readonly zoom: PlotZoomState;
   readonly selection: SelectionState;
   readonly interval: IntervalState;
@@ -65,7 +65,7 @@ export type InteractionStates = {
  * ports (reducer, emitSelection, commitZoom, inspection/interval/zoom
  * getters) are wired internally — hosts never see them.
  */
-export type InteractionStatesOptions = {
+type InteractionStatesOptions = {
   readonly interval: Pick<IntervalStateOptions, "consumptionCandidates">;
   readonly surface: Pick<
     SurfaceStateOptions,

--- a/packages/svelte/src/lib/interval/interval-state.svelte.ts
+++ b/packages/svelte/src/lib/interval/interval-state.svelte.ts
@@ -21,22 +21,18 @@
 import {
   decodeKey,
   encodeKey,
-  type CandidateFacts,
-  type RenderModel,
   type ScenePanel,
   type SemanticViewportSelection,
 } from "@ggsvelte/core";
 import type { TemporalScaleKind } from "@ggsvelte/spec";
 
-import type { PlotInteractionController } from "../interaction/controller.svelte.js";
+import type { InteractionContext } from "../interaction/interaction-context.svelte.js";
 import type {
   InteractionSource,
   IntervalSelection,
   PlotInteractionInterval,
-  PlotInteractionScope,
   PlotSelection,
   ReadonlyIntervalDomains,
-  ResolvedInteractionConfig,
   SemanticIntervalAxis,
 } from "../interaction/interaction.js";
 import { createIntervalScopedStore } from "../interaction/scoped-store.svelte.js";
@@ -60,33 +56,27 @@ import { boundsEditorInputForScale, semanticAxisFromBounds } from "./precise-bou
 // Public types
 // ---------------------------------------------------------------------------
 
-export type IntervalStateDeps = {
-  model: () => RenderModel | null;
-  interaction: () => PlotInteractionController<PropertyKey> | undefined;
-  resolvedInteractionScope: () => PlotInteractionScope;
-  /** Narrow getter over `interactionConfig.select`. */
-  selectConfig: () => ResolvedInteractionConfig["select"];
-  /** Host alias over the S4 zoom controller (construction-safe). */
-  effectiveZoomDomains: () => ContinuousZoomDomains | null;
-  /** S4 controller write path for the bounds-editor zoom branch (stable fn). */
-  commitZoom: (domains: ContinuousZoomDomains | null, source: InteractionSource) => void;
-  captureSurface: () => HTMLDivElement | null;
-  /** Used by the precise-bounds lineage projection. */
-  candidateSemanticKeys: (candidate: CandidateFacts) => PropertyKey[];
+/**
+ * Interval-specific ports beyond the shared InteractionContext. Sibling
+ * controllers are wired by the assembly (interaction-states.svelte.ts).
+ */
+export type IntervalStateOptions = {
+  /** Alias over the zoom controller (construction-safe). */
+  readonly effectiveZoomDomains: () => ContinuousZoomDomains | null;
+  /** Zoom controller write path for the bounds-editor zoom branch (stable fn). */
+  readonly commitZoom: (domains: ContinuousZoomDomains | null, source: InteractionSource) => void;
   /**
    * Deferred semantic Candidate view for non-union interval consumption.
    * Projection ownership stays outside interval behavior.
    */
-  consumptionCandidates: () => readonly IntervalConsumptionCandidate<PropertyKey>[];
+  readonly consumptionCandidates: () => readonly IntervalConsumptionCandidate<PropertyKey>[];
   /**
-   * Handler-only: `openBoundsEditor` select branch reads the host's inspection
-   * panel id as its fallback target. Host derived is earlier than the factory
-   * and returns bounds + id (or null).
+   * Handler-only: `openBoundsEditor` select branch reads the inspection
+   * controller's panel id as its fallback target.
    */
-  inspectionPanel: () => Readonly<{ id: string }> | null;
-  /** Hoisted host fn (shared with point selection until S7/S8). */
-  emitSelection: (event: PlotSelection) => void;
-  announce: (message: string) => void;
+  readonly inspectionPanel: () => Readonly<{ id: string }> | null;
+  /** Selection controller write path (stable fn). */
+  readonly emitSelection: (event: PlotSelection) => void;
 };
 
 export type IntervalState = {
@@ -161,14 +151,17 @@ function viewportSelection(domains: ReadonlyIntervalDomains): SemanticViewportSe
  * construction (original host positions relative to the runtime model effects
  * and the later semantic-key diagnostics effects).
  */
-export function createIntervalState(deps: IntervalStateDeps): IntervalState {
+export function createIntervalState(
+  context: InteractionContext,
+  options: IntervalStateOptions,
+): IntervalState {
   let committedInterval = $state<IntervalSelection | null>(null);
   // Semantic snapshot of the record backing `committedInterval`, so external
   // same-panel replacements are detected by content, not just presence.
   let committedIntervalRecord = $state<PlotInteractionInterval<PropertyKey> | null>(null);
   const committedIntervals = createIntervalScopedStore({
-    controller: deps.interaction,
-    scope: deps.resolvedInteractionScope,
+    controller: context.interaction,
+    scope: context.resolvedInteractionScope,
   });
   let boundsEditor = $state<{
     action: "select" | "zoom";
@@ -181,7 +174,7 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
   const effectiveIntervals = $derived(committedIntervals.value);
 
   const effectiveIntervalKeys: readonly PropertyKey[] = $derived.by(() => {
-    const model = deps.model();
+    const model = context.model();
     if (model === null || effectiveIntervals.length === 0) return [];
     // Union consumes only stored record keys, and this derived re-runs on
     // every controller revision — skip the O(candidates) semantic projection
@@ -196,7 +189,7 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
     return consumeIntervalKeys({
       records: effectiveIntervals,
       panels: model.scene.panels,
-      candidates: deps.consumptionCandidates(),
+      candidates: options.consumptionCandidates(),
     });
   });
 
@@ -212,7 +205,7 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
   });
 
   const currentIntervalPanel = $derived.by((): ScenePanel | undefined => {
-    const model = deps.model();
+    const model = context.model();
     if (currentIntervalRecord === null || model === null) {
       // Explicit undefined keeps consistent-return happy on the .ts surface
       // (host .svelte used bare `return`; type-aware lint only runs on .ts).
@@ -240,7 +233,7 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
 
   function intervalPanelLabel(panel: ScenePanel): string {
     const display = panel.strip.trim() || "panel";
-    const model = deps.model();
+    const model = context.model();
     if (
       model === null ||
       model.scene.panels.filter((candidate) => candidate.strip.trim() === panel.strip.trim())
@@ -254,7 +247,7 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
   }
 
   const currentIntervalTargetLabel = $derived.by((): string | undefined => {
-    if (currentIntervalRecord === null || deps.model() === null) {
+    if (currentIntervalRecord === null || context.model() === null) {
       return undefined;
     }
     if (currentIntervalPanel === undefined) return "unavailable panel";
@@ -269,8 +262,8 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
 
   const boundsEditorInput = $derived.by((): BoundsEditorInput | null => {
     const editor = boundsEditor;
-    if (editor === null || deps.model() === null) return null;
-    const model = deps.model()!;
+    if (editor === null || context.model() === null) return null;
+    const model = context.model()!;
     // Axis guide plans carry temporalKind (including monthDay); the trained
     // continuous scale does not. Use the first matching axis plan so the
     // bounds editor can format drafts without the reference year.
@@ -286,7 +279,7 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
       if (viewportPanel === undefined) return null;
       const scale = viewportPanel.axisEditModel(editor.axis);
       if (scale.kind === "band") return null;
-      const bounds = deps.effectiveZoomDomains()?.[editor.axis] ?? scale.domain;
+      const bounds = options.effectiveZoomDomains()?.[editor.axis] ?? scale.domain;
       return boundsEditorInputForScale({
         axis: editor.axis,
         action: "zoom",
@@ -324,8 +317,8 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
     // capture surface is the stable recovery target for reactive cancellation;
     // explicit Apply/Cancel still restores the initiating button.
     queueMicrotask(() => {
-      deps.captureSurface()?.focus();
-      deps.announce(`Bounds editing cancelled because ${target} is no longer available.`);
+      context.captureSurface()?.focus();
+      context.announce(`Bounds editing cancelled because ${target} is no longer available.`);
     });
   });
 
@@ -339,7 +332,7 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
     committedIntervals.clear(source);
     const event = clearIntervalSelectionEvent(
       current ?? {
-        mode: deps.selectConfig()?.mode ?? "xy",
+        mode: context.selectConfig()?.mode ?? "xy",
         panelId: null,
         pixels: { x0: 0, y0: 0, x1: 0, y1: 0 },
       },
@@ -347,7 +340,7 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
     );
     committedInterval = null;
     committedIntervalRecord = null;
-    deps.emitSelection(event);
+    options.emitSelection(event);
   }
 
   function clearCurrentPanelInterval(source: InteractionSource): void {
@@ -356,7 +349,7 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
     committedIntervals.remove(intervalPanelId, source);
     const event = clearIntervalSelectionEvent(
       committedInterval ?? {
-        mode: deps.selectConfig()?.mode ?? "xy",
+        mode: context.selectConfig()?.mode ?? "xy",
         panelId: intervalPanelId,
         pixels: { x0: 0, y0: 0, x1: 0, y1: 0 },
       },
@@ -364,7 +357,7 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
     );
     committedInterval = null;
     committedIntervalRecord = null;
-    deps.emitSelection(event);
+    options.emitSelection(event);
   }
 
   function semanticAxis(
@@ -372,8 +365,8 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
     axis: "x" | "y",
     bounds: readonly [unknown, unknown] | undefined,
   ): SemanticIntervalAxis | undefined {
-    if (bounds === undefined || deps.model() === null) return undefined;
-    const viewportPanel = deps.model()!.viewport.panel(panelId);
+    if (bounds === undefined || context.model() === null) return undefined;
+    const viewportPanel = context.model()!.viewport.panel(panelId);
     if (viewportPanel === null) return undefined;
     const scale = viewportPanel.axisEditModel(axis);
     if (scale.kind === "band") {
@@ -400,7 +393,7 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
     targetPanelId: string,
     domains: ReadonlyIntervalDomains,
   ): { readonly keys: readonly PropertyKey[]; readonly lineageCount: number } {
-    const model = deps.model();
+    const model = context.model();
     if (model === null) return { keys: Object.freeze([]), lineageCount: 0 };
     type ProjectionCandidate =
       RecomputePanelIntervalProjectionInput<PropertyKey>["candidates"][number];
@@ -416,7 +409,7 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
         panelId: candidate.panelId,
         xValue: candidate.xValue,
         yValue: candidate.yValue,
-        keys: deps.candidateSemanticKeys(candidate),
+        keys: context.candidateSemanticKeys(candidate),
         sourceRows,
       });
     }
@@ -430,8 +423,8 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
   /** Private — no remaining external consumer (codex P2-7). */
   function commitIntervalSelection(event: IntervalSelection, source: InteractionSource): void {
     const targetPanelId = event.panelId;
-    if (targetPanelId === null || deps.model() === null) return;
-    const model = deps.model()!;
+    if (targetPanelId === null || context.model() === null) return;
+    const model = context.model()!;
     if (model.viewport.panel(targetPanelId) === null) return;
     const x = semanticAxis(targetPanelId, "x", event.domain.x);
     const y = semanticAxis(targetPanelId, "y", event.domain.y);
@@ -441,7 +434,7 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
     if (x === undefined && y === undefined) return;
     const record: PlotInteractionInterval<PropertyKey> = Object.freeze({
       panelId: targetPanelId,
-      preset: deps.selectConfig()?.preset ?? "independent",
+      preset: context.selectConfig()?.preset ?? "independent",
       domains: Object.freeze({
         ...(x !== undefined && { x }),
         ...(y !== undefined && { y }),
@@ -454,7 +447,7 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
 
   function finishBrushSelect(eventValue: IntervalSelection, source: InteractionSource): void {
     // Snapshot once (drift-safe under reactive selectConfig replacement).
-    const persistent = deps.selectConfig()?.persistent;
+    const persistent = context.selectConfig()?.persistent;
     committedInterval = persistentSelectionOrNull(persistent, eventValue);
     // TRUTHY guard — untyped JS consumers may pass truthy non-boolean
     // `persistent` values, which the config normalizer forwards unchanged.
@@ -462,7 +455,7 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
     // truthiness is identical.
     if (persistent ?? false) commitIntervalSelection(eventValue, source);
     // Emit after writes so listeners observe committed state (load-bearing).
-    deps.emitSelection(eventValue);
+    options.emitSelection(eventValue);
   }
 
   function openBoundsEditor(
@@ -472,11 +465,11 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
   ): void {
     boundsReturnFocus = trigger;
     if (action === "select") {
-      const model = deps.model();
+      const model = context.model();
       const panel =
         currentIntervalRecord === null
           ? (() => {
-              const inspectionTarget = deps.inspectionPanel();
+              const inspectionTarget = options.inspectionPanel();
               if (inspectionTarget !== null && model !== null) {
                 return model.scene.panels.find((candidate) => candidate.id === inspectionTarget.id);
               }
@@ -498,9 +491,9 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
   function applyPreciseBounds(event: PreciseBoundsApplyEvent): void {
     if (event.action === "zoom") {
       if (event.scale === "band") return;
-      deps.commitZoom(
+      options.commitZoom(
         frozenZoomDomains({
-          ...deps.effectiveZoomDomains(),
+          ...options.effectiveZoomDomains(),
           [event.axis]: [...event.bounds],
         }),
         event.inputSource,
@@ -510,8 +503,8 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
     }
     const prior = currentIntervalRecord;
     const targetPanelId = prior?.panelId ?? boundsEditor?.panelId;
-    if (targetPanelId === null || targetPanelId === undefined || deps.model() === null) return;
-    const model = deps.model()!;
+    if (targetPanelId === null || targetPanelId === undefined || context.model() === null) return;
+    const model = context.model()!;
     if (model.viewport.panel(targetPanelId) === null) return;
     const axis = semanticAxis(targetPanelId, event.axis, event.bounds);
     if (axis === undefined) return;
@@ -524,14 +517,14 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
     const { keys, lineageCount } = recomputePanelIntervalSelection(targetPanelId, domains);
     const next: PlotInteractionInterval<PropertyKey> = Object.freeze({
       panelId: targetPanelId,
-      preset: prior?.preset ?? deps.selectConfig()?.preset ?? "independent",
+      preset: prior?.preset ?? context.selectConfig()?.preset ?? "independent",
       domains,
       keys,
     });
     // Precise bounds persist exactly like the brush path: with
     // `persistent: false` the end event still fires, but no durable record,
     // committed rectangle, or clear-selection controls appear.
-    const persistent = deps.selectConfig()?.persistent === true;
+    const persistent = context.selectConfig()?.persistent === true;
     if (persistent) {
       committedIntervalRecord = next;
       committedIntervals.upsert(next, event.inputSource);
@@ -541,7 +534,7 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
     const selection = viewportSelection(domains);
     const eventValue = buildIntervalSelection({
       phase: "end",
-      mode: deps.selectConfig()?.mode ?? "xy",
+      mode: context.selectConfig()?.mode ?? "xy",
       panelId: targetPanelId,
       domain: viewportPanel.resolve(selection),
       // The overlay must depict the interval that was actually applied, so
@@ -552,8 +545,8 @@ export function createIntervalState(deps: IntervalStateDeps): IntervalState {
       lineageCount,
       source: event.inputSource,
     });
-    committedInterval = persistentSelectionOrNull(deps.selectConfig()?.persistent, eventValue);
-    deps.emitSelection(eventValue);
+    committedInterval = persistentSelectionOrNull(context.selectConfig()?.persistent, eventValue);
+    options.emitSelection(eventValue);
     boundsEditor = null;
   }
 

--- a/packages/svelte/src/lib/plot-engine.svelte.ts
+++ b/packages/svelte/src/lib/plot-engine.svelte.ts
@@ -11,29 +11,25 @@
  *
  * Construction / effect-order contract
  * ------------------------------------
- * Construction order is the topological order of direct construction-time
- * reads; effect registration sequence is load-bearing. Deferred thunks break
- * the runtime cycles (surface ↔ inspection ↔ interval ↔ selection). This
- * module preserves the pre-S11 top-to-bottom declaration order from GGPlot.
+ * The five interaction controllers (zoom / selection / interval / surface /
+ * inspection) are constructed by the interaction assembly
+ * (interaction/interaction-states.svelte.ts), which owns their topological
+ * order and sibling ports internally. Shared deps flow through one
+ * InteractionContext (interaction/interaction-context.svelte.ts) instead of
+ * per-factory hand-wired bags. Leaf modules register their own effects at
+ * construction; the engine only wires host-held deriveds into catalog
+ * reconcile where data is not available at leaf construction time.
  *
  * Residual late bindings (definite-assignment / late hooks only where the
  * cycle is real):
- * - surfaceState! — inspection needs the surface reducer; surface needs
- *   inspection handlers
  * - semanticCandidateProjection! — interval consumptionCandidates close over
- *   the projection built after legend focus
+ *   the projection, which itself reads the assembled states
  * - legendFocusState.installHostDerivedEffects() — host $derived entry lists
  *   require this factory's compute* methods (#627)
  *
  * Surface tool enablement (`availableTools`, point-select) is host-derived
- * before surface construction so chrome is not a surface construction-time
- * dep (#1082). Chrome recomputes the same pure formulas for UI consumers.
- *
- * Cross-module transition side effects (e.g. inspection dismiss → brush/tool)
- * are applied via `applyInspectionDismissSideEffects` at the surface call site
- * (#627). Leaf modules register their own effects at construction; the engine
- * only wires host-held deriveds into catalog reconcile where data is not
- * available at leaf construction time.
+ * before the assembly so chrome is not a surface construction-time dep
+ * (#1082). Chrome recomputes the same pure formulas for UI consumers.
  *
  * Call `createPlotEngine` once during component init so every `$effect`
  * registers in the component effect tree. No `$props`, `$props.id()`, or
@@ -74,6 +70,8 @@ import {
   type PlotInteractionScope,
   type ResolvedInteractionConfig,
 } from "./interaction/interaction.js";
+import { resolveInteractionContext } from "./interaction/interaction-context.svelte.js";
+import { createInteractionStates } from "./interaction/interaction-states.svelte.js";
 import {
   createCapabilityResolution,
   ssrSafeDerived,
@@ -83,9 +81,7 @@ import {
   duplicateInspectCapabilityDiagnostics,
 } from "./interaction/resolve-inspect-capability.js";
 import { collectWiringDiagnostics } from "./interaction/wiring-advisories.js";
-import { createInspectionState } from "./inspection/inspection-state.svelte.js";
 import type { InspectionState } from "./inspection/inspection-state.svelte.js";
-import { createIntervalState } from "./interval/interval-state.svelte.js";
 import type { IntervalState } from "./interval/interval-state.svelte.js";
 import { createLegendEntryKeyIndex } from "./legend/entry-key-index.svelte.js";
 import { createLegendFilterState } from "./legend/filter-state.svelte.js";
@@ -115,11 +111,7 @@ import {
   dataIdentityEpochToken,
 } from "./runtime/semantic-data-identity.js";
 import { createSourceIdentityTracker } from "./runtime/semantic-source-identity.js";
-import {
-  createSemanticKeyService,
-  type SemanticKeyService,
-} from "./runtime/semantic-keys.svelte.js";
-import { createSelectionState } from "./selection/selection-state.svelte.js";
+import { createSemanticKeyService } from "./runtime/semantic-keys.svelte.js";
 import type { SelectionState } from "./selection/selection-state.svelte.js";
 import {
   hoverChromeForKind,
@@ -131,9 +123,7 @@ import {
   glyphExtentsFromBatch,
   type CrosshairGapBox,
 } from "./scene/geometry.js";
-import { createSurfaceState } from "./surface/surface-state.svelte.js";
 import type { SurfaceState } from "./surface/surface-state.svelte.js";
-import { createPlotZoomState } from "./zoom/zoom-state.svelte.js";
 import type { PlotZoomState } from "./zoom/zoom-state.svelte.js";
 
 // ---------------------------------------------------------------------------
@@ -494,23 +484,76 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
     announcer.announce(message);
   };
 
-  // Construction order is the topological order of direct construction-time
-  // reads. Cross-module dismiss tails go through transition-owner at the
-  // surface call site; leaf effects register at construction (#627).
+  // Cross-module dismiss tails go through transition-owner at the surface
+  // call site; leaf effects register at construction (#627). The interaction
+  // assembly owns controller construction order.
 
-  // ------------------------------------------------------------ zoom respec
-  // Construction-time deriveds read interaction/scope/zoomConfig/assembled
-  // only — model/announce are deferred getters (later-declared).
-  const zoomState = createPlotZoomState({
+  // ------------------------------------------------- interaction deriveds
+  // Shared enablement predicates (avoid re-typing the same config gates).
+  const interactive = $derived(interactionConfig().interactive);
+  const surfaceInteractive = $derived(interactionConfig().availableTools.length > 0);
+  const inspectEnabled = $derived(interactionConfig().inspect !== null);
+  const legendFocusEnabled = $derived(interactionConfig().legendFocus !== null);
+  const coordFlipped = $derived(assembled()?.coord?.type === "flip");
+  let tooltipHovered = $state(false);
+
+  // ------------------------------------------------- interaction context
+  // One shared bag replaces the ~60 hand-wired dep fields the five controller
+  // factories used to declare individually. Model / semantic-key getters are
+  // handler-only deferred closures over later declarations (runtime,
+  // semanticKeys) — never read at construction.
+  const interactionContext = resolveInteractionContext({
+    model: () => runtime.model,
+    root: host.root,
+    captureSurface: host.captureSurface,
     interaction: () => host.props.interaction,
     resolvedInteractionScope: () => resolvedInteractionScope,
-    zoomConfig: () => interactionConfig().zoom,
-    assembled,
-    // Model is declared after the runtime; handlers only.
-    model: () => runtime.model,
-    onzoom: () => host.props.onzoom,
-    oninteraction: () => host.props.oninteraction,
+    selectConfig: () => interactionConfig().select,
+    inspectConfig: () => interactionConfig().inspect,
+    tooltipHovered: () => tooltipHovered,
     announce: announceSink,
+    oninteraction: () => host.props.oninteraction,
+    oninspect: () => host.props.oninspect,
+    onselect: () => host.props.onselect,
+    onzoom: () => host.props.onzoom,
+    ontoolchange: () => host.props.ontoolchange,
+    keyAt: (index) => semanticKeys.keyAt(index),
+    semanticKey: (row, index) => semanticKeys.semanticKey(row, index),
+    candidateSemanticKeys: (candidate) => semanticKeys.candidateSemanticKeys(candidate),
+  });
+
+  // ------------------------------------------------- interaction assembly
+  // zoom → selection → interval → surface → inspection, with sibling ports
+  // wired inside the assembly. The projection is the one remaining late
+  // binding: interval consumption closes over it, and it needs the assembled
+  // states — handler-only reads (#165 pattern).
+  let semanticCandidateProjection!: ReturnType<typeof createSemanticCandidateProjection>;
+  const states = createInteractionStates(interactionContext, {
+    zoom: {
+      zoomConfig: () => interactionConfig().zoom,
+      assembled,
+    },
+    interval: {
+      consumptionCandidates: () => semanticCandidateProjection.intervalConsumptionCandidates,
+    },
+    surface: {
+      toolProp: () => host.props.tool,
+      initialTool: () => interactionConfig().initialTool,
+      availableTools: () => surfaceAvailableTools,
+      pointSelectEnabled: () => surfacePointSelectEnabled,
+      surfaceInteractive: () => surfaceInteractive,
+    },
+    inspection: {
+      inspectEnabled: () => inspectEnabled,
+      dataIdentityEpoch: () => dataIdentityEpoch,
+      plotId: () => host.plotId,
+      clearTooltipHovered: () => {
+        tooltipHovered = false;
+      },
+      clearAnnouncement: () => {
+        announcer.clear();
+      },
+    },
   });
 
   // Source identity/order epoch: O(R) row-ref order over data/spec *props*
@@ -540,7 +583,7 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
   // Construction-time deriveds read legendFilter/effectiveSpec only —
   // model is deferred (declared after the runtime).
   const legendFilterState = createLegendFilterState({
-    effectiveSpec: () => zoomState.effectiveSpec,
+    effectiveSpec: () => states.zoom.effectiveSpec,
     // GuideLegend children (or deprecated plot prop) — not plot prop alone.
     legendFilterProp: () => legendFilterResolved().configInput,
     onlegendfilter: () => host.props.onlegendfilter,
@@ -553,18 +596,18 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
   });
 
   // ------------------------------------------------- plot runtime
-  // Factory sits after zoom-respec and legend-filter so every direct
+  // Factory sits after the interaction assembly and legend-filter so every direct
   // construction-time dep is already initialized (TDZ).
   const runtime = createPlotRuntime({
     widthProp: () => host.props.width,
     heightProp: () => host.props.height,
     assembled,
-    effectiveSpec: () => zoomState.effectiveSpec,
-    effectiveZoomDomains: () => zoomState.effectiveZoomDomains,
+    effectiveSpec: () => states.zoom.effectiveSpec,
+    effectiveZoomDomains: () => states.zoom.effectiveZoomDomains,
     effectiveLegendFilters: () => legendFilterState.filters,
     root: host.root,
     resetZoom: () => {
-      zoomState.resetForScales();
+      states.zoom.resetForScales();
     },
     onrender: () => host.props.onrender,
   });
@@ -580,10 +623,6 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
     sourceIdentity: (value: unknown) => identityTracker.sourceIdentity(value),
     deliverDiagnostic,
   });
-  const semanticKey: SemanticKeyService["semanticKey"] = (...args) =>
-    semanticKeys.semanticKey(...args);
-  const candidateSemanticKeys: SemanticKeyService["candidateSemanticKeys"] = (...args) =>
-    semanticKeys.candidateSemanticKeys(...args);
 
   // Legend entry → key index (lifted from semantic-keys in S16). Same relative
   // construction position as the derived it replaces — after semanticKeys,
@@ -593,84 +632,13 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
     keyAt: (i) => semanticKeys.keyAt(i),
   });
 
-  // ---------------------------------------------------------- interaction
   // source rows/spec -> pipeline/scene + CandidateStore -> semantic resolver
   // -> chart-local reducer -> tooltip/crosshair/tools/callbacks. Presentation
   // consumes one resolved inspection and never reconstructs grouping itself.
-  const interactive = $derived(interactionConfig().interactive);
-  const surfaceInteractive = $derived(interactionConfig().availableTools.length > 0);
 
-  // Shared enablement predicates (avoid re-typing the same config gates).
-  const inspectEnabled = $derived(interactionConfig().inspect !== null);
-  const legendFocusEnabled = $derived(interactionConfig().legendFocus !== null);
-  const coordFlipped = $derived(assembled()?.coord?.type === "flip");
-  let tooltipHovered = $state(false);
-
-  // ------------------------------------------------- selection
-  // Before surface so emit/toggle are direct (not deferred sibling getters).
-  const selectionState = createSelectionState({
-    interaction: () => host.props.interaction,
-    resolvedInteractionScope: () => resolvedInteractionScope,
-    selectConfig: () => interactionConfig().select,
-    onselect: () => host.props.onselect,
-    oninteraction: () => host.props.oninteraction,
-    announce: announceSink,
-  });
-
-  // ------------------------------------------------- inspection
-  // Reducer is still owned by surface (created next). Inspection takes a
-  // deferred reducer getter only for that TDZ edge; clearBrush/chooseTool are
-  // NOT wired here — surface applies dismiss plan tails via transition-owner.
-  let surfaceState!: ReturnType<typeof createSurfaceState>;
-  const inspectionState = createInspectionState({
-    model: () => runtime.model,
-    reducer: () => surfaceState.reducer,
-    inspectConfig: () => interactionConfig().inspect,
-    inspectEnabled: () => inspectEnabled,
-    dataIdentityEpoch: () => dataIdentityEpoch,
-    keyAt: (index) => semanticKeys.keyAt(index),
-    root: host.root,
-    captureSurface: host.captureSurface,
-    plotId: () => host.plotId,
-    tooltipHovered: () => tooltipHovered,
-    clearTooltipHovered: () => {
-      tooltipHovered = false;
-    },
-    oninspect: () => host.props.oninspect,
-    oninteraction: () => host.props.oninteraction,
-    announce: announceSink,
-    clearAnnouncement: () => {
-      announcer.clear();
-    },
-  });
-
-  // ------------------------------------------------- interval selection
-  // Before surface so finishBrushSelect is a direct ref (not deferred).
-  // consumptionCandidates still late-binds the projection module.
-  let semanticCandidateProjection!: ReturnType<typeof createSemanticCandidateProjection>;
-  const intervalState = createIntervalState({
-    model: () => runtime.model,
-    interaction: () => host.props.interaction,
-    resolvedInteractionScope: () => resolvedInteractionScope,
-    selectConfig: () => interactionConfig().select,
-    effectiveZoomDomains: () => zoomState.effectiveZoomDomains,
-    commitZoom: (...args: Parameters<PlotZoomState["commitZoom"]>) => {
-      zoomState.commitZoom(...args);
-    },
-    captureSurface: host.captureSurface,
-    candidateSemanticKeys: (candidate) => candidateSemanticKeys(candidate),
-    consumptionCandidates: () => semanticCandidateProjection.intervalConsumptionCandidates,
-    inspectionPanel: () => inspectionState.inspectionPanel,
-    emitSelection: (...args: Parameters<SelectionState["emitSelection"]>) => {
-      selectionState.emitSelection(...args);
-    },
-    announce: announceSink,
-  });
-
-  // ------------------------------------------------- surface
-  // Inspection + interval + selection already constructed — no sibling TDZ
-  // getters for those. Tool enablement is host-derived (same pure formulas as
-  // chrome) so surface does not close over later chromeState (#1082).
+  // Surface tool enablement is host-derived (same pure formulas as chrome) so
+  // surface does not close over later chromeState (#1082). Declared after the
+  // runtime (direct model read); the assembly reads them lazily via options.
   const surfaceAvailableTools = $derived(
     resolveFilteredAvailableTools(
       interactionConfig().availableTools,
@@ -679,31 +647,6 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
     ),
   );
   const surfacePointSelectEnabled = $derived(canPublishPointSelection(interactionConfig().select));
-  surfaceState = createSurfaceState({
-    model: () => runtime.model,
-    root: host.root,
-    toolProp: () => host.props.tool,
-    initialTool: () => interactionConfig().initialTool,
-    availableTools: () => surfaceAvailableTools,
-    inspectConfig: () => interactionConfig().inspect,
-    selectConfig: () => interactionConfig().select,
-    pointSelectEnabled: () => surfacePointSelectEnabled,
-    ontoolchange: () => host.props.ontoolchange,
-    surfaceInteractive: () => surfaceInteractive,
-    candidateSemanticKeys: (candidate) => candidateSemanticKeys(candidate),
-    inspection: () => inspectionState,
-    interval: () => intervalState,
-    zoom: () => zoomState,
-    emitSelection: (event) => {
-      selectionState.emitSelection(event);
-    },
-    semanticKey: (row, index) => semanticKey(row, index),
-    togglePointKeys: (keys, source) => {
-      selectionState.togglePointKeys(keys, source);
-    },
-    tooltipHovered: () => tooltipHovered,
-    announce: announceSink,
-  });
 
   // ------------------------------------------------- legend focus
   // Host-held entry lists are $derived after this factory; effects that read
@@ -724,14 +667,14 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
   });
   semanticCandidateProjection = createSemanticCandidateProjection({
     model: () => runtime.model,
-    candidateSemanticKeys: (candidate) => candidateSemanticKeys(candidate),
-    selectedKeys: () => selectionState.effectiveSelectedKeys,
-    intervalKeys: () => intervalState.effectiveIntervalKeys,
-    intervals: () => intervalState.effectiveIntervals,
+    candidateSemanticKeys: (candidate) => semanticKeys.candidateSemanticKeys(candidate),
+    selectedKeys: () => states.selection.effectiveSelectedKeys,
+    intervalKeys: () => states.interval.effectiveIntervalKeys,
+    intervals: () => states.interval.effectiveIntervals,
     emphasisKeys: () => legendFocusState.effectiveEmphasisKeys,
     muteSiblingsOnInspect: () => interactionConfig().inspect?.muteSiblings === true,
     // Inspection owns the projection (#1080); wiring no longer re-assembles it.
-    inspectionFocus: () => inspectionState.presentationFocus,
+    inspectionFocus: () => states.inspection.presentationFocus,
   });
   // ------------------------------------------------- plot chrome
   // All host bindings earlier-declared. Pure construction-time deriveds —
@@ -745,9 +688,9 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
     configuredAvailableTools: () => interactionConfig().availableTools,
     interactionDiagnostics: () => interactionConfig().diagnostics,
     interactive: () => interactive,
-    effectiveZoomDomains: () => zoomState.effectiveZoomDomains,
-    effectiveIntervals: () => intervalState.effectiveIntervals,
-    effectiveSelectedKeys: () => selectionState.effectiveSelectedKeys,
+    effectiveZoomDomains: () => states.zoom.effectiveZoomDomains,
+    effectiveIntervals: () => states.interval.effectiveIntervals,
+    effectiveSelectedKeys: () => states.selection.effectiveSelectedKeys,
     effectiveEmphasisKeys: () => legendFocusState.effectiveEmphasisKeys,
     legendFocusEnabled: () => legendFocusEnabled,
     hasCanvas: () => runtime.hasCanvas,
@@ -811,7 +754,7 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
     readonly height: number;
     readonly textAnchor: "start" | "middle" | "end";
   } | null {
-    const seed = inspectionState.inspectionSeed;
+    const seed = states.inspection.inspectionSeed;
     const model = runtime.model;
     if (seed === null || model === null || seed.kind !== "glyphs") return null;
     const batch = model.scene.batches[seed.batchIndex];
@@ -826,7 +769,7 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
   const EMPTY_CROSSHAIR_GAP_OBSTACLES: readonly CrosshairGapBox[] = Object.freeze([]);
   const crosshairGapObstacles = $derived.by((): readonly CrosshairGapBox[] => {
     const model = runtime.model;
-    const panel = inspectionState.inspectionPanel;
+    const panel = states.inspection.inspectionPanel;
     if (model === null || panel === null) return EMPTY_CROSSHAIR_GAP_OBSTACLES;
     return crosshairGlyphObstacles(model.scene.batches, model.scene.panels, panel.id);
   });
@@ -835,14 +778,14 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
   legendFocusState.installHostDerivedEffects();
 
   return {
-    zoomState,
+    zoomState: states.zoom,
     legendFilterState,
     runtime,
-    inspectionState,
-    surfaceState,
-    selectionState,
+    inspectionState: states.inspection,
+    surfaceState: states.surface,
+    selectionState: states.selection,
     legendFocusState,
-    intervalState,
+    intervalState: states.interval,
     chromeState,
     announcer,
 
@@ -874,9 +817,9 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
       // Hover chrome is separate from selection/emphasis anchor rings: open
       // path strokes still gap the crosshair; rects and closed path fills
       // (areas) mute (#1270). Null inspection → default ring.
-      const focus = inspectionState.presentationFocus;
+      const focus = states.inspection.presentationFocus;
       if (focus === null) return "ring";
-      const seed = inspectionState.inspectionSeed;
+      const seed = states.inspection.inspectionSeed;
       const batch = seed === null ? undefined : runtime.model?.scene.batches[seed.batchIndex];
       const closedPath = batch?.kind === "paths" && batch.closed === true;
       return hoverChromeForKind(focus.kind, closedPath);

--- a/packages/svelte/src/lib/plot-engine.svelte.ts
+++ b/packages/svelte/src/lib/plot-engine.svelte.ts
@@ -12,11 +12,14 @@
  * Construction / effect-order contract
  * ------------------------------------
  * The five interaction controllers (zoom / selection / interval / surface /
- * inspection) are constructed by the interaction assembly
- * (interaction/interaction-states.svelte.ts), which owns their topological
- * order and sibling ports internally. Shared deps flow through one
- * InteractionContext (interaction/interaction-context.svelte.ts) instead of
- * per-factory hand-wired bags. Leaf modules register their own effects at
+ * inspection) are constructed by the two-phase interaction assembly
+ * (interaction/interaction-states.svelte.ts): phase 1 builds zoom before the
+ * legend-filter / runtime chain; phase 2 (`complete`) builds the model-
+ * reading controllers after the runtime + semantic-key service, because SSR
+ * evaluates $derived eagerly at construction. The assembly owns sibling
+ * ports internally. Shared deps flow through one InteractionContext
+ * (interaction/interaction-context.svelte.ts) instead of per-factory
+ * hand-wired bags. Leaf modules register their own effects at
  * construction; the engine only wires host-held deriveds into catalog
  * reconcile where data is not available at leaf construction time.
  *
@@ -71,7 +74,7 @@ import {
   type ResolvedInteractionConfig,
 } from "./interaction/interaction.js";
 import { resolveInteractionContext } from "./interaction/interaction-context.svelte.js";
-import { createInteractionStates } from "./interaction/interaction-states.svelte.js";
+import { createInteractionAssembly } from "./interaction/interaction-states.svelte.js";
 import {
   createCapabilityResolution,
   ssrSafeDerived,
@@ -522,37 +525,15 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
     candidateSemanticKeys: (candidate) => semanticKeys.candidateSemanticKeys(candidate),
   });
 
-  // ------------------------------------------------- interaction assembly
-  // zoom → selection → interval → surface → inspection, with sibling ports
-  // wired inside the assembly. The projection is the one remaining late
-  // binding: interval consumption closes over it, and it needs the assembled
-  // states — handler-only reads (#165 pattern).
-  let semanticCandidateProjection!: ReturnType<typeof createSemanticCandidateProjection>;
-  const states = createInteractionStates(interactionContext, {
+  // ------------------------------------------------- interaction assembly (phase 1)
+  // Zoom is the only controller the legend-filter / runtime chain reads.
+  // SSR evaluates $derived eagerly at construction, so the model-reading
+  // controllers (selection / interval / surface / inspection) must wait for
+  // the runtime — phase 2 (`complete`) runs after semanticKeys below.
+  const interactionAssembly = createInteractionAssembly(interactionContext, {
     zoom: {
       zoomConfig: () => interactionConfig().zoom,
       assembled,
-    },
-    interval: {
-      consumptionCandidates: () => semanticCandidateProjection.intervalConsumptionCandidates,
-    },
-    surface: {
-      toolProp: () => host.props.tool,
-      initialTool: () => interactionConfig().initialTool,
-      availableTools: () => surfaceAvailableTools,
-      pointSelectEnabled: () => surfacePointSelectEnabled,
-      surfaceInteractive: () => surfaceInteractive,
-    },
-    inspection: {
-      inspectEnabled: () => inspectEnabled,
-      dataIdentityEpoch: () => dataIdentityEpoch,
-      plotId: () => host.plotId,
-      clearTooltipHovered: () => {
-        tooltipHovered = false;
-      },
-      clearAnnouncement: () => {
-        announcer.clear();
-      },
     },
   });
 
@@ -583,7 +564,7 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
   // Construction-time deriveds read legendFilter/effectiveSpec only —
   // model is deferred (declared after the runtime).
   const legendFilterState = createLegendFilterState({
-    effectiveSpec: () => states.zoom.effectiveSpec,
+    effectiveSpec: () => interactionAssembly.zoom.effectiveSpec,
     // GuideLegend children (or deprecated plot prop) — not plot prop alone.
     legendFilterProp: () => legendFilterResolved().configInput,
     onlegendfilter: () => host.props.onlegendfilter,
@@ -602,12 +583,12 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
     widthProp: () => host.props.width,
     heightProp: () => host.props.height,
     assembled,
-    effectiveSpec: () => states.zoom.effectiveSpec,
-    effectiveZoomDomains: () => states.zoom.effectiveZoomDomains,
+    effectiveSpec: () => interactionAssembly.zoom.effectiveSpec,
+    effectiveZoomDomains: () => interactionAssembly.zoom.effectiveZoomDomains,
     effectiveLegendFilters: () => legendFilterState.filters,
     root: host.root,
     resetZoom: () => {
-      states.zoom.resetForScales();
+      interactionAssembly.zoom.resetForScales();
     },
     onrender: () => host.props.onrender,
   });
@@ -647,6 +628,36 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
     ),
   );
   const surfacePointSelectEnabled = $derived(canPublishPointSelection(interactionConfig().select));
+
+  // ------------------------------------------------- interaction assembly (phase 2)
+  // selection → interval → surface → inspection, sibling ports wired inside
+  // the assembly. The projection is the one remaining late binding: interval
+  // consumption closes over it, and it needs the assembled states —
+  // handler-only reads (#165 pattern).
+  let semanticCandidateProjection!: ReturnType<typeof createSemanticCandidateProjection>;
+  const states = interactionAssembly.complete({
+    interval: {
+      consumptionCandidates: () => semanticCandidateProjection.intervalConsumptionCandidates,
+    },
+    surface: {
+      toolProp: () => host.props.tool,
+      initialTool: () => interactionConfig().initialTool,
+      availableTools: () => surfaceAvailableTools,
+      pointSelectEnabled: () => surfacePointSelectEnabled,
+      surfaceInteractive: () => surfaceInteractive,
+    },
+    inspection: {
+      inspectEnabled: () => inspectEnabled,
+      dataIdentityEpoch: () => dataIdentityEpoch,
+      plotId: () => host.plotId,
+      clearTooltipHovered: () => {
+        tooltipHovered = false;
+      },
+      clearAnnouncement: () => {
+        announcer.clear();
+      },
+    },
+  });
 
   // ------------------------------------------------- legend focus
   // Host-held entry lists are $derived after this factory; effects that read

--- a/packages/svelte/src/lib/selection/selection-state.svelte.ts
+++ b/packages/svelte/src/lib/selection/selection-state.svelte.ts
@@ -8,16 +8,9 @@
  * `commitPointSelection` is PRIVATE (no external caller — toggle/clear only).
  * Public API speaks PropertyKey; PublicKey casts stay at the host boundary.
  */
-import type { CellValue } from "@ggsvelte/core";
 
-import type { PlotInteractionController } from "../interaction/controller.svelte.js";
-import type {
-  InteractionSource,
-  PlotInteractionEvent,
-  PlotInteractionScope,
-  PlotSelection,
-  ResolvedInteractionConfig,
-} from "../interaction/interaction.js";
+import type { InteractionContext } from "../interaction/interaction-context.svelte.js";
+import type { InteractionSource, PlotSelection } from "../interaction/interaction.js";
 import { createScopedStore } from "../interaction/scoped-store.svelte.js";
 import { selectionAnnouncement } from "../assembly/labels.js";
 import {
@@ -29,20 +22,6 @@ import {
 // ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
-
-export type SelectionStateDeps = {
-  interaction: () => PlotInteractionController<PropertyKey> | undefined;
-  resolvedInteractionScope: () => PlotInteractionScope;
-  /** Narrow getter over `interactionConfig.select`. */
-  selectConfig: () => ResolvedInteractionConfig["select"];
-  /** Deferred callback getters (handler-only; never construction). */
-  onselect: () => ((event: PlotSelection) => void) | undefined;
-  oninteraction: () =>
-    | ((event: PlotInteractionEvent<Record<string, CellValue>>) => void)
-    | undefined;
-  /** Stable sink; announcer is declared later — handler-only. */
-  announce: (message: string) => void;
-};
 
 export type SelectionState = {
   readonly effectiveSelectedKeys: readonly PropertyKey[];
@@ -59,11 +38,11 @@ export type SelectionState = {
  * Create the point-selection controller. Construction registers only the
  * `effectiveSelectedKeys` derived over interaction and scope.
  */
-export function createSelectionState(deps: SelectionStateDeps): SelectionState {
+export function createSelectionState(context: InteractionContext): SelectionState {
   const selectedKeys = createScopedStore<readonly PropertyKey[]>({
     initial: [],
-    controller: deps.interaction,
-    scope: deps.resolvedInteractionScope,
+    controller: context.interaction,
+    scope: context.resolvedInteractionScope,
     read: (controller, scope) => controller.selected(scope),
     write: (controller, next, scope, source) => {
       const transition = controller.setSelection(next, { scope, source });
@@ -94,9 +73,9 @@ export function createSelectionState(deps: SelectionStateDeps): SelectionState {
 
   function emitSelection(event: PlotSelection): void {
     const message = selectionAnnouncement(event);
-    if (message !== null) deps.announce(message);
-    deps.onselect()?.(event);
-    deps.oninteraction()?.(event);
+    if (message !== null) context.announce(message);
+    context.onselect()?.(event);
+    context.oninteraction()?.(event);
   }
 
   function togglePointKeys(keys: readonly PropertyKey[], source: InteractionSource): void {
@@ -104,7 +83,7 @@ export function createSelectionState(deps: SelectionStateDeps): SelectionState {
     const next = nextPointSelectionKeys(
       selectedKeys.value,
       keys,
-      deps.selectConfig()?.multiple ?? false,
+      context.selectConfig()?.multiple ?? false,
     );
     commitPointSelection(next, source);
   }

--- a/packages/svelte/src/lib/surface/surface-state.svelte.ts
+++ b/packages/svelte/src/lib/surface/surface-state.svelte.ts
@@ -6,18 +6,18 @@
  * pointer/keyboard/capture handler switches, and both surface effects
  * (window-teardown then tool-sync).
  *
- * Construction topology (host): inspectionState is FIRST; this factory sits at
- * the original reducer position. Construction-time deriveds read ONLY module-
- * internal state + inspectConfig. Sibling controllers, sinks, and chrome
- * getters are handler/effect-only (armed for the construction guard).
+ * Construction topology (assembly): surface is constructed BEFORE inspection
+ * so the shared reducer exists as a concrete instance; inspection receives it
+ * via options. Construction-time deriveds read ONLY module-internal state +
+ * context.inspectConfig. Sibling controller ports, sinks, and chrome getters
+ * are handler/effect-only (armed for the construction guard).
  *
  * Window-teardown + tool-sync effects register inside this factory (#627).
  * Tool-scoped pure decision tables stay in pointer.ts, keyboard.ts, and
  * area-brush.ts — those seams narrow traffic; this module is the single owner.
  */
-import type { CandidateFacts, CellValue, RenderModel } from "@ggsvelte/core";
-
 import type { InspectionState } from "../inspection/inspection-state.svelte.js";
+import type { InteractionContext } from "../interaction/interaction-context.svelte.js";
 import type { IntervalState } from "../interval/interval-state.svelte.js";
 import type {
   InteractionSource,
@@ -73,31 +73,29 @@ type BrushRect = {
   y1: number;
 };
 
-export type SurfaceStateDeps = {
-  model: () => RenderModel | null;
-  root: () => HTMLDivElement | null;
-  /** Controlled-tool prop + resolved config/chrome (host/S8-held). */
-  toolProp: () => InteractionTool | undefined;
-  initialTool: () => ResolvedInteractionConfig["initialTool"];
-  availableTools: () => readonly InteractionTool[];
-  inspectConfig: () => ResolvedInteractionConfig["inspect"];
-  selectConfig: () => ResolvedInteractionConfig["select"];
+/**
+ * Surface-specific ports beyond the shared InteractionContext. Sibling
+ * controllers are wired by the assembly (interaction-states.svelte.ts) as
+ * handler-only getters over the bundle under construction.
+ */
+export type SurfaceStateOptions = {
+  /** Controlled-tool prop + resolved config/chrome (host-held). */
+  readonly toolProp: () => InteractionTool | undefined;
+  readonly initialTool: () => ResolvedInteractionConfig["initialTool"];
+  readonly availableTools: () => readonly InteractionTool[];
   /**
    * Host point-select enablement (`select?.type === "point"`). Host-derived
    * before this factory so surface does not close over later chromeState
    * (#1082). Same formula as chrome `canPublishPointSelection`.
    */
-  pointSelectEnabled: () => boolean;
-  ontoolchange: () => ((tool: InteractionTool) => void) | undefined;
+  readonly pointSelectEnabled: () => boolean;
   /**
    * Required by the window-teardown effect — NOT derivable from filtered
    * availableTools (codex P1-4).
    */
-  surfaceInteractive: () => boolean;
-  /** Capture-click reads it — deferred closure, same #165 pattern. */
-  candidateSemanticKeys: (candidate: CandidateFacts) => PropertyKey[];
-  /** Sibling controllers (handler-only; inspection earlier, interval later). */
-  inspection: () => Pick<
+  readonly surfaceInteractive: () => boolean;
+  /** Sibling controller ports (handler-only reads). */
+  readonly inspection: () => Pick<
     InspectionState,
     | "inspection"
     | "inspectionPanel"
@@ -112,14 +110,11 @@ export type SurfaceStateDeps = {
     | "cycleCoincident"
     | "resetTraversalIndex"
   >;
-  interval: () => Pick<IntervalState, "finishBrushSelect" | "committedInterval">;
-  zoom: () => Pick<PlotZoomState, "applyBrushZoom">;
-  /** S8 host-held sinks. */
-  emitSelection: (event: PlotSelection) => void;
-  semanticKey: (row: Record<string, CellValue> | null, index: number | null) => PropertyKey | null;
-  togglePointKeys: (keys: readonly PropertyKey[], source: InteractionSource) => void;
-  tooltipHovered: () => boolean;
-  announce: (message: string) => void;
+  readonly interval: () => Pick<IntervalState, "finishBrushSelect" | "committedInterval">;
+  readonly zoom: () => Pick<PlotZoomState, "applyBrushZoom">;
+  /** Selection controller write paths. */
+  readonly emitSelection: (event: PlotSelection) => void;
+  readonly togglePointKeys: (keys: readonly PropertyKey[], source: InteractionSource) => void;
 };
 
 export type SurfaceState = {
@@ -152,7 +147,10 @@ export type SurfaceState = {
  * Construction-order note: deps must not be invoked during construction —
  * construction-read discipline enforced by the armed-getter suite.
  */
-export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
+export function createSurfaceState(
+  context: InteractionContext,
+  options: SurfaceStateOptions,
+): SurfaceState {
   let reducerRevision = $state(0);
   let brushRect = $state<BrushRect | null>(null);
   let queuedAreaSource: InteractionSource = "pointer";
@@ -176,7 +174,7 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
         applyAreaMove(action.point);
         return true;
       }
-      return deps.inspection().onInspectPointerFrame(action);
+      return options.inspection().onInspectPointerFrame(action);
     },
   });
 
@@ -190,7 +188,7 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
   const surfaceDescription = $derived.by(() =>
     buildSurfaceDescription(
       activeTool,
-      activeTool === "inspect" && deps.inspectConfig()?.pin === true,
+      activeTool === "inspect" && context.inspectConfig()?.pin === true,
     ),
   );
 
@@ -216,22 +214,22 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
     // Decision table is pure (interaction/capability); this switch owns side effects.
     const action = resolveChooseToolAction({
       next,
-      available: deps.availableTools(),
-      isControlled: deps.toolProp() !== undefined,
+      available: options.availableTools(),
+      isControlled: options.toolProp() !== undefined,
     });
     switch (action.type) {
       case "ignore":
         return;
       case "request":
-        deps.ontoolchange()?.(next);
+        context.ontoolchange()?.(next);
         return;
       case "apply":
         reducer.dispatch({ type: "set-tool", tool: next });
         brushRect = null;
         // set-tool already full-cancels the schedule; clear inspect payload only
         // (preserve pinned stash — matches prior clearQueuedPointer-only path).
-        deps.inspection().cancelPointerInspect({ pendingPinned: "preserve" });
-        deps.ontoolchange()?.(next);
+        options.inspection().cancelPointerInspect({ pendingPinned: "preserve" });
+        context.ontoolchange()?.(next);
         break;
     }
   }
@@ -240,7 +238,7 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
     x: number;
     y: number;
   } {
-    const model = deps.model();
+    const model = context.model();
     if (model === null) return { x: 0, y: 0 };
     const target = event.currentTarget as HTMLElement | null;
     if (target === null) return { x: 0, y: 0 };
@@ -248,7 +246,7 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
   }
 
   function panelAtPoint(point: Readonly<{ x: number; y: number }>) {
-    return deps.model()?.viewport.panelAtOrOnly(point) ?? null;
+    return context.model()?.viewport.panelAtOrOnly(point) ?? null;
   }
 
   function onPointerMove(event: PointerEvent): void {
@@ -265,11 +263,11 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
       hasTouchInspectStart: touchInspectStart !== null,
       brushing,
       hasBrushDraft: brushRect !== null,
-      inspect: deps.inspectConfig(),
+      inspect: context.inspectConfig(),
     });
     switch (action.type) {
       case "touch-inspect-drag-cancel":
-        deps.inspection().cancelPointerInspect({ pendingPinned: "preserve" });
+        options.inspection().cancelPointerInspect({ pendingPinned: "preserve" });
         return;
       case "queue-area-move":
         queuedAreaSource = action.source;
@@ -278,7 +276,7 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
       case "queue-inspect":
         // mode/maxDistance from pure snapshot — no inspect config re-gate.
         // Inspection owns nearest lookup, token, and reducer.queuePointer.
-        deps.inspection().schedulePointerInspect({
+        options.inspection().schedulePointerInspect({
           point: p,
           source: action.source,
           mode: action.mode,
@@ -299,12 +297,12 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
     const next = brushWithEnd(draft, point);
     brushRect = next;
     if (activeTool === "select-area")
-      deps.emitSelection(selectionEvent("change", normalizedRect(next), source));
+      options.emitSelection(selectionEvent("change", normalizedRect(next), source));
   }
 
   /** Map the live render model into the pure interval query scene adapter. */
   function intervalQueryScene(): IntervalQueryScene | null {
-    const model = deps.model();
+    const model = context.model();
     if (model === null) return null;
     return intervalQuerySceneFromModel(model);
   }
@@ -318,19 +316,19 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
     switch (finish.type) {
       case "keep-second-corner":
         brushRect = finish.corners;
-        deps.announce(BRUSH_SECOND_CORNER_ANNOUNCEMENT);
+        context.announce(BRUSH_SECOND_CORNER_ANNOUNCEMENT);
         break;
       case "select-end": {
         brushRect = null;
         const eventValue = selectionEvent("end", finish.rect, source);
         // Interval owns commit + emit; surface only routes FinishBrushAction.
-        deps.interval().finishBrushSelect(eventValue, source);
+        options.interval().finishBrushSelect(eventValue, source);
         reducer.dispatch({ type: "cancel-area" });
         break;
       }
       case "zoom-end":
         brushRect = null;
-        deps.zoom().applyBrushZoom(finish.rect, source);
+        options.zoom().applyBrushZoom(finish.rect, source);
         reducer.dispatch({ type: "cancel-area" });
         break;
       case "end-area":
@@ -348,20 +346,20 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
       if (
         !shouldClearInspectionOnPointerLeave({
           brushing,
-          tooltipHovered: deps.tooltipHovered(),
+          tooltipHovered: context.tooltipHovered(),
         })
       )
         return;
-      deps.inspection().cancelPointerInspect({ pendingPinned: "discard" });
+      options.inspection().cancelPointerInspect({ pendingPinned: "discard" });
       reducer.cancelScheduledPointer();
-      deps.inspection().setInspection(null, "pointer");
+      options.inspection().setInspection(null, "pointer");
     });
   }
 
   function onPointerDown(event: PointerEvent): void {
     // Always cancel queued inspection before pure routing (host cleanup).
     // Preserve pinned stash; full schedule cancel (inspect + move-area).
-    deps.inspection().cancelPointerInspect({ pendingPinned: "preserve" });
+    options.inspection().cancelPointerInspect({ pendingPinned: "preserve" });
     reducer.cancelScheduledPointer();
     // point always computed (pure begin-area needs it; touch/none ignore).
     const p = plotPoint(event);
@@ -385,7 +383,7 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
         // panel from the reducer; a fresh brush anchors to the hit panel.
         const area = reducer.state.area;
         const extending = areaAwaitingSecond && brushRect !== null;
-        const model = deps.model();
+        const model = context.model();
         const originPanel = extending
           ? area.kind === "idle" || area.panelId === null
             ? null
@@ -394,7 +392,7 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
         if (originPanel === null) break;
         // Pure table owns fresh vs extend corner policy.
         brushRect = action.corners;
-        deps.inspection().setInspection(null, action.source);
+        options.inspection().setInspection(null, action.source);
         reducer.dispatch({
           type: "begin-area",
           point: p,
@@ -402,7 +400,7 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
         });
         if (action.emitSelectStart) {
           const startEvent = selectionEvent("start", normalizedRect(action.corners), action.source);
-          deps.emitSelection(startEvent);
+          options.emitSelection(startEvent);
         }
         try {
           (event.currentTarget as HTMLElement).setPointerCapture(event.pointerId);
@@ -423,16 +421,17 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
   ): IntervalSelection {
     const originPanelId =
       reducer.state.area.kind === "idle"
-        ? deps.interval().committedInterval?.panelId
+        ? options.interval().committedInterval?.panelId
         : reducer.state.area.panelId;
     return buildIntervalSelectionFromScene({
       phase,
-      mode: deps.selectConfig()?.mode ?? "xy",
+      mode: context.selectConfig()?.mode ?? "xy",
       source,
       pixels: rect,
       scene: intervalQueryScene(),
       ...(originPanelId !== undefined && { panelId: originPanelId }),
-      keyForRow: (rowIndex) => deps.semanticKey(deps.model()?.row(rowIndex) ?? null, rowIndex),
+      keyForRow: (rowIndex) =>
+        context.semanticKey(context.model()?.row(rowIndex) ?? null, rowIndex),
     });
   }
 
@@ -442,7 +441,7 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
     const action = resolvePointerUpAction({
       pointerType: event.pointerType,
       activeTool,
-      inspect: deps.inspectConfig(),
+      inspect: context.inspectConfig(),
       hasTouchInspectStart: touchInspectStart !== null,
       touchInspectMoved,
       brushing,
@@ -460,7 +459,7 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
         touchInspectMoved = false;
         // mode/maxDistance/state from pure inspect snapshot — no re-gate.
         // Resolved target owns panel-scoped nearest + tap distance policy (#1080 / #787).
-        const model = deps.model();
+        const model = context.model();
         const target =
           model === null
             ? null
@@ -471,7 +470,7 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
                 inspect: { mode: action.mode, maxDistance: action.maxDistance },
               });
         if (target !== null) {
-          deps.inspection().setInspection(target.match, "touch", action.state, target.mode);
+          options.inspection().setInspection(target.match, "touch", action.state, target.mode);
           suppressClickUntil = performance.now() + TOUCH_INSPECT_CLICK_SUPPRESS_MS;
         }
         break;
@@ -489,36 +488,37 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
 
   function onSurfaceBlur(event: FocusEvent): void {
     const blurAction = resolveSurfaceBlurAction({
-      relatedTargetInsideRoot: deps.root()?.contains(event.relatedTarget as Node | null) === true,
-      inspectionState: deps.inspection().inspection?.state ?? "none",
+      relatedTargetInsideRoot:
+        context.root()?.contains(event.relatedTarget as Node | null) === true,
+      inspectionState: options.inspection().inspection?.state ?? "none",
     });
     if (blurAction.type === "ignore") return;
     // Shared for keep-pinned and clear-inspection (ordering is load-bearing).
-    deps.inspection().resetTraversalIndex();
-    deps.inspection().cancelPointerInspect({ pendingPinned: "preserve" });
+    options.inspection().resetTraversalIndex();
+    options.inspection().cancelPointerInspect({ pendingPinned: "preserve" });
     if (blurAction.type === "blur-clear-inspection")
-      deps.inspection().setInspection(null, "keyboard");
+      options.inspection().setInspection(null, "keyboard");
   }
 
   function onSurfaceKeyDown(event: KeyboardEvent): void {
     // Decision table is pure (surface/keyboard); this switch owns side
     // effects only. brushCorners is the draft source of truth (not reducer
     // brushing); nudge/complete-area carry pure payloads so host only applies.
-    const inspection = deps.inspection();
+    const inspection = options.inspection();
     const { action, preventDefault } = resolveSurfaceKeyAction({
       key: event.key,
       shiftKey: event.shiftKey,
       activeTool,
       brushCorners: brushRect,
       hasInspection: inspection.inspection !== null,
-      pinEnabled: deps.inspectConfig()?.pin === true,
+      pinEnabled: context.inspectConfig()?.pin === true,
       focusKey: inspection.inspection?.focus.key ?? null,
       sourceKeys: inspection.inspection?.focus.sourceKeys ?? [],
       inspectionAnchor: inspection.inspection?.focus.anchor ?? null,
       inspectionPanel: inspection.inspectionPanel,
       // Viewport is the sole panel authority — not scene.panels[0] (#1038).
       firstPanel: (() => {
-        const panel = deps.model()?.viewport.panels[0];
+        const panel = context.model()?.viewport.panels[0];
         return panel === undefined ? undefined : panelBoundsFrom(panel.bounds);
       })(),
     });
@@ -544,7 +544,7 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
           point: action.anchor,
           panelId: originPanel.id,
         });
-        deps.announce(BRUSH_SECOND_CORNER_ANNOUNCEMENT);
+        context.announce(BRUSH_SECOND_CORNER_ANNOUNCEMENT);
         return;
       }
       case "complete-area": {
@@ -559,7 +559,7 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
         inspection.navigateDirection(action.dx, action.dy);
         return;
       case "toggle-point-keys":
-        deps.togglePointKeys(action.keys, "keyboard");
+        options.togglePointKeys(action.keys, "keyboard");
         return;
       case "toggle-pin":
         inspection.toggleInspectionPin("keyboard");
@@ -580,13 +580,13 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
   }
 
   function onCaptureClick(event: MouseEvent): void {
-    const inspection = deps.inspection();
+    const inspection = options.inspection();
     const action = resolveCaptureClickAction({
       suppressClick: performance.now() < suppressClickUntil,
       activeTool,
-      pointSelectEnabled: deps.pointSelectEnabled(),
-      inspectEnabled: deps.inspectConfig() !== null,
-      pinEnabled: deps.inspectConfig()?.pin === true,
+      pointSelectEnabled: options.pointSelectEnabled(),
+      inspectEnabled: context.inspectConfig() !== null,
+      pinEnabled: context.inspectConfig()?.pin === true,
       hasInspection: inspection.inspection !== null,
     });
     switch (action.type) {
@@ -596,7 +596,7 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
       case "toggle-point": {
         const point = plotPoint(event);
         // Resolved target owns panel-scoped nearest + point-select radius (#1080 / #787).
-        const model = deps.model();
+        const model = context.model();
         const target =
           model === null
             ? null
@@ -607,7 +607,7 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
                 inspect: null,
               });
         if (target === null) break;
-        deps.togglePointKeys(deps.candidateSemanticKeys(target.match), "pointer");
+        options.togglePointKeys(context.candidateSemanticKeys(target.match), "pointer");
         break;
       }
       case "toggle-pin":
@@ -621,7 +621,7 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
   /** Pointer-cancel always drops draft/queue/touch-inspect and cancels area. */
   function onPointerCancel(): void {
     // Preserve pinned stash (leave discards; cancel preserves).
-    deps.inspection().cancelPointerInspect({ pendingPinned: "preserve" });
+    options.inspection().cancelPointerInspect({ pendingPinned: "preserve" });
     touchInspectStart = null;
     touchInspectMoved = false;
     reducer.cancelScheduledPointer();
@@ -652,20 +652,20 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
   // registerSurfaceEffects — registered at construction, #627).
   $effect(() => {
     // No-op cleanup keeps every code path returning a teardown (consistent-return).
-    if (!deps.surfaceInteractive()) return () => {};
+    if (!options.surfaceInteractive()) return () => {};
     const onOutsidePointer = (event: PointerEvent) => {
       if (
         !shouldClosePinnedOnOutsidePointer({
-          inspectionState: deps.inspection().inspection?.state,
-          targetInsideRoot: deps.root()?.contains(event.target as Node) === true,
+          inspectionState: options.inspection().inspection?.state,
+          targetInsideRoot: context.root()?.contains(event.target as Node) === true,
         })
       )
         return;
-      deps.inspection().closeInspection("pointer", false);
+      options.inspection().closeInspection("pointer", false);
     };
     const cancelDraft = () => {
       brushRect = null;
-      deps.inspection().cancelPointerInspect({ pendingPinned: "preserve" });
+      options.inspection().cancelPointerInspect({ pendingPinned: "preserve" });
       clearTouchInspectStart();
       reducer.cancelScheduledPointer();
       reducer.dispatch({ type: "cancel-area" });
@@ -679,7 +679,10 @@ export function createSurfaceState(deps: SurfaceStateDeps): SurfaceState {
   });
 
   $effect(() => {
-    const next = resolveEffectiveTool(deps.toolProp() ?? deps.initialTool(), deps.availableTools());
+    const next = resolveEffectiveTool(
+      options.toolProp() ?? options.initialTool(),
+      options.availableTools(),
+    );
     reducer.dispatch({ type: "set-tool", tool: next });
   });
 

--- a/packages/svelte/src/lib/zoom/zoom-state.svelte.ts
+++ b/packages/svelte/src/lib/zoom/zoom-state.svelte.ts
@@ -6,17 +6,10 @@
  * NOT read model/announce (later-declared / handler-only;
  * construction-order DAG). Those are handler-only deferred getters.
  */
-import type { CellValue, RenderModel } from "@ggsvelte/core";
 import type { PortableSpec } from "@ggsvelte/spec";
 
-import type { PlotInteractionController } from "../interaction/controller.svelte.js";
-import type {
-  InteractionSource,
-  PlotInteractionEvent,
-  PlotInteractionScope,
-  ResolvedInteractionConfig,
-  ZoomEvent,
-} from "../interaction/interaction.js";
+import type { InteractionContext } from "../interaction/interaction-context.svelte.js";
+import type { InteractionSource, ResolvedInteractionConfig } from "../interaction/interaction.js";
 import { createScopedStore } from "../interaction/scoped-store.svelte.js";
 import { frozenZoomDomains, type ContinuousZoomDomains } from "../scene/geometry.js";
 import { zoomAnnouncement } from "../assembly/labels.js";
@@ -35,23 +28,14 @@ import {
 // Public types
 // ---------------------------------------------------------------------------
 
-export type PlotZoomStateDeps = {
-  interaction: () => PlotInteractionController<PropertyKey> | undefined;
-  resolvedInteractionScope: () => PlotInteractionScope;
+/**
+ * Zoom-specific options beyond the shared InteractionContext. zoomConfig is
+ * the narrow `interactionConfig.zoom` slice; assembled feeds effectiveSpec.
+ */
+export type PlotZoomStateOptions = {
   /** Narrow getter over `interactionConfig.zoom` (mode + null gate). */
-  zoomConfig: () => ResolvedInteractionConfig["zoom"];
-  assembled: () => PortableSpec | null;
-  /**
-   * Deferred: the runtime model alias and the coord-flip derived are declared
-   * after createPlotRuntime in the host — handler-only reads.
-   */
-  model: () => RenderModel | null;
-  onzoom: () => ((event: ZoomEvent) => void) | undefined;
-  oninteraction: () =>
-    | ((event: PlotInteractionEvent<Record<string, CellValue>>) => void)
-    | undefined;
-  /** Stable sink; announcer is declared later — handler-only. */
-  announce: (message: string) => void;
+  readonly zoomConfig: () => ResolvedInteractionConfig["zoom"];
+  readonly assembled: () => PortableSpec | null;
 };
 
 export type PlotZoomState = {
@@ -84,22 +68,28 @@ export type PlotZoomState = {
  * earlier host bindings). Handlers may read later-declared bindings via
  * deferred getters (`model`, `announce`).
  */
-export function createPlotZoomState(deps: PlotZoomStateDeps): PlotZoomState {
+export function createPlotZoomState(
+  context: InteractionContext,
+  options: PlotZoomStateOptions,
+): PlotZoomState {
   // Memoize prior bag so selection/emphasis revisions do not retrain zoom.
   let previousEffectiveZoomDomains: ContinuousZoomDomains | null = null;
 
   const zoomDomains = createScopedStore<ContinuousZoomDomains | null>({
     initial: null,
     empty: null,
-    controller: deps.interaction,
-    scope: deps.resolvedInteractionScope,
+    controller: context.interaction,
+    scope: context.resolvedInteractionScope,
     read: (controller, scope) =>
       // Gate shared domains by this plot's resolved zoom mode (null when
       // disabled / faceted-unsupported) so x-only plots ignore y domains.
-      filterZoomDomainsByMode(controller.zoom(scope), deps.zoomConfig()?.mode ?? null),
+      filterZoomDomainsByMode(controller.zoom(scope), options.zoomConfig()?.mode ?? null),
     write: (controller, next, scope, source) => {
       // Match filterZoomDomainsByMode: x-only plots must not mutate shared y.
-      const mutationScope = filterScopeChannelsByZoomMode(scope, deps.zoomConfig()?.mode ?? null);
+      const mutationScope = filterScopeChannelsByZoomMode(
+        scope,
+        options.zoomConfig()?.mode ?? null,
+      );
       if (next === null) {
         const transition = controller.resetZoom({ scope: mutationScope, source });
         return transition === null ? null : { value: null };
@@ -118,7 +108,7 @@ export function createPlotZoomState(deps: PlotZoomStateDeps): PlotZoomState {
     },
     clearShared: (controller, scope, source) =>
       controller.resetZoom({
-        scope: filterScopeChannelsByZoomMode(scope, deps.zoomConfig()?.mode ?? null),
+        scope: filterScopeChannelsByZoomMode(scope, options.zoomConfig()?.mode ?? null),
         source,
       }) !== null,
   });
@@ -130,7 +120,7 @@ export function createPlotZoomState(deps: PlotZoomStateDeps): PlotZoomState {
   });
 
   function resolveEffectiveSpec(): PortableSpec | null {
-    const assembled = deps.assembled();
+    const assembled = options.assembled();
     if (assembled === null || effectiveZoomDomains === null) return assembled;
     return applyZoomToSpec(assembled, effectiveZoomDomains);
   }
@@ -140,9 +130,9 @@ export function createPlotZoomState(deps: PlotZoomStateDeps): PlotZoomState {
     const committed = zoomDomains.set(domains, source);
     if (committed === null) return;
     const event = buildZoomEvent(committed.value, source);
-    deps.announce(zoomAnnouncement(committed.value));
-    deps.onzoom()?.(event);
-    deps.oninteraction()?.(event);
+    context.announce(zoomAnnouncement(committed.value));
+    context.onzoom()?.(event);
+    context.oninteraction()?.(event);
   }
 
   function resetZoom(source: InteractionSource = "programmatic"): void {
@@ -151,13 +141,13 @@ export function createPlotZoomState(deps: PlotZoomStateDeps): PlotZoomState {
   }
 
   function setZoomDomains(domains: Partial<ContinuousZoomDomains>): void {
-    const next = sanitizePartialZoomDomains(domains, deps.model()?.scales, effectiveZoomDomains);
+    const next = sanitizePartialZoomDomains(domains, context.model()?.scales, effectiveZoomDomains);
     if (next === null) return;
     commitZoom(frozenZoomDomains(next), "programmatic");
   }
 
   function onDblClick(): void {
-    if (deps.zoomConfig() === null) return;
+    if (options.zoomConfig() === null) return;
     resetZoom("pointer");
   }
 
@@ -178,9 +168,9 @@ export function createPlotZoomState(deps: PlotZoomStateDeps): PlotZoomState {
   ): void {
     // Pure owns null/multi-panel gate, invert, and freeze for commit.
     const next = resolveBrushZoomFromModel({
-      model: deps.model(),
+      model: context.model(),
       rect,
-      mode: deps.zoomConfig()?.mode ?? "xy",
+      mode: options.zoomConfig()?.mode ?? "xy",
       current: effectiveZoomDomains,
     });
     if (next === null) return;

--- a/packages/svelte/tests/helpers/interaction-context.ts
+++ b/packages/svelte/tests/helpers/interaction-context.ts
@@ -1,0 +1,64 @@
+/**
+ * Shared InteractionContext builder for controller factory harnesses.
+ *
+ * One context now carries what used to be re-typed into every controller's
+ * deps bag; harnesses pass only the getters their suite makes reactive and
+ * take static defaults for the rest. Per-controller ports (reducer, sibling
+ * getters, commitZoom, …) stay in each factory's options.
+ */
+import type { CandidateFacts } from "@ggsvelte/core";
+
+import type { InteractionContext } from "../../src/lib/interaction/interaction-context.svelte.js";
+import type { PlotInteractionScope } from "../../src/lib/interaction/interaction.js";
+
+const defaultTestScope: PlotInteractionScope = {
+  keys: "plot",
+  x: "x",
+  y: "y",
+};
+
+/** Getter that supplies no controller / no handler (chart-local mode). */
+const noHandler = (): undefined => {
+  /* test default */
+};
+
+/** Identity semantic keys — enough for local consumption without a host service. */
+export function identityCandidateKeys(candidate: CandidateFacts): PropertyKey[] {
+  if (candidate.rowIndex === null) return [];
+  return [String(candidate.rowIndex)];
+}
+
+/** No-op announce sink. */
+const silentAnnounce = (): void => {
+  /* test default */
+};
+
+/**
+ * Static-default context; overrides win. Defaults are inert (null model, no
+ * controller, no handlers) so a suite must opt into every reactive input it
+ * depends on.
+ */
+export function testInteractionContext(
+  overrides: Partial<InteractionContext> = {},
+): InteractionContext {
+  return {
+    model: () => null,
+    root: () => null,
+    captureSurface: () => null,
+    interaction: noHandler,
+    resolvedInteractionScope: () => defaultTestScope,
+    selectConfig: () => null,
+    inspectConfig: () => null,
+    tooltipHovered: () => false,
+    announce: silentAnnounce,
+    oninteraction: noHandler,
+    oninspect: noHandler,
+    onselect: noHandler,
+    onzoom: noHandler,
+    ontoolchange: noHandler,
+    keyAt: () => null,
+    semanticKey: () => null,
+    candidateSemanticKeys: identityCandidateKeys,
+    ...overrides,
+  };
+}

--- a/packages/svelte/tests/inspection/inspection-state.construction-effects.test.ts
+++ b/packages/svelte/tests/inspection/inspection-state.construction-effects.test.ts
@@ -8,6 +8,7 @@ import type { CandidateFacts, CellValue, RenderModel } from "@ggsvelte/core";
 
 import type { PlotInspection } from "../../src/lib/interaction/interaction.js";
 import { withEffectRoot } from "../helpers/effect-root.svelte.js";
+import { testInteractionContext } from "../helpers/interaction-context.js";
 import { reactiveBox } from "../helpers/reactive-box.svelte.js";
 import {
   applyInspect,
@@ -40,49 +41,53 @@ describe("createInspectionState construction", () => {
     const reducer = createInteractionReducer();
 
     const { value: state, destroy } = withEffectRoot(() =>
-      createInspectionState({
-        model: () => constructionModel,
-        reducer: () => {
-          reducerCalls++;
-          return reducer;
+      createInspectionState(
+        testInteractionContext({
+          model: () => constructionModel,
+          inspectConfig: defaultInspect,
+          keyAt: (index) => {
+            keyAtCalls++;
+            return String(index);
+          },
+          root: () => null,
+          captureSurface: () => {
+            captureSurfaceCalls++;
+            return null;
+          },
+          tooltipHovered: () => {
+            tooltipHoveredCalls++;
+            return false;
+          },
+          oninspect: () => {
+            oninspectCalls++;
+            return noInspect();
+          },
+          oninteraction: () => {
+            oninteractionCalls++;
+            return noInteraction();
+          },
+          announce: () => {},
+        }),
+        {
+          reducer: () => {
+            reducerCalls++;
+            return reducer;
+          },
+          inspectEnabled: () => {
+            inspectEnabledCalls++;
+            return true;
+          },
+          dataIdentityEpoch: () => "epoch-1",
+          plotId: () => {
+            plotIdCalls++;
+            return "plot";
+          },
+          clearTooltipHovered: () => {
+            clearTooltipHoveredCalls++;
+          },
+          clearAnnouncement: () => {},
         },
-        inspectConfig: defaultInspect,
-        inspectEnabled: () => {
-          inspectEnabledCalls++;
-          return true;
-        },
-        dataIdentityEpoch: () => "epoch-1",
-        keyAt: (index) => {
-          keyAtCalls++;
-          return String(index);
-        },
-        root: () => null,
-        captureSurface: () => {
-          captureSurfaceCalls++;
-          return null;
-        },
-        plotId: () => {
-          plotIdCalls++;
-          return "plot";
-        },
-        tooltipHovered: () => {
-          tooltipHoveredCalls++;
-          return false;
-        },
-        clearTooltipHovered: () => {
-          clearTooltipHoveredCalls++;
-        },
-        oninspect: () => {
-          oninspectCalls++;
-          return noInspect();
-        },
-        oninteraction: () => {
-          oninteractionCalls++;
-          return noInteraction();
-        },
-        announce: () => {},
-        clearAnnouncement: () => {},
-      }),
+      ),
     );
 
     expect(reducerCalls).toBe(0);

--- a/packages/svelte/tests/inspection/inspection-state.harness.ts
+++ b/packages/svelte/tests/inspection/inspection-state.harness.ts
@@ -12,11 +12,10 @@ import type {
 } from "../../src/lib/interaction/interaction.js";
 import { normalizeInteractionConfig } from "../../src/lib/interaction/interaction.js";
 import { createInteractionReducer } from "../../src/lib/interaction/reducer.js";
-import {
-  createInspectionState,
-  type InspectionStateDeps,
-} from "../../src/lib/inspection/inspection-state.svelte.js";
+import type { InteractionContext } from "../../src/lib/interaction/interaction-context.svelte.js";
+import { createInspectionState } from "../../src/lib/inspection/inspection-state.svelte.js";
 import { withFlushedEffectRoot } from "../helpers/effect-root.svelte.js";
+import { testInteractionContext } from "../helpers/interaction-context.js";
 import { modelFor } from "../helpers/model.js";
 
 const continuousRows = [
@@ -146,7 +145,7 @@ function createDeferredFrameScheduler(): {
 
 /**
  * Mount the controller with production-shaped deps: every reactive dep is a
- * getter (mirroring InspectionStateDeps). Harness owns the component-held
+ * getter (context + options split). Harness owns the component-held
  * reducer and passes a getter. Effects register inside the factory (#627).
  *
  * When `deferredFrames` is true, owns a deferred scheduler and wires
@@ -165,8 +164,8 @@ export function mountInspectionController(
     plotId?: () => string;
     tooltipHovered?: () => boolean;
     clearTooltipHovered?: () => void;
-    oninspect?: InspectionStateDeps["oninspect"];
-    oninteraction?: InspectionStateDeps["oninteraction"];
+    oninspect?: InteractionContext["oninspect"];
+    oninteraction?: InteractionContext["oninteraction"];
     announce?: (message: string) => void;
     clearAnnouncement?: () => void;
     /** Wire deferred frame + onInspectPointerFrame (for schedulePointerInspect). */
@@ -200,28 +199,32 @@ export function mountInspectionController(
   const getReducer = options.reducer ?? (() => ownedReducer!);
 
   const { value: state, destroy } = withFlushedEffectRoot(() => {
-    const controller = createInspectionState({
-      model: options.model ?? (() => defaultModel),
-      reducer: getReducer,
-      inspectConfig: options.inspectConfig ?? defaultInspect,
-      inspectEnabled: options.inspectEnabled ?? (() => true),
-      dataIdentityEpoch: options.dataIdentityEpoch ?? (() => "epoch-1"),
-      keyAt:
-        options.keyAt ??
-        ((index) => {
-          const model = options.model?.() ?? defaultModel;
-          return keyAtForModel(model)(index);
-        }),
-      root: options.root ?? (() => null),
-      captureSurface: options.captureSurface ?? (() => null),
-      plotId: options.plotId ?? (() => "plot-test"),
-      tooltipHovered: options.tooltipHovered ?? (() => false),
-      clearTooltipHovered: options.clearTooltipHovered ?? (() => {}),
-      oninspect: options.oninspect ?? noInspect,
-      oninteraction: options.oninteraction ?? noInteraction,
-      announce: options.announce ?? (() => {}),
-      clearAnnouncement: options.clearAnnouncement ?? (() => {}),
-    });
+    const controller = createInspectionState(
+      testInteractionContext({
+        model: options.model ?? (() => defaultModel),
+        inspectConfig: options.inspectConfig ?? defaultInspect,
+        keyAt:
+          options.keyAt ??
+          ((index) => {
+            const model = options.model?.() ?? defaultModel;
+            return keyAtForModel(model)(index);
+          }),
+        root: options.root ?? (() => null),
+        captureSurface: options.captureSurface ?? (() => null),
+        tooltipHovered: options.tooltipHovered ?? (() => false),
+        oninspect: options.oninspect ?? noInspect,
+        oninteraction: options.oninteraction ?? noInteraction,
+        announce: options.announce ?? (() => {}),
+      }),
+      {
+        reducer: getReducer,
+        inspectEnabled: options.inspectEnabled ?? (() => true),
+        dataIdentityEpoch: options.dataIdentityEpoch ?? (() => "epoch-1"),
+        plotId: options.plotId ?? (() => "plot-test"),
+        clearTooltipHovered: options.clearTooltipHovered ?? (() => {}),
+        clearAnnouncement: options.clearAnnouncement ?? (() => {}),
+      },
+    );
     controllerRef = controller;
     return controller;
   });
@@ -239,4 +242,4 @@ export function mountInspectionController(
 // Re-exports used by construction / armed-getter suites
 export { createInspectionState, createInteractionReducer, modelFor };
 export { withFlushedEffectRoot } from "../helpers/effect-root.svelte.js";
-export type { InspectionStateDeps, RenderModel, CandidateFacts, PortableSpec };
+export type { RenderModel, CandidateFacts, PortableSpec };

--- a/packages/svelte/tests/inspection/inspection-state.pin-queue.test.ts
+++ b/packages/svelte/tests/inspection/inspection-state.pin-queue.test.ts
@@ -8,6 +8,7 @@ import type { CandidateFacts, CellValue } from "@ggsvelte/core";
 
 import type { PlotInspection } from "../../src/lib/interaction/interaction.js";
 import { reactiveBox } from "../helpers/reactive-box.svelte.js";
+import { testInteractionContext } from "../helpers/interaction-context.js";
 import {
   candidateHit,
   continuousSpec,
@@ -463,25 +464,29 @@ describe("createInspectionState setInspection(null) clear ordering", () => {
     const stateTag = (): string => (controllerRef?.inspection === null ? "null" : "non-null");
 
     const handle = withFlushedEffectRoot(() => {
-      const controller = createInspectionState({
-        model: () => model,
-        reducer: () => createInteractionReducer(),
-        inspectConfig: defaultInspect,
-        inspectEnabled: () => true,
-        dataIdentityEpoch: () => "epoch-1",
-        keyAt: keyAtForModel(model),
-        root: () => null,
-        captureSurface: () => null,
-        plotId: () => "plot",
-        tooltipHovered: () => false,
-        clearTooltipHovered: () => {},
-        oninspect: () => (event) => {
-          if (event.phase === "clear") log.push(`emit-clear-inspection-${stateTag()}`);
+      const controller = createInspectionState(
+        testInteractionContext({
+          model: () => model,
+          inspectConfig: defaultInspect,
+          keyAt: keyAtForModel(model),
+          root: () => null,
+          captureSurface: () => null,
+          tooltipHovered: () => false,
+          oninspect: () => (event) => {
+            if (event.phase === "clear") log.push(`emit-clear-inspection-${stateTag()}`);
+          },
+          oninteraction: noInteraction,
+          announce: () => {},
+        }),
+        {
+          reducer: () => createInteractionReducer(),
+          inspectEnabled: () => true,
+          dataIdentityEpoch: () => "epoch-1",
+          plotId: () => "plot",
+          clearTooltipHovered: () => {},
+          clearAnnouncement: () => {},
         },
-        oninteraction: noInteraction,
-        announce: () => {},
-        clearAnnouncement: () => {},
-      });
+      );
       controllerRef = controller;
       return controller;
     });

--- a/packages/svelte/tests/interaction/interaction-states.test.ts
+++ b/packages/svelte/tests/interaction/interaction-states.test.ts
@@ -6,7 +6,7 @@ import { flushSync } from "svelte";
 import { describe, expect, it } from "vitest";
 
 import type { PlotInteractionEvent, PlotSelection } from "../../src/lib/interaction/interaction.js";
-import { createInteractionStates } from "../../src/lib/interaction/interaction-states.svelte.js";
+import { createInteractionAssembly } from "../../src/lib/interaction/interaction-states.svelte.js";
 import { withFlushedEffectRoot } from "../helpers/effect-root.svelte.js";
 import { testInteractionContext } from "../helpers/interaction-context.js";
 import { modelFor } from "../helpers/model.js";
@@ -25,8 +25,8 @@ function mountAssembly(
 ) {
   const spec = continuousSpec();
   const model = modelFor(spec);
-  return withFlushedEffectRoot(() =>
-    createInteractionStates(
+  return withFlushedEffectRoot(() => {
+    const assembly = createInteractionAssembly(
       testInteractionContext({
         model: () => model,
         resolvedInteractionScope: () => ({ keys: "plot", x: "x", y: "y", intervals: "plot" }),
@@ -40,38 +40,44 @@ function mountAssembly(
           zoomConfig: () => null,
           assembled: () => spec,
         },
-        interval: {
-          consumptionCandidates: () => [],
-        },
-        surface: {
-          toolProp: () => {
-            /* uncontrolled */
-          },
-          initialTool: () => "inspect",
-          availableTools: () => [],
-          pointSelectEnabled: () => false,
-          surfaceInteractive: () => false,
-        },
-        inspection: {
-          inspectEnabled: () => false,
-          dataIdentityEpoch: () => "epoch-1",
-          plotId: () => "plot-test",
-          clearTooltipHovered: () => {},
-          clearAnnouncement: () => {},
-        },
       },
-    ),
-  );
+    );
+    return assembly.complete({
+      interval: {
+        consumptionCandidates: () => [],
+      },
+      surface: {
+        toolProp: () => {
+          /* uncontrolled */
+        },
+        initialTool: () => "inspect",
+        availableTools: () => [],
+        pointSelectEnabled: () => false,
+        surfaceInteractive: () => false,
+      },
+      inspection: {
+        inspectEnabled: () => false,
+        dataIdentityEpoch: () => "epoch-1",
+        plotId: () => "plot-test",
+        clearTooltipHovered: () => {},
+        clearAnnouncement: () => {},
+      },
+    });
+  });
 }
 
-describe("createInteractionStates construction", () => {
+describe("createInteractionAssembly construction", () => {
   it("builds all five controllers without invoking announce/handler sinks", () => {
     const announcements: string[] = [];
     const interactions: PlotInteractionEvent[] = [];
 
     const { value: states, destroy } = mountAssembly({
-      announce: (message) => announcements.push(message),
-      oninteraction: (event) => interactions.push(event),
+      announce: (message) => {
+        announcements.push(message);
+      },
+      oninteraction: (event) => {
+        interactions.push(event);
+      },
     });
 
     expect(states.zoom).toBeDefined();
@@ -90,14 +96,18 @@ describe("createInteractionStates construction", () => {
   });
 });
 
-describe("createInteractionStates sibling ports", () => {
+describe("createInteractionAssembly sibling ports", () => {
   it("wires interval finish → selection emit through the real controllers", () => {
     const interactions: PlotInteractionEvent[] = [];
     const selections: PlotSelection[] = [];
 
     const { value: states, destroy } = mountAssembly({
-      oninteraction: (event) => interactions.push(event),
-      onselect: (event) => selections.push(event),
+      oninteraction: (event) => {
+        interactions.push(event);
+      },
+      onselect: (event) => {
+        selections.push(event);
+      },
     });
     const model = modelFor(continuousSpec());
 
@@ -119,8 +129,12 @@ describe("createInteractionStates sibling ports", () => {
     const selections: PlotSelection[] = [];
 
     const { value: states, destroy } = mountAssembly({
-      oninteraction: (event) => interactions.push(event),
-      onselect: (event) => selections.push(event),
+      oninteraction: (event) => {
+        interactions.push(event);
+      },
+      onselect: (event) => {
+        selections.push(event);
+      },
     });
 
     states.selection.togglePointKeys(["a"], "pointer");

--- a/packages/svelte/tests/interaction/interaction-states.test.ts
+++ b/packages/svelte/tests/interaction/interaction-states.test.ts
@@ -1,0 +1,135 @@
+/**
+ * createInteractionStates tests — bundle shape, construction laziness, and
+ * sibling-port wiring through the assembly (interval → selection emit).
+ */
+import { flushSync } from "svelte";
+import { describe, expect, it } from "vitest";
+
+import type { PlotInteractionEvent, PlotSelection } from "../../src/lib/interaction/interaction.js";
+import { createInteractionStates } from "../../src/lib/interaction/interaction-states.svelte.js";
+import { withFlushedEffectRoot } from "../helpers/effect-root.svelte.js";
+import { testInteractionContext } from "../helpers/interaction-context.js";
+import { modelFor } from "../helpers/model.js";
+import {
+  brushEvent,
+  continuousSpec,
+  persistentSelect,
+} from "../interval/interval-state.harness.js";
+
+function mountAssembly(
+  overrides: {
+    oninteraction?: (event: PlotInteractionEvent) => void;
+    onselect?: (event: PlotSelection) => void;
+    announce?: (message: string) => void;
+  } = {},
+) {
+  const spec = continuousSpec();
+  const model = modelFor(spec);
+  return withFlushedEffectRoot(() =>
+    createInteractionStates(
+      testInteractionContext({
+        model: () => model,
+        resolvedInteractionScope: () => ({ keys: "plot", x: "x", y: "y", intervals: "plot" }),
+        selectConfig: persistentSelect,
+        oninteraction: () => overrides.oninteraction,
+        onselect: () => overrides.onselect,
+        announce: overrides.announce ?? (() => {}),
+      }),
+      {
+        zoom: {
+          zoomConfig: () => null,
+          assembled: () => spec,
+        },
+        interval: {
+          consumptionCandidates: () => [],
+        },
+        surface: {
+          toolProp: () => {
+            /* uncontrolled */
+          },
+          initialTool: () => "inspect",
+          availableTools: () => [],
+          pointSelectEnabled: () => false,
+          surfaceInteractive: () => false,
+        },
+        inspection: {
+          inspectEnabled: () => false,
+          dataIdentityEpoch: () => "epoch-1",
+          plotId: () => "plot-test",
+          clearTooltipHovered: () => {},
+          clearAnnouncement: () => {},
+        },
+      },
+    ),
+  );
+}
+
+describe("createInteractionStates construction", () => {
+  it("builds all five controllers without invoking announce/handler sinks", () => {
+    const announcements: string[] = [];
+    const interactions: PlotInteractionEvent[] = [];
+
+    const { value: states, destroy } = mountAssembly({
+      announce: (message) => announcements.push(message),
+      oninteraction: (event) => interactions.push(event),
+    });
+
+    expect(states.zoom).toBeDefined();
+    expect(states.selection).toBeDefined();
+    expect(states.interval).toBeDefined();
+    expect(states.surface).toBeDefined();
+    expect(states.inspection).toBeDefined();
+    // Shared reducer is a concrete instance hoisted by the assembly — the
+    // surface↔inspection late binding is gone.
+    expect(states.surface.reducer).toBeDefined();
+
+    expect(announcements).toEqual([]);
+    expect(interactions).toEqual([]);
+
+    destroy();
+  });
+});
+
+describe("createInteractionStates sibling ports", () => {
+  it("wires interval finish → selection emit through the real controllers", () => {
+    const interactions: PlotInteractionEvent[] = [];
+    const selections: PlotSelection[] = [];
+
+    const { value: states, destroy } = mountAssembly({
+      oninteraction: (event) => interactions.push(event),
+      onselect: (event) => selections.push(event),
+    });
+    const model = modelFor(continuousSpec());
+
+    states.interval.finishBrushSelect(brushEvent(model), "pointer");
+    flushSync();
+
+    expect(states.interval.committedInterval).not.toBeNull();
+    // The assembly wires interval's emitSelection to the real selection
+    // controller, which emits on both sinks.
+    expect(selections).toHaveLength(1);
+    expect(selections[0]?.mode).not.toBe("point");
+    expect(interactions.length).toBeGreaterThan(0);
+
+    destroy();
+  });
+
+  it("wires selection toggles to the interaction sinks", () => {
+    const interactions: PlotInteractionEvent[] = [];
+    const selections: PlotSelection[] = [];
+
+    const { value: states, destroy } = mountAssembly({
+      oninteraction: (event) => interactions.push(event),
+      onselect: (event) => selections.push(event),
+    });
+
+    states.selection.togglePointKeys(["a"], "pointer");
+    flushSync();
+
+    expect(states.selection.effectiveSelectedKeys).toEqual(["a"]);
+    expect(selections).toHaveLength(1);
+    expect(interactions.length).toBeGreaterThan(0);
+
+    destroy();
+  });
+});

--- a/packages/svelte/tests/interval/interval-state.construction-modes.test.ts
+++ b/packages/svelte/tests/interval/interval-state.construction-modes.test.ts
@@ -8,6 +8,7 @@ import type { RenderModel } from "@ggsvelte/core";
 import { encodeKey } from "@ggsvelte/core";
 
 import { withEffectRoot } from "../helpers/effect-root.svelte.js";
+import { testInteractionContext } from "../helpers/interaction-context.js";
 import { reactiveBox } from "../helpers/reactive-box.svelte.js";
 import {
   bandXSpec,
@@ -39,39 +40,42 @@ describe("createIntervalState construction", () => {
     const constructionModel = modelFor(continuousSpec());
 
     const { value: state, destroy } = withEffectRoot(() =>
-      createIntervalState({
-        model: () => constructionModel,
-        interaction: noController,
-        resolvedInteractionScope: () => defaultScope,
-        selectConfig: persistentSelect,
-        effectiveZoomDomains: () => null,
-        commitZoom: () => {
-          commitZoomCalls++;
+      createIntervalState(
+        testInteractionContext({
+          model: () => constructionModel,
+          interaction: noController,
+          resolvedInteractionScope: () => defaultScope,
+          selectConfig: persistentSelect,
+          captureSurface: () => null,
+          // Issue #165 history: under the retired eager-SSR floor, a
+          // pre-populated non-union controller + non-null model reached this
+          // at construction. Deriveds are lazy at the 5.33.1 floor, so this
+          // guard pins the common empty-intervals construction path only.
+          candidateSemanticKeys: (candidate) => {
+            candidateSemanticKeysCalls++;
+            return identityCandidateKeys(candidate);
+          },
+          announce: () => {
+            announceCalls++;
+          },
+        }),
+        {
+          effectiveZoomDomains: () => null,
+          commitZoom: () => {
+            commitZoomCalls++;
+          },
+          consumptionCandidates: () => {
+            throw new Error("consumptionCandidates must remain lazy for empty intervals");
+          },
+          inspectionPanel: () => {
+            inspectionPanelCalls++;
+            return null;
+          },
+          emitSelection: () => {
+            emitCalls++;
+          },
         },
-        coordFlipped: () => false,
-        captureSurface: () => null,
-        // Issue #165 history: under the retired eager-SSR floor, a
-        // pre-populated non-union controller + non-null model reached this
-        // at construction. Deriveds are lazy at the 5.33.1 floor, so this
-        // guard pins the common empty-intervals construction path only.
-        candidateSemanticKeys: (candidate) => {
-          candidateSemanticKeysCalls++;
-          return identityCandidateKeys(candidate);
-        },
-        consumptionCandidates: () => {
-          throw new Error("consumptionCandidates must remain lazy for empty intervals");
-        },
-        inspectionPanel: () => {
-          inspectionPanelCalls++;
-          return null;
-        },
-        emitSelection: () => {
-          emitCalls++;
-        },
-        announce: () => {
-          announceCalls++;
-        },
-      }),
+      ),
     );
 
     expect(emitCalls).toBe(0);

--- a/packages/svelte/tests/interval/interval-state.harness.ts
+++ b/packages/svelte/tests/interval/interval-state.harness.ts
@@ -15,11 +15,12 @@ import type {
 import { createPlotInteraction } from "../../src/lib/interaction/controller.svelte.js";
 import {
   createIntervalState,
-  type IntervalStateDeps,
+  type IntervalStateOptions,
 } from "../../src/lib/interval/interval-state.svelte.js";
 import type { ContinuousZoomDomains } from "../../src/lib/scene/geometry.js";
 import { buildIntervalSelection } from "../../src/lib/interval/interval.js";
 import { withFlushedEffectRoot } from "../helpers/effect-root.svelte.js";
+import { identityCandidateKeys, testInteractionContext } from "../helpers/interaction-context.js";
 import { modelFor } from "../helpers/model.js";
 
 const continuousRows = [
@@ -90,11 +91,8 @@ export function facetSpec(): PortableSpec {
     .spec();
 }
 
-/** Identity semantic keys — enough for local consumption without a host service. */
-export function identityCandidateKeys(candidate: CandidateFacts): PropertyKey[] {
-  if (candidate.rowIndex === null) return [];
-  return [String(candidate.rowIndex)];
-}
+/** Identity semantic keys — re-exported from the shared context helper. */
+export { identityCandidateKeys } from "../helpers/interaction-context.js";
 
 export function brushEvent(
   model: RenderModel,
@@ -137,7 +135,7 @@ export type IntervalHarness = {
 
 /**
  * Mount the controller with production-shaped deps: every reactive dep is a
- * getter (mirroring IntervalStateDeps). Tests that need reactivity pass
+ * getter (context + options split). Tests that need reactivity pass
  * getters over their own reactive boxes; omitted options get static defaults.
  */
 export function mountIntervalController(
@@ -147,11 +145,10 @@ export function mountIntervalController(
     resolvedInteractionScope?: () => PlotInteractionScope;
     selectConfig?: () => SelectConfig;
     effectiveZoomDomains?: () => ContinuousZoomDomains | null;
-    commitZoom?: IntervalStateDeps["commitZoom"];
-    coordFlipped?: () => boolean;
+    commitZoom?: IntervalStateOptions["commitZoom"];
     captureSurface?: () => HTMLDivElement | null;
     candidateSemanticKeys?: (candidate: CandidateFacts) => PropertyKey[];
-    consumptionCandidates?: IntervalStateDeps["consumptionCandidates"];
+    consumptionCandidates?: IntervalStateOptions["consumptionCandidates"];
     inspectionPanel?: () => Readonly<{ id: string }> | null;
     emitSelection?: (event: PlotSelection) => void;
     announce?: (message: string) => void;
@@ -160,37 +157,40 @@ export function mountIntervalController(
   const defaultModel = modelFor(continuousSpec());
 
   const { value: state, destroy } = withFlushedEffectRoot(() =>
-    createIntervalState({
-      model: options.model ?? (() => defaultModel),
-      interaction: options.interaction ?? noController,
-      resolvedInteractionScope: options.resolvedInteractionScope ?? (() => defaultScope),
-      selectConfig: options.selectConfig ?? persistentSelect,
-      effectiveZoomDomains: options.effectiveZoomDomains ?? (() => null),
-      commitZoom: options.commitZoom ?? (() => {}),
-      coordFlipped: options.coordFlipped ?? (() => false),
-      captureSurface: options.captureSurface ?? (() => null),
-      candidateSemanticKeys: options.candidateSemanticKeys ?? identityCandidateKeys,
-      consumptionCandidates:
-        options.consumptionCandidates ??
-        (() => {
-          const currentModel = options.model?.() ?? defaultModel;
-          const candidates = [];
-          for (let id = 0; id < currentModel.candidates.size; id++) {
-            const candidate = currentModel.candidates.candidate(id);
-            if (candidate === null) continue;
-            candidates.push({
-              panelId: candidate.panelId,
-              xValue: candidate.xValue,
-              yValue: candidate.yValue,
-              keys: identityCandidateKeys(candidate),
-            });
-          }
-          return candidates;
-        }),
-      inspectionPanel: options.inspectionPanel ?? (() => null),
-      emitSelection: options.emitSelection ?? (() => {}),
-      announce: options.announce ?? (() => {}),
-    }),
+    createIntervalState(
+      testInteractionContext({
+        model: options.model ?? (() => defaultModel),
+        interaction: options.interaction ?? noController,
+        resolvedInteractionScope: options.resolvedInteractionScope ?? (() => defaultScope),
+        selectConfig: options.selectConfig ?? persistentSelect,
+        captureSurface: options.captureSurface ?? (() => null),
+        candidateSemanticKeys: options.candidateSemanticKeys ?? identityCandidateKeys,
+        announce: options.announce ?? (() => {}),
+      }),
+      {
+        effectiveZoomDomains: options.effectiveZoomDomains ?? (() => null),
+        commitZoom: options.commitZoom ?? (() => {}),
+        consumptionCandidates:
+          options.consumptionCandidates ??
+          (() => {
+            const currentModel = options.model?.() ?? defaultModel;
+            const candidates = [];
+            for (let id = 0; id < currentModel.candidates.size; id++) {
+              const candidate = currentModel.candidates.candidate(id);
+              if (candidate === null) continue;
+              candidates.push({
+                panelId: candidate.panelId,
+                xValue: candidate.xValue,
+                yValue: candidate.yValue,
+                keys: identityCandidateKeys(candidate),
+              });
+            }
+            return candidates;
+          }),
+        inspectionPanel: options.inspectionPanel ?? (() => null),
+        emitSelection: options.emitSelection ?? (() => {}),
+      },
+    ),
   );
 
   return { state, destroy };

--- a/packages/svelte/tests/selection/selection-state.test.ts
+++ b/packages/svelte/tests/selection/selection-state.test.ts
@@ -17,6 +17,7 @@ import { createPlotInteraction } from "../../src/lib/interaction/controller.svel
 import { buildPointSelectionEvent } from "../../src/lib/selection/selection.js";
 import { createSelectionState } from "../../src/lib/selection/selection-state.svelte.js";
 import { withEffectRoot, withFlushedEffectRoot } from "../helpers/effect-root.svelte.js";
+import { testInteractionContext } from "../helpers/interaction-context.js";
 import { reactiveBox } from "../helpers/reactive-box.svelte.js";
 
 type SelectConfig = ResolvedInteractionConfig["select"];
@@ -71,14 +72,16 @@ function mountSelectionController(
   } = {},
 ): SelectionHarness {
   const { value: state, destroy } = withFlushedEffectRoot(() =>
-    createSelectionState({
-      interaction: options.interaction ?? noController,
-      resolvedInteractionScope: options.resolvedInteractionScope ?? (() => defaultScope),
-      selectConfig: options.selectConfig ?? pointSelectSingle,
-      onselect: options.onselect ?? noSelectCb,
-      oninteraction: options.oninteraction ?? noInteractionCb,
-      announce: options.announce ?? (() => {}),
-    }),
+    createSelectionState(
+      testInteractionContext({
+        interaction: options.interaction ?? noController,
+        resolvedInteractionScope: options.resolvedInteractionScope ?? (() => defaultScope),
+        selectConfig: options.selectConfig ?? pointSelectSingle,
+        onselect: options.onselect ?? noSelectCb,
+        oninteraction: options.oninteraction ?? noInteractionCb,
+        announce: options.announce ?? (() => {}),
+      }),
+    ),
   );
   return { state, destroy };
 }
@@ -90,22 +93,24 @@ describe("createSelectionState construction", () => {
     let announceCalls = 0;
 
     const { value: state, destroy } = withEffectRoot(() =>
-      createSelectionState({
-        interaction: noController,
-        resolvedInteractionScope: () => defaultScope,
-        selectConfig: pointSelectSingle,
-        onselect: (): SelectCb => {
-          onselectCalls++;
-          return noSelectCb();
-        },
-        oninteraction: (): InteractionCb => {
-          oninteractionCalls++;
-          return noInteractionCb();
-        },
-        announce: () => {
-          announceCalls++;
-        },
-      }),
+      createSelectionState(
+        testInteractionContext({
+          interaction: noController,
+          resolvedInteractionScope: () => defaultScope,
+          selectConfig: pointSelectSingle,
+          onselect: (): SelectCb => {
+            onselectCalls++;
+            return noSelectCb();
+          },
+          oninteraction: (): InteractionCb => {
+            oninteractionCalls++;
+            return noInteractionCb();
+          },
+          announce: () => {
+            announceCalls++;
+          },
+        }),
+      ),
     );
 
     expect(state.effectiveSelectedKeys).toEqual([]);

--- a/packages/svelte/tests/surface/surface-state.construction-effects.test.ts
+++ b/packages/svelte/tests/surface/surface-state.construction-effects.test.ts
@@ -5,6 +5,7 @@ import { flushSync } from "svelte";
 import { describe, expect, it } from "vitest";
 
 import { withEffectRoot } from "../helpers/effect-root.svelte.js";
+import { testInteractionContext } from "../helpers/interaction-context.js";
 import {
   continuousSpec,
   firstCandidate,
@@ -15,7 +16,7 @@ import {
   fromAny,
   panelCenterClient,
   pointerEvent,
-  type SurfaceStateDeps,
+  type SurfaceStateOptions,
   type InteractionTool,
 } from "./surface-state.harness.js";
 
@@ -44,7 +45,7 @@ describe("createSurfaceState construction", () => {
 
     // Minimal stubs so construction can close the cycle without real siblings.
     const stubInspection = fromAny<
-      SurfaceStateDeps["inspection"] extends () => infer R ? R : never
+      SurfaceStateOptions["inspection"] extends () => infer R ? R : never
     >({
       get inspection() {
         inspectionCalls++;
@@ -87,79 +88,85 @@ describe("createSurfaceState construction", () => {
       },
     });
 
-    const stubInterval = fromAny<SurfaceStateDeps["interval"] extends () => infer R ? R : never>({
-      get committedInterval() {
-        intervalCalls++;
-        return null;
+    const stubInterval = fromAny<SurfaceStateOptions["interval"] extends () => infer R ? R : never>(
+      {
+        get committedInterval() {
+          intervalCalls++;
+          return null;
+        },
+        finishBrushSelect: () => {
+          intervalCalls++;
+        },
       },
-      finishBrushSelect: () => {
-        intervalCalls++;
-      },
-    });
+    );
 
-    const stubZoom = fromAny<SurfaceStateDeps["zoom"] extends () => infer R ? R : never>({
+    const stubZoom = fromAny<SurfaceStateOptions["zoom"] extends () => infer R ? R : never>({
       applyBrushZoom: () => {
         zoomCalls++;
       },
     });
 
     const { value: state, destroy } = withEffectRoot(() =>
-      createSurfaceState({
-        model: () => model,
-        root: () => null,
-        toolProp: () => {
-          toolPropCalls++;
+      createSurfaceState(
+        testInteractionContext({
+          model: () => model,
+          root: () => null,
+          inspectConfig: () => config.inspect,
+          selectConfig: () => config.select,
+          ontoolchange: () => {
+            ontoolchangeCalls++;
+          },
+          candidateSemanticKeys: () => {
+            candidateSemanticKeysCalls++;
+            return [];
+          },
+          semanticKey: () => {
+            semanticKeyCalls++;
+            return null;
+          },
+          tooltipHovered: () => {
+            tooltipHoveredCalls++;
+            return false;
+          },
+          announce: () => {},
+        }),
+        {
+          toolProp: () => {
+            toolPropCalls++;
+          },
+          initialTool: () => config.initialTool,
+          availableTools: () => {
+            availableToolsCalls++;
+            return config.availableTools;
+          },
+          pointSelectEnabled: () => {
+            pointSelectEnabledCalls++;
+            return false;
+          },
+          surfaceInteractive: () => {
+            surfaceInteractiveCalls++;
+            return true;
+          },
+          inspection: () => {
+            inspectionCalls++;
+            return stubInspection;
+          },
+          interval: () => {
+            intervalCalls++;
+            return stubInterval;
+          },
+          zoom: () => {
+            zoomCalls++;
+            return stubZoom;
+          },
+          emitSelection: () => {
+            emitSelectionCalls++;
+          },
+          togglePointKeys: () => {
+            togglePointKeysCalls++;
+          },
         },
-        initialTool: () => config.initialTool,
-        availableTools: () => {
-          availableToolsCalls++;
-          return config.availableTools;
-        },
-        inspectConfig: () => config.inspect,
-        selectConfig: () => config.select,
-        pointSelectEnabled: () => {
-          pointSelectEnabledCalls++;
-          return false;
-        },
-        ontoolchange: () => {
-          ontoolchangeCalls++;
-        },
-        surfaceInteractive: () => {
-          surfaceInteractiveCalls++;
-          return true;
-        },
-        candidateSemanticKeys: () => {
-          candidateSemanticKeysCalls++;
-          return [];
-        },
-        inspection: () => {
-          inspectionCalls++;
-          return stubInspection;
-        },
-        interval: () => {
-          intervalCalls++;
-          return stubInterval;
-        },
-        zoom: () => {
-          zoomCalls++;
-          return stubZoom;
-        },
-        emitSelection: () => {
-          emitSelectionCalls++;
-        },
-        semanticKey: () => {
-          semanticKeyCalls++;
-          return null;
-        },
-        togglePointKeys: () => {
-          togglePointKeysCalls++;
-        },
-        tooltipHovered: () => {
-          tooltipHoveredCalls++;
-          return false;
-        },
-        announce: () => {},
-      }),
+      ),
     );
 
     // Public accessors only — brushing is private. Sibling controllers must
@@ -211,7 +218,7 @@ describe("createSurfaceState construction", () => {
     });
     let inspectConfigCalls = 0;
     const stubInspection = fromAny<
-      SurfaceStateDeps["inspection"] extends () => infer R ? R : never
+      SurfaceStateOptions["inspection"] extends () => infer R ? R : never
     >({
       get inspection() {
         return null;
@@ -230,45 +237,51 @@ describe("createSurfaceState construction", () => {
         return null;
       },
     });
-    const stubInterval = fromAny<SurfaceStateDeps["interval"] extends () => infer R ? R : never>({
-      finishBrushSelect: () => {},
-      get committedInterval() {
-        return null;
+    const stubInterval = fromAny<SurfaceStateOptions["interval"] extends () => infer R ? R : never>(
+      {
+        finishBrushSelect: () => {},
+        get committedInterval() {
+          return null;
+        },
       },
-    });
-    const stubZoom = fromAny<SurfaceStateDeps["zoom"] extends () => infer R ? R : never>({
+    );
+    const stubZoom = fromAny<SurfaceStateOptions["zoom"] extends () => infer R ? R : never>({
       applyBrushZoom: () => {},
     });
 
     const { value: state, destroy } = withEffectRoot(() =>
-      createSurfaceState({
-        model: () => model,
-        root: () => null,
-        toolProp: () => {
-          /* uncontrolled */
+      createSurfaceState(
+        testInteractionContext({
+          model: () => model,
+          root: () => null,
+          inspectConfig: () => {
+            inspectConfigCalls++;
+            return config.inspect;
+          },
+          selectConfig: () => config.select,
+          ontoolchange: () => {
+            /* no controlled callback */
+          },
+          candidateSemanticKeys: () => [],
+          semanticKey: () => null,
+          tooltipHovered: () => false,
+          announce: () => {},
+        }),
+        {
+          toolProp: () => {
+            /* uncontrolled */
+          },
+          initialTool: () => config.initialTool,
+          availableTools: () => config.availableTools,
+          pointSelectEnabled: () => false,
+          surfaceInteractive: () => true,
+          inspection: () => stubInspection,
+          interval: () => stubInterval,
+          zoom: () => stubZoom,
+          emitSelection: () => {},
+          togglePointKeys: () => {},
         },
-        initialTool: () => config.initialTool,
-        availableTools: () => config.availableTools,
-        inspectConfig: () => {
-          inspectConfigCalls++;
-          return config.inspect;
-        },
-        selectConfig: () => config.select,
-        pointSelectEnabled: () => false,
-        ontoolchange: () => {
-          /* no controlled callback */
-        },
-        surfaceInteractive: () => true,
-        candidateSemanticKeys: () => [],
-        inspection: () => stubInspection,
-        interval: () => stubInterval,
-        zoom: () => stubZoom,
-        emitSelection: () => {},
-        semanticKey: () => null,
-        togglePointKeys: () => {},
-        tooltipHovered: () => false,
-        announce: () => {},
-      }),
+      ),
     );
 
     flushSync();

--- a/packages/svelte/tests/surface/surface-state.harness.ts
+++ b/packages/svelte/tests/surface/surface-state.harness.ts
@@ -33,9 +33,10 @@ import { createPlotZoomState, type PlotZoomState } from "../../src/lib/zoom/zoom
 import {
   createSurfaceState,
   type SurfaceState,
-  type SurfaceStateDeps,
+  type SurfaceStateOptions,
 } from "../../src/lib/surface/surface-state.svelte.js";
 import { withFlushedEffectRoot } from "../helpers/effect-root.svelte.js";
+import { identityCandidateKeys, testInteractionContext } from "../helpers/interaction-context.js";
 import { modelFor } from "../helpers/model.js";
 import { reactiveBox } from "../helpers/reactive-box.svelte.js";
 
@@ -94,11 +95,6 @@ function identityKeyAt(model: RenderModel): (index: number) => PropertyKey | nul
     const id = row["id"];
     return id === undefined || id === null ? String(index) : String(id);
   };
-}
-
-function identityCandidateKeys(candidate: CandidateFacts): PropertyKey[] {
-  if (candidate.rowIndex === null) return [];
-  return [String(candidate.rowIndex)];
 }
 
 function identitySemanticKey(): (
@@ -270,67 +266,62 @@ export function mountSurfaceComposite(
   const semanticKey = identitySemanticKey();
 
   const { value: bundle, destroy: destroyRoot } = withFlushedEffectRoot(() => {
-    // Production order: zoom → inspection → surface → interval → effects.
-    // Deferred getters close over later const bindings (handler/effect only).
-    let surface!: SurfaceState;
-    let interval!: IntervalState;
-
-    // 1. zoom (pre-existing)
-    const zoom = createPlotZoomState({
-      interaction: noController,
-      resolvedInteractionScope: () => ({ keys: "plot", x: "x", y: "y" }),
-      zoomConfig: () => config.zoom,
-      assembled: () => options.spec ?? continuousSpec(),
+    // One shared context; per-factory options carry ports + host-derived
+    // enablement. Deferred getters close over later const bindings
+    // (handler/effect only).
+    const context = testInteractionContext({
       model: () => model,
-      onzoom: () => {
-        /* no callback */
+      root: () => root,
+      captureSurface: () => capture,
+      interaction: noController,
+      resolvedInteractionScope: () => ({ keys: "plot", x: "x", y: "y", intervals: "plot" }),
+      selectConfig: () => config.select,
+      inspectConfig: () => config.inspect,
+      tooltipHovered: () => false,
+      announce: (message) => {
+        announcements.push(message);
       },
       oninteraction: () => {
         /* no callback */
       },
-      announce: (message) => {
-        announcements.push(message);
-      },
-    });
-
-    // 2. inspection (before surface — reversed reducer dep)
-    const inspection = createInspectionState({
-      model: () => model,
-      reducer: () => surface.reducer,
-      inspectConfig: () => config.inspect,
-      inspectEnabled: () => config.inspect !== null,
-      dataIdentityEpoch: () => "epoch-1",
-      keyAt,
-      root: () => root,
-      captureSurface: () => capture,
-      plotId: () => "plot-test",
-      tooltipHovered: () => false,
-      clearTooltipHovered: () => {},
       oninspect: () => {
         /* no callback */
       },
-      oninteraction: () => {
+      onzoom: () => {
         /* no callback */
       },
-      announce: (message) => {
-        announcements.push(message);
-      },
+      ontoolchange: () => onToolChangeBox.value,
+      keyAt,
+      semanticKey,
+      candidateSemanticKeys: identityCandidateKeys,
+    });
+
+    let surface!: SurfaceState;
+    let interval!: IntervalState;
+
+    // 1. zoom
+    const zoom = createPlotZoomState(context, {
+      zoomConfig: () => config.zoom,
+      assembled: () => options.spec ?? continuousSpec(),
+    });
+
+    // 2. inspection (before surface — reversed reducer dep)
+    const inspection = createInspectionState(context, {
+      reducer: () => surface.reducer,
+      inspectEnabled: () => config.inspect !== null,
+      dataIdentityEpoch: () => "epoch-1",
+      plotId: () => "plot-test",
+      clearTooltipHovered: () => {},
       clearAnnouncement: () => {},
     });
 
     // 3. surface (owns reducer). Global rAF is the deferred suite pump.
-    surface = createSurfaceState({
-      model: () => model,
-      root: () => root,
+    surface = createSurfaceState(context, {
       toolProp: () => toolPropBox.value,
       initialTool: () => config.initialTool,
       availableTools: () => config.availableTools,
-      inspectConfig: () => config.inspect,
-      selectConfig: () => config.select,
       pointSelectEnabled: () => config.select?.type === "point",
-      ontoolchange: () => onToolChangeBox.value,
       surfaceInteractive: () => options.surfaceInteractive ?? true,
-      candidateSemanticKeys: identityCandidateKeys,
       inspection: () => inspection,
       interval: () => interval,
       zoom: () => zoom,
@@ -346,28 +337,17 @@ export function mountSurfaceComposite(
         }
         selectionEvents.push(event);
       },
-      semanticKey,
       togglePointKeys: (keys, source) => {
         toggleCalls.push({ keys, source });
-      },
-      tooltipHovered: () => false,
-      announce: (message) => {
-        announcements.push(message);
       },
     });
 
     // 4. interval AFTER surface (production order — deferred surface→interval)
-    interval = createIntervalState({
-      model: () => model,
-      interaction: noController,
-      resolvedInteractionScope: () => ({ keys: "plot", x: "x", y: "y", intervals: "plot" }),
-      selectConfig: () => config.select,
+    interval = createIntervalState(context, {
       effectiveZoomDomains: () => zoom.effectiveZoomDomains,
       commitZoom: (domains, source) => {
         zoom.commitZoom(domains, source);
       },
-      captureSurface: () => capture,
-      candidateSemanticKeys: identityCandidateKeys,
       consumptionCandidates: () => {
         const candidates = [];
         for (let id = 0; id < model.candidates.size; id++) {
@@ -394,9 +374,6 @@ export function mountSurfaceComposite(
           selectionOrderLog.push(`emit:${event.phase}`);
         }
         selectionEvents.push(event);
-      },
-      announce: (message) => {
-        announcements.push(message);
       },
     });
 
@@ -460,4 +437,4 @@ void originalCaf;
 
 // Re-exports used by construction-armed tests
 export { fromAny, createSurfaceState, normalizeInteractionConfig, modelFor };
-export type { SurfaceStateDeps, InteractionTool };
+export type { SurfaceStateOptions, InteractionTool };

--- a/packages/svelte/tests/zoom/zoom-state.domains.test.ts
+++ b/packages/svelte/tests/zoom/zoom-state.domains.test.ts
@@ -126,7 +126,6 @@ describe("createPlotZoomState applyBrushZoom", () => {
     const flipped = reactiveBox(false);
     const { state, destroy } = mountZoomController({
       model: () => contModel.value,
-      coordFlipped: () => flipped.value,
       onzoom: () => (event) => {
         zoomEvents.push(event);
       },

--- a/packages/svelte/tests/zoom/zoom-state.harness.ts
+++ b/packages/svelte/tests/zoom/zoom-state.harness.ts
@@ -18,6 +18,7 @@ import type {
 import { createPlotInteraction } from "../../src/lib/interaction/controller.svelte.js";
 import { createPlotZoomState } from "../../src/lib/zoom/zoom-state.svelte.js";
 import { withFlushedEffectRoot } from "../helpers/effect-root.svelte.js";
+import { testInteractionContext } from "../helpers/interaction-context.js";
 import { modelFor } from "../helpers/model.js";
 
 const zoomRows = [
@@ -93,7 +94,7 @@ export type ZoomHarness = {
 
 /**
  * Mount the controller with production-shaped deps: every reactive dep is a
- * getter (mirroring PlotZoomStateDeps). Tests that need reactivity pass
+ * getter (context + options split). Tests that need reactivity pass
  * getters over their own reactive boxes; omitted options get static defaults.
  */
 export function mountZoomController(
@@ -103,7 +104,6 @@ export function mountZoomController(
     zoomConfig?: () => ZoomConfig;
     assembled?: () => PortableSpec | null;
     model?: () => RenderModel | null;
-    coordFlipped?: () => boolean;
     onzoom?: () => ZoomCb;
     oninteraction?: () => InteractionCb;
     announce?: (message: string) => void;
@@ -113,17 +113,20 @@ export function mountZoomController(
   const defaultModel = modelFor(defaultAssembled);
 
   const { value: state, destroy } = withFlushedEffectRoot(() =>
-    createPlotZoomState({
-      interaction: options.interaction ?? noController,
-      resolvedInteractionScope: options.resolvedInteractionScope ?? (() => defaultScope),
-      zoomConfig: options.zoomConfig ?? xyZoomConfig,
-      assembled: options.assembled ?? (() => defaultAssembled),
-      model: options.model ?? (() => defaultModel),
-      coordFlipped: options.coordFlipped ?? (() => false),
-      onzoom: options.onzoom ?? noZoomCallback,
-      oninteraction: options.oninteraction ?? noInteractionCallback,
-      announce: options.announce ?? (() => {}),
-    }),
+    createPlotZoomState(
+      testInteractionContext({
+        interaction: options.interaction ?? noController,
+        resolvedInteractionScope: options.resolvedInteractionScope ?? (() => defaultScope),
+        model: options.model ?? (() => defaultModel),
+        onzoom: options.onzoom ?? noZoomCallback,
+        oninteraction: options.oninteraction ?? noInteractionCallback,
+        announce: options.announce ?? (() => {}),
+      }),
+      {
+        zoomConfig: options.zoomConfig ?? xyZoomConfig,
+        assembled: options.assembled ?? (() => defaultAssembled),
+      },
+    ),
   );
 
   return { state, destroy };

--- a/packages/svelte/tests/zoom/zoom-state.integration.test.ts
+++ b/packages/svelte/tests/zoom/zoom-state.integration.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from "vitest";
 
 import { createPlotRuntime } from "../../src/lib/runtime/runtime.svelte.js";
 import { withFlushedEffectRoot } from "../helpers/effect-root.svelte.js";
+import { testInteractionContext } from "../helpers/interaction-context.js";
 import { reactiveBox } from "../helpers/reactive-box.svelte.js";
 import { createReactiveRuntimeDeps } from "../helpers/runtime-deps.svelte.js";
 import {
@@ -33,19 +34,22 @@ describe("runtime + zoom real cycle", () => {
       // Host wiring: zoom factory BEFORE createPlotRuntime; runtime deps
       // wired to controller aliases.
       const assembledBox = reactiveBox<PortableSpec | null>(initialSpec);
-      const zoom = createPlotZoomState({
-        interaction: noController,
-        resolvedInteractionScope: () => defaultScope,
-        zoomConfig: xyZoomConfig,
-        assembled: () => assembledBox.value,
-        model: () => runtime.model,
-        coordFlipped: () => false,
-        onzoom: () => (event) => {
-          zoomEvents.push(event);
+      const zoom = createPlotZoomState(
+        testInteractionContext({
+          interaction: noController,
+          resolvedInteractionScope: () => defaultScope,
+          model: () => runtime.model,
+          onzoom: () => (event) => {
+            zoomEvents.push(event);
+          },
+          oninteraction: noInteractionCallback,
+          announce: () => {},
+        }),
+        {
+          zoomConfig: xyZoomConfig,
+          assembled: () => assembledBox.value,
         },
-        oninteraction: noInteractionCallback,
-        announce: () => {},
-      });
+      );
       // Host aliases (construction-order DAG).
       const effectiveZoomDomains = () => zoom.effectiveZoomDomains;
       const effectiveSpec = () => zoom.effectiveSpec;

--- a/packages/svelte/tests/zoom/zoom-state.modes.test.ts
+++ b/packages/svelte/tests/zoom/zoom-state.modes.test.ts
@@ -6,6 +6,7 @@ import { flushSync } from "svelte";
 import { describe, expect, it } from "vitest";
 
 import { withEffectRoot } from "../helpers/effect-root.svelte.js";
+import { testInteractionContext } from "../helpers/interaction-context.js";
 import {
   continuousSpec,
   createPlotInteraction,
@@ -25,33 +26,31 @@ import {
 describe("createPlotZoomState construction", () => {
   it("does not invoke armed later-declared getters during construction (before first flush)", () => {
     let modelCalls = 0;
-    let coordFlippedCalls = 0;
     let announceCalls = 0;
 
     const { value: state, destroy } = withEffectRoot(() =>
-      createPlotZoomState({
-        interaction: noController,
-        resolvedInteractionScope: () => defaultScope,
-        zoomConfig: xyZoomConfig,
-        assembled: () => continuousSpec(),
-        model: () => {
-          modelCalls++;
-          return null;
+      createPlotZoomState(
+        testInteractionContext({
+          interaction: noController,
+          resolvedInteractionScope: () => defaultScope,
+          model: () => {
+            modelCalls++;
+            return null;
+          },
+          onzoom: noZoomCallback,
+          oninteraction: noInteractionCallback,
+          announce: () => {
+            announceCalls++;
+          },
+        }),
+        {
+          zoomConfig: xyZoomConfig,
+          assembled: () => continuousSpec(),
         },
-        coordFlipped: () => {
-          coordFlippedCalls++;
-          return false;
-        },
-        onzoom: noZoomCallback,
-        oninteraction: noInteractionCallback,
-        announce: () => {
-          announceCalls++;
-        },
-      }),
+      ),
     );
 
     expect(modelCalls).toBe(0);
-    expect(coordFlippedCalls).toBe(0);
     expect(announceCalls).toBe(0);
     // Deriveds are lazy on client and server at the 5.33.1 floor, so this
     // guard proves the exposed accessors reach no armed getter (reads + one
@@ -61,7 +60,6 @@ describe("createPlotZoomState construction", () => {
     expect(state.effectiveSpec).not.toBeNull();
     flushSync();
     expect(modelCalls).toBe(0);
-    expect(coordFlippedCalls).toBe(0);
     expect(announceCalls).toBe(0);
     destroy();
   });


### PR DESCRIPTION
## Problem

The five interaction controller factories (`zoom`, `selection`, `interval`, `surface`, `inspection`) each declared their own 6–19-field deps type, and `plot-engine.svelte.ts` hand-wired ~60 fields — most of them the same model / config-slice / handler / DOM getters re-typed per controller. The surface ↔ inspection ↔ interval ↔ selection cycles were held together by deferred thunks and `let surfaceState!` / `let semanticCandidateProjection!` late bindings, with a load-bearing construction order documented only in comments. Understanding one gesture meant bouncing across six modules *and* the engine's wiring.

## Solution

Deepen the module behind the existing plot-engine seam:

- **`interaction/interaction-context.svelte.ts`** — one shared `InteractionContext` (model, config slices, handlers, announce, DOM refs, semantic-key service) replaces the per-factory hand-written bags.
- **Factories are now `create*(context, options)`** — options hold only what is genuinely controller-specific (sibling ports, host-derived enablement, narrow config slices). Dep bags shrink from 6–19 fields to 0–6 options.
- **`interaction/interaction-states.svelte.ts`** — a single `createInteractionStates` assembly owns the construction order (zoom → selection → interval → surface → inspection) and wires sibling ports internally. The shared interaction reducer is a hoisted concrete instance, so **`let surfaceState!` is gone**; the semantic-candidate projection remains the one documented late binding (interval consumption ↔ projection is a real data cycle).
- `plot-engine.svelte.ts` keeps host-level deriveds, diagnostics, legend/chrome wiring; the header's construction-order contract shrinks accordingly.

Deliberately **not** done: no directory moves, no per-dir barrels (repo convention, CONTRIBUTING "No per-directory barrels"); legend focus/filter and chrome controllers keep their own factories (they import only interaction vocabulary types); `legendFocusState.installHostDerivedEffects()` stays (irreducible host-derived data, #627).

## Behavior

No public API or behavior change — pure internal refactor (`@ggsvelte/svelte` patch changeset marked internal). Public exports from `index.ts` untouched.

## Verification

- `bun run check:svelte` — 0 errors, 0 warnings
- `bun run lint` / `knip` — clean (deprecated `*Deps` aliases deleted, not shimmed)
- `bun run test:browser` — 4853 passed; 1 known load-dependent pixel-layout flake in `tests/legend/filter-state.test.ts` passes in isolation and in the full legend-suite run (675 tests)
- `bun run test:ssr` — 128 passed
- New `tests/interaction/interaction-states.test.ts` — assembly bundle construction laziness + interval→selection sibling-port wiring through the real controllers
- Harnesses now build one shared `tests/helpers/interaction-context.ts` context instead of re-typing full bags per suite
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1395" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->