### PR TITLE
fix(core): do not treat NaN x-keys as already sorted

### DIFF
--- a/.changeset/ribbon-nan-x-sort.md
+++ b/.changeset/ribbon-nan-x-sort.md
@@ -5,5 +5,5 @@
 # Sort ribbon/area groups when x keys include missing values
 
 Migration: none. Ribbon/area groups with non-finite running coordinates no
-longer skip x-sorting (NaN made the ordered-check always succeed), so shaded
-bands with gaps keep left-to-right vertex order after the finite filter.
+longer skip x-sorting, and finite rows sort in place so missing slots still
+split shaded bands into separate runs (ggplot2 NA gaps).

--- a/.changeset/ribbon-nan-x-sort.md
+++ b/.changeset/ribbon-nan-x-sort.md
@@ -1,0 +1,9 @@
+---
+"@ggsvelte/core": patch
+---
+
+# Sort ribbon/area groups when x keys include missing values
+
+Migration: none. Ribbon/area groups with non-finite running coordinates no
+longer skip x-sorting (NaN made the ordered-check always succeed), so shaded
+bands with gaps keep left-to-right vertex order after the finite filter.

--- a/packages/core/src/pipeline/geometry-ribbon.ts
+++ b/packages/core/src/pipeline/geometry-ribbon.ts
@@ -12,6 +12,7 @@ import {
   DEFAULT_LINEWIDTH,
   positionOf,
   removedWarning,
+  sortFiniteSlotsInPlace,
   sortGroupRowsByX,
 } from "./geometry-shared.js";
 import {
@@ -109,8 +110,9 @@ function sortGroupRowsByRunning(
     for (const rows of groupRows) rows.sort((a, b) => keys[a]! - keys[b]!);
     return;
   }
+  // Gap-preserving continuous sort (same as x path via sortGroupRowsByX).
   const y = frame.yNumeric!;
-  for (const rows of groupRows) rows.sort((a, b) => y[a]! - y[b]!);
+  for (const rows of groupRows) sortFiniteSlotsInPlace(rows, y);
 }
 
 /**

--- a/packages/core/src/pipeline/geometry-shared-bucket.ts
+++ b/packages/core/src/pipeline/geometry-shared-bucket.ts
@@ -109,7 +109,8 @@ export function sortGroupRowsByX(
     }
     for (const rows of groupRows) {
       if (isNonDecreasing(rows, keys)) continue;
-      rows.sort((a, b) => compareSortKeys(keys[a]!, keys[b]!));
+      // Band ranks are always finite (unknown → MAX_SAFE_INTEGER).
+      rows.sort((a, b) => keys[a]! - keys[b]!);
     }
     return;
   }
@@ -118,7 +119,10 @@ export function sortGroupRowsByX(
     // Multi-series long form is usually already x-sorted within each group
     // after bucketByGroup's ascending row walk — O(n) check beats O(n log n).
     if (isNonDecreasing(rows, x)) continue;
-    rows.sort((a, b) => compareSortKeys(x[a]!, x[b]!));
+    // Ribbon calls this *before* its finite filter and uses non-finite slots
+    // to split runs (ggplot2 NA gaps). Sort only finite-keyed rows in place so
+    // NaN/missing positions stay put and still break the band.
+    sortFiniteSlotsInPlace(rows, x);
   }
 }
 
@@ -131,12 +135,23 @@ function isNonDecreasing(rows: readonly number[], keys: ArrayLike<number>): bool
   return true;
 }
 
-/** Ascending compare; NaN sorts after every finite key (ribbon pre-filter). */
-function compareSortKeys(a: number, b: number): number {
-  const aNan = Number.isNaN(a);
-  const bNan = Number.isNaN(b);
-  if (aNan && bNan) return 0;
-  if (aNan) return 1;
-  if (bNan) return -1;
-  return a - b;
+/**
+ * Ascending sort of finite-keyed row indices only; leave non-finite slots in
+ * their original positions so ribbon gap splitting still sees them mid-group.
+ */
+function sortFiniteSlotsInPlace(rows: number[], keys: ArrayLike<number>): void {
+  const slots: number[] = [];
+  const finiteRows: number[] = [];
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i]!;
+    if (Number.isFinite(keys[row]!)) {
+      slots.push(i);
+      finiteRows.push(row);
+    }
+  }
+  if (finiteRows.length < 2) return;
+  finiteRows.sort((a, b) => keys[a]! - keys[b]!);
+  for (let j = 0; j < slots.length; j++) {
+    rows[slots[j]!] = finiteRows[j]!;
+  }
 }

--- a/packages/core/src/pipeline/geometry-shared-bucket.ts
+++ b/packages/core/src/pipeline/geometry-shared-bucket.ts
@@ -138,8 +138,9 @@ function isNonDecreasing(rows: readonly number[], keys: ArrayLike<number>): bool
 /**
  * Ascending sort of finite-keyed row indices only; leave non-finite slots in
  * their original positions so ribbon gap splitting still sees them mid-group.
+ * Exported for y-oriented ribbon running-coord sorts.
  */
-function sortFiniteSlotsInPlace(rows: number[], keys: ArrayLike<number>): void {
+export function sortFiniteSlotsInPlace(rows: number[], keys: ArrayLike<number>): void {
   const slots: number[] = [];
   const finiteRows: number[] = [];
   for (let i = 0; i < rows.length; i++) {

--- a/packages/core/src/pipeline/geometry-shared-bucket.ts
+++ b/packages/core/src/pipeline/geometry-shared-bucket.ts
@@ -124,7 +124,9 @@ export function sortGroupRowsByX(
 
 function isNonDecreasing(rows: readonly number[], keys: ArrayLike<number>): boolean {
   for (let i = 1; i < rows.length; i++) {
-    if (keys[rows[i]!]! < keys[rows[i - 1]!]!) return false;
+    // NaN keys (ribbon sorts before its finite filter) are never "ordered":
+    // every comparison involving NaN is false, so `a < b` would skip sort.
+    if (!(keys[rows[i]!]! >= keys[rows[i - 1]!]!)) return false;
   }
   return true;
 }

--- a/packages/core/src/pipeline/geometry-shared-bucket.ts
+++ b/packages/core/src/pipeline/geometry-shared-bucket.ts
@@ -109,7 +109,7 @@ export function sortGroupRowsByX(
     }
     for (const rows of groupRows) {
       if (isNonDecreasing(rows, keys)) continue;
-      rows.sort((a, b) => keys[a]! - keys[b]!);
+      rows.sort((a, b) => compareSortKeys(keys[a]!, keys[b]!));
     }
     return;
   }
@@ -118,7 +118,7 @@ export function sortGroupRowsByX(
     // Multi-series long form is usually already x-sorted within each group
     // after bucketByGroup's ascending row walk — O(n) check beats O(n log n).
     if (isNonDecreasing(rows, x)) continue;
-    rows.sort((a, b) => x[a]! - x[b]!);
+    rows.sort((a, b) => compareSortKeys(x[a]!, x[b]!));
   }
 }
 
@@ -129,4 +129,14 @@ function isNonDecreasing(rows: readonly number[], keys: ArrayLike<number>): bool
     if (!(keys[rows[i]!]! >= keys[rows[i - 1]!]!)) return false;
   }
   return true;
+}
+
+/** Ascending compare; NaN sorts after every finite key (ribbon pre-filter). */
+function compareSortKeys(a: number, b: number): number {
+  const aNan = Number.isNaN(a);
+  const bNan = Number.isNaN(b);
+  if (aNan && bNan) return 0;
+  if (aNan) return 1;
+  if (bNan) return -1;
+  return a - b;
 }

--- a/packages/core/src/pipeline/geometry-shared.ts
+++ b/packages/core/src/pipeline/geometry-shared.ts
@@ -16,6 +16,7 @@ export {
 } from "./geometry-shared-position.js";
 export {
   bucketByGroup,
+  sortFiniteSlotsInPlace,
   sortGroupRowsByX,
   warnSingleObservationGroups,
 } from "./geometry-shared-bucket.js";

--- a/packages/core/tests/geometry-shared-bucket-sort.test.ts
+++ b/packages/core/tests/geometry-shared-bucket-sort.test.ts
@@ -103,4 +103,24 @@ describe("sortGroupRowsByX", () => {
     expect(groupRows[0]).toEqual([1, 0]);
     expect(groupRows[1]).toEqual([3, 2]);
   });
+
+  it("does not treat NaN keys as already-ordered (ribbon sorts before finite filter) (#1371)", () => {
+    // isNonDecreasing used `a < b`, which is false for any NaN comparison, so
+    // groups like [5, NaN, 1] skipped sort and finite survivors kept raw order.
+    const linear = trainContinuous([[0, 1, 5]], {});
+    const xNumeric = Float64Array.of(5, Number.NaN, 1);
+    const frame = fromAny<LayerFrame>({
+      n: 3,
+      xValues: null,
+      xNumeric,
+      groups: [0, 0, 0],
+    });
+    const fx = fromPartial<Frame>({ xScale: linear });
+    const groupRows = [[0, 1, 2]];
+    sortGroupRowsByX(groupRows, frame, fx);
+    // Finite x values must end up non-decreasing among themselves (NaN placement
+    // is implementation-defined; check the finite subsequence).
+    const finiteOrder = groupRows[0]!.filter((row) => Number.isFinite(xNumeric[row]!));
+    expect(finiteOrder.map((row) => xNumeric[row]!)).toEqual([1, 5]);
+  });
 });

--- a/packages/core/tests/geometry-shared-bucket-sort.test.ts
+++ b/packages/core/tests/geometry-shared-bucket-sort.test.ts
@@ -104,9 +104,10 @@ describe("sortGroupRowsByX", () => {
     expect(groupRows[1]).toEqual([3, 2]);
   });
 
-  it("does not treat NaN keys as already-ordered (ribbon sorts before finite filter) (#1371)", () => {
+  it("sorts finite x keys in place without moving NaN gap slots (#1371)", () => {
     // isNonDecreasing used `a < b`, which is false for any NaN comparison, so
-    // groups like [5, NaN, 1] skipped sort and finite survivors kept raw order.
+    // groups like [5, NaN, 1] skipped sort. Sorting must order finite rows but
+    // keep the NaN slot mid-group so ribbon can still split runs on the gap.
     const linear = trainContinuous([[0, 1, 5]], {});
     const xNumeric = Float64Array.of(5, Number.NaN, 1);
     const frame = fromAny<LayerFrame>({
@@ -118,9 +119,7 @@ describe("sortGroupRowsByX", () => {
     const fx = fromPartial<Frame>({ xScale: linear });
     const groupRows = [[0, 1, 2]];
     sortGroupRowsByX(groupRows, frame, fx);
-    // Finite x values must end up non-decreasing among themselves (NaN placement
-    // is implementation-defined; check the finite subsequence).
-    const finiteOrder = groupRows[0]!.filter((row) => Number.isFinite(xNumeric[row]!));
-    expect(finiteOrder.map((row) => xNumeric[row]!)).toEqual([1, 5]);
+    expect(groupRows[0]!.map((row) => xNumeric[row]!)).toEqual([1, Number.NaN, 5]);
+    expect(Number.isNaN(xNumeric[groupRows[0]![1]!]!)).toBe(true);
   });
 });

--- a/packages/core/tests/pipeline-m2/ribbon.test.ts
+++ b/packages/core/tests/pipeline-m2/ribbon.test.ts
@@ -138,6 +138,20 @@ describe("ribbon geom", () => {
     expect(batch.pathOffsets.length - 1).toBe(1);
   });
 
+  it("keeps a gap when the running y is missing mid-group (#1371)", () => {
+    const model = runPipeline(
+      gg(
+        { y: [5, null, 1, 2], lo: [0, 0, 0, 0], hi: [1, 1, 1, 1] },
+        aes({ y: "y", xmin: "lo", xmax: "hi" }),
+      )
+        .geomRibbon()
+        .spec(),
+      size,
+    );
+    const batch = model.scene.batches[0] as PathsBatch;
+    expect(batch.pathOffsets.length - 1).toBe(1);
+  });
+
   it("survives coord flip", () => {
     const model = runPipeline(
       gg({ x: [1, 2, 3], lo: [1, 2, 1], hi: [3, 4, 3] }, aes({ x: "x", ymin: "lo", ymax: "hi" }))

--- a/packages/core/tests/pipeline-m2/ribbon.test.ts
+++ b/packages/core/tests/pipeline-m2/ribbon.test.ts
@@ -120,6 +120,24 @@ describe("ribbon geom", () => {
     expect(batch.pathOffsets.length - 1).toBe(2);
   });
 
+  it("keeps a gap when the running x is missing mid-group (#1371)", () => {
+    // x-sort must not relocate the missing running coord to the tail, or the
+    // two finite sides would merge into one continuous band.
+    const model = runPipeline(
+      gg(
+        { x: [5, null, 1, 2], lo: [0, 0, 0, 0], hi: [1, 1, 1, 1] },
+        aes({ x: "x", ymin: "lo", ymax: "hi" }),
+      )
+        .geomRibbon()
+        .spec(),
+      size,
+    );
+    const batch = model.scene.batches[0] as PathsBatch;
+    // Finite sides [5] alone + [1,2] → only the 2-row side emits a closed path.
+    // If NaN were moved to the end, [5,1,2] would wrongly form one run.
+    expect(batch.pathOffsets.length - 1).toBe(1);
+  });
+
   it("survives coord flip", () => {
     const model = runPipeline(
       gg({ x: [1, 2, 3], lo: [1, 2, 1], hi: [3, 4, 3] }, aes({ x: "x", ymin: "lo", ymax: "hi" }))


### PR DESCRIPTION
## Summary

Follow-up for unrebutted post-merge review on #1371.

**Finding:** `sortGroupRowsByX` early-out (`isNonDecreasing`) used `keys[i] < keys[i-1]`. Any comparison involving NaN is false, so groups with missing coordinates (ribbon sorts *before* its finite filter) were treated as ordered and left unsorted.

**Fix:** use `!(keys[i] >= keys[i-1])` so NaN forces a sort. Regression test for continuous x with NaN keys.

## Tests

- `bun test packages/core/tests/geometry-shared-bucket-sort.test.ts packages/core/tests/pipeline-m2/ribbon.test.ts`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1402" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->