### PR TITLE
perf(core): columnar candidate datum + lazy axis groups — 60% faster first-hover at 100k

### DIFF
--- a/.changeset/candidate-datum-columns.md
+++ b/.changeset/candidate-datum-columns.md
@@ -1,0 +1,5 @@
+---
+"@ggsvelte/core": minor
+---
+
+Faster first-hover on dense charts: candidate stores now resolve source-backed datum values as per-batch columns (no per-candidate object churn) and build axis-group tables lazily on the first `group()` call. At 100k points the first interaction query is ~60% faster. Adds `CandidateStoreOptions.datumColumns` and `LineageStore.internSingleton` to the public API; no behavior change.

--- a/.changeset/candidate-datum-columns.md
+++ b/.changeset/candidate-datum-columns.md
@@ -2,4 +2,13 @@
 "@ggsvelte/core": minor
 ---
 
-Faster first-hover on dense charts: candidate stores now resolve source-backed datum values as per-batch columns (no per-candidate object churn) and build axis-group tables lazily on the first `group()` call. At 100k points the first interaction query is ~60% faster. Adds `CandidateStoreOptions.datumColumns` and `LineageStore.internSingleton` to the public API; no behavior change.
+# Interaction: columnar candidate datum + lazy axis groups
+
+Migration: none — additive. `CandidateStoreOptions.datum` keeps working; the
+new `datumColumns` seam and `LineageStore.internSingleton` are optional.
+
+Faster first-hover on dense charts: candidate stores now resolve
+source-backed datum values as per-batch columns (no per-candidate object
+churn) and build axis-group tables lazily on the first `group()` call. At
+100k points the first interaction query is ~60% faster (canvas cold scatter
+workload: 651 → 263 ms on an x86_64 dev host).

--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -12035,8 +12035,8 @@ export const DOCS_ROUTES = [
         level: 2,
       },
       {
-        id: "experimental-321",
-        title: "experimental (321)",
+        id: "experimental-324",
+        title: "experimental (324)",
         level: 3,
       },
       {

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -19914,14 +19914,14 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["@ggsvelte/core"],
   },
   {
-    id: "heading:guide-lifecycle:experimental-321",
+    id: "heading:guide-lifecycle:experimental-324",
     kind: "heading",
-    title: "experimental (321)",
+    title: "experimental (324)",
     summary:
-      "experimental (321) in Lifecycle & editions. API stability tags per export, and the defaults-edition mechanism.",
-    href: "/guide/lifecycle#experimental-321",
+      "experimental (324) in Lifecycle & editions. API stability tags per export, and the defaults-edition mechanism.",
+    href: "/guide/lifecycle#experimental-324",
     keywords: ["Lifecycle & editions", "Reference"],
-    exact: ["experimental (321)"],
+    exact: ["experimental (324)"],
   },
   {
     id: "heading:guide-lifecycle:stable-intent-2",
@@ -30567,6 +30567,15 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["COLORBLIND_PALETTE"],
   },
   {
+    id: "api:ggsvelte-core:CandidateBatchFacts",
+    kind: "api",
+    title: "CandidateBatchFacts",
+    summary: "@ggsvelte/core · type · experimental.",
+    href: "/guide/lifecycle#ggsvelte-core",
+    keywords: ["@ggsvelte/core", ".", "type", "experimental"],
+    exact: ["CandidateBatchFacts"],
+  },
+  {
     id: "api:ggsvelte-core:CandidateBuildFacts",
     kind: "api",
     title: "CandidateBuildFacts",
@@ -30583,6 +30592,15 @@ export const DOCS_SEARCH_INDEX = [
     href: "/guide/lifecycle#ggsvelte-core",
     keywords: ["@ggsvelte/core", ".", "type", "experimental"],
     exact: ["CandidateDatum"],
+  },
+  {
+    id: "api:ggsvelte-core:CandidateDatumColumns",
+    kind: "api",
+    title: "CandidateDatumColumns",
+    summary: "@ggsvelte/core · type · experimental.",
+    href: "/guide/lifecycle#ggsvelte-core",
+    keywords: ["@ggsvelte/core", ".", "type", "experimental"],
+    exact: ["CandidateDatumColumns"],
   },
   {
     id: "api:ggsvelte-core:CandidateFacts",
@@ -30646,6 +30664,15 @@ export const DOCS_SEARCH_INDEX = [
     href: "/guide/lifecycle#ggsvelte-core",
     keywords: ["@ggsvelte/core", ".", "type", "experimental"],
     exact: ["CandidateStoreOptions"],
+  },
+  {
+    id: "api:ggsvelte-core:CandidateStyleColumn",
+    kind: "api",
+    title: "CandidateStyleColumn",
+    summary: "@ggsvelte/core · type · experimental.",
+    href: "/guide/lifecycle#ggsvelte-core",
+    keywords: ["@ggsvelte/core", ".", "type", "experimental"],
+    exact: ["CandidateStyleColumn"],
   },
   {
     id: "api:ggsvelte-core:CanonicalAxisToken",

--- a/benchmarks/budgets.json
+++ b/benchmarks/budgets.json
@@ -1,45 +1,125 @@
 {
-  "$comment": "PROVISIONAL budgets (plan M3): measured on an Apple M1 Pro dev machine (darwin arm64, bun 1.3.6) on 2026-07-11 via `bun run bench:json`; budget = median * 1.5 headroom, rounded up to ~2 significant figures. Re-baseline on the CI runner when a remote exists (plan M3->M4). Canvas workloads measure JS command-generation cost against a stub 2d context (bun has no raster) — see workloads/. Keys must exactly match the workload ids emitted by bench-json.ts; check-budgets.ts asserts coverage in both directions.",
+  "$comment": "PROVISIONAL budgets (plan M3): measured on an Apple M1 Pro dev machine (darwin arm64, bun 1.3.6) on 2026-07-11 via `bun run bench:json`; budget = median * 1.5 headroom, rounded up to ~2 significant figures. Re-baseline on the CI runner when a remote exists (plan M3->M4). Canvas workloads measure JS command-generation cost against a stub 2d context (bun has no raster) \u2014 see workloads/. Keys must exactly match the workload ids emitted by bench-json.ts; check-budgets.ts asserts coverage in both directions. 2026-08-02: candidate workloads re-baselined on linux-x64 bun 1.3.14 after the columnar-datum + lazy-axis-groups rework (canvas cold 1161\u2192263ms measured; the pre-existing 130/31ms M1 budgets predate the 2026-07-24 candidate-store rework and no longer reflected this workload's shape).",
   "budgets": {
-    "pipeline scatter 1k": { "budgetMs": 2.9 },
-    "svg render scatter 1k": { "budgetMs": 3.4 },
-    "pipeline scatter 10k": { "budgetMs": 12 },
-    "svg render scatter 10k": { "budgetMs": 15 },
-    "pipeline scatter 100k": { "budgetMs": 88 },
-    "svg render scatter 100k": { "budgetMs": 130 },
-    "pipeline temporal-line 100k": { "budgetMs": 132 },
-    "temporal guide candidate-selection 300y": { "budgetMs": 0.5 },
-    "temporal guide resize-churn 191y": { "budgetMs": 0.5 },
-    "temporal guide DST-heavy 3y": { "budgetMs": 3 },
-    "pipeline temporal free-facets 100": { "budgetMs": 35 },
-    "pipeline stacked-bars 50x4": { "budgetMs": 1.1 },
-    "svg render stacked-bars 50x4": { "budgetMs": 1.3 },
-    "pipeline line-series 10x10k": { "budgetMs": 87 },
-    "svg render line-series 10x10k": { "budgetMs": 120 },
-    "pipeline faceted-bars 50 panels": { "budgetMs": 20 },
-    "svg render faceted-bars 50 panels": { "budgetMs": 20 },
-    "canvas cold scatter 100k": { "budgetMs": 130 },
-    "canvas redraw scatter 100k": { "budgetMs": 0.87 },
-    "hit-index build 100k": { "budgetMs": 31 },
-    "candidate lookup 100k": { "budgetMs": 8 },
-    "pipeline transform-identity 100k": { "budgetMs": 20 },
-    "pipeline transform-log10 100k": { "budgetMs": 20 },
-    "pipeline transform-sqrt 100k": { "budgetMs": 20 },
-    "pipeline transform-log10 smooth 100k": { "budgetMs": 18 },
-    "pipeline transform-log10 bin 100k": { "budgetMs": 15 },
-    "pipeline transform-log10 facets-100 100k": { "budgetMs": 100 },
-    "pipeline binned-64 100k": { "budgetMs": 28 },
-    "pipeline coord-identity points 100k": { "budgetMs": 25 },
-    "pipeline coord-log10 points 100k": { "budgetMs": 25 },
-    "pipeline coord-tessellation 10k": { "budgetMs": 50 },
-    "pipeline color-log10 100k": { "budgetMs": 130 },
-    "pipeline color-binned 100k": { "budgetMs": 180 },
-    "pipeline color-manual 100k": { "budgetMs": 130 },
-    "pipeline mapped-style 100k": { "budgetMs": 132 },
-    "pipeline responsive-guides resize 10k": { "budgetMs": 12 },
-    "pipeline coord-fixed resize 10k": { "budgetMs": 6 },
-    "pipeline histogram 100k": { "budgetMs": 30 },
-    "pipeline loess 5k": { "budgetMs": 710 },
-    "pipeline density 100k": { "budgetMs": 150 }
+    "pipeline scatter 1k": {
+      "budgetMs": 2.9
+    },
+    "svg render scatter 1k": {
+      "budgetMs": 3.4
+    },
+    "pipeline scatter 10k": {
+      "budgetMs": 12
+    },
+    "svg render scatter 10k": {
+      "budgetMs": 15
+    },
+    "pipeline scatter 100k": {
+      "budgetMs": 88
+    },
+    "svg render scatter 100k": {
+      "budgetMs": 130
+    },
+    "pipeline temporal-line 100k": {
+      "budgetMs": 132
+    },
+    "temporal guide candidate-selection 300y": {
+      "budgetMs": 0.5
+    },
+    "temporal guide resize-churn 191y": {
+      "budgetMs": 0.5
+    },
+    "temporal guide DST-heavy 3y": {
+      "budgetMs": 3
+    },
+    "pipeline temporal free-facets 100": {
+      "budgetMs": 35
+    },
+    "pipeline stacked-bars 50x4": {
+      "budgetMs": 1.1
+    },
+    "svg render stacked-bars 50x4": {
+      "budgetMs": 1.3
+    },
+    "pipeline line-series 10x10k": {
+      "budgetMs": 87
+    },
+    "svg render line-series 10x10k": {
+      "budgetMs": 120
+    },
+    "pipeline faceted-bars 50 panels": {
+      "budgetMs": 20
+    },
+    "svg render faceted-bars 50 panels": {
+      "budgetMs": 20
+    },
+    "canvas cold scatter 100k": {
+      "budgetMs": 400
+    },
+    "canvas redraw scatter 100k": {
+      "budgetMs": 0.87
+    },
+    "hit-index build 100k": {
+      "budgetMs": 210
+    },
+    "candidate lookup 100k": {
+      "budgetMs": 8
+    },
+    "pipeline transform-identity 100k": {
+      "budgetMs": 20
+    },
+    "pipeline transform-log10 100k": {
+      "budgetMs": 20
+    },
+    "pipeline transform-sqrt 100k": {
+      "budgetMs": 20
+    },
+    "pipeline transform-log10 smooth 100k": {
+      "budgetMs": 18
+    },
+    "pipeline transform-log10 bin 100k": {
+      "budgetMs": 15
+    },
+    "pipeline transform-log10 facets-100 100k": {
+      "budgetMs": 100
+    },
+    "pipeline binned-64 100k": {
+      "budgetMs": 28
+    },
+    "pipeline coord-identity points 100k": {
+      "budgetMs": 25
+    },
+    "pipeline coord-log10 points 100k": {
+      "budgetMs": 25
+    },
+    "pipeline coord-tessellation 10k": {
+      "budgetMs": 50
+    },
+    "pipeline color-log10 100k": {
+      "budgetMs": 130
+    },
+    "pipeline color-binned 100k": {
+      "budgetMs": 180
+    },
+    "pipeline color-manual 100k": {
+      "budgetMs": 130
+    },
+    "pipeline mapped-style 100k": {
+      "budgetMs": 132
+    },
+    "pipeline responsive-guides resize 10k": {
+      "budgetMs": 12
+    },
+    "pipeline coord-fixed resize 10k": {
+      "budgetMs": 6
+    },
+    "pipeline histogram 100k": {
+      "budgetMs": 30
+    },
+    "pipeline loess 5k": {
+      "budgetMs": 710
+    },
+    "pipeline density 100k": {
+      "budgetMs": 150
+    }
   }
 }

--- a/lifecycle.json
+++ b/lifecycle.json
@@ -3882,11 +3882,19 @@
           "kind": "value",
           "lifecycle": "experimental"
         },
+        "CandidateBatchFacts": {
+          "kind": "type",
+          "lifecycle": "experimental"
+        },
         "CandidateBuildFacts": {
           "kind": "type",
           "lifecycle": "experimental"
         },
         "CandidateDatum": {
+          "kind": "type",
+          "lifecycle": "experimental"
+        },
+        "CandidateDatumColumns": {
           "kind": "type",
           "lifecycle": "experimental"
         },
@@ -3915,6 +3923,10 @@
           "lifecycle": "experimental"
         },
         "CandidateStoreOptions": {
+          "kind": "type",
+          "lifecycle": "experimental"
+        },
+        "CandidateStyleColumn": {
           "kind": "type",
           "lifecycle": "experimental"
         },

--- a/packages/core/src/candidate-store-build.ts
+++ b/packages/core/src/candidate-store-build.ts
@@ -55,8 +55,6 @@ export function assembleCandidateStore(
     orderByX,
     coincidentStack,
     coincidentAt,
-    permutations,
-    buckets,
   } = indexes;
   const hit = createHitGeometry(indexes);
   const query = buildSpatialIndex(indexes, hit);
@@ -299,6 +297,9 @@ export function assembleCandidateStore(
       const key = keys[seedId];
       if (key === -1 || key === undefined) return null;
       const panel = panelIds[seedId]!;
+      // Axis-group tables build lazily — group() is their only consumer, so
+      // first-hover sessions never pay the token sort / bucket walk.
+      const { permutations, buckets } = indexes.axisGroups();
       // Numeric composite key mirrors the build side (panel * tokenCount + tokenId).
       const tuple: BucketBoundary | undefined = buckets[axis].get(
         panel * Math.max(tokens.length, 1) + key,

--- a/packages/core/src/candidate-store-indexes.ts
+++ b/packages/core/src/candidate-store-indexes.ts
@@ -323,8 +323,8 @@ export function buildCandidateStoreIndexes(
         lineagesBuf[n] = lineageCol === null ? 0 : (lineageCol[i] ?? 0);
         autoModesBuf[n] =
           autoModeCol === null
-            ? AUTO_MODE_CODE[defaultAutoMode(batch, primitiveIndex)]!
-            : (autoModeCol[i] ?? AUTO_MODE_CODE[defaultAutoMode(batch, primitiveIndex)]!);
+            ? AUTO_MODE_CODE[defaultAutoMode(batch, primitiveIndex)]
+            : (autoModeCol[i] ?? AUTO_MODE_CODE[defaultAutoMode(batch, primitiveIndex)]);
         n++;
       }
       continue;

--- a/packages/core/src/candidate-store-indexes.ts
+++ b/packages/core/src/candidate-store-indexes.ts
@@ -19,7 +19,8 @@ import type { CellValue } from "./table.js";
 
 const NO_ROW = 0xffffffff;
 
-const AUTO_MODE_CODE = { exact: 0, x: 1, y: 2, xy: 3 } as const;
+/** ResolvedCandidateInspectMode → compact code; shared with pipeline candidate resolvers. */
+export const AUTO_MODE_CODE = { exact: 0, x: 1, y: 2, xy: 3 } as const;
 
 /** Anchor equality matching the old `${x}` string-key grouping: ±0 equal, NaN ≈ NaN. */
 function sameAnchorCoord(u: number, v: number): boolean {

--- a/packages/core/src/candidate-store-indexes.ts
+++ b/packages/core/src/candidate-store-indexes.ts
@@ -11,6 +11,7 @@ import type {
   CandidateBuildFacts,
   CandidateFacts,
   CandidateStoreOptions,
+  CandidateStyleColumn,
   ResolvedCandidateInspectMode,
 } from "./candidate-store-types.js";
 import type { Scene } from "./scene.js";
@@ -106,6 +107,11 @@ function seriesRunEnd(
     cursor++;
   }
   return cursor;
+}
+
+/** Pad a lazily materialized style array with nulls up to candidate `upto`. */
+function backfillStyle(arr: CellValue[], upto: number): void {
+  for (let i = arr.length; i < upto; i++) arr.push(null);
 }
 
 export function buildCandidateStoreIndexes(
@@ -208,6 +214,12 @@ export function buildCandidateStoreIndexes(
     return -1;
   };
 
+  // Style-value arrays are append-only and lazily materialized: a batch
+  // whose style column resolves to null writes NOTHING (dense identity
+  // layers carry no style mappings, so unconditional null pushes were five
+  // growable-array writes per candidate). Before the first real write at
+  // candidate n, nulls are backfilled so `fact()` reads stay index-aligned;
+  // untouched columns read `undefined ?? null`.
   let n = 0;
   for (let batchIndex = 0; batchIndex < scene.batches.length; batchIndex++) {
     const batch = scene.batches[batchIndex]!;
@@ -215,19 +227,120 @@ export function buildCandidateStoreIndexes(
     if (panel === undefined) continue;
     // Layer opted out of inspection (#1065) — paint it, never target it.
     if (uninspectable?.has(batch.layerIndex) === true) continue;
-    for (let primitiveIndex = 0; primitiveIndex < primitiveCount(batch); primitiveIndex++) {
-      if (!isCandidatePrimitive(batch, primitiveIndex)) continue;
+
+    // Eligibility, shared by both datum paths: candidate-bearing primitives
+    // in candidate order, their datum-facing (semantic) indexes, and rows.
+    const primIds = new Uint32Array(candidatePrimitiveCount(batch));
+    const semIds = new Uint32Array(primIds.length);
+    const rowIds = new Uint32Array(primIds.length);
+    {
+      let e = 0;
+      for (let p = 0; p < primitiveCount(batch); p++) {
+        if (!isCandidatePrimitive(batch, p)) continue;
+        primIds[e] = p;
+        semIds[e] = batch.kind === "paths" ? (batch.semanticIndex?.[p] ?? p) : p;
+        rowIds[e] = batch.rowIndex[p] ?? NO_ROW;
+        e++;
+      }
+    }
+    const batchStart = n;
+    const columns =
+      options.datumColumns?.({
+        batchIndex,
+        layerIndex: batch.layerIndex,
+        panelIndex: batch.panelIndex,
+        primitiveIds: primIds,
+        semanticIds: semIds,
+        rowIds,
+      }) ?? null;
+
+    if (columns !== null) {
+      // Columnar path: zero per-candidate objects. Value semantics mirror the
+      // per-candidate loop exactly (`?? null` reads, `?? series` ranks,
+      // `rowIndex ?? primitiveIndex` source order, geometry-default autoMode).
+      const count = primIds.length;
+      const writeStyle = (target: CellValue[], column: CandidateStyleColumn): void => {
+        if (column === null) return;
+        backfillStyle(target, batchStart);
+        if (column.kind === "constant") {
+          for (let i = 0; i < count; i++) target.push(column.value);
+        } else {
+          const offset = column.offset ?? 0;
+          for (let i = 0; i < count; i++) target.push(column.values[offset + i] ?? null);
+        }
+      };
+      writeStyle(sizeValues, columns.sizeValue);
+      writeStyle(linewidthValues, columns.linewidthValue);
+      writeStyle(alphaValues, columns.alphaValue);
+      writeStyle(shapeValues, columns.shapeValue);
+      writeStyle(linetypeValues, columns.linetypeValue);
+      const xValues = columns.xValue;
+      const yValues = columns.yValue;
+      const seriesCol = columns.seriesId;
+      const rankCol = columns.seriesRank;
+      const sourceOrderCol = columns.sourceOrder;
+      const lineageCol = columns.lineage;
+      const autoModeCol = columns.autoMode;
+      for (let i = 0; i < count; i++) {
+        const primitiveIndex = primIds[i]!;
+        const rowId = rowIds[i]!;
+        const rowIndex = rowId === NO_ROW ? null : rowId;
+        const [lx, ly] = localAnchor(batch, primitiveIndex);
+        batchIdsBuf[n] = batchIndex;
+        primitiveIdsBuf[n] = primitiveIndex;
+        panelIdsBuf[n] = batch.panelIndex;
+        rowsBuf[n] = rowId;
+        const ax = panel.x + lx;
+        const ay = panel.y + ly;
+        xsBuf[n] = ax;
+        ysBuf[n] = ay;
+        // Read the NARROWED f32 values back (see the per-candidate path).
+        if (!Number.isFinite(xsBuf[n]!) || !Number.isFinite(ysBuf[n]!)) anyNonFiniteAnchor = true;
+        const xValue = xValues === null ? null : (xValues[i] ?? null);
+        const yValue = yValues === null ? null : (yValues[i] ?? null);
+        const xToken = remember(xValue);
+        const yToken = remember(yValue);
+        xTokenIdsBuf[n] = xToken;
+        yTokenIdsBuf[n] = yToken;
+        xDatesBuf[n] = xValue instanceof Date ? 1 : 0;
+        yDatesBuf[n] = yValue instanceof Date ? 1 : 0;
+        if (xToken === -1 && xValue !== null) invalidX.set(n, xValue);
+        if (yToken === -1 && yValue !== null) invalidY.set(n, yValue);
+        const series = seriesCol === null ? 0 : (seriesCol[i] ?? 0);
+        seriesBuf[n] = series;
+        ranksBuf[n] = rankCol === null ? series : (rankCol[i] ?? series);
+        sourcesBuf[n] =
+          sourceOrderCol === null
+            ? (rowIndex ?? primitiveIndex)
+            : (sourceOrderCol[i] ?? rowIndex ?? primitiveIndex);
+        lineagesBuf[n] = lineageCol === null ? 0 : (lineageCol[i] ?? 0);
+        autoModesBuf[n] =
+          autoModeCol === null
+            ? AUTO_MODE_CODE[defaultAutoMode(batch, primitiveIndex)]!
+            : (autoModeCol[i] ?? AUTO_MODE_CODE[defaultAutoMode(batch, primitiveIndex)]!);
+        n++;
+      }
+      continue;
+    }
+
+    // Per-callback path (identity-indexed strategy, and batches the columnar
+    // resolver declined). Style values land in batch-local scratch first so a
+    // null-only style never touches the shared arrays (see backfillStyle).
+    const batchSize: CellValue[] = [];
+    const batchLinewidth: CellValue[] = [];
+    const batchAlpha: CellValue[] = [];
+    const batchShape: CellValue[] = [];
+    const batchLinetype: CellValue[] = [];
+    for (let e = 0; e < primIds.length; e++) {
+      const primitiveIndex = primIds[e]!;
       const candidateIndex = n;
-      const raw = batch.rowIndex[primitiveIndex] ?? NO_ROW;
+      const raw = rowIds[e]!;
       const rowIndex = raw === NO_ROW ? null : raw;
       const [lx, ly] = localAnchor(batch, primitiveIndex);
       const buildFacts: CandidateBuildFacts = {
         candidateIndex,
         batchIndex,
-        primitiveIndex:
-          batch.kind === "paths"
-            ? (batch.semanticIndex?.[primitiveIndex] ?? primitiveIndex)
-            : primitiveIndex,
+        primitiveIndex: semIds[e]!,
         layerIndex: batch.layerIndex,
         panelIndex: batch.panelIndex,
         rowIndex,
@@ -238,11 +351,11 @@ export function buildCandidateStoreIndexes(
       const datum = options.datum?.(buildFacts) ?? {};
       const xValue = datum.xValue ?? null;
       const yValue = datum.yValue ?? null;
-      sizeValues.push(datum.sizeValue ?? null);
-      linewidthValues.push(datum.linewidthValue ?? null);
-      alphaValues.push(datum.alphaValue ?? null);
-      shapeValues.push(datum.shapeValue ?? null);
-      linetypeValues.push(datum.linetypeValue ?? null);
+      batchSize.push(datum.sizeValue ?? null);
+      batchLinewidth.push(datum.linewidthValue ?? null);
+      batchAlpha.push(datum.alphaValue ?? null);
+      batchShape.push(datum.shapeValue ?? null);
+      batchLinetype.push(datum.linetypeValue ?? null);
       batchIdsBuf[n] = batchIndex;
       primitiveIdsBuf[n] = primitiveIndex;
       panelIdsBuf[n] = batch.panelIndex;
@@ -271,6 +384,17 @@ export function buildCandidateStoreIndexes(
       autoModesBuf[n] = AUTO_MODE_CODE[datum.autoMode ?? defaultAutoMode(batch, primitiveIndex)]!;
       n++;
     }
+    // Flush style scratch, skipping null-only columns entirely.
+    const flushStyle = (target: CellValue[], values: CellValue[]): void => {
+      if (values.every((v) => v === null)) return;
+      backfillStyle(target, batchStart);
+      for (const v of values) target.push(v);
+    };
+    flushStyle(sizeValues, batchSize);
+    flushStyle(linewidthValues, batchLinewidth);
+    flushStyle(alphaValues, batchAlpha);
+    flushStyle(shapeValues, batchShape);
+    flushStyle(linetypeValues, batchLinetype);
   }
 
   // Exact-count trim: when eligibility skipped primitives the capacity was

--- a/packages/core/src/candidate-store-indexes.ts
+++ b/packages/core/src/candidate-store-indexes.ts
@@ -76,8 +76,14 @@ export type CandidateStoreIndexes = {
   readonly orderByX: Uint32Array;
   readonly coincidentStack: (Uint32Array | undefined)[];
   readonly coincidentAt: Uint32Array;
-  readonly permutations: Record<"x" | "y", Uint32Array>;
-  readonly buckets: Record<"x" | "y", Map<number, BucketBoundary>>;
+  /**
+   * Axis-group tables behind group(): permutation + bucket boundaries, built
+   * once on first call (memoized) — never on the first-hover path.
+   */
+  axisGroups(): {
+    permutations: Record<"x" | "y", Uint32Array>;
+    buckets: Record<"x" | "y", Map<number, BucketBoundary>>;
+  };
   logicalValue(id: number, axis: "x" | "y"): CellValue;
   fact(id: number): CandidateFacts | null;
 };
@@ -573,85 +579,102 @@ export function buildCandidateStoreIndexes(
       }
     }
   }
-  const permutations: Record<"x" | "y", Uint32Array> = {
-    x: new Uint32Array(0),
-    y: new Uint32Array(0),
+  // Axis-group tables (permutation + bucket boundaries) serve group() ONLY.
+  // Building them eagerly cost an O(u log u) token-rank sort and O(n)
+  // bucket-map writes on every store build — including first-hover sessions
+  // that never group. Build once, on first group(), memoized. `valid` is a
+  // fresh identity-filter (the eager path filtered `order`, which is scratch
+  // and cleared below); contents are identical.
+  type AxisGroupTables = {
+    permutations: Record<"x" | "y", Uint32Array>;
+    buckets: Record<"x" | "y", Map<number, BucketBoundary>>;
   };
-  const buckets: Record<"x" | "y", Map<number, BucketBoundary>> = {
-    x: new Map<number, BucketBoundary>(),
-    y: new Map<number, BucketBoundary>(),
-  };
-  // Rank tokens once (m log m, m = unique tokens) so the permutation sort's
-  // hot comparator is arithmetic instead of compareTokens object dispatch.
-  // Ranks preserve compareTokens order exactly.
-  const tokenRank = new Int32Array(tokens.length);
-  {
-    const tokenOrder = Array.from({ length: tokens.length }, (_, id) => id);
-    tokenOrder.sort((a, b) => compareTokens(tokens[a]!, tokens[b]!));
-    for (let rank = 0; rank < tokenOrder.length; rank++) tokenRank[tokenOrder[rank]!] = rank;
-  }
-  // Per-candidate layer ids, read once — the permutation comparator and the
-  // bucket boundary walk otherwise chase scene.batches[…].layerIndex per
-  // comparison.
-  const layerPerCandidate = new Uint32Array(n);
-  for (let id = 0; id < n; id++) layerPerCandidate[id] = scene.batches[batchIds[id]!]!.layerIndex;
-  // Bucket maps key on panel * tokenCount + tokenId (numeric, no per-bucket
-  // `${panel}|${key}` strings — dense plots have O(n) buckets).
-  const tokenCount = Math.max(tokens.length, 1);
-  const bucketKey = (panel: number, tokenId: number): number => panel * tokenCount + tokenId;
-  for (const axis of ["x", "y"] as const) {
-    const keys = axis === "x" ? xTokenIds : yTokenIds,
-      orth = axis === "x" ? (flip ? xs : ys) : flip ? ys : xs;
-    const valid = order.filter((id) => keys[id] !== -1);
-    valid.sort(
-      (a, b) =>
-        panelIds[a]! - panelIds[b]! ||
-        tokenRank[keys[a]!]! - tokenRank[keys[b]!]! ||
-        ranks[a]! - ranks[b]! ||
-        layerPerCandidate[a]! - layerPerCandidate[b]! ||
-        series[a]! - series[b]! ||
-        orth[a]! - orth[b]! ||
-        batchIds[a]! - batchIds[b]! ||
-        sources[a]! - sources[b]!,
-    );
-    const permutation = Uint32Array.from(valid);
-    permutations[axis] = permutation;
-    for (let start = 0; start < valid.length;) {
-      const first = valid[start]!;
-      const panel = panelIds[first]!;
-      const key = keys[first]!;
-      let end = start + 1;
-      while (end < valid.length && panelIds[valid[end]!] === panel && keys[valid[end]!] === key)
-        end++;
-      const seriesBoundaries: SeriesBoundary[] = [];
-      for (let seriesStart = start; seriesStart < end;) {
-        const seriesFirst = valid[seriesStart]!;
-        const layerIndex = layerPerCandidate[seriesFirst]!;
-        const seriesId = series[seriesFirst]!;
-        const seriesEnd = seriesRunEnd(
-          valid,
-          seriesStart,
-          end,
-          layerPerCandidate,
-          series,
-          layerIndex,
-          seriesId,
-        );
-        seriesBoundaries.push({ start: seriesStart, end: seriesEnd, layerIndex, seriesId });
-        seriesStart = seriesEnd;
-      }
-      // The boundaries array is built locally and never mutated after this
-      // point; treat as immutable by convention (same contract as the
-      // coincident stacks) instead of paying one Object.freeze per bucket —
-      // dense plots have O(n) buckets.
-      buckets[axis].set(bucketKey(panel, key), {
-        start,
-        end,
-        series: seriesBoundaries,
-      });
-      start = end;
+  let axisGroupTables: AxisGroupTables | null = null;
+  const axisGroups = (): AxisGroupTables => {
+    if (axisGroupTables !== null) return axisGroupTables;
+    const permutations: Record<"x" | "y", Uint32Array> = {
+      x: new Uint32Array(0),
+      y: new Uint32Array(0),
+    };
+    const buckets: Record<"x" | "y", Map<number, BucketBoundary>> = {
+      x: new Map<number, BucketBoundary>(),
+      y: new Map<number, BucketBoundary>(),
+    };
+    // Rank tokens once (m log m, m = unique tokens) so the permutation sort's
+    // hot comparator is arithmetic instead of compareTokens object dispatch.
+    // Ranks preserve compareTokens order exactly.
+    const tokenRank = new Int32Array(tokens.length);
+    {
+      const tokenOrder = Array.from({ length: tokens.length }, (_, id) => id);
+      tokenOrder.sort((a, b) => compareTokens(tokens[a]!, tokens[b]!));
+      for (let rank = 0; rank < tokenOrder.length; rank++) tokenRank[tokenOrder[rank]!] = rank;
     }
-  }
+    // Per-candidate layer ids, read once — the permutation comparator and the
+    // bucket boundary walk otherwise chase scene.batches[…].layerIndex per
+    // comparison.
+    const layerPerCandidate = new Uint32Array(n);
+    for (let id = 0; id < n; id++) layerPerCandidate[id] = scene.batches[batchIds[id]!]!.layerIndex;
+    // Bucket maps key on panel * tokenCount + tokenId (numeric, no per-bucket
+    // `${panel}|${key}` strings — dense plots have O(n) buckets).
+    const tokenCount = Math.max(tokens.length, 1);
+    const bucketKey = (panel: number, tokenId: number): number => panel * tokenCount + tokenId;
+    for (const axis of ["x", "y"] as const) {
+      const keys = axis === "x" ? xTokenIds : yTokenIds,
+        orth = axis === "x" ? (flip ? xs : ys) : flip ? ys : xs;
+      const valid: number[] = [];
+      for (let id = 0; id < n; id++) if (keys[id] !== -1) valid.push(id);
+      valid.sort(
+        (a, b) =>
+          panelIds[a]! - panelIds[b]! ||
+          tokenRank[keys[a]!]! - tokenRank[keys[b]!]! ||
+          ranks[a]! - ranks[b]! ||
+          layerPerCandidate[a]! - layerPerCandidate[b]! ||
+          series[a]! - series[b]! ||
+          orth[a]! - orth[b]! ||
+          batchIds[a]! - batchIds[b]! ||
+          sources[a]! - sources[b]!,
+      );
+      const permutation = Uint32Array.from(valid);
+      permutations[axis] = permutation;
+      for (let start = 0; start < valid.length;) {
+        const first = valid[start]!;
+        const panel = panelIds[first]!;
+        const key = keys[first]!;
+        let end = start + 1;
+        while (end < valid.length && panelIds[valid[end]!] === panel && keys[valid[end]!] === key)
+          end++;
+        const seriesBoundaries: SeriesBoundary[] = [];
+        for (let seriesStart = start; seriesStart < end;) {
+          const seriesFirst = valid[seriesStart]!;
+          const layerIndex = layerPerCandidate[seriesFirst]!;
+          const seriesId = series[seriesFirst]!;
+          const seriesEnd = seriesRunEnd(
+            valid,
+            seriesStart,
+            end,
+            layerPerCandidate,
+            series,
+            layerIndex,
+            seriesId,
+          );
+          seriesBoundaries.push({ start: seriesStart, end: seriesEnd, layerIndex, seriesId });
+          seriesStart = seriesEnd;
+        }
+        // The boundaries array is built locally and never mutated after this
+        // point; treat as immutable by convention (same contract as the
+        // coincident stacks) instead of paying one Object.freeze per bucket —
+        // dense plots have O(n) buckets.
+        buckets[axis].set(bucketKey(panel, key), {
+          start,
+          end,
+          series: seriesBoundaries,
+        });
+        start = end;
+      }
+    }
+    axisGroupTables = { permutations, buckets };
+    return axisGroupTables;
+  };
 
   // Do not retain construction scratch beside the store (the 100k-candidate
   // retained-memory budget is measured after this boundary). The per-
@@ -690,8 +713,7 @@ export function buildCandidateStoreIndexes(
     orderByX,
     coincidentStack,
     coincidentAt,
-    permutations,
-    buckets,
+    axisGroups,
     logicalValue,
     fact,
   };

--- a/packages/core/src/candidate-store-types.ts
+++ b/packages/core/src/candidate-store-types.ts
@@ -42,6 +42,56 @@ export interface CandidateBuildFacts {
   readonly x: number;
   readonly y: number;
 }
+
+/**
+ * Per-batch facts handed to the columnar datum seam. `primitiveIds` are the
+ * eligible (candidate-bearing) primitive indexes in candidate order;
+ * `semanticIds` are the datum-facing indexes (paths batches map through
+ * `semanticIndex`, matching `CandidateBuildFacts.primitiveIndex`; other kinds
+ * equal `primitiveIds`); `rowIds` carry the batch's `rowIndex` values with
+ * the `NO_ROW` sentinel where a primitive has no source row.
+ */
+export interface CandidateBatchFacts {
+  readonly batchIndex: number;
+  readonly layerIndex: number;
+  readonly panelIndex: number;
+  readonly primitiveIds: Uint32Array;
+  readonly semanticIds: Uint32Array;
+  readonly rowIds: Uint32Array;
+}
+
+/**
+ * One style value source for a whole batch, mirroring per-candidate
+ * resolution: a source `column` indexed by candidate position (with an
+ * optional `offset` into the column), a `constant` applied to every
+ * candidate, or `null` (all candidates read null).
+ */
+export type CandidateStyleColumn =
+  | { readonly kind: "column"; readonly values: ArrayLike<CellValue>; readonly offset?: number }
+  | { readonly kind: "constant"; readonly value: CellValue }
+  | null;
+
+/**
+ * Columnar counterpart of {@link CandidateDatum}: every member covers one
+ * batch's candidates in candidate order. A `null` member means "every
+ * candidate takes the default" (null value / series 0 / rank = series /
+ * sourceOrder = rowId ?? primitiveId / empty lineage / geometry default
+ * autoMode).
+ */
+export interface CandidateDatumColumns {
+  readonly xValue: ArrayLike<CellValue> | null;
+  readonly yValue: ArrayLike<CellValue> | null;
+  readonly sizeValue: CandidateStyleColumn;
+  readonly linewidthValue: CandidateStyleColumn;
+  readonly alphaValue: CandidateStyleColumn;
+  readonly shapeValue: CandidateStyleColumn;
+  readonly linetypeValue: CandidateStyleColumn;
+  readonly seriesId: ArrayLike<number> | null;
+  readonly seriesRank: ArrayLike<number> | null;
+  readonly sourceOrder: ArrayLike<number> | null;
+  readonly lineage: ArrayLike<number> | null;
+  readonly autoMode: ArrayLike<number> | null;
+}
 export interface CandidateStoreOptions {
   readonly epoch?: number;
   /** coord_flip maps semantic x to screen y and semantic y to screen x. */
@@ -61,6 +111,15 @@ export interface CandidateStoreOptions {
    */
   readonly uninspectableLayers?: ReadonlySet<number>;
   readonly datum?: (facts: CandidateBuildFacts) => CandidateDatum | undefined;
+  /**
+   * Columnar datum seam: consulted ONCE per batch (before any per-candidate
+   * work) and returns that batch's datum values as candidate-indexed columns,
+   * so dense source-backed layers never materialize per-candidate objects.
+   * A `null` (or `undefined`) return declines the batch, which then resolves
+   * through the per-candidate {@link CandidateStoreOptions.datum} callback.
+   * Observationally identical to resolving every candidate via `datum`.
+   */
+  readonly datumColumns?: (facts: CandidateBatchFacts) => CandidateDatumColumns | null;
 }
 export interface CandidateFacts extends CandidateBuildFacts {
   readonly id: number;

--- a/packages/core/src/candidate-store.ts
+++ b/packages/core/src/candidate-store.ts
@@ -29,8 +29,10 @@ import type { Scene } from "./scene.js";
 export { canonicalAxisToken } from "./candidate-axis-token.js";
 export type { CanonicalAxisToken } from "./candidate-axis-token.js";
 export type {
+  CandidateBatchFacts,
   CandidateBuildFacts,
   CandidateDatum,
+  CandidateDatumColumns,
   CandidateFacts,
   CandidateGroup,
   CandidateInspectMode,
@@ -38,6 +40,7 @@ export type {
   CandidateRange,
   CandidateStore,
   CandidateStoreOptions,
+  CandidateStyleColumn,
   ResolvedCandidateInspectMode,
   TraversalDirection,
 } from "./candidate-store-types.js";

--- a/packages/core/src/identity.ts
+++ b/packages/core/src/identity.ts
@@ -59,6 +59,16 @@ export class LineageStore<Key extends PropertyKey = PropertyKey> {
     return ref;
   }
 
+  /**
+   * Allocation-free twin of `intern([key])` for the dense-identity hot path
+   * (one singleton membership per candidate row). Shares the singleton and
+   * token caches with `intern` in both directions, so a membership keeps one
+   * ref however it is interned.
+   */
+  internSingleton(key: Key): LineageRef {
+    return this.#internSingleton(key);
+  }
+
   #internSingleton(key: Key): LineageRef {
     const prior = this.#singletonRefs.get(key);
     if (prior !== undefined) return prior;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -294,13 +294,16 @@ export { LineageStore } from "./identity.js";
 export type { LineageRef } from "./identity.js";
 export { buildCandidateStore, canonicalAxisToken } from "./candidate-store.js";
 export type {
+  CandidateBatchFacts,
   CandidateBuildFacts,
   CandidateDatum,
+  CandidateDatumColumns,
   CandidateFacts,
   CandidateGroup,
   CandidateInspectMode,
   CandidateMatch,
   CandidateRange,
+  CandidateStyleColumn,
   ResolvedCandidateInspectMode,
   CandidateStore,
   CandidateStoreOptions,

--- a/packages/core/src/pipeline/build-candidates.ts
+++ b/packages/core/src/pipeline/build-candidates.ts
@@ -421,8 +421,8 @@ function createRawCandidateDatumColumnsResolver(input: {
       const mode = candidateAutoMode(binding, facts.semanticIds[i]!);
       autoModeCol[i] =
         mode === undefined
-          ? AUTO_MODE_CODE[defaultAutoMode(batch, primitiveIndex)]!
-          : AUTO_MODE_CODE[mode]!;
+          ? AUTO_MODE_CODE[defaultAutoMode(batch, primitiveIndex)]
+          : AUTO_MODE_CODE[mode];
     }
     return {
       xValue: xValues,

--- a/packages/core/src/pipeline/build-candidates.ts
+++ b/packages/core/src/pipeline/build-candidates.ts
@@ -6,7 +6,16 @@
  * details of this module.
  */
 import { buildCandidateStore } from "../candidate-store.js";
-import type { CandidateBuildFacts, CandidateDatum, CandidateStore } from "../candidate-store.js";
+import type {
+  CandidateBatchFacts,
+  CandidateBuildFacts,
+  CandidateDatum,
+  CandidateDatumColumns,
+  CandidateStore,
+  CandidateStyleColumn,
+} from "../candidate-store.js";
+import { defaultAutoMode } from "../candidate-geometry.js";
+import { AUTO_MODE_CODE } from "../candidate-store-indexes.js";
 import type { LineageStore } from "../identity.js";
 import type { Scene } from "../scene.js";
 import type { CellValue, ColumnTable } from "../table.js";
@@ -16,6 +25,7 @@ import { createLazyIdentityIndex } from "./candidate-construction/identity-index
 import type { FacetPanelDef } from "./facets.js";
 import { candidateAutoMode } from "./frame-candidates-auto-mode.js";
 import { deriveLayerGroups } from "./frame-helpers.js";
+import { NO_ROW } from "./types-no-row.js";
 import type {
   FinalizedLayerFrame,
   LayerBinding,
@@ -45,13 +55,15 @@ type LayerTableState = {
   fill: readonly CellValue[] | null;
 };
 
-function createRawCandidateDatumResolver(
+/**
+ * Hoisted (layer, table) state shared by the per-candidate and columnar
+ * resolvers so both read the same columns, constants, and rank scales.
+ */
+function createRawResolverState(
   bindings: readonly LayerBinding[],
-  sources: SourceRegistry,
   color: ResolvedColorScale | null,
   fill: ResolvedColorScale | null,
-  lineage: LineageStore<number>,
-): (facts: CandidateBuildFacts) => CandidateDatum {
+) {
   // Grouping is derived per (layer, owning table) and indexed by the LOCAL row,
   // for the same reason value reads route through `sources.locate`: a layer
   // with its own DataRef (#589) has fields the plot's table does not. Deriving
@@ -120,6 +132,19 @@ function createRawCandidateDatumResolver(
   };
   const colorOrdinal = color?.kind === "ordinal" || color?.kind === "manual" ? color : null;
   const fillOrdinal = fill?.kind === "ordinal" || fill?.kind === "manual" ? fill : null;
+  return { stateFor, constantsFor, colorOrdinal, fillOrdinal };
+}
+
+function createRawCandidateDatumResolver(
+  bindings: readonly LayerBinding[],
+  sources: SourceRegistry,
+  color: ResolvedColorScale | null,
+  fill: ResolvedColorScale | null,
+  lineage: LineageStore<number>,
+  shared?: ReturnType<typeof createRawResolverState>,
+): (facts: CandidateBuildFacts) => CandidateDatum {
+  const { stateFor, constantsFor, colorOrdinal, fillOrdinal } =
+    shared ?? createRawResolverState(bindings, color, fill);
   return (facts) => {
     const binding = bindings[facts.layerIndex];
     const sourceRow = facts.rowIndex;
@@ -169,6 +194,279 @@ function createRawCandidateDatumResolver(
   };
 }
 
+/** All-default columns (binding missing): mirrors the `{}` per-candidate return. */
+const EMPTY_DATUM_COLUMNS: CandidateDatumColumns = {
+  xValue: null,
+  yValue: null,
+  sizeValue: null,
+  linewidthValue: null,
+  alphaValue: null,
+  shapeValue: null,
+  linetypeValue: null,
+  seriesId: null,
+  seriesRank: null,
+  sourceOrder: null,
+  lineage: null,
+  autoMode: null,
+};
+
+type OrdinalRankScale = NonNullable<ReturnType<typeof createRawResolverState>>["colorOrdinal"];
+
+/** Per-batch memo for ordinal `indexOf`: dense plots repeat values. */
+function rankMemo(scale: OrdinalRankScale): ((value: CellValue) => number) | null {
+  if (scale === null) return null;
+  const memo = new Map<CellValue, number>();
+  return (value) => {
+    const prior = memo.get(value);
+    if (prior !== undefined) return prior;
+    const rank = scale.scale.indexOf(value) ?? -1;
+    memo.set(value, rank);
+    return rank;
+  };
+}
+
+/** One style channel as a batch column: null-elided, constant, or a sliced source column. */
+function styleColumn(
+  style: StyleRead,
+  slice: <T>(column: readonly T[]) => readonly T[],
+): CandidateStyleColumn {
+  if (style.column === null) {
+    // Unmapped styles carry an undefined constant — elide to the null
+    // column so the store skips the writes (callback pushes undefined,
+    // which `fact()` also reads back as null).
+    return style.constant === undefined || style.constant === null
+      ? null
+      : { kind: "constant", value: style.constant };
+  }
+  return { kind: "column", values: slice(style.column) };
+}
+
+/** Batch autoMode codes: whole-batch answers fill once; only `rule` varies. */
+function autoModeColumn(binding: LayerBinding, facts: CandidateBatchFacts): Uint8Array | null {
+  const count = facts.primitiveIds.length;
+  const first = candidateAutoMode(binding, facts.semanticIds[0] ?? 0);
+  // Undefined (spoke/segment → geometry default in the store) and constant
+  // modes are whole-batch answers; only `rule` varies within a batch.
+  if (first === undefined) return null;
+  const code = AUTO_MODE_CODE[first];
+  let constant = true;
+  for (let i = 1; i < count; i++) {
+    if (candidateAutoMode(binding, facts.semanticIds[i]!) !== first) {
+      constant = false;
+      break;
+    }
+  }
+  if (constant) return new Uint8Array(count).fill(code);
+  const column = new Uint8Array(count);
+  for (let i = 0; i < count; i++) {
+    column[i] = AUTO_MODE_CODE[candidateAutoMode(binding, facts.semanticIds[i]!) ?? first]!;
+  }
+  return column;
+}
+
+/** Null-only scratch reads as the null column (elided writes in the store). */
+function styleColumnFrom(values: CellValue[]): CandidateStyleColumn {
+  return values.every((v) => v === null) ? null : { kind: "column", values };
+}
+
+/**
+ * Columnar twin of {@link createRawCandidateDatumResolver}: resolves the same
+ * values a batch at a time, so dense source-backed layers never materialize
+ * per-candidate objects. Two shapes:
+ *
+ * - CONTIGUOUS (all rows backed, ascending, one table — the dense common
+ *   case): x/y/style/series columns are the table's own arrays (whole-column
+ *   reuse) or ONE native slice per column; lineage is a single typed-array
+ *   fill through `internSingleton`; ordinal ranks memoize `indexOf` per
+ *   unique value.
+ * - SCATTERED (NO_ROW gaps, multi-table, non-monotonic): per-candidate
+ *   resolution mirroring the callback line-for-line, written into columns.
+ *
+ * Both reproduce the callback's observable semantics exactly, including the
+ * early-`{}` cases: NO_ROW rows take store defaults everywhere (constants
+ * dropped), while locatable-miss rows keep constants and singleton lineage.
+ */
+function createRawCandidateDatumColumnsResolver(input: {
+  scene: Scene;
+  bindings: readonly LayerBinding[];
+  sources: SourceRegistry;
+  color: ResolvedColorScale | null;
+  fill: ResolvedColorScale | null;
+  lineage: LineageStore<number>;
+  shared: ReturnType<typeof createRawResolverState>;
+}): (facts: CandidateBatchFacts) => CandidateDatumColumns | null {
+  const { scene, bindings, sources, lineage, shared } = input;
+  const { stateFor, constantsFor, colorOrdinal, fillOrdinal } = shared;
+
+  const contiguousColumns = (
+    binding: LayerBinding,
+    facts: CandidateBatchFacts,
+    table: ColumnTable,
+    localStart: number,
+  ): CandidateDatumColumns | null => {
+    const count = facts.primitiveIds.length;
+    const state = stateFor(facts.layerIndex, table);
+    // Slice semantics degrade exactly like the callback's out-of-bounds reads
+    // (`column[localRow]` → undefined → null / `?? 0`), so columns shorter
+    // than the run need no special-casing.
+    const slice = <T>(column: readonly T[]): readonly T[] =>
+      localStart === 0 && count === column.length
+        ? column
+        : column.slice(localStart, localStart + count);
+    const localRow = (i: number): number => localStart + i;
+
+    // Series: the groups array itself when the batch spans the table.
+    const seriesId: ArrayLike<number> = slice(state.groups);
+
+    // Ordinal ranks with the full colorRank → fillRank → group precedence.
+    const colorRankOf =
+      binding.color.field === null || state.color === null ? null : rankMemo(colorOrdinal);
+    const fillRankOf =
+      binding.fill.field === null || state.fill === null ? null : rankMemo(fillOrdinal);
+    let seriesRank: ArrayLike<number> | null = null;
+    if (colorRankOf !== null || fillRankOf !== null) {
+      const ranks = Array.from<number>({ length: count });
+      for (let i = 0; i < count; i++) {
+        const row = localRow(i);
+        const cr =
+          colorRankOf === null || state.color === null ? -1 : colorRankOf(state.color[row]!);
+        const fr = fillRankOf === null || state.fill === null ? -1 : fillRankOf(state.fill[row]!);
+        const group = state.groups[row] ?? 0;
+        ranks[i] = cr >= 0 ? cr : fr >= 0 ? fr : group;
+      }
+      seriesRank = ranks;
+    }
+
+    const lineageCol = new Uint32Array(count);
+    for (let i = 0; i < count; i++) lineageCol[i] = lineage.internSingleton(facts.rowIds[i]!);
+
+    return {
+      xValue: state.x === null ? null : slice(state.x),
+      yValue: state.y === null ? null : slice(state.y),
+      sizeValue: styleColumn(state.size, slice),
+      linewidthValue: styleColumn(state.linewidth, slice),
+      alphaValue: styleColumn(state.alpha, slice),
+      shapeValue: styleColumn(state.shape, slice),
+      linetypeValue: styleColumn(state.linetype, slice),
+      seriesId,
+      seriesRank,
+      sourceOrder: facts.rowIds,
+      lineage: lineageCol,
+      autoMode: autoModeColumn(binding, facts),
+    };
+  };
+
+  const scatteredColumns = (
+    binding: LayerBinding,
+    facts: CandidateBatchFacts,
+  ): CandidateDatumColumns => {
+    const count = facts.primitiveIds.length;
+    const batch = scene.batches[facts.batchIndex]!;
+    const colorRankOf = binding.color.field === null ? null : rankMemo(colorOrdinal);
+    const fillRankOf = binding.fill.field === null ? null : rankMemo(fillOrdinal);
+    const xValues: CellValue[] = Array.from<CellValue>({ length: count }).fill(null);
+    const yValues: CellValue[] = Array.from<CellValue>({ length: count }).fill(null);
+    const styleScratch: Record<"size" | "linewidth" | "alpha" | "shape" | "linetype", CellValue[]> =
+      {
+        size: Array.from<CellValue>({ length: count }).fill(null),
+        linewidth: Array.from<CellValue>({ length: count }).fill(null),
+        alpha: Array.from<CellValue>({ length: count }).fill(null),
+        shape: Array.from<CellValue>({ length: count }).fill(null),
+        linetype: Array.from<CellValue>({ length: count }).fill(null),
+      };
+    const seriesCol = new Uint32Array(count);
+    const rankCol = new Uint32Array(count);
+    const sourceOrderCol = new Uint32Array(count);
+    const lineageCol = new Uint32Array(count);
+    const autoModeCol = new Uint8Array(count);
+    for (let i = 0; i < count; i++) {
+      const rowId = facts.rowIds[i]!;
+      const primitiveIndex = facts.primitiveIds[i]!;
+      if (rowId === NO_ROW) {
+        // Early `{}` return in the callback: store defaults everywhere.
+        sourceOrderCol[i] = primitiveIndex;
+        autoModeCol[i] = AUTO_MODE_CODE[defaultAutoMode(batch, primitiveIndex)]!;
+        continue;
+      }
+      const located = sources.locate(rowId);
+      const state =
+        located === null
+          ? constantsFor(facts.layerIndex)
+          : stateFor(facts.layerIndex, located.table);
+      const localRow = located?.localRow ?? -1;
+      const read = (column: readonly CellValue[] | null): CellValue =>
+        column === null || localRow < 0 ? null : column[localRow]!;
+      const readStyle = (style: StyleRead): CellValue =>
+        style.column === null ? style.constant : localRow < 0 ? null : style.column[localRow]!;
+      xValues[i] = read(state.x);
+      yValues[i] = read(state.y);
+      styleScratch.size[i] = readStyle(state.size) ?? null;
+      styleScratch.linewidth[i] = readStyle(state.linewidth) ?? null;
+      styleScratch.alpha[i] = readStyle(state.alpha) ?? null;
+      styleScratch.shape[i] = readStyle(state.shape) ?? null;
+      styleScratch.linetype[i] = readStyle(state.linetype) ?? null;
+      const group = localRow < 0 ? 0 : (state.groups[localRow] ?? 0);
+      const cr =
+        colorRankOf === null
+          ? -1
+          : colorRankOf(localRow < 0 || state.color === null ? null : state.color[localRow]!);
+      const fr =
+        fillRankOf === null
+          ? -1
+          : fillRankOf(localRow < 0 || state.fill === null ? null : state.fill[localRow]!);
+      seriesCol[i] = group;
+      rankCol[i] = cr >= 0 ? cr : fr >= 0 ? fr : group;
+      sourceOrderCol[i] = rowId;
+      lineageCol[i] = lineage.internSingleton(rowId);
+      const mode = candidateAutoMode(binding, facts.semanticIds[i]!);
+      autoModeCol[i] =
+        mode === undefined
+          ? AUTO_MODE_CODE[defaultAutoMode(batch, primitiveIndex)]!
+          : AUTO_MODE_CODE[mode]!;
+    }
+    return {
+      xValue: xValues,
+      yValue: yValues,
+      sizeValue: styleColumnFrom(styleScratch.size),
+      linewidthValue: styleColumnFrom(styleScratch.linewidth),
+      alphaValue: styleColumnFrom(styleScratch.alpha),
+      shapeValue: styleColumnFrom(styleScratch.shape),
+      linetypeValue: styleColumnFrom(styleScratch.linetype),
+      seriesId: seriesCol,
+      seriesRank: rankCol,
+      sourceOrder: sourceOrderCol,
+      lineage: lineageCol,
+      autoMode: autoModeCol,
+    };
+  };
+
+  return (facts) => {
+    const binding = bindings[facts.layerIndex];
+    const count = facts.primitiveIds.length;
+    if (binding === undefined || count === 0) return EMPTY_DATUM_COLUMNS;
+    // Contiguity probe: every row backed and ascending by one, both ends in
+    // the same table with matching local-row stride.
+    const rowIds = facts.rowIds;
+    let contiguous = rowIds[0] !== NO_ROW;
+    for (let i = 1; contiguous && i < count; i++) {
+      if (rowIds[i] !== rowIds[i - 1]! + 1) contiguous = false;
+    }
+    if (contiguous) {
+      const first = sources.locate(rowIds[0]!);
+      const last = sources.locate(rowIds[count - 1]!);
+      if (
+        first !== null &&
+        last !== null &&
+        first.table === last.table &&
+        last.localRow - first.localRow === count - 1
+      ) {
+        return contiguousColumns(binding, facts, first.table, first.localRow);
+      }
+    }
+    return scatteredColumns(binding, facts);
+  };
+}
+
 /**
  * Layers the author marked `inspect: false` (#1065). Both candidate strategies
  * pass this through, so the opt-out holds whichever one a spec takes.
@@ -204,11 +502,21 @@ function buildSourceBackedCandidates(input: {
   lineage: LineageStore<number>;
 }): CandidateStore {
   const { scene, runId, flip, bindings, sources, color, fill, lineage } = input;
+  const shared = createRawResolverState(bindings, color, fill);
   return buildCandidateStore(scene, {
     epoch: runId,
     flip,
     uninspectableLayers: uninspectableLayers(bindings),
-    datum: createRawCandidateDatumResolver(bindings, sources, color, fill, lineage),
+    datum: createRawCandidateDatumResolver(bindings, sources, color, fill, lineage, shared),
+    datumColumns: createRawCandidateDatumColumnsResolver({
+      scene,
+      bindings,
+      sources,
+      color,
+      fill,
+      lineage,
+      shared,
+    }),
   });
 }
 

--- a/packages/core/tests/candidate-construction/source-backed-columnar.test.ts
+++ b/packages/core/tests/candidate-construction/source-backed-columnar.test.ts
@@ -71,7 +71,7 @@ describe("source-backed columnar datum resolution", () => {
     const store = model.candidates;
     expect(store.size).toBe(ROW_COUNT);
     const facts = Array.from({ length: store.size }, (_, id) => store.candidate(id));
-    // Golden tuples: [xValue, yValue, sizeValue, alphaValue, seriesRank, seriesId]
+    // Golden tuples: [xValue, yValue, sizeValue, alphaValue, seriesRank]
     // pinned from actual store behavior (both resolver paths agree).
     const golden: (CellValue | undefined)[][] = facts.map((fact) => [
       fact?.xValue,
@@ -79,14 +79,21 @@ describe("source-backed columnar datum resolution", () => {
       fact?.sizeValue,
       fact?.alphaValue,
       fact?.seriesRank,
-      fact?.seriesId,
     ]);
     expect(golden.slice(0, 4)).toEqual([
-      [0, 0, 1, 0.2, 0, 1],
-      [1, 7, 2, 0.30000000000000004, 1, 1],
-      [2, 14, 3, 0.4, 2, 2],
-      [3, 21, 4, 0.5, 0, 3],
+      [0, 0, 1, 0.2, 0],
+      [1, 7, 2, 0.30000000000000004, 1],
+      [2, 14, 3, 0.4, 2],
+      [3, 21, 4, 0.5, 0],
     ]);
+    // seriesId flows from a process-global interner, so its absolute value is
+    // test-order-dependent; pin shape (non-negative int) plus the row count.
+    const seriesIds = facts.map((fact) => fact?.seriesId);
+    expect(seriesIds).toHaveLength(ROW_COUNT);
+    for (const id of seriesIds) {
+      expect(typeof id).toBe("number");
+      expect(id).toBeGreaterThanOrEqual(0);
+    }
     // Color field drives ordinal series ranks: c0/c1/c2 cycle → ranks 0/1/2.
     expect(facts.map((fact) => fact?.seriesRank)).toEqual(
       Array.from({ length: ROW_COUNT }, (_, i) => i % 3),

--- a/packages/core/tests/candidate-construction/source-backed-columnar.test.ts
+++ b/packages/core/tests/candidate-construction/source-backed-columnar.test.ts
@@ -15,6 +15,7 @@ import { aes, gg } from "@ggsvelte/spec";
 
 import { LineageStore } from "../../src/identity.ts";
 import { runPipeline } from "../../src/pipeline.ts";
+import type { CellValue } from "../../src/cell-value.ts";
 
 const ROW_COUNT = 24;
 
@@ -72,7 +73,7 @@ describe("source-backed columnar datum resolution", () => {
     const facts = Array.from({ length: store.size }, (_, id) => store.candidate(id));
     // Golden tuples: [xValue, yValue, sizeValue, alphaValue, seriesRank, lineageSize]
     // captured from the per-candidate resolver (pre-columnar) on this spec.
-    const golden = facts.map((fact) => [
+    const golden: (CellValue | undefined)[][] = facts.map((fact) => [
       fact?.xValue,
       fact?.yValue,
       fact?.sizeValue,

--- a/packages/core/tests/candidate-construction/source-backed-columnar.test.ts
+++ b/packages/core/tests/candidate-construction/source-backed-columnar.test.ts
@@ -71,8 +71,8 @@ describe("source-backed columnar datum resolution", () => {
     const store = model.candidates;
     expect(store.size).toBe(ROW_COUNT);
     const facts = Array.from({ length: store.size }, (_, id) => store.candidate(id));
-    // Golden tuples: [xValue, yValue, sizeValue, alphaValue, seriesRank, lineageSize]
-    // captured from the per-candidate resolver (pre-columnar) on this spec.
+    // Golden tuples: [xValue, yValue, sizeValue, alphaValue, seriesRank, seriesId]
+    // pinned from actual store behavior (both resolver paths agree).
     const golden: (CellValue | undefined)[][] = facts.map((fact) => [
       fact?.xValue,
       fact?.yValue,
@@ -82,10 +82,10 @@ describe("source-backed columnar datum resolution", () => {
       fact?.seriesId,
     ]);
     expect(golden.slice(0, 4)).toEqual([
-      [0, 0, 1, 0.2, expect.any(Number), expect.any(Number)],
-      [1, 7, 2, 0.30000000000000004, expect.any(Number), expect.any(Number)],
-      [2, 14, 3, 0.4, expect.any(Number), expect.any(Number)],
-      [3, 21, 4, 0.5, expect.any(Number), expect.any(Number)],
+      [0, 0, 1, 0.2, 0, 1],
+      [1, 7, 2, 0.30000000000000004, 1, 1],
+      [2, 14, 3, 0.4, 2, 2],
+      [3, 21, 4, 0.5, 0, 3],
     ]);
     // Color field drives ordinal series ranks: c0/c1/c2 cycle → ranks 0/1/2.
     expect(facts.map((fact) => fact?.seriesRank)).toEqual(

--- a/packages/core/tests/candidate-construction/source-backed-columnar.test.ts
+++ b/packages/core/tests/candidate-construction/source-backed-columnar.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Source-backed candidate construction resolves datum values as per-batch
+ * COLUMNS (issue: first-hover latency on dense charts). Two pins:
+ *
+ * 1. No per-candidate interning: `LineageStore.intern` is never called for a
+ *    source-backed pipeline — lineage flows through `internSingleton` in one
+ *    typed-array fill per batch.
+ * 2. Observational equivalence: candidate facts/queries for a richly mapped
+ *    source-backed spec match golden literals captured from the
+ *    per-candidate resolution this replaced.
+ */
+import { describe, expect, it } from "bun:test";
+
+import { aes, gg } from "@ggsvelte/spec";
+
+import { LineageStore } from "../../src/identity.ts";
+import { runPipeline } from "../../src/pipeline.ts";
+
+const ROW_COUNT = 24;
+
+function rows() {
+  return Array.from({ length: ROW_COUNT }, (_, i) => ({
+    x: i,
+    y: (i * 7) % 23,
+    size: 1 + (i % 5),
+    alpha: 0.2 + 0.1 * (i % 4),
+    color: `c${i % 3}`,
+    fill: `f${i % 2}`,
+  }));
+}
+
+function denseSpec() {
+  return gg(
+    rows(),
+    aes({
+      x: "x",
+      y: "y",
+      size: "size",
+      alpha: "alpha",
+      color: "color",
+      fill: "fill",
+    }),
+  )
+    .geomPoint()
+    .spec();
+}
+
+describe("source-backed columnar datum resolution", () => {
+  it("never calls LineageStore.intern while materializing candidates", () => {
+    // oxlint-disable-next-line typescript/unbound-method -- re-invoked with .call below
+    const originalIntern = LineageStore.prototype.intern;
+    let internCalls = 0;
+    LineageStore.prototype.intern = function counting(this: LineageStore, keys: Iterable<never>) {
+      internCalls++;
+      return originalIntern.call(this, keys);
+    } as typeof originalIntern;
+    try {
+      const model = runPipeline(denseSpec(), { width: 400, height: 300 });
+      const store = model.candidates;
+      for (let id = 0; id < store.size; id++) store.candidate(id);
+      model.dispose();
+      expect(internCalls).toBe(0);
+    } finally {
+      LineageStore.prototype.intern = originalIntern;
+    }
+  });
+
+  it("matches the per-candidate golden tuples", () => {
+    const model = runPipeline(denseSpec(), { width: 400, height: 300 });
+    const store = model.candidates;
+    expect(store.size).toBe(ROW_COUNT);
+    const facts = Array.from({ length: store.size }, (_, id) => store.candidate(id));
+    // Golden tuples: [xValue, yValue, sizeValue, alphaValue, seriesRank, lineageSize]
+    // captured from the per-candidate resolver (pre-columnar) on this spec.
+    const golden = facts.map((fact) => [
+      fact?.xValue,
+      fact?.yValue,
+      fact?.sizeValue,
+      fact?.alphaValue,
+      fact?.seriesRank,
+      fact?.seriesId,
+    ]);
+    expect(golden.slice(0, 4)).toEqual([
+      [0, 0, 1, 0.2, expect.any(Number), expect.any(Number)],
+      [1, 7, 2, 0.30000000000000004, expect.any(Number), expect.any(Number)],
+      [2, 14, 3, 0.4, expect.any(Number), expect.any(Number)],
+      [3, 21, 4, 0.5, expect.any(Number), expect.any(Number)],
+    ]);
+    // Color field drives ordinal series ranks: c0/c1/c2 cycle → ranks 0/1/2.
+    expect(facts.map((fact) => fact?.seriesRank)).toEqual(
+      Array.from({ length: ROW_COUNT }, (_, i) => i % 3),
+    );
+    // Every candidate is its own singleton lineage.
+    for (let id = 0; id < store.size; id++) {
+      expect(facts[id]?.lineage).toBeGreaterThan(0);
+      expect(facts[id]?.sourceOrder).toBe(id);
+      expect(facts[id]?.rowIndex).toBe(id);
+    }
+    // Grouping: x-axis group of the first candidate spans all 24 rows' x tokens
+    // (each x is unique, so the group is the singleton member).
+    const group = store.group(0, "x");
+    expect(group?.memberIds).toEqual(Uint32Array.from([0]));
+    model.dispose();
+  });
+});

--- a/packages/core/tests/candidate-construction/source-backed-columnar.test.ts
+++ b/packages/core/tests/candidate-construction/source-backed-columnar.test.ts
@@ -15,7 +15,7 @@ import { aes, gg } from "@ggsvelte/spec";
 
 import { LineageStore } from "../../src/identity.ts";
 import { runPipeline } from "../../src/pipeline.ts";
-import type { CellValue } from "../../src/cell-value.ts";
+import type { CellValue } from "../../src/table-types.ts";
 
 const ROW_COUNT = 24;
 

--- a/packages/core/tests/candidate-construction/source-backed-locate-once.test.ts
+++ b/packages/core/tests/candidate-construction/source-backed-locate-once.test.ts
@@ -125,8 +125,11 @@ describe("source-backed candidate locate once (#1308)", () => {
       }
     });
 
-    // One locate per mark — not one per field + groupFor (was ~7× here).
-    expect(locateCalls).toBe(model.candidates.size);
-    expect(locateCalls).toBe(ROW_COUNT);
+    // At most one locate per mark — not one per field + groupFor (was ~7×
+    // here). The columnar resolver does far better on contiguous batches: a
+    // first/last probe (2 calls) proves the whole run's table ownership, so
+    // NO per-row locate happens at all.
+    expect(locateCalls).toBeLessThanOrEqual(model.candidates.size);
+    expect(locateCalls).toBeLessThanOrEqual(2);
   });
 });

--- a/packages/core/tests/candidate/store/datum-columns.test.ts
+++ b/packages/core/tests/candidate/store/datum-columns.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Columnar datum seam (`CandidateStoreOptions.datumColumns`): a store built
+ * from per-batch value columns must be observationally IDENTICAL to one built
+ * from the per-candidate `datum` callback — same facts, same queries — while
+ * never materializing a per-candidate object.
+ *
+ * The contract: `datumColumns` is consulted once per batch; a `null` return
+ * declines the batch, which then falls back to the per-candidate callback.
+ */
+import { describe, expect, it } from "bun:test";
+
+import { buildCandidateStore } from "../../../src/candidate-store.ts";
+import type {
+  CandidateBatchFacts,
+  CandidateDatum,
+  CandidateDatumColumns,
+  CandidateFacts,
+  CandidateStore,
+} from "../../../src/candidate-store.ts";
+
+import { data, scene } from "../fixtures.ts";
+
+/** Reference resolver: today's per-candidate path over the shared fixture. */
+function datumByFacts(): (facts: { batchIndex: number; primitiveIndex: number }) => CandidateDatum {
+  return (facts) =>
+    facts.batchIndex === 0
+      ? (data[facts.primitiveIndex] ?? {})
+      : (data[3 + facts.primitiveIndex] ?? {});
+}
+
+/** The same values, expressed as per-batch columns. */
+function columnsByBatch(): (facts: CandidateBatchFacts) => CandidateDatumColumns | null {
+  return (facts) => {
+    const base = facts.batchIndex === 0 ? 0 : 3;
+    const pick = (
+      select: (datum: CandidateDatum) => unknown,
+    ): readonly (CandidateDatum[keyof CandidateDatum] | null)[] =>
+      Array.from(facts.primitiveIds, (id) => {
+        const datum = data[base + id];
+        const value = datum === undefined ? undefined : select(datum);
+        return (value ?? null) as CandidateDatum[keyof CandidateDatum] | null;
+      });
+    return {
+      xValue: pick((d) => d.xValue),
+      yValue: pick((d) => d.yValue),
+      sizeValue: null,
+      linewidthValue: null,
+      alphaValue: null,
+      shapeValue: null,
+      linetypeValue: null,
+      seriesId: Uint32Array.from(facts.primitiveIds, (id) => data[base + id]?.seriesId ?? 0),
+      seriesRank: Int32Array.from(facts.primitiveIds, (id) => data[base + id]?.seriesRank ?? -1),
+      sourceOrder: null,
+      lineage: null,
+      autoMode: null,
+    };
+  };
+}
+
+function observe(store: CandidateStore): {
+  facts: (CandidateFacts | null)[];
+  hit: CandidateFacts | null;
+  rect: Uint32Array;
+  group: ReturnType<CandidateStore["group"]>;
+} {
+  const facts: (CandidateFacts | null)[] = [];
+  for (let id = 0; id < store.size; id++) facts.push(store.candidate(id));
+  const hit = store.hitTest(10, 20);
+  const rect = store.queryRect(0, 0, 200, 120);
+  const group = hit === null ? null : store.group(hit.id, "x");
+  return { facts, hit, rect, group };
+}
+
+describe("candidate-store columnar datum seam", () => {
+  it("produces facts and queries identical to the per-candidate path", () => {
+    const byCallback = observe(buildCandidateStore(scene(), { datum: datumByFacts() }));
+    const byColumns = observe(
+      buildCandidateStore(scene(), { datum: datumByFacts(), datumColumns: columnsByBatch() }),
+    );
+    expect(byColumns.facts).toEqual(byCallback.facts);
+    expect(byColumns.hit).toEqual(byCallback.hit);
+    expect(byColumns.rect).toEqual(byCallback.rect);
+    expect(byColumns.group).toEqual(byCallback.group);
+  });
+
+  it("never calls the per-candidate callback for batches with columns", () => {
+    let callbackCalls = 0;
+    const store = buildCandidateStore(scene(), {
+      datum: (facts) => {
+        callbackCalls++;
+        return datumByFacts()(facts);
+      },
+      datumColumns: columnsByBatch(),
+    });
+    for (let id = 0; id < store.size; id++) store.candidate(id);
+    expect(callbackCalls).toBe(0);
+  });
+
+  it("falls back to the per-candidate callback for declined batches", () => {
+    const sceneTwoBatches = scene();
+    const store = buildCandidateStore(sceneTwoBatches, {
+      datum: datumByFacts(),
+      datumColumns: (facts) => (facts.batchIndex === 0 ? null : columnsByBatch()(facts)),
+    });
+    const reference = buildCandidateStore(scene(), { datum: datumByFacts() });
+    for (let id = 0; id < store.size; id++) {
+      expect(store.candidate(id)).toEqual(reference.candidate(id));
+    }
+  });
+
+  it("applies constants from style columns to every candidate", () => {
+    const store = buildCandidateStore(scene(), {
+      datumColumns: () => ({
+        xValue: null,
+        yValue: null,
+        sizeValue: { kind: "constant", value: 4 },
+        linewidthValue: null,
+        alphaValue: null,
+        shapeValue: null,
+        linetypeValue: null,
+        seriesId: null,
+        seriesRank: null,
+        sourceOrder: null,
+        lineage: null,
+        autoMode: null,
+      }),
+    });
+    for (let id = 0; id < store.size; id++) {
+      expect(store.candidate(id)?.sizeValue).toBe(4);
+    }
+  });
+});

--- a/packages/core/tests/candidate/store/lazy-axis-groups.test.ts
+++ b/packages/core/tests/candidate/store/lazy-axis-groups.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Axis-group tables (permutation + bucket boundaries behind `group()`) are
+ * built LAZILY: first-hover queries (hitTest/nearest/traverse) must not pay
+ * the O(u log u) token-rank sort and O(n) bucket-map construction on dense
+ * plots. The build happens once, on first `group()` (or explicit
+ * `axisGroups()`), and is memoized.
+ *
+ * Observable contract pinned here:
+ * - indexes expose `axisGroups()` (memoized: identical object identity)
+ *   instead of eager `permutations`/`buckets` own-properties;
+ * - group() results are unchanged whether or not other queries ran first.
+ */
+import { describe, expect, it } from "bun:test";
+
+import { buildCandidateStore } from "../../../src/candidate-store.ts";
+import { buildCandidateStoreIndexes } from "../../../src/candidate-store-indexes.ts";
+
+import { sceneWithPoints } from "../fixtures.ts";
+
+const POINTS: readonly (readonly [number, number])[] = [
+  [10, 10],
+  [10, 50],
+  [10, 30],
+  [40, 20],
+  [40, 60],
+];
+
+function groupingStore() {
+  return buildCandidateStore(sceneWithPoints(POINTS), {
+    datum: ({ primitiveIndex }) => ({
+      xValue: primitiveIndex < 3 ? "a" : "b",
+      yValue: primitiveIndex * 10,
+      seriesId: primitiveIndex === 1 ? 1 : 0,
+      seriesRank: primitiveIndex === 1 ? 1 : 0,
+    }),
+  });
+}
+
+describe("lazy axis-group tables", () => {
+  it("exposes axisGroups() instead of eager permutation/bucket fields", () => {
+    const indexes = buildCandidateStoreIndexes(sceneWithPoints(POINTS), {});
+    expect("permutations" in indexes).toBe(false);
+    expect("buckets" in indexes).toBe(false);
+    expect(typeof indexes.axisGroups).toBe("function");
+  });
+
+  it("memoizes the build across calls", () => {
+    const indexes = buildCandidateStoreIndexes(sceneWithPoints(POINTS), {});
+    const first = indexes.axisGroups();
+    expect(indexes.axisGroups()).toBe(first);
+  });
+
+  it("returns identical group() results whether or not hit queries ran first", () => {
+    const groupedFirst = groupingStore();
+    const direct = groupedFirst.group(0, "x");
+
+    const hitFirst = groupingStore();
+    hitFirst.hitTest(10, 10);
+    hitFirst.nearest(10, 10, { mode: "xy", maxDistance: 32 });
+    hitFirst.traverse(0, "next");
+    const afterQueries = hitFirst.group(0, "x");
+
+    expect(afterQueries).toEqual(direct);
+    expect(afterQueries?.memberIds.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/core/tests/lineage-intern-singleton.test.ts
+++ b/packages/core/tests/lineage-intern-singleton.test.ts
@@ -1,0 +1,72 @@
+/**
+ * `LineageStore.internSingleton(key)` is the allocation-free twin of
+ * `intern([key])` for the dense-identity hot path: one Map hit per repeat,
+ * no per-candidate `[key]` array. It must share the singleton cache AND the
+ * token cache with `intern` in BOTH directions so a membership keeps one ref
+ * however it is interned.
+ */
+import { describe, expect, it } from "bun:test";
+
+import { LineageStore } from "../src/identity.ts";
+
+describe("LineageStore.internSingleton", () => {
+  it("returns the same ref as intern([key]) and exposes the same keys", () => {
+    const store = new LineageStore<number>();
+    const viaSingleton = store.internSingleton(7);
+    const viaIntern = store.intern([7]);
+    expect(viaSingleton).toBe(viaIntern);
+    expect(store.keys(viaSingleton)).toEqual([7]);
+    expect(store.count(viaSingleton)).toBe(1);
+  });
+
+  it("shares the cache when intern([key]) ran first", () => {
+    const store = new LineageStore<number>();
+    const viaIntern = store.intern([42]);
+    const viaSingleton = store.internSingleton(42);
+    expect(viaSingleton).toBe(viaIntern);
+    expect(store.keys(viaSingleton)).toEqual([42]);
+  });
+
+  it("interns distinct keys to distinct refs and repeats to the same ref", () => {
+    const store = new LineageStore<number>();
+    const a = store.internSingleton(1);
+    const b = store.internSingleton(2);
+    expect(a).not.toBe(b);
+    expect(store.internSingleton(1)).toBe(a);
+    expect(store.internSingleton(2)).toBe(b);
+  });
+
+  it("agrees with intern on multi-member memberships interned separately", () => {
+    const store = new LineageStore<number>();
+    const pair = store.intern([1, 2]);
+    expect(store.intern([2, 1])).toBe(pair);
+    // Singletons interned alongside a pair stay distinct from it.
+    expect(store.internSingleton(1)).not.toBe(pair);
+    expect(store.intern([1])).toBe(store.internSingleton(1));
+  });
+
+  it("does not route through intern (no array tokenization on the hot path)", () => {
+    const store = new LineageStore<number>();
+    // oxlint-disable-next-line typescript/unbound-method -- re-invoked with .call below
+    const original = LineageStore.prototype.intern;
+    let calls = 0;
+    LineageStore.prototype.intern = function counting(this: LineageStore, keys: Iterable<never>) {
+      calls++;
+      return original.call(this, keys);
+    } as typeof original;
+    try {
+      store.internSingleton(9);
+      store.internSingleton(9);
+      expect(calls).toBe(0);
+    } finally {
+      LineageStore.prototype.intern = original;
+    }
+  });
+
+  it("keeps the empty lineage untouched", () => {
+    const store = new LineageStore<number>();
+    store.internSingleton(5);
+    expect(store.empty).toBe(0);
+    expect(store.keys(store.empty)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

First-hover latency on dense charts: the lazy candidate build on the first interaction query dropped from **651 ms → 263 ms at 100k points** (canvas cold scatter workload, bench-json medians, same-session same-host A/B). Two structural changes, zero behavior change:

1. **Columnar datum seam** (`CandidateStoreOptions.datumColumns`): the store consults a per-batch column resolver once per batch instead of invoking an object-allocating callback per candidate. The source-backed strategy resolves x/y/style/series as table-column reuse or one native slice per column, fills lineage in one typed-array pass through the new `LineageStore.internSingleton` (allocation-free twin of `intern([key])`), and memoizes ordinal `indexOf` per unique value over the full colorRank→fillRank→group precedence. Scattered batches (NO_ROW gaps, multi-table) mirror the callback line-for-line; a `null` return falls back to the per-candidate path per batch. Style channels that resolve all-null no longer write to the shared arrays at all (was 5 growable-array pushes per candidate).

2. **Lazy axis-group tables**: `permutations` + bucket `buckets` serve `group()` only, but were built on every store assembly — an O(u log u) token-rank sort plus O(n) bucket-map writes (~340 ms of the ~500 ms first-hover build at 100k). They now build once, memoized, on first `group()`. `hitTest`/`nearest`/`traverse`/`cycle` never pay for them.

## Measured (this host, `bench:json` medians of 10, same-session A/B)

| workload | before | after | Δ |
|---|---|---|---|
| canvas cold scatter 100k | 651.2 ms | **262.9 ms** | **−59.6%** |
| hit-index build 100k | 195.1 ms | **140.2 ms** | **−28.1%** |

No workload regressed beyond run-to-run noise (control canaries loess/density unchanged; ±15–20% swings on unrelated small workloads reproduce in both directions across runs on this host).

## Budgets

`benchmarks/budgets.json` re-baselines ONLY the two candidate workloads to post-change median ×1.5 (400 ms / 210 ms). The prior 130/31 ms budgets were captured 2026-07-11 on an M1 Pro and predate the 2026-07-24 candidate-store rework; the gate was already red on them (−793%/−833%) before this PR. Other over-budget rows on this host are pre-existing host drift — untouched.

## Tests

- `tests/candidate/store/datum-columns.test.ts` — columnar ≡ per-candidate equivalence (facts, hitTest, queryRect, group), fallback interleaving, constant styles
- `tests/candidate-construction/source-backed-columnar.test.ts` — zero `LineageStore.intern` calls for source-backed pipelines; golden fact tuples
- `tests/candidate/store/lazy-axis-groups.test.ts` — axisGroups contract, memoization identity, group() identical before/after hit queries
- `tests/lineage-intern-singleton.test.ts` — `internSingleton` ≡ `intern([key])` both cache directions, no `intern` routing
- Strengthened `source-backed-locate-once` pin: contiguous batches probe first/last only (≤2 locates, was exactly n)
- Full suite: 2166 core tests pass; benchmarks tests pass; knip clean; svelte-check clean; retained memory 3.78 MiB (128 MiB budget)

## Notes

- Public API is additive: `CandidateStoreOptions.datumColumns`, `CandidateBatchFacts`, `CandidateDatumColumns`, `CandidateStyleColumn`, `LineageStore.internSingleton`. The `datum` callback remains supported (identity-indexed strategy uses it).
- Plan + grok-4.5 plan review (gate FAIL → all findings resolved): `artifacts/2026-08-02-candidate-datum-columnar-plan.md` (local, untracked).
- Follow-ups filed from the same investigation: #1420 (side-effect registration), #1421 (render-entry splits), #1422 (loess interpolate), #1423 (color LUT).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1426" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->