### PR TITLE
docs(readme): one-line intro for agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,7 @@
 
 [![codecov](https://codecov.io/gh/ljodea/ggsvelte/branch/main/graph/badge.svg)](https://app.codecov.io/gh/ljodea/ggsvelte)
 
-ggplot2's layered grammar for Svelte 5. Author with components; agents emit the
-same chart as PortableSpec JSON — validate, apply the fix, render headless.
-The agent skill is the [`@ggsvelte/skill`](packages/skill) package (`SKILL.md` +
-`references/` at the package root).
+A layered grammar of graphics in Svelte for agents. Inspired by ggplot.
 
 [Documentation](https://ggsvelte.sh/) · [Examples](https://ggsvelte.sh/examples) ·
 [Getting started](https://ggsvelte.sh/guide/getting-started)


### PR DESCRIPTION
## Summary

Replace the dense README first paragraph with a single line:

> A layered grammar of graphics in Svelte for agents. Inspired by ggplot.

Install, Agents, Packages, and the docs links already carry the rest.

## Test plan

- [x] `bun test scripts/readme-showcase.test.ts`
- [ ] CI green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1439" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->