### PR TITLE
test(svelte): extract shared diagnostic mount harness

### DIFF
--- a/packages/svelte/tests/interaction/diagnostic-harness.ts
+++ b/packages/svelte/tests/interaction/diagnostic-harness.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared harness for browser-lane GGPlot-mount diagnostic tests.
+ *
+ * Why browser lane only: every advisory delivery path in plot-engine.svelte.ts
+ * (deliverAdvisoriesOnce, the config-diagnostics effect) runs inside $effect,
+ * which svelte/server render() never executes. Assertions on ondiagnostic
+ * payloads placed in *.ssr.test.ts would be vacuous passes — keep them here.
+ */
+import { expect } from "vitest";
+
+import type { PlotDiagnostic } from "../../src/lib/diagnostics/deprecation.js";
+
+export function collect(): {
+  diagnostics: PlotDiagnostic[];
+  ondiagnostic: (diagnostic: PlotDiagnostic) => void;
+} {
+  const diagnostics: PlotDiagnostic[] = [];
+  return {
+    diagnostics,
+    ondiagnostic: (diagnostic) => {
+      diagnostics.push(diagnostic);
+    },
+  };
+}
+
+export async function settled(container: Element): Promise<void> {
+  await expect.poll(() => container.querySelector("svg") !== null).toBe(true);
+  // One extra macrotask drain so pending $effect flushes cannot race the
+  // absence assertions below.
+  await new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}

--- a/packages/svelte/tests/interaction/wiring-diagnostics.test.ts
+++ b/packages/svelte/tests/interaction/wiring-diagnostics.test.ts
@@ -9,8 +9,8 @@ import { describe, expect, it, vi } from "vitest";
 import GGPlot from "../../src/lib/GGPlot.svelte";
 import { createPlotInteraction } from "../../src/lib/interaction/controller.svelte.js";
 import type { InteractionDiagnostic } from "../../src/lib/interaction/interaction.js";
-import type { PlotDiagnostic } from "../../src/lib/diagnostics/deprecation.js";
 import { render } from "../helpers/render.js";
+import { collect, settled } from "./diagnostic-harness.js";
 
 const rows = [
   { id: "a", x: 1, y: 10 },
@@ -25,28 +25,6 @@ const base = {
   // Default identity: rows expose `id` — no plot-level `key` (deprecated).
   ...size,
 };
-
-function collect(): {
-  diagnostics: PlotDiagnostic[];
-  ondiagnostic: (diagnostic: PlotDiagnostic) => void;
-} {
-  const diagnostics: PlotDiagnostic[] = [];
-  return {
-    diagnostics,
-    ondiagnostic: (diagnostic) => {
-      diagnostics.push(diagnostic);
-    },
-  };
-}
-
-async function settled(container: Element): Promise<void> {
-  await expect.poll(() => container.querySelector("svg") !== null).toBe(true);
-  // One extra macrotask drain so pending $effect flushes cannot race the
-  // absence assertions below.
-  await new Promise((resolve) => {
-    setTimeout(resolve, 0);
-  });
-}
 
 describe("scope-without-controller advisory", () => {
   it("advises when interactionScope is supplied without a controller", async () => {


### PR DESCRIPTION
collect()/settled() move out of wiring-diagnostics.test.ts into
tests/interaction/diagnostic-harness.ts so the upcoming inspect-advisory
mount tests (#1206) reuse the same race-safe primitives instead of
duplicating them. File header documents why these assertions must live
in the browser lane (diagnostic delivery runs in $effect, which
svelte/server never executes).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>