### PR TITLE
fix(bench): fair area overlay and drop duplicate replace sample

### DIFF
--- a/benchmarks/competitive/README.md
+++ b/benchmarks/competitive/README.md
@@ -43,12 +43,13 @@ Results: `results/bundles.json`, `results/browser.json`.
 1. **Apples and oranges by design.** uPlot is a lean canvas time-series painter with almost no grammar. ggsvelte runs a ggplot-like pipeline (scales, stats hooks, guides, candidates). Beating uPlot on raw line paint is a long game; the matrix shows the gap honestly.
 2. **ggsvelte-canvas harness draws mark strata only** (no axis/legend SVG chrome). That isolates mark cost; production `GGPlot` still composites SVG chrome.
 3. **ggsvelte-svg** is `renderToSVGString` innerHTML — full chart including axes.
-4. **`replace` is a full remount**, not in-place `setData`. Streaming / partial update is intentionally out of scope until a second metric lands (LightningChart's streaming score).
-5. **No interaction (mousemove) or max-capacity sweep yet.** uPlot's table and LC's capacity/stream metrics are the next expansion targets.
-6. **SveltePlot / LayerCake** remain bundle-only until component fixtures mount in Playwright.
-7. Compare **within one machine and one run**. Absolute ms are host-sensitive (same as internal budgets).
-8. **Paint-inclusive timing** waits two animation frames after mount, so small cases sit near a ~1–2 frame floor. Use denser cases (`line-3x10k`, `scatter-color-10k`, full matrix) to rank libraries.
-9. **uPlot scatter** sorts x ascending before paint (uPlot requires monotonic `data[0]`); that sort is inside the timed path for this adapter.
+4. **`replace` is a full remount**, not in-place `setData`. The browser harness therefore **does not re-sample** replace (it mirrors mount stats) until a real in-place update metric lands (LightningChart's streaming score).
+5. **`area-multiseries` is overlaid (identity), not stacked.** ggsvelte `geomArea` defaults to `stack`; adapters pass `position: "identity"` so ggsvelte matches D3/Chart.js/ECharts/uPlot overlays. `bars-stacked` remains the stack fairness cell.
+6. **No interaction (mousemove) or max-capacity sweep yet.** uPlot's table and LC's capacity/stream metrics are the next expansion targets.
+7. **SveltePlot / LayerCake** remain bundle-only until component fixtures mount in Playwright.
+8. Compare **within one machine and one run**. Absolute ms are host-sensitive (same as internal budgets).
+9. **Paint-inclusive timing** waits two animation frames after mount, so small cases sit near a ~1–2 frame floor. Use denser cases (`line-3x10k`, `scatter-color-10k`, full matrix) to rank libraries.
+10. **uPlot scatter** sorts x ascending before paint (uPlot requires monotonic `data[0]`); that sort is inside the timed path for this adapter.
 
 ## Scenario catalog
 

--- a/benchmarks/competitive/adapters/ggsvelte-canvas.ts
+++ b/benchmarks/competitive/adapters/ggsvelte-canvas.ts
@@ -30,8 +30,9 @@ function lineSpec(data: SeriesColumns) {
 }
 
 function areaSpec(data: SeriesColumns) {
+  // Identity (not stack): competitors overlay series; default geomArea is stack.
   return gg(data, aes({ x: "x", y: "y", fill: "series", group: "series" }))
-    .geomArea({ render: "canvas" })
+    .geomArea({ position: "identity", render: "canvas" })
     .toPortable();
 }
 

--- a/benchmarks/competitive/adapters/ggsvelte-svg.ts
+++ b/benchmarks/competitive/adapters/ggsvelte-svg.ts
@@ -28,8 +28,9 @@ function lineSpec(data: SeriesColumns) {
 }
 
 function areaSpec(data: SeriesColumns) {
+  // Identity (not stack): competitors overlay series; default geomArea is stack.
   return gg(data, aes({ x: "x", y: "y", fill: "series", group: "series" }))
-    .geomArea()
+    .geomArea({ position: "identity" })
     .toPortable();
 }
 

--- a/benchmarks/competitive/measure-browser.ts
+++ b/benchmarks/competitive/measure-browser.ts
@@ -2,7 +2,8 @@
  * Browser paint competitive bench (Playwright Chromium).
  *
  * Matrix: browser-enabled libs × scenario cases (default subset, or COMPETITIVE_FULL=1).
- * Metrics per cell: cold mount median ms (includes double-rAF) and full remount median ms.
+ * Metrics per cell: cold mount median ms (includes double-rAF). replace* columns
+ * mirror mount until in-place setData exists (full remount is not re-sampled).
  *
  *   bun run measure-browser.ts
  *   COMPETITIVE_FULL=1 bun run measure-browser.ts
@@ -143,17 +144,9 @@ for (const cell of matrix) {
       );
       return r.ms;
     });
-    process.stderr.write(`bench replace ${label}...\n`);
-    const replaceStats = await medianMs(async () => {
-      const r = await page.evaluate(
-        async ({ library, caseId }) => {
-          const w = window as unknown as { competitiveBench: BenchApi };
-          return w.competitiveBench.replace(library, caseId);
-        },
-        { library: cell.lib.id, caseId: cell.caseId },
-      );
-      return r.ms;
-    });
+    // replaceLib is a full remount alias of mountLib today — re-running the
+    // median loop doubles wall time with no new information (#1357). Mirror
+    // mount stats until a real in-place setData metric lands.
     results.push({
       lib: cell.lib.id,
       caseId: cell.caseId,
@@ -163,9 +156,9 @@ for (const cell of matrix) {
       mountMedianMs: mountStats.median,
       mountMeanMs: mountStats.mean,
       mountP95Ms: mountStats.p95,
-      replaceMedianMs: replaceStats.median,
-      replaceMeanMs: replaceStats.mean,
-      replaceP95Ms: replaceStats.p95,
+      replaceMedianMs: mountStats.median,
+      replaceMeanMs: mountStats.mean,
+      replaceP95Ms: mountStats.p95,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/benchmarks/competitive/scenarios.test.ts
+++ b/benchmarks/competitive/scenarios.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
 
 import {
   CASES,
@@ -90,5 +91,21 @@ describe("competitive scenario catalog", () => {
       expect(libSupports(lib, "scatter-color")).toBe(true);
       expect(libSupports(lib, "line-multiseries")).toBe(true);
     }
+  });
+
+  test("area-multiseries ggsvelte adapters force identity position (fair vs competitors) (#1357)", () => {
+    // Competitors draw overlaid areas; geomArea defaults to stack.
+    const svg = readFileSync(new URL("./adapters/ggsvelte-svg.ts", import.meta.url), "utf8");
+    const canvas = readFileSync(new URL("./adapters/ggsvelte-canvas.ts", import.meta.url), "utf8");
+    expect(svg).toMatch(/geomArea\(\s*\{\s*position:\s*["']identity["']/);
+    expect(canvas).toMatch(/geomArea\(\s*\{[^}]*position:\s*["']identity["']/s);
+  });
+
+  test("browser harness does not re-sample replace as a second mount loop (#1357)", () => {
+    // replaceLib is a full remount alias of mountLib; re-running medianMs doubles
+    // wall time with no new information until in-place setData exists.
+    const harness = readFileSync(new URL("./measure-browser.ts", import.meta.url), "utf8");
+    expect(harness).not.toMatch(/competitiveBench\.replace/);
+    expect(harness).toMatch(/replaceMedianMs:\s*mountStats\.median|replaceMedianMs:\s*mountStats/);
   });
 });


### PR DESCRIPTION
## Summary

Follow-up for unrebutted post-merge review on #1357 (competitive matrix).

### Findings

1. **Area unfairness** — `geomArea()` defaults to `stack`; competitors draw overlaid areas. Both ggsvelte adapters now pass `position: "identity"`. Documented in README fairness notes.
2. **Duplicate replace sample** — `replaceLib` is a full remount alias of `mountLib`; re-running the median loop doubled wall time with no new signal. Browser harness mirrors mount stats for replace columns until in-place `setData` exists.

## Tests

- `bun test benchmarks/competitive/scenarios.test.ts`

Note: `oxlint` pre-commit was skipped (`SKIP=oxlint`) because `benchmarks/competitive/**` is in oxlint ignorePatterns and the hook errors when only ignored paths are staged.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1400" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->