### PR TITLE
fix(docs): gallery focus rings and tighter eager previews

### DIFF
--- a/apps/docs/src/routes/examples/+page.svelte
+++ b/apps/docs/src/routes/examples/+page.svelte
@@ -145,16 +145,17 @@
           <a href={`${base}/examples/${entry.id}`} aria-label={entry.title}>
             <figure>
               <div class="preview-paper">
-                <!-- First six cover a typical first screen; the rest stay lazy
-                     so cold gallery transfers do not pull ~2MB of PNG up front. -->
+                <!-- Eager the first two (covers a phone row + desktop start).
+                     Only the LCP candidate gets fetchpriority=high so the
+                     signal is not diluted across a full desktop row. -->
                 <img
                   src={`${base}${entry.previewPath}`}
                   alt=""
                   width="640"
                   height={entry.vrHeight ?? 400}
-                  loading={index < 6 ? "eager" : "lazy"}
+                  loading={index < 2 ? "eager" : "lazy"}
                   decoding="async"
-                  fetchpriority={index < 6 ? "high" : "low"}
+                  fetchpriority={index === 0 ? "high" : "low"}
                 />
               </div>
             </figure>
@@ -188,8 +189,11 @@
   }
 
   .example-grid > li {
+    /* content-visibility implies paint containment; pad so the global
+       outline-offset focus ring is not clipped (#1364). */
     content-visibility: auto;
     contain-intrinsic-size: auto 14rem;
+    padding: 0.4rem;
   }
 
   figure {

--- a/scripts/docs-gallery-preview-priority.test.ts
+++ b/scripts/docs-gallery-preview-priority.test.ts
@@ -1,6 +1,7 @@
 /**
  * Gallery first-screen previews stay eager; the rest stay lazy so cold loads
- * do not pull the full ~2MB PNG corpus up front.
+ * do not pull the full ~2MB PNG corpus up front. content-visibility must not
+ * clip keyboard focus rings (#1364).
  */
 import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
@@ -10,10 +11,19 @@ const root = path.join(import.meta.dirname, "..");
 const page = readFileSync(path.join(root, "apps/docs/src/routes/examples/+page.svelte"), "utf8");
 
 describe("docs gallery preview priority", () => {
-  it("eagers only the first six results and lazy-loads the rest", () => {
-    expect(page).toContain('loading={index < 6 ? "eager" : "lazy"}');
-    expect(page).toContain('fetchpriority={index < 6 ? "high" : "low"}');
+  it("eagers a small first-screen window and reserves high priority for LCP only (#1364)", () => {
+    // One column on phones (~17rem min); eager budget must not assume six columns.
+    expect(page).toContain('loading={index < 2 ? "eager" : "lazy"}');
+    // fetchpriority high is diluted when applied to many images — only the LCP candidate.
+    expect(page).toContain('fetchpriority={index === 0 ? "high" : "low"}');
     expect(page).toContain('decoding="async"');
     expect(page).toContain("content-visibility: auto");
+  });
+
+  it("leaves room for focus outlines under content-visibility paint containment (#1364)", () => {
+    // content-visibility implies paint containment; outline-offset:3px is clipped
+    // unless the <li> padding box includes the outline.
+    expect(page).toMatch(/\.example-grid\s*>\s*li\s*\{[^}]*content-visibility:\s*auto/s);
+    expect(page).toMatch(/\.example-grid\s*>\s*li\s*\{[^}]*padding:\s*0\.4rem/s);
   });
 });


### PR DESCRIPTION
## Summary

Follow-up for unrebutted post-merge review on #1364.

### Findings

1. **Focus ring clipped** — `content-visibility: auto` applies paint containment, so the global `outline-offset: 3px` on card links was cut off. Pad each `<li>` by `0.4rem`.
2. **Over-eager mobile loads** — hardcoded first six previews at `fetchpriority=high` over-fetches on one-column phones and dilutes the LCP priority signal. Eager the first two; high priority only for `index === 0`.

## Tests

- `bun test scripts/docs-gallery-preview-priority.test.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1398" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->