### PR TITLE
perf(core): mapped-style scale collection — catalog walks, group interning, fused conversions

### DIFF
--- a/.changeset/style-scale-collect-perf.md
+++ b/.changeset/style-scale-collect-perf.md
@@ -1,0 +1,28 @@
+---
+"@ggsvelte/core": patch
+---
+
+# Faster mapped-style scale training and collection
+
+Migration: none. Internal-only performance work; no public API or behavior
+changes.
+
+Measured on a loaded x86_64 box, min-of-20 reps of `pipeline mapped-style
+100k` (budget 132 ms): **~124 → ~56 ms**.
+
+- The source-catalog walk encodes each value once per row (was twice:
+  `indexableKeys` and the catalog dedupe kept separate `Set` addictions).
+- Provably-continuous aesthetics (sequential/binned/identity numeric style
+  scales) skip the full-column catalog dedupe walk entirely — the discrete
+  resolutions that read the catalog are unreachable, decided from field
+  discreteness metadata, never row data.
+- A single mapped frame (the common case) aliases its value column instead
+  of rebuilding it with one push per row; multi-frame plots and
+  Float64Array frame columns keep the historical concatenation.
+- `deriveGroups` interns homogeneous primitive single columns directly
+  (SameValueZero groups exactly like the `cellKey` string, NaN/±0
+  included), falling back to the canonical key path on the first Date or
+  mixed-type column.
+- All-number style value columns convert to their semantic Float64 view in
+  one fused loop instead of a per-element `cellToNumber` callback inside
+  `Float64Array.from`.

--- a/packages/core/src/grouping.ts
+++ b/packages/core/src/grouping.ts
@@ -133,14 +133,12 @@ function canonicalGroupsSingleColumn(
   let kind: "string" | "number" | "boolean" | "bigint" | "null" | null = null;
   for (let i = 0; i < n; i++) {
     const v = column[i]!;
+    const t = typeof v;
     const vKind =
       v === null
-        ? "null"
-        : typeof v === "string" ||
-            typeof v === "number" ||
-            typeof v === "boolean" ||
-            typeof v === "bigint"
-          ? typeof v
+        ? ("null" as const)
+        : t === "string" || t === "number" || t === "boolean" || t === "bigint"
+          ? t
           : null;
     if (vKind === null) return null; // Date (or any object): epoch-ms grouping
     if (kind === null) kind = vKind;

--- a/packages/core/src/grouping.ts
+++ b/packages/core/src/grouping.ts
@@ -115,6 +115,47 @@ function fieldDiscreteness(
 }
 
 /**
+ * Single-column interning without per-row key strings. A raw-value Map
+ * (SameValueZero) groups strings/numbers/booleans/bigint/null exactly as
+ * cellKey does — including NaN and ±0 — so the `typeof${SEP}String(v)` key
+ * is only needed to tell TYPES apart within one column and to group Dates
+ * by epoch ms. Homogeneous primitive columns (the common case: one string
+ * group column) therefore intern directly; the first Date (or mixed
+ * primitive types, which cellKey would separate) falls back to the
+ * canonical key path.
+ */
+function canonicalGroupsSingleColumn(
+  n: number,
+  column: readonly CellValue[],
+): { groups: number[]; groupCount: number } | null {
+  const groups = Array.from<number>({ length: n });
+  const ids = new Map<CellValue, number>();
+  let kind: "string" | "number" | "boolean" | "bigint" | "null" | null = null;
+  for (let i = 0; i < n; i++) {
+    const v = column[i]!;
+    const vKind =
+      v === null
+        ? "null"
+        : typeof v === "string" ||
+            typeof v === "number" ||
+            typeof v === "boolean" ||
+            typeof v === "bigint"
+          ? typeof v
+          : null;
+    if (vKind === null) return null; // Date (or any object): epoch-ms grouping
+    if (kind === null) kind = vKind;
+    else if (kind !== vKind) return null; // mixed types: cellKey separates them
+    let id = ids.get(v);
+    if (id === undefined) {
+      id = ids.size;
+      ids.set(v, id);
+    }
+    groups[i] = id;
+  }
+  return { groups, groupCount: ids.size };
+}
+
+/**
  * Canonicalize row keys to group ids numbered by first occurrence.
  * `groupCount` is the Map size (O(1) after the O(R) pass) — never re-derived
  * via `Math.max(...groups)`, which re-scans R rows and can RangeError when
@@ -163,7 +204,8 @@ export function deriveGroups(
       throw new Error(`deriveGroups: unknown field "${groupChannel.field}" in aes.group`);
     }
     // Group by value regardless of discreteness (matches ggplot2's id()).
-    const { groups, groupCount } = canonicalGroups(n, (i) => cellKey(column[i]!));
+    const { groups, groupCount } =
+      canonicalGroupsSingleColumn(n, column) ?? canonicalGroups(n, (i) => cellKey(column[i]!));
     return {
       groups,
       groupCount,
@@ -209,11 +251,17 @@ export function deriveGroups(
   }
 
   const constantKey = constantParts.join(SEP);
-  const { groups, groupCount } = canonicalGroups(n, (i) => {
-    const parts = discreteColumns.map(({ column }) => cellKey(column[i]!));
-    if (constantKey !== "") parts.push(constantKey);
-    return parts.join(SEP);
-  });
+  const single =
+    discreteColumns.length === 1 && constantKey === ""
+      ? canonicalGroupsSingleColumn(n, discreteColumns[0]!.column)
+      : null;
+  const { groups, groupCount } =
+    single ??
+    canonicalGroups(n, (i) => {
+      const parts = discreteColumns.map(({ column }) => cellKey(column[i]!));
+      if (constantKey !== "") parts.push(constantKey);
+      return parts.join(SEP);
+    });
   return {
     groups,
     groupCount,

--- a/packages/core/src/pipeline/scale-style-collect.ts
+++ b/packages/core/src/pipeline/scale-style-collect.ts
@@ -17,6 +17,14 @@ export function collectStyleValues(input: {
   bindings: readonly LayerBinding[];
   table: ColumnTable;
   sourceTable: ColumnTable;
+  /**
+   * Whether the source catalog (a full-column dedupe walk per mapped field)
+   * is needed at all. Sequential/binned/identity resolutions never read the
+   * catalog, so the caller passes "never" when the scale type is explicitly
+   * continuous and "auto" to let this walk decide from field discreteness
+   * metadata. "always" preserves the historical walk.
+   */
+  catalogMode: "always" | "auto" | "never";
 }): {
   values: CellValue[];
   catalog: CellValue[];
@@ -25,7 +33,7 @@ export function collectStyleValues(input: {
   anyIndexable: boolean;
   nonInteractiveValues: CellValue[];
 } {
-  const { aesthetic, frames, bindings, table, sourceTable } = input;
+  const { aesthetic, frames, bindings, table, sourceTable, catalogMode } = input;
   const values: CellValue[] = [];
   let anyField = false;
   let anyDiscrete = false;
@@ -77,6 +85,25 @@ export function collectStyleValues(input: {
     seen.add(key);
     catalog.push(value);
   };
+  // Metadata pass: flags and the walk decision come from field discreteness,
+  // never from row data, so they are computed before (and independently of)
+  // the full-column catalog walk.
+  const walkCatalog = (() => {
+    if (catalogMode === "never") return false;
+    if (catalogMode === "always") return true;
+    for (const binding of bindings) {
+      const mapped = bindingOf(binding, aesthetic);
+      const catalogTable = binding.sourceTable ?? sourceTable;
+      if (
+        (mapped.field !== null &&
+          catalogTable.has(mapped.field) &&
+          catalogTable.discreteness(mapped.field) === "discrete") ||
+        mapped.scaledConstant !== null
+      )
+        return true;
+    }
+    return anyDiscrete;
+  })();
   for (const binding of bindings) {
     const mapped = bindingOf(binding, aesthetic);
     // Prefer the layer's own source table so multi-table catalogs union correctly (#589).
@@ -85,15 +112,17 @@ export function collectStyleValues(input: {
       anyField = true;
       anyIndexable = true;
       if (catalogTable.discreteness(mapped.field) === "discrete") anyDiscrete = true;
-      // One encodeKey per row (not two — indexableKeys and the catalog
-      // dedupe keyed separately); this walk dominates mapped-style profiles.
-      const column = catalogTable.column(mapped.field);
-      for (let i = 0; i < column.length; i++) {
-        const key = encodeKey(column[i]!);
-        indexableKeys.add(key);
-        if (!seen.has(key)) {
-          seen.add(key);
-          catalog.push(column[i]!);
+      if (walkCatalog) {
+        // One encodeKey per row (not two — indexableKeys and the catalog
+        // dedupe keyed separately); this walk dominates mapped-style profiles.
+        const column = catalogTable.column(mapped.field);
+        for (let i = 0; i < column.length; i++) {
+          const key = encodeKey(column[i]!);
+          indexableKeys.add(key);
+          if (!seen.has(key)) {
+            seen.add(key);
+            catalog.push(column[i]!);
+          }
         }
       }
     }
@@ -106,7 +135,7 @@ export function collectStyleValues(input: {
         anyIndexable = true;
         indexableKeys.add(encodeKey(mapped.scaledConstant));
       }
-      add(mapped.scaledConstant);
+      if (walkCatalog) add(mapped.scaledConstant);
     }
   }
   // In a mixed legend (a data-backed mapping makes the whole scale interactive

--- a/packages/core/src/pipeline/scale-style-collect.ts
+++ b/packages/core/src/pipeline/scale-style-collect.ts
@@ -47,7 +47,7 @@ export function collectStyleValues(input: {
    */
   catalogMode: "always" | "auto" | "never";
 }): {
-  values: CellValue[];
+  values: readonly CellValue[];
   catalog: CellValue[];
   anyField: boolean;
   anyDiscrete: boolean;
@@ -55,6 +55,22 @@ export function collectStyleValues(input: {
   nonInteractiveValues: CellValue[];
 } {
   const { aesthetic, frames, bindings, table, sourceTable, catalogMode } = input;
+  // Sole-contributor fast path: a single mapped frame run (the common case)
+  // aliases the frame's values array instead of paying one push per row.
+  // Consumers never mutate `values` (missing-count filter, scale training).
+  // Float64Array frame columns are not aliasable (readonly CellValue[]
+  // return type) and keep the historical copy.
+  let contributions = 0;
+  let soleRun: readonly CellValue[] | null = null;
+  for (const frame of frames) {
+    const binding = bindingOf(frame.binding, aesthetic);
+    const mapped = styleFrameValues(frame, aesthetic);
+    if ((binding.field !== null || binding.statColumn !== null) && mapped !== null) {
+      contributions++;
+      soleRun = mapped instanceof Float64Array ? null : mapped;
+    }
+    if (binding.scaledConstant !== null) contributions++;
+  }
   const values: CellValue[] = [];
   let anyField = false;
   let anyDiscrete = false;
@@ -81,10 +97,12 @@ export function collectStyleValues(input: {
         anyDiscrete = true;
       }
       if (binding.field !== null) anyIndexable = true;
-      // One push per element — never spread a row-length column into push.
-      // Spread hits the engine argument limit (RangeError) on large data (#1338).
-      // Match the colour path in scale-color-collect.ts.
-      for (const v of mapped) values.push(v);
+      if (contributions !== 1 || soleRun === null) {
+        // One push per element — never spread a row-length column into push.
+        // Spread hits the engine argument limit (RangeError) on large data (#1338).
+        // Match the colour path in scale-color-collect.ts.
+        for (const v of mapped) values.push(v);
+      }
     }
     if (binding.scaledConstant !== null) {
       anyField = true;
@@ -159,5 +177,12 @@ export function collectStyleValues(input: {
   const nonInteractiveValues = anyIndexable
     ? annotationConstants.filter((value) => !indexableKeys.has(encodeKey(value)))
     : [];
-  return { values, catalog, anyField, anyDiscrete, anyIndexable, nonInteractiveValues };
+  return {
+    values: contributions === 1 && soleRun !== null ? soleRun : values,
+    catalog,
+    anyField,
+    anyDiscrete,
+    anyIndexable,
+    nonInteractiveValues,
+  };
 }

--- a/packages/core/src/pipeline/scale-style-collect.ts
+++ b/packages/core/src/pipeline/scale-style-collect.ts
@@ -11,6 +11,27 @@ function bindingOf(binding: LayerBinding, aesthetic: StyleAesthetic) {
   return binding[aesthetic];
 }
 
+/**
+ * Catalog walk for one mapped column. One encodeKey per row (not two —
+ * indexableKeys and the catalog dedupe keyed separately); this walk
+ * dominates mapped-style profiles.
+ */
+function walkCatalogColumn(
+  column: readonly CellValue[],
+  indexableKeys: Set<string>,
+  seen: Set<string>,
+  catalog: CellValue[],
+): void {
+  for (let i = 0; i < column.length; i++) {
+    const key = encodeKey(column[i]!);
+    indexableKeys.add(key);
+    if (!seen.has(key)) {
+      seen.add(key);
+      catalog.push(column[i]!);
+    }
+  }
+}
+
 export function collectStyleValues(input: {
   aesthetic: StyleAesthetic;
   frames: readonly LayerFrame[];
@@ -113,17 +134,7 @@ export function collectStyleValues(input: {
       anyIndexable = true;
       if (catalogTable.discreteness(mapped.field) === "discrete") anyDiscrete = true;
       if (walkCatalog) {
-        // One encodeKey per row (not two — indexableKeys and the catalog
-        // dedupe keyed separately); this walk dominates mapped-style profiles.
-        const column = catalogTable.column(mapped.field);
-        for (let i = 0; i < column.length; i++) {
-          const key = encodeKey(column[i]!);
-          indexableKeys.add(key);
-          if (!seen.has(key)) {
-            seen.add(key);
-            catalog.push(column[i]!);
-          }
-        }
+        walkCatalogColumn(catalogTable.column(mapped.field), indexableKeys, seen, catalog);
       }
     }
     if (mapped.scaledConstant !== null) {

--- a/packages/core/src/pipeline/scale-style-collect.ts
+++ b/packages/core/src/pipeline/scale-style-collect.ts
@@ -85,9 +85,16 @@ export function collectStyleValues(input: {
       anyField = true;
       anyIndexable = true;
       if (catalogTable.discreteness(mapped.field) === "discrete") anyDiscrete = true;
-      for (const value of catalogTable.column(mapped.field)) {
-        indexableKeys.add(encodeKey(value));
-        add(value);
+      // One encodeKey per row (not two — indexableKeys and the catalog
+      // dedupe keyed separately); this walk dominates mapped-style profiles.
+      const column = catalogTable.column(mapped.field);
+      for (let i = 0; i < column.length; i++) {
+        const key = encodeKey(column[i]!);
+        indexableKeys.add(key);
+        if (!seen.has(key)) {
+          seen.add(key);
+          catalog.push(column[i]!);
+        }
       }
     }
     if (mapped.scaledConstant !== null) {

--- a/packages/core/src/pipeline/scale-style-values.ts
+++ b/packages/core/src/pipeline/scale-style-values.ts
@@ -96,7 +96,18 @@ export function resolveNumericStyleValueView(input: {
     config?.timezone !== undefined ||
     config?.disambiguation !== undefined;
   if (!requestsTemporal) {
-    const semantic = Float64Array.from(values, (value) => cellToNumber(value));
+    // Dense plots feed all-number columns; a per-element cellToNumber
+    // callback inside Float64Array.from does not inline well. Single fused
+    // pass with a coercion fallback on the first non-number.
+    const semantic = new Float64Array(values.length);
+    for (let i = 0; i < values.length; i++) {
+      const value = values[i]!;
+      if (typeof value !== "number") {
+        for (let j = i; j < values.length; j++) semantic[j] = cellToNumber(values[j]!);
+        break;
+      }
+      semantic[i] = value;
+    }
     return {
       semantic,
       temporalKind: null,

--- a/packages/core/src/pipeline/scale-style.ts
+++ b/packages/core/src/pipeline/scale-style.ts
@@ -21,8 +21,19 @@ export function resolveStyleScale(input: {
   title: string;
   warnings: PipelineWarning[];
 }): StyleResolution {
-  const collected = collectStyleValues(input);
   const { aesthetic, config, prevState, title, warnings } = input;
+  // Sequential/binned/identity resolutions never read the source catalog,
+  // so a provably-continuous numeric aesthetic skips the full-column dedupe
+  // walk (100k rows × encodeKey × Set per mapped field on dense plots).
+  const catalogMode =
+    aesthetic === "shape" || aesthetic === "linetype"
+      ? "always"
+      : config?.type === undefined
+        ? "auto"
+        : config.type === "sequential" || config.type === "binned" || config.type === "identity"
+          ? "never"
+          : "always";
+  const collected = collectStyleValues({ ...input, catalogMode });
   if (!collected.anyField) {
     return { aesthetic, resolved: null, legendInput: null, guidePlan: null, state: null };
   }


### PR DESCRIPTION
## What

Five internal-only slices shrinking mapped-style scale collection/training (`pipeline mapped-style 100k`, previously 1.15× over budget). No public API or behavior changes; full core suite green after every slice, profiled before/after with `bun --cpu-prof`.

## Measured

`pipeline mapped-style 100k`, min-of-20 on a loaded x86_64 box: **~124 → ~56 ms** (budget 132 ms).

## Slices (one commit each)

1. **Encode each catalog value once per row** — the source-catalog walk called `encodeKey` twice per row (`indexableKeys` + dedupe Set). ~124 → ~108 ms.
2. **Skip the catalog walk for provably-continuous aesthetics** — `resolveNumericStyleScale` only reads the catalog on the discrete path; sequential/binned/identity never do. `collectStyleValues` gains a `catalogMode` (`"never"` for explicit continuous types, `"auto"` decided from field discreteness metadata, `"always"` for finite/discrete). The workload's size+alpha scales no longer walk 200k rows through `encodeKey`+Set to build catalogs nobody reads. ~108 → ~81 ms.
3. **Single-column group interning** — `deriveGroups` interned every row through a `typeof`-tagged key string (plus a one-element map/join per row in the interaction case); homogeneous primitive columns now intern raw values directly (SameValueZero ≡ `cellKey` grouping, NaN/±0 included) with fallback on Dates/mixed types.
4. **All-number semantic views** — `resolveNumericStyleValueView` converted values via per-element `cellToNumber` callback inside `Float64Array.from`; all-number columns now copy in one fused loop with coercion fallback.
5. **Alias sole-contributor frame value runs** — a single mapped frame no longer pays one push per row to rebuild an array identical to its value column (consumers never mutate); multi-frame plots and Float64Array columns keep concatenation. ~62 → ~56 ms.

## Not in this PR

- **Temporal preflight parse caching** across differing parser/option keys (`fallbackNumeric` walks per call-site key) — overlaps with the startup-cost angle; next PR.
- **Vectorized per-row style application** (`mappedStyleVector`'s per-row `mappedStyleOutput` callback) — needs resolved-scale interface surgery; future slice.
- **Geometry pixel packing** (`pointsBatch` `Float32Array.from`) — geometry assembly, separate concern.

## Test plan

- `bun run test` (4362), `bun run check`, `bun run lint`, `bun run lint:type-aware`, `bun run knip` all green.
- Behavior pinned by existing grouping/scale tests throughout (no test changes needed — every slice is semantics-preserving).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1403" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->