### PR TITLE
test(svelte): mount-level inspect advisory delivery tests (#1206)

### DIFF
--- a/packages/svelte/tests/fixtures/InspectGeomAdvisoriesFixture.svelte
+++ b/packages/svelte/tests/fixtures/InspectGeomAdvisoriesFixture.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  /**
+   * Host for inspect-geom advisory mount tests (#1206). Mounts GeomCol (and
+   * optionally GeomText value labels) as CHILD components under GGPlot so the
+   * registry → assembled().layers → collector path is exercised; the
+   * layers-prop path is covered inline in inspect-geom-diagnostics.test.ts.
+   */
+  import type { PlotDiagnostic } from "../../src/lib/diagnostics/deprecation.js";
+  import type { InspectInput } from "../../src/lib/interaction/interaction.js";
+  import GGPlot from "../../src/lib/GGPlot.svelte";
+  import GeomCol from "../../src/lib/geoms/GeomCol.svelte";
+  import GeomText from "../../src/lib/geoms/GeomText.svelte";
+
+  type Row = { id: string; x: number; y: number; label: string };
+
+  const {
+    data,
+    aes,
+    width = 480,
+    height = 320,
+    inspect,
+    withLabels = false,
+    ondiagnostic,
+  }: {
+    data: readonly Row[];
+    aes: { x: string; y: string };
+    width?: number;
+    height?: number;
+    inspect: InspectInput;
+    withLabels?: boolean;
+    ondiagnostic?: (diagnostic: PlotDiagnostic) => void;
+  } = $props();
+</script>
+
+<GGPlot {data} {aes} {width} {height} {inspect} {ondiagnostic}>
+  <GeomCol />
+  {#if withLabels}
+    <GeomText aes={{ x: aes.x, y: aes.y, label: "label" }} />
+  {/if}
+</GGPlot>

--- a/packages/svelte/tests/interaction/inspect-geom-diagnostics.test.ts
+++ b/packages/svelte/tests/interaction/inspect-geom-diagnostics.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Inspect advisory delivery through a mounted <GGPlot> (#1206, expanded):
+ * the pure collectors in inspect-geom-advisories.ts are unit-tested in
+ * inspect-geom-advisories.test.ts; this file pins the plot-engine wire-up —
+ * registry/prop layers → assembled().layers → deliverAdvisoriesOnce →
+ * ondiagnostic — plus the config-diagnostic path for faceted zoom.
+ *
+ * Browser lane on purpose: every delivery path runs inside $effect, which
+ * svelte/server render() never executes, so these assertions would be
+ * vacuous in the SSR lane.
+ */
+import { describe, expect, it } from "vitest";
+
+import GGPlot from "../../src/lib/GGPlot.svelte";
+import InspectGeomAdvisoriesFixture from "../fixtures/InspectGeomAdvisoriesFixture.svelte";
+import { withGrammarAsSpec } from "../helpers/ggplot-input.js";
+import { render } from "../helpers/render.js";
+import { collect, settled } from "./diagnostic-harness.js";
+
+const rows = [
+  { id: "a", x: 1, y: 10, label: "10" },
+  { id: "b", x: 2, y: 20, label: "20" },
+  { id: "c", x: 3, y: 15, label: "15" },
+];
+const size = { width: 480, height: 320 };
+const aes = { x: "x", y: "y" };
+
+const X_GUIDE_CODES = [
+  "INTERACTION_INSPECT_X_ON_COL",
+  "INTERACTION_INSPECT_X_ON_BAR",
+  "INTERACTION_INSPECT_X_BISECTS_COL_LABELS",
+  "INTERACTION_INSPECT_X_BISECTS_BAR_LABELS",
+] as const;
+
+// geom "bar" only supports count/bin stats — discrete x, no y.
+const categoricalRows = [
+  { id: "a", cat: "one", label: "one", labelY: 1 },
+  { id: "b", cat: "two", label: "two", labelY: 1 },
+  { id: "c", cat: "two", label: "two", labelY: 1 },
+  { id: "d", cat: "three", label: "three", labelY: 1 },
+];
+
+describe("inspect x-guide advisories on bar/col (#1206)", () => {
+  it("fires X_ON_COL for mode xy with a GeomCol child component", async () => {
+    const { diagnostics, ondiagnostic } = collect();
+    render(InspectGeomAdvisoriesFixture, {
+      data: rows,
+      aes,
+      inspect: { mode: "xy" as const },
+      ondiagnostic,
+      ...size,
+    });
+    await expect
+      .poll(() => diagnostics.find((d) => d.code === "INTERACTION_INSPECT_X_ON_COL"))
+      .toMatchObject({ severity: "advisory", prop: "inspect.mode", actual: "xy" });
+  });
+
+  it("escalates to BISECTS_COL_LABELS when GeomText value labels are present", async () => {
+    const { diagnostics, ondiagnostic } = collect();
+    const { container } = render(InspectGeomAdvisoriesFixture, {
+      data: rows,
+      aes,
+      inspect: { mode: "xy" as const },
+      withLabels: true,
+      ondiagnostic,
+      ...size,
+    });
+    await expect
+      .poll(() => diagnostics.find((d) => d.code === "INTERACTION_INSPECT_X_BISECTS_COL_LABELS"))
+      .toMatchObject({ severity: "warning", prop: "inspect.mode", actual: "xy" });
+    await settled(container);
+    // The stronger bisect warning REPLACES the plain-geom advisory.
+    expect(diagnostics.map((d) => d.code)).not.toContain("INTERACTION_INSPECT_X_ON_COL");
+  });
+
+  it("fires X_ON_BAR for mode xy via the layers prop form", async () => {
+    const { diagnostics, ondiagnostic } = collect();
+    render(GGPlot, {
+      data: categoricalRows,
+      layers: [{ geom: "bar" as const, aes: { x: { field: "cat" } } }],
+      inspect: { mode: "xy" as const },
+      ondiagnostic,
+      ...size,
+    });
+    await expect
+      .poll(() => diagnostics.find((d) => d.code === "INTERACTION_INSPECT_X_ON_BAR"))
+      .toMatchObject({ severity: "advisory", prop: "inspect.mode", actual: "xy" });
+  });
+
+  it("escalates to BISECTS_BAR_LABELS for layers-prop bar + text labels", async () => {
+    const { diagnostics, ondiagnostic } = collect();
+    const { container } = render(GGPlot, {
+      data: categoricalRows,
+      layers: [
+        { geom: "bar" as const, aes: { x: { field: "cat" } } },
+        {
+          geom: "text" as const,
+          aes: { x: { field: "cat" }, y: { field: "labelY" }, label: { field: "label" } },
+        },
+      ],
+      inspect: { mode: "xy" as const },
+      ondiagnostic,
+      ...size,
+    });
+    await expect
+      .poll(() => diagnostics.find((d) => d.code === "INTERACTION_INSPECT_X_BISECTS_BAR_LABELS"))
+      .toMatchObject({ severity: "warning", prop: "inspect.mode", actual: "xy" });
+    await settled(container);
+    expect(diagnostics.map((d) => d.code)).not.toContain("INTERACTION_INSPECT_X_ON_BAR");
+  });
+
+  it("fires for mode x, the other x-guide mode", async () => {
+    const { diagnostics, ondiagnostic } = collect();
+    render(GGPlot, {
+      data: rows,
+      aes,
+      layers: [{ geom: "col" as const }],
+      inspect: { mode: "x" as const },
+      ondiagnostic,
+      ...size,
+    });
+    await expect
+      .poll(() => diagnostics.find((d) => d.code === "INTERACTION_INSPECT_X_ON_COL"))
+      .toMatchObject({ severity: "advisory", actual: "x" });
+  });
+
+  it("stays silent when mode resolves to auto (bare inspect: true)", async () => {
+    const { diagnostics, ondiagnostic } = collect();
+    const { container } = render(GGPlot, {
+      data: rows,
+      aes,
+      layers: [{ geom: "col" as const }],
+      inspect: true,
+      ondiagnostic,
+      ...size,
+    });
+    await settled(container);
+    for (const code of X_GUIDE_CODES) expect(diagnostics.map((d) => d.code)).not.toContain(code);
+  });
+
+  it("stays silent for mode exact", async () => {
+    const { diagnostics, ondiagnostic } = collect();
+    const { container } = render(GGPlot, {
+      data: rows,
+      aes,
+      layers: [{ geom: "col" as const }],
+      inspect: { mode: "exact" as const },
+      ondiagnostic,
+      ...size,
+    });
+    await settled(container);
+    for (const code of X_GUIDE_CODES) expect(diagnostics.map((d) => d.code)).not.toContain(code);
+  });
+
+  it("delivers once per plot instance, not once per reactive update", async () => {
+    const { diagnostics, ondiagnostic } = collect();
+    const view = render(GGPlot, {
+      data: rows,
+      aes,
+      layers: [{ geom: "col" as const }],
+      inspect: { mode: "xy" as const },
+      ondiagnostic,
+      ...size,
+    });
+    await expect
+      .poll(() => diagnostics.filter((d) => d.code === "INTERACTION_INSPECT_X_ON_COL").length)
+      .toBe(1);
+    await view.rerender({ height: 340 });
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+    expect(diagnostics.filter((d) => d.code === "INTERACTION_INSPECT_X_ON_COL")).toHaveLength(1);
+  });
+});
+
+describe("high-cardinality discrete color + inspect (#1274)", () => {
+  const categories = (n: number) =>
+    Array.from({ length: n }, (_, i) => ({
+      id: `r${i}`,
+      x: i,
+      y: i * 2,
+      series: `s${i}`,
+    }));
+
+  it("fires at the threshold of 16 discrete color categories", async () => {
+    const { diagnostics, ondiagnostic } = collect();
+    render(GGPlot, {
+      data: categories(16),
+      aes: { x: "x", y: "y", color: "series" },
+      layers: [{ geom: "point" as const }],
+      inspect: true,
+      ondiagnostic,
+      ...size,
+    });
+    // Needs the trained model — poll rather than drain.
+    await expect
+      .poll(() =>
+        diagnostics.find((d) => d.code === "INTERACTION_INSPECT_HIGH_CARDINALITY_DISCRETE"),
+      )
+      .toMatchObject({ severity: "advisory", prop: "color", actual: 16 });
+  });
+
+  it("stays silent one category below the threshold", async () => {
+    const { diagnostics, ondiagnostic } = collect();
+    const { container } = render(GGPlot, {
+      data: categories(15),
+      aes: { x: "x", y: "y", color: "series" },
+      layers: [{ geom: "point" as const }],
+      inspect: true,
+      ondiagnostic,
+      ...size,
+    });
+    await settled(container);
+    expect(diagnostics.map((d) => d.code)).not.toContain(
+      "INTERACTION_INSPECT_HIGH_CARDINALITY_DISCRETE",
+    );
+  });
+
+  it("stays silent at 16 categories when inspect is off", async () => {
+    const { diagnostics, ondiagnostic } = collect();
+    const { container } = render(GGPlot, {
+      data: categories(16),
+      aes: { x: "x", y: "y", color: "series" },
+      layers: [{ geom: "point" as const }],
+      ondiagnostic,
+      ...size,
+    });
+    await settled(container);
+    expect(diagnostics.map((d) => d.code)).not.toContain(
+      "INTERACTION_INSPECT_HIGH_CARDINALITY_DISCRETE",
+    );
+  });
+});
+
+describe("faceted zoom config diagnostic", () => {
+  const facetedRows = rows.map((r, i) => ({ ...r, g: i < 2 ? "p1" : "p2" }));
+
+  it("warns INTERVAL_FACET_UNSUPPORTED when zoom meets a faceted plot", async () => {
+    const { diagnostics, ondiagnostic } = collect();
+    render(
+      GGPlot,
+      withGrammarAsSpec({
+        data: facetedRows,
+        aes,
+        layers: [{ geom: "point" as const }],
+        facet: { wrap: "g" },
+        zoom: true,
+        ondiagnostic,
+        ...size,
+      }),
+    );
+    // Config diagnostics re-deliver on every interactionConfig() recompute —
+    // assert presence, never a count.
+    await expect
+      .poll(() => diagnostics.some((d) => d.code === "INTERACTION_INTERVAL_FACET_UNSUPPORTED"))
+      .toBe(true);
+    expect(
+      diagnostics.find((d) => d.code === "INTERACTION_INTERVAL_FACET_UNSUPPORTED"),
+    ).toMatchObject({ severity: "warning", prop: "zoom" });
+  });
+
+  it("stays silent for zoom on an unfaceted plot", async () => {
+    const { diagnostics, ondiagnostic } = collect();
+    const { container } = render(GGPlot, {
+      data: rows,
+      aes,
+      layers: [{ geom: "point" as const }],
+      zoom: true,
+      ondiagnostic,
+      ...size,
+    });
+    await settled(container);
+    expect(diagnostics.map((d) => d.code)).not.toContain("INTERACTION_INTERVAL_FACET_UNSUPPORTED");
+  });
+});


### PR DESCRIPTION
Pins the plot-engine wire-up that pure collector tests cannot see:
registry/prop layers → assembled().layers → deliverAdvisoriesOnce →
ondiagnostic, in the browser lane (delivery runs in $effect, which
svelte/server never executes).

- x-guide four: X_ON_COL via <GeomCol> child, BISECTS_COL_LABELS with
  <GeomText> labels (replaces plain advisory), X_ON_BAR and
  BISECTS_BAR_LABELS via the layers prop form, mode x, auto/exact
  silence, once-per-instance rerender pin
- INTERACTION_INSPECT_HIGH_CARDINALITY_DISCRETE (#1274): fires at 16
  discrete color categories, silent at 15, silent with inspect off
- INTERACTION_INTERVAL_FACET_UNSUPPORTED: faceted + zoom warns via the
  config-diagnostic path (presence-only assertion — re-delivers per
  recompute); unfaceted zoom stays silent

Closes #1206

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>