### PR TITLE
perf(core): lazy interaction candidates — lean render entry drops candidate-store graph (#1421)

### DIFF
--- a/.changeset/lazy-interaction-candidates.md
+++ b/.changeset/lazy-interaction-candidates.md
@@ -1,0 +1,27 @@
+---
+"@ggsvelte/core": minor
+---
+
+# Interaction: lazy candidate store behind a runtime hook (#1421)
+
+The interaction candidate store (hit-testing) no longer ships in the lean
+`@ggsvelte/core/render` graph and no longer builds during `runPipeline`:
+
+- Candidate construction runs through a runtime hook
+  (`candidate-runtime.ts`, mirroring `temporal-runtime.ts`). The full barrel
+  installs it via `install-candidates.ts`; the lean render entry omits it, so
+  headless/SSR bundles drop ~95 KB raw of candidate-store/hit/spatial code
+  (ggsvelte-svg 156.0 → 136.1 KB gzip, ggsvelte-canvas 148.6 → 128.6 KB gzip,
+  measured same-tree).
+- `RenderModel.candidates` / `RenderModel.lineage` are now lazy getters that
+  build the store once on first access. Full-entry behavior is unchanged;
+  a `renderToSVGString` run never pays candidate-build cost at runtime.
+- Accessing either on a lean-entry model throws an `Error` naming the full
+  entry. `semantic-viewport` resolves the store at interaction time.
+
+CI bundle guard: `benchmarks/competitive/lean-candidates-graph.test.ts`
+asserts the lean graphs exclude the candidate-store modules.
+
+Migration: none — additive behavior for `@ggsvelte/core` consumers;
+`@ggsvelte/core/render` consumers who read `model.candidates` or
+`model.lineage` must switch to the full `@ggsvelte/core` entry.

--- a/benchmarks/competitive/lean-candidates-graph.test.ts
+++ b/benchmarks/competitive/lean-candidates-graph.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Vite tree-shaken client graphs for the competitive lean ggsvelte entries
+ * (SVG + canvas) must not include the interaction candidate-store graph
+ * (#1421): build-candidates, candidate-store(+indexes/spatial), hit geometry
+ * and candidate construction are full-entry-only. `candidate-geometry.ts`
+ * (primitive counts, segment distance) legitimately stays — the lean render
+ * path uses it.
+ */
+import { describe, expect, it } from "bun:test";
+import { mkdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { build } from "vite";
+
+const root = import.meta.dir;
+
+const LEAN_BANNED = /candidate-store|candidate-hit-|build-candidates|candidate-construction/;
+
+async function buildEntry(entryName: string): Promise<{ moduleIds: string[]; rawBytes: number }> {
+  const outDir = path.join(root, "results", "bundles", `_lean-candidates-test-${entryName}`);
+  mkdirSync(outDir, { recursive: true });
+
+  const result = await build({
+    configFile: false,
+    logLevel: "error",
+    build: {
+      lib: {
+        entry: path.join(root, "entries", entryName),
+        formats: ["es"],
+        fileName: () => "bundle.js",
+      },
+      outDir,
+      emptyOutDir: true,
+      minify: "esbuild",
+      target: "es2022",
+      rollupOptions: { external: [] },
+      write: true,
+    },
+    resolve: {
+      conditions: ["import", "module", "default"],
+    },
+  });
+
+  const outputs = (Array.isArray(result) ? result : [result]).flatMap((item) => item.output ?? []);
+  const chunk = outputs.find((item) => item.type === "chunk");
+  expect(chunk?.type).toBe("chunk");
+  if (chunk?.type !== "chunk") throw new Error("expected a chunk output");
+
+  const raw = readFileSync(path.join(outDir, "bundle.js"));
+  return { moduleIds: Object.keys(chunk.modules), rawBytes: raw.byteLength };
+}
+
+function expectCandidateFree(
+  { moduleIds, rawBytes }: { moduleIds: string[]; rawBytes: number },
+  maxRawBytes: number,
+): void {
+  expect(moduleIds.filter((id) => LEAN_BANNED.test(id))).toEqual([]);
+  // Post-#1421 lean graphs measure ~542KB (svg) / ~514KB (canvas) raw; the
+  // candidate-store graph was ~95KB raw on top of that.
+  expect(rawBytes).toBeGreaterThan(50_000);
+  expect(rawBytes).toBeLessThan(maxRawBytes);
+}
+
+describe("lean competitive SVG graph", () => {
+  it("excludes the candidate-store graph after minify", async () => {
+    expectCandidateFree(await buildEntry("ggsvelte-svg__scatter-color.ts"), 570_000);
+  }, 120_000);
+});
+
+describe("lean competitive canvas graph", () => {
+  it("excludes the candidate-store graph after minify", async () => {
+    expectCandidateFree(await buildEntry("ggsvelte-canvas__scatter-color.ts"), 540_000);
+  }, 120_000);
+});

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -10,6 +10,7 @@ preload = [
   # Spec-src graph: unit tests import packages/spec/src/*.ts directly.
   "./packages/spec/src/temporal-polyfill.ts",
   "./packages/core/src/install-temporal.ts",
+  "./packages/core/src/install-candidates.ts",
   "./packages/core/src/pipeline/frame-stats-register-all.ts",
   "./packages/core/src/pipeline/geometry-register-all.ts",
 ]

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,6 +33,7 @@
     "./dist/render-entry.js",
     "./dist/temporal-entry.js",
     "./dist/install-temporal.js",
+    "./dist/install-candidates.js",
     "./dist/pipeline/frame-stats-register-all.js",
     "./dist/pipeline/geometry-register-all.js",
     "./dist/pipeline/geometry-register-basic.js",

--- a/packages/core/src/candidate-runtime.ts
+++ b/packages/core/src/candidate-runtime.ts
@@ -1,0 +1,57 @@
+/**
+ * Optional candidate-build runtime hook.
+ *
+ * The lean `@ggsvelte/core/render` entry leaves this unset so headless/SSR
+ * bundles never carry the candidate-store graph (build-candidates →
+ * candidate-store → hit geometry/spatial indexes). The full package barrel
+ * installs it via `install-candidates.ts` (mirrors `temporal-runtime.ts` +
+ * `install-temporal.ts`).
+ *
+ * `RenderModel.candidates` / `RenderModel.lineage` build lazily through this
+ * hook on first access; a pipeline run that only renders never pays the
+ * candidate-build cost.
+ */
+import type { CandidateStore } from "./candidate-store.js";
+import type { LineageStore } from "./identity.js";
+import type { buildPipelineCandidates } from "./pipeline/build-candidates.js";
+
+/** Inputs finalize retains for the lazy candidate build (type-only import —
+ * this module stays in the lean render graph, build-candidates does not). */
+export type CandidateBuildInput = Parameters<typeof buildPipelineCandidates>[0];
+
+export interface CandidateBuildRuntime {
+  readonly build: (input: CandidateBuildInput) => CandidateStore;
+}
+
+/**
+ * Finalize's lazy interaction bundle: the lineage store is created eagerly
+ * (cheap, empty) but populated only by `ensure()`, so every accessor must go
+ * through `ensure()` first — a bare read of the store would be silently stale.
+ */
+export interface LazyInteraction {
+  readonly lineageStore: LineageStore<number>;
+  /** Build (once) and return the candidate store; populates `lineageStore`. */
+  readonly ensure: () => CandidateStore;
+  /** The built store, or null when interaction was never accessed. */
+  readonly built: () => CandidateStore | null;
+}
+
+let runtime: CandidateBuildRuntime | null = null;
+
+/** Install candidate construction (full entry). Idempotent; may replace. */
+export function installCandidateRuntime(next: CandidateBuildRuntime): void {
+  runtime = next;
+}
+
+export function getCandidateRuntime(): CandidateBuildRuntime | null {
+  return runtime;
+}
+
+/**
+ * Test-only: clear the runtime so the lean render path is exercised.
+ * Restore with `installCandidates()` (bunfig preload shares module state
+ * across test files).
+ */
+export function resetCandidateRuntimeForTests(): void {
+  runtime = null;
+}

--- a/packages/core/src/candidate-runtime.ts
+++ b/packages/core/src/candidate-runtime.ts
@@ -17,7 +17,7 @@ import type { buildPipelineCandidates } from "./pipeline/build-candidates.js";
 
 /** Inputs finalize retains for the lazy candidate build (type-only import —
  * this module stays in the lean render graph, build-candidates does not). */
-export type CandidateBuildInput = Parameters<typeof buildPipelineCandidates>[0];
+type CandidateBuildInput = Parameters<typeof buildPipelineCandidates>[0];
 
 export interface CandidateBuildRuntime {
   readonly build: (input: CandidateBuildInput) => CandidateStore;

--- a/packages/core/src/candidate-runtime.ts
+++ b/packages/core/src/candidate-runtime.ts
@@ -17,7 +17,7 @@ import type { buildPipelineCandidates } from "./pipeline/build-candidates.js";
 
 /** Inputs finalize retains for the lazy candidate build (type-only import —
  * this module stays in the lean render graph, build-candidates does not). */
-type CandidateBuildInput = Parameters<typeof buildPipelineCandidates>[0];
+export type CandidateBuildInput = Parameters<typeof buildPipelineCandidates>[0];
 
 export interface CandidateBuildRuntime {
   readonly build: (input: CandidateBuildInput) => CandidateStore;
@@ -34,6 +34,9 @@ export interface LazyInteraction {
   readonly ensure: () => CandidateStore;
   /** The built store, or null when interaction was never accessed. */
   readonly built: () => CandidateStore | null;
+  /** Drop the retained build inputs (model dispose) so a released model does
+   *  not keep the source table / prepared panels alive through the thunk. */
+  readonly release: () => void;
 }
 
 let runtime: CandidateBuildRuntime | null = null;

--- a/packages/core/src/candidate-runtime.ts
+++ b/packages/core/src/candidate-runtime.ts
@@ -51,6 +51,30 @@ export function getCandidateRuntime(): CandidateBuildRuntime | null {
   return runtime;
 }
 
+const EMPTY_F32 = new Float32Array(0);
+const EMPTY_U32 = new Uint32Array(0);
+
+/**
+ * Inert store returned when interaction is first accessed after the model's
+ * dispose released the build inputs. Preserves the pre-#1421 contract for
+ * late hit-tests on a released chart (quiet nulls, never a crash) without
+ * keeping the source table alive. Interface drift breaks tsc, not callers.
+ */
+export const RELEASED_CANDIDATE_STORE: CandidateStore = {
+  epoch: -1,
+  size: 0,
+  x: EMPTY_F32,
+  y: EMPTY_F32,
+  candidate: () => null,
+  hitTest: () => null,
+  nearest: () => null,
+  group: () => null,
+  traverse: () => null,
+  cycle: () => null,
+  queryRect: () => EMPTY_U32,
+  dispose: () => {},
+};
+
 /**
  * Test-only: clear the runtime so the lean render path is exercised.
  * Restore with `installCandidates()` (bunfig preload shares module state

--- a/packages/core/src/candidate-runtime.ts
+++ b/packages/core/src/candidate-runtime.ts
@@ -25,12 +25,13 @@ export interface CandidateBuildRuntime {
 
 /**
  * Finalize's lazy interaction bundle: the lineage store is created eagerly
- * (cheap, empty) but populated only by `ensure()`, so every accessor must go
- * through `ensure()` first — a bare read of the store would be silently stale.
+ * (cheap, empty) and populated by the store's assembly once `ensure()` has
+ * produced it — `ensure()` is the only guarded accessor.
  */
 export interface LazyInteraction {
   readonly lineageStore: LineageStore<number>;
-  /** Build (once) and return the candidate store; populates `lineageStore`. */
+  /** Build (once) and return the candidate store; its assembly populates
+   *  `lineageStore`. */
   readonly ensure: () => CandidateStore;
   /** The built store, or null when interaction was never accessed. */
   readonly built: () => CandidateStore | null;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,6 +19,8 @@ import "./pipeline/frame-stats-register-all.js";
 import "./pipeline/geometry-register-all.js";
 // Full temporal: Temporal polyfill parsing + guide planner.
 import "./install-temporal.js";
+// Interaction candidates: lazy candidate-store construction (#1421).
+import "./install-candidates.js";
 
 // Data binding
 export {

--- a/packages/core/src/install-candidates.ts
+++ b/packages/core/src/install-candidates.ts
@@ -1,0 +1,19 @@
+/**
+ * Side-effect module: wire candidate-store construction into the pipeline.
+ * Imported by the full `@ggsvelte/core` barrel (and the test preload) so
+ * `RenderModel.candidates` resolves; the lean `@ggsvelte/core/render` entry
+ * omits it and never carries the candidate-store graph (#1421).
+ */
+import { installCandidateRuntime, getCandidateRuntime } from "./candidate-runtime.js";
+import { buildPipelineCandidates } from "./pipeline/build-candidates.js";
+
+let installed = false;
+
+export function installCandidates(): void {
+  // Re-install after test-only runtime clears; skip when already wired.
+  if (installed && getCandidateRuntime() !== null) return;
+  installed = true;
+  installCandidateRuntime({ build: (input) => buildPipelineCandidates(input) });
+}
+
+installCandidates();

--- a/packages/core/src/install-candidates.ts
+++ b/packages/core/src/install-candidates.ts
@@ -5,15 +5,21 @@
  * omits it and never carries the candidate-store graph (#1421).
  */
 import { installCandidateRuntime, getCandidateRuntime } from "./candidate-runtime.js";
+import type { CandidateBuildRuntime } from "./candidate-runtime.js";
 import { buildPipelineCandidates } from "./pipeline/build-candidates.js";
 
-let installed = false;
+const REAL_RUNTIME: CandidateBuildRuntime = {
+  build: (input) => buildPipelineCandidates(input),
+};
 
+/**
+ * Install the real candidate-build runtime. Idempotent, and restores the real
+ * runtime after a test-only clear OR replacement (a counting wrapper that
+ * delegates must not survive its test's restore).
+ */
 export function installCandidates(): void {
-  // Re-install after test-only runtime clears; skip when already wired.
-  if (installed && getCandidateRuntime() !== null) return;
-  installed = true;
-  installCandidateRuntime({ build: (input) => buildPipelineCandidates(input) });
+  if (getCandidateRuntime() === REAL_RUNTIME) return;
+  installCandidateRuntime(REAL_RUNTIME);
 }
 
 installCandidates();

--- a/packages/core/src/pipeline.ts
+++ b/packages/core/src/pipeline.ts
@@ -62,5 +62,7 @@ import "./pipeline/frame-stats-register-all.js";
 import "./pipeline/geometry-register-all.js";
 // Full temporal polyfill + guide planner (lean render entry skips this).
 import "./install-temporal.js";
+// Lazy interaction candidate construction (lean render entry skips this).
+import "./install-candidates.js";
 
 export { runPipeline } from "./pipeline/run-pipeline.js";

--- a/packages/core/src/pipeline/assemble-render-model-lifecycle.ts
+++ b/packages/core/src/pipeline/assemble-render-model-lifecycle.ts
@@ -5,15 +5,16 @@
 import type { Scene } from "../scene.js";
 import type { CellValue } from "../table.js";
 import type { ColumnTable } from "../table.js";
-import type { CandidateStore } from "../candidate-store.js";
+import type { LazyInteraction } from "../candidate-runtime.js";
 
 import type { SourceRegistry } from "./source-registry.js";
 import { NO_ROW } from "./types.js";
 
 export function createRenderModelLifecycle(input: {
   scene: Scene;
-  /** Lazy candidates (#1421): dispose only when the store was ever built. */
-  builtCandidates: () => CandidateStore | null;
+  /** Lazy candidates (#1421): dispose a built store; release drops the
+   *  retained build inputs so a disposed model frees the source table. */
+  interaction: LazyInteraction;
   table: ColumnTable;
   /** When present, model.row resolves multi-table global source ids. */
   sourceRegistry?: SourceRegistry | null;
@@ -24,7 +25,7 @@ export function createRenderModelLifecycle(input: {
   let disposed = false;
   let retainedTable: ColumnTable | null = input.table;
   let retainedRegistry: SourceRegistry | null = input.sourceRegistry ?? null;
-  const { scene, builtCandidates } = input;
+  const { scene, interaction } = input;
 
   return {
     row(index: number): Record<string, CellValue> | null {
@@ -39,7 +40,8 @@ export function createRenderModelLifecycle(input: {
     dispose(): void {
       if (disposed) return;
       disposed = true;
-      builtCandidates()?.dispose();
+      interaction.built()?.dispose();
+      interaction.release();
       retainedTable = null;
       retainedRegistry = null;
       // Release geometry (typed arrays) and per-panel structures; the bound

--- a/packages/core/src/pipeline/assemble-render-model-lifecycle.ts
+++ b/packages/core/src/pipeline/assemble-render-model-lifecycle.ts
@@ -12,7 +12,8 @@ import { NO_ROW } from "./types.js";
 
 export function createRenderModelLifecycle(input: {
   scene: Scene;
-  candidates: CandidateStore;
+  /** Lazy candidates (#1421): dispose only when the store was ever built. */
+  builtCandidates: () => CandidateStore | null;
   table: ColumnTable;
   /** When present, model.row resolves multi-table global source ids. */
   sourceRegistry?: SourceRegistry | null;
@@ -23,7 +24,7 @@ export function createRenderModelLifecycle(input: {
   let disposed = false;
   let retainedTable: ColumnTable | null = input.table;
   let retainedRegistry: SourceRegistry | null = input.sourceRegistry ?? null;
-  const { scene, candidates } = input;
+  const { scene, builtCandidates } = input;
 
   return {
     row(index: number): Record<string, CellValue> | null {
@@ -38,7 +39,7 @@ export function createRenderModelLifecycle(input: {
     dispose(): void {
       if (disposed) return;
       disposed = true;
-      candidates.dispose();
+      builtCandidates()?.dispose();
       retainedTable = null;
       retainedRegistry = null;
       // Release geometry (typed arrays) and per-panel structures; the bound

--- a/packages/core/src/pipeline/assemble-render-model.ts
+++ b/packages/core/src/pipeline/assemble-render-model.ts
@@ -11,8 +11,7 @@ import type { ScaleState } from "../scales/state.js";
 import type { PositionScale } from "../scales/train.js";
 import type { Scene } from "../scene.js";
 import type { CellValue, ColumnTable } from "../table.js";
-import type { CandidateStore } from "../candidate-store.js";
-import type { LineageStore } from "../identity.js";
+import type { LazyInteraction } from "../candidate-runtime.js";
 import { createSemanticViewport } from "../semantic-viewport.js";
 import type { AdvisoryCode } from "../diagnostics.js";
 
@@ -65,8 +64,7 @@ export interface AssembleRenderModelInput {
   layerScaledConstants: ReadonlyArray<Readonly<Partial<Record<string, CellValue>>>>;
   baselineDomains: ScaleDomainSnapshot;
   effectiveDomains: ScaleDomainSnapshot;
-  lineage: LineageStore<number>;
-  candidates: CandidateStore;
+  interaction: LazyInteraction;
   formatX: TickFormatter | undefined;
   formatY: TickFormatter | undefined;
   table: ColumnTable;
@@ -250,11 +248,11 @@ function guidePlanIdsByAesthetic(
 }
 
 export function assembleRenderModel(input: AssembleRenderModelInput): RenderModel {
-  const { scene, candidates } = input;
+  const { scene, interaction } = input;
   const scales = buildRenderModelScales(input);
   const lifecycle = createRenderModelLifecycle({
     scene,
-    candidates,
+    builtCandidates: interaction.built,
     table: input.table,
     ...(input.sourceRegistry !== undefined && { sourceRegistry: input.sourceRegistry }),
   });
@@ -284,7 +282,7 @@ export function assembleRenderModel(input: AssembleRenderModelInput): RenderMode
       scales,
       coordProjectors: input.coordProjectors,
       flipped: input.flipped,
-      candidates,
+      candidates: interaction.ensure,
       sceneSize: { width: scene.width, height: scene.height },
     }),
     runId: input.runId,
@@ -292,8 +290,16 @@ export function assembleRenderModel(input: AssembleRenderModelInput): RenderMode
     layerFields: input.layerFields,
     layerScaledConstants: input.layerScaledConstants,
     domains: freezeRenderModelDomains(input.baselineDomains, input.effectiveDomains),
-    lineage: input.lineage,
-    candidates,
+    // Lazy getters (#1421): the candidate store builds on first access through
+    // the installed runtime hook, and the same build populates lineage — the
+    // lineage getter ensures first so it never hands out an empty stale store.
+    get lineage() {
+      interaction.ensure();
+      return interaction.lineageStore;
+    },
+    get candidates() {
+      return interaction.ensure();
+    },
     axisFormatters: buildRenderModelAxisFormatters(
       input.xScale,
       input.yScale,

--- a/packages/core/src/pipeline/assemble-render-model.ts
+++ b/packages/core/src/pipeline/assemble-render-model.ts
@@ -252,7 +252,7 @@ export function assembleRenderModel(input: AssembleRenderModelInput): RenderMode
   const scales = buildRenderModelScales(input);
   const lifecycle = createRenderModelLifecycle({
     scene,
-    builtCandidates: interaction.built,
+    interaction,
     table: input.table,
     ...(input.sourceRegistry !== undefined && { sourceRegistry: input.sourceRegistry }),
   });

--- a/packages/core/src/pipeline/assemble-render-model.ts
+++ b/packages/core/src/pipeline/assemble-render-model.ts
@@ -290,11 +290,11 @@ export function assembleRenderModel(input: AssembleRenderModelInput): RenderMode
     layerFields: input.layerFields,
     layerScaledConstants: input.layerScaledConstants,
     domains: freezeRenderModelDomains(input.baselineDomains, input.effectiveDomains),
-    // Lazy getters (#1421): the candidate store builds on first access through
-    // the installed runtime hook, and the same build populates lineage — the
-    // lineage getter ensures first so it never hands out an empty stale store.
+    // Lazy getters (#1421): `candidates` builds the store on first access
+    // through the installed runtime hook. `lineage` does NOT ensure: the
+    // store populates it when it assembles (first candidate read), exactly
+    // like the pre-#1421 eager build — a lineage-only reader pays nothing.
     get lineage() {
-      interaction.ensure();
       return interaction.lineageStore;
     },
     get candidates() {

--- a/packages/core/src/pipeline/finalize.ts
+++ b/packages/core/src/pipeline/finalize.ts
@@ -8,7 +8,7 @@
  */
 import type { PortableSpec } from "@ggsvelte/spec";
 
-import { getCandidateRuntime } from "../candidate-runtime.js";
+import { getCandidateRuntime, RELEASED_CANDIDATE_STORE } from "../candidate-runtime.js";
 import type { CandidateBuildInput, LazyInteraction } from "../candidate-runtime.js";
 import type { CandidateStore } from "../candidate-store.js";
 import { buildPanelCoordProjector } from "../coord-projector.js";
@@ -134,7 +134,10 @@ export function finalize(run: PipelineRunState): RenderModel {
       if (builtCandidates !== null) return builtCandidates;
       const input = retained;
       if (input === null) {
-        throw new Error("Interaction candidates are released with this model's dispose().");
+        // Disposed before any interaction: quiet-null inert store, matching
+        // the pre-#1421 built-then-disposed contract for late hit-tests.
+        builtCandidates = RELEASED_CANDIDATE_STORE;
+        return builtCandidates;
       }
       const runtime = getCandidateRuntime();
       if (runtime === null) {

--- a/packages/core/src/pipeline/finalize.ts
+++ b/packages/core/src/pipeline/finalize.ts
@@ -8,12 +8,14 @@
  */
 import type { PortableSpec } from "@ggsvelte/spec";
 
+import { getCandidateRuntime } from "../candidate-runtime.js";
+import type { LazyInteraction } from "../candidate-runtime.js";
+import type { CandidateStore } from "../candidate-store.js";
 import { buildPanelCoordProjector } from "../coord-projector.js";
 import { LineageStore } from "../identity.js";
 import type { ThemeTokens } from "../theme.js";
 
 import { assembleRenderModel } from "./assemble-render-model.js";
-import { buildPipelineCandidates } from "./build-candidates.js";
 import { computeBaselineDomains, computeEffectiveDomains } from "./compute-domains.js";
 import { dedupeScaleDiagnostics } from "./diagnostics-emit.js";
 import { finalizeGeometryAndScene } from "./finalize-geometry-scene.js";
@@ -97,24 +99,46 @@ export function finalize(run: PipelineRunState): RenderModel {
     effectiveDomains,
   });
 
-  // --- lineage + interaction candidates ---
-  const lineage = new LineageStore<number>();
-  const candidates = buildPipelineCandidates({
-    scene,
-    runId,
-    flip,
-    bindings,
-    panelFrames: prepared.panelFrames,
-    facetPanels: prepared.facetPanels,
-    // Candidate sourceRow indexes and lineage rows are source-table based
-    // (runtime filters preserve identity), so value lookups must be too.
-    table: prepared.sourceTable,
-    sources: prepared.sourceRegistry,
-    layerFields,
-    color: trained.colorResolution.resolved,
-    fill: trained.fillResolution.resolved,
-    lineage,
-  });
+  // --- lineage + interaction candidates (lazy, #1421) ---
+  // The candidate store builds on first `model.candidates` / `model.lineage`
+  // access so headless/SSR renders never pay for it, and the lean render entry
+  // never carries the candidate-store graph (no runtime installed there). The
+  // build populates `lineage`, so every access must go through `ensure()` — a
+  // bare read of the eager-but-empty store would be silently stale.
+  const lineageStore = new LineageStore<number>();
+  let builtCandidates: CandidateStore | null = null;
+  const interaction: LazyInteraction = {
+    lineageStore,
+    ensure(): CandidateStore {
+      if (builtCandidates !== null) return builtCandidates;
+      const runtime = getCandidateRuntime();
+      if (runtime === null) {
+        throw new Error(
+          "Interaction candidates require @ggsvelte/core (full entry); the lean @ggsvelte/core/render graph does not carry the candidate store.",
+        );
+      }
+      builtCandidates = runtime.build({
+        scene,
+        runId,
+        flip,
+        bindings,
+        panelFrames: prepared.panelFrames,
+        facetPanels: prepared.facetPanels,
+        // Candidate sourceRow indexes and lineage rows are source-table based
+        // (runtime filters preserve identity), so value lookups must be too.
+        table: prepared.sourceTable,
+        sources: prepared.sourceRegistry,
+        layerFields,
+        color: trained.colorResolution.resolved,
+        fill: trained.fillResolution.resolved,
+        lineage: lineageStore,
+      });
+      return builtCandidates;
+    },
+    built(): CandidateStore | null {
+      return builtCandidates;
+    },
+  };
 
   // --- pack trained scales + contracts into the render model ---
   const { colorResolution, fillResolution, styleResolutions } = trained;
@@ -167,8 +191,7 @@ export function finalize(run: PipelineRunState): RenderModel {
     layerScaledConstants,
     baselineDomains,
     effectiveDomains,
-    lineage,
-    candidates,
+    interaction,
     formatX: panelLayout.formatX,
     formatY: panelLayout.formatY,
     // Retain the unfiltered source table + multi-table registry: model.row()

--- a/packages/core/src/pipeline/finalize.ts
+++ b/packages/core/src/pipeline/finalize.ts
@@ -100,11 +100,12 @@ export function finalize(run: PipelineRunState): RenderModel {
   });
 
   // --- lineage + interaction candidates (lazy, #1421) ---
-  // The candidate store builds on first `model.candidates` / `model.lineage`
-  // access so headless/SSR renders never pay for it, and the lean render entry
-  // never carries the candidate-store graph (no runtime installed there). The
-  // build populates `lineage`, so every access must go through `ensure()` — a
-  // bare read of the eager-but-empty store would be silently stale.
+  // The candidate store builds on first `model.candidates` access so
+  // headless/SSR renders never pay for it, and the lean render entry
+  // never carries the candidate-store graph (no runtime installed there).
+  // `lineageStore` is created eagerly and populated by the store's assembly
+  // (first candidate read) — the same deferred shape as the pre-#1421 eager
+  // build, so `model.lineage` needs no ensure of its own.
   const lineageStore = new LineageStore<number>();
   let builtCandidates: CandidateStore | null = null;
   // Retained build inputs live in a null-able box: a successful build hands

--- a/packages/core/src/pipeline/finalize.ts
+++ b/packages/core/src/pipeline/finalize.ts
@@ -9,7 +9,7 @@
 import type { PortableSpec } from "@ggsvelte/spec";
 
 import { getCandidateRuntime } from "../candidate-runtime.js";
-import type { LazyInteraction } from "../candidate-runtime.js";
+import type { CandidateBuildInput, LazyInteraction } from "../candidate-runtime.js";
 import type { CandidateStore } from "../candidate-store.js";
 import { buildPanelCoordProjector } from "../coord-projector.js";
 import { LineageStore } from "../identity.js";
@@ -107,36 +107,49 @@ export function finalize(run: PipelineRunState): RenderModel {
   // bare read of the eager-but-empty store would be silently stale.
   const lineageStore = new LineageStore<number>();
   let builtCandidates: CandidateStore | null = null;
+  // Retained build inputs live in a null-able box: a successful build hands
+  // its own references to the store (which dispose() clears), and model
+  // dispose drops the box either way — a released model must not keep the
+  // source table / prepared panels alive through this closure.
+  let retained: CandidateBuildInput | null = {
+    scene,
+    runId,
+    flip,
+    bindings,
+    panelFrames: prepared.panelFrames,
+    facetPanels: prepared.facetPanels,
+    // Candidate sourceRow indexes and lineage rows are source-table based
+    // (runtime filters preserve identity), so value lookups must be too.
+    table: prepared.sourceTable,
+    sources: prepared.sourceRegistry,
+    layerFields,
+    color: trained.colorResolution.resolved,
+    fill: trained.fillResolution.resolved,
+    lineage: lineageStore,
+  };
   const interaction: LazyInteraction = {
     lineageStore,
     ensure(): CandidateStore {
       if (builtCandidates !== null) return builtCandidates;
+      const input = retained;
+      if (input === null) {
+        throw new Error("Interaction candidates are released with this model's dispose().");
+      }
       const runtime = getCandidateRuntime();
       if (runtime === null) {
         throw new Error(
           "Interaction candidates require @ggsvelte/core (full entry); the lean @ggsvelte/core/render graph does not carry the candidate store.",
         );
       }
-      builtCandidates = runtime.build({
-        scene,
-        runId,
-        flip,
-        bindings,
-        panelFrames: prepared.panelFrames,
-        facetPanels: prepared.facetPanels,
-        // Candidate sourceRow indexes and lineage rows are source-table based
-        // (runtime filters preserve identity), so value lookups must be too.
-        table: prepared.sourceTable,
-        sources: prepared.sourceRegistry,
-        layerFields,
-        color: trained.colorResolution.resolved,
-        fill: trained.fillResolution.resolved,
-        lineage: lineageStore,
-      });
+      builtCandidates = runtime.build(input);
+      retained = null;
       return builtCandidates;
     },
     built(): CandidateStore | null {
       return builtCandidates;
+    },
+    release(): void {
+      retained = null;
     },
   };
 

--- a/packages/core/src/pipeline/types-render-model.ts
+++ b/packages/core/src/pipeline/types-render-model.ts
@@ -52,9 +52,13 @@ export interface RenderModel {
   layerScaledConstants: ReadonlyArray<Readonly<Partial<Record<string, CellValue>>>>;
   /** Stable baseline plus the domains actually used for this render. */
   domains: Readonly<{ baseline: ScaleDomainSnapshot; effective: ScaleDomainSnapshot }>;
-  /** Interned source-row memberships. Public adapters resolve these through keys. */
+  /** Interned source-row memberships. Public adapters resolve these through keys.
+   *  Lazily populated by the same build as `candidates` (#1421) — the getter
+   *  triggers that build, so the store is never observed empty. */
   lineage: LineageStore<number>;
-  /** Shared epoch-scoped interaction candidate storage. */
+  /** Shared epoch-scoped interaction candidate storage. Built lazily on first
+   *  access (#1421): headless renders never pay for it, and the lean
+   *  `@ggsvelte/core/render` entry throws here (full entry required). */
   candidates: CandidateStore;
   /** Trained semantic formatters. Coord transforms never swap x and y here. */
   axisFormatters: Readonly<{ x: AxisValueFormatter; y: AxisValueFormatter }>;

--- a/packages/core/src/pipeline/types-render-model.ts
+++ b/packages/core/src/pipeline/types-render-model.ts
@@ -53,8 +53,9 @@ export interface RenderModel {
   /** Stable baseline plus the domains actually used for this render. */
   domains: Readonly<{ baseline: ScaleDomainSnapshot; effective: ScaleDomainSnapshot }>;
   /** Interned source-row memberships. Public adapters resolve these through keys.
-   *  Lazily populated by the same build as `candidates` (#1421) — the getter
-   *  triggers that build, so the store is never observed empty. */
+   *  Populated when the candidate store assembles (first candidate read /
+   *  hit-test); reading it before that yields an empty store — unchanged from
+   *  the pre-#1421 eager build, which assembled lazily too. */
   lineage: LineageStore<number>;
   /** Shared epoch-scoped interaction candidate storage. Built lazily on first
    *  access (#1421): headless renders never pay for it, and the lean

--- a/packages/core/src/semantic-viewport.ts
+++ b/packages/core/src/semantic-viewport.ts
@@ -287,7 +287,7 @@ function createPanel(
   scales: Readonly<{ x: PositionScale; y: PositionScale }>,
   coord: PanelCoordProjector | undefined,
   flipped: boolean,
-  candidates: CandidateStore,
+  candidates: () => CandidateStore,
   indexFor: (scale: PositionScale) => ReadonlyMap<string, BandKeyEntry>,
 ): SemanticViewportPanel {
   const xBandValuesByKey = indexFor(scales.x);
@@ -370,20 +370,21 @@ function createPanel(
               : { ...rect, x0: panel.x, x1: panel.x + panel.width }
             : rect;
       const matches: CandidateFacts[] = [];
-      for (const id of candidates.queryRect(
+      const store = candidates();
+      for (const id of store.queryRect(
         expanded.x0,
         expanded.y0,
         expanded.x1,
         expanded.y1,
         panel.id,
       )) {
-        const candidate = candidates.candidate(id);
+        const candidate = store.candidate(id);
         if (candidate !== null) matches.push(candidate);
       }
       return matches;
     },
     nearest(point, options) {
-      return candidates.nearest(point.x, point.y, {
+      return candidates().nearest(point.x, point.y, {
         mode: options.mode,
         maxDistance: options.maxDistance,
         panelId: panel.id,
@@ -397,7 +398,9 @@ export type CreateSemanticViewportInput = {
   readonly scales: ViewportScales;
   readonly coordProjectors: readonly PanelCoordProjector[];
   readonly flipped: boolean;
-  readonly candidates: CandidateStore;
+  /** Lazy candidate store (#1421): resolved at interaction time so headless
+   * renders never build it. */
+  readonly candidates: () => CandidateStore;
   /** Plot pixel size used by `locate` for client → scene scaling. */
   readonly sceneSize: Readonly<{ width: number; height: number }>;
 };

--- a/packages/core/tests/candidate/lazy-interaction.test.ts
+++ b/packages/core/tests/candidate/lazy-interaction.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Lazy interaction candidates (#1421).
+ *
+ * The lean render entry (`@ggsvelte/core/render`) must not carry the
+ * candidate-store graph, and even the full entry must not BUILD the store
+ * until something actually touches `model.candidates` / `model.lineage`
+ * (headless SSR renders never hit-test).
+ *
+ * Candidate construction therefore runs through a runtime hook
+ * (`candidate-runtime.ts`, mirroring `temporal-runtime.ts`): the full barrel
+ * installs it via `install-candidates.ts`; the lean entry leaves it unset and
+ * candidate access throws a plain Error naming the full entry.
+ */
+import { afterAll, describe, expect, it } from "bun:test";
+import { aes, gg } from "@ggsvelte/spec";
+
+import {
+  getCandidateRuntime,
+  installCandidateRuntime,
+  resetCandidateRuntimeForTests,
+} from "../../src/candidate-runtime.js";
+import { installCandidates } from "../../src/install-candidates.js";
+import { runPipeline } from "../../src/pipeline/run-pipeline.js";
+import { renderToSVGString } from "../../src/render-svg.js";
+
+const spec = gg({ x: [1, 2, 3, 4], y: [4, 3, 5, 2] }, aes({ x: "x", y: "y" }))
+  .geomPoint()
+  .spec();
+
+const size = { width: 400, height: 300 };
+
+/** Swap in a build-counting wrapper around the installed runtime. */
+function countBuilds(): { builds: () => number } {
+  const real = getCandidateRuntime();
+  if (real === null) throw new Error("expected the full candidate runtime (test preload)");
+  let builds = 0;
+  installCandidateRuntime({
+    build: (input) => {
+      builds += 1;
+      return real.build(input);
+    },
+  });
+  return { builds: () => builds };
+}
+
+afterAll(() => {
+  installCandidates();
+});
+
+describe("lazy interaction candidates", () => {
+  it("builds zero stores during runPipeline; first .candidates access builds exactly one", () => {
+    const counter = countBuilds();
+    try {
+      const model = runPipeline(spec, size);
+      // The SSR/headless win: a pipeline run that never interacts builds nothing.
+      expect(counter.builds()).toBe(0);
+
+      const first = model.candidates;
+      expect(counter.builds()).toBe(1);
+      expect(first.size).toBeGreaterThan(0);
+
+      // Memoized: repeat candidate + lineage access shares the one build.
+      expect(model.candidates).toBe(first);
+      void model.lineage;
+      expect(counter.builds()).toBe(1);
+    } finally {
+      installCandidates();
+    }
+  });
+
+  it(".lineage access alone triggers the shared build (no stale empty store)", () => {
+    const counter = countBuilds();
+    try {
+      const model = runPipeline(spec, size);
+      expect(counter.builds()).toBe(0);
+      const lineage = model.lineage;
+      expect(counter.builds()).toBe(1);
+      // The build populated the store: every candidate lineage id resolves.
+      const candidate = model.candidates.candidate(0);
+      expect(candidate).not.toBeNull();
+      expect(lineage.keys(candidate!.lineage).length).toBeGreaterThan(0);
+    } finally {
+      installCandidates();
+    }
+  });
+
+  it("lean render path: no runtime → renderToSVGString works, candidate access throws", () => {
+    resetCandidateRuntimeForTests();
+    try {
+      const svg = renderToSVGString(spec, size);
+      expect(svg).toContain("<svg");
+
+      const model = runPipeline(spec, size);
+      expect(() => model.candidates).toThrowError(/@ggsvelte\/core/);
+      expect(() => model.lineage).toThrowError(/@ggsvelte\/core/);
+    } finally {
+      installCandidates();
+    }
+  });
+});

--- a/packages/core/tests/candidate/lazy-interaction.test.ts
+++ b/packages/core/tests/candidate/lazy-interaction.test.ts
@@ -9,7 +9,8 @@
  * Candidate construction therefore runs through a runtime hook
  * (`candidate-runtime.ts`, mirroring `temporal-runtime.ts`): the full barrel
  * installs it via `install-candidates.ts`; the lean entry leaves it unset and
- * candidate access throws a plain Error naming the full entry.
+ * candidate access throws a plain Error naming the full entry. `model.lineage`
+ * is populated by the store's assembly, exactly as before #1421.
  */
 import { afterAll, describe, expect, it } from "bun:test";
 import { aes, gg } from "@ggsvelte/spec";
@@ -59,23 +60,23 @@ describe("lazy interaction candidates", () => {
       expect(counter.builds()).toBe(1);
       expect(first.size).toBeGreaterThan(0);
 
-      // Memoized: repeat candidate + lineage access shares the one build.
+      // Memoized: repeat access returns the same store without rebuilding.
       expect(model.candidates).toBe(first);
-      void model.lineage;
       expect(counter.builds()).toBe(1);
     } finally {
       installCandidates();
     }
   });
 
-  it(".lineage access alone triggers the shared build (no stale empty store)", () => {
+  it(".lineage alone builds nothing; candidate assembly populates it (pre-change semantics)", () => {
     const counter = countBuilds();
     try {
       const model = runPipeline(spec, size);
-      expect(counter.builds()).toBe(0);
+      // A lineage-only reader pays nothing — same as the pre-#1421 eager
+      // build, which also assembled (and populated lineage) lazily.
       const lineage = model.lineage;
-      expect(counter.builds()).toBe(1);
-      // The build populated the store: every candidate lineage id resolves.
+      expect(counter.builds()).toBe(0);
+
       const candidate = model.candidates.candidate(0);
       expect(candidate).not.toBeNull();
       expect(lineage.keys(candidate!.lineage).length).toBeGreaterThan(0);
@@ -92,7 +93,6 @@ describe("lazy interaction candidates", () => {
 
       const model = runPipeline(spec, size);
       expect(() => model.candidates).toThrowError(/@ggsvelte\/core/);
-      expect(() => model.lineage).toThrowError(/@ggsvelte\/core/);
     } finally {
       installCandidates();
     }
@@ -124,5 +124,12 @@ describe("lazy interaction candidates", () => {
     } finally {
       installCandidates();
     }
+  });
+
+  it("installCandidates() restores the real runtime after a test-only swap", () => {
+    const real = getCandidateRuntime();
+    installCandidateRuntime({ build: (input) => real!.build(input) });
+    installCandidates();
+    expect(getCandidateRuntime()).toBe(real);
   });
 });

--- a/packages/core/tests/candidate/lazy-interaction.test.ts
+++ b/packages/core/tests/candidate/lazy-interaction.test.ts
@@ -97,4 +97,32 @@ describe("lazy interaction candidates", () => {
       installCandidates();
     }
   });
+
+  it("dispose releases the retained build inputs (no eager build, no leak)", () => {
+    const counter = countBuilds();
+    try {
+      const model = runPipeline(spec, size);
+      expect(counter.builds()).toBe(0);
+      model.dispose();
+      // Never built: dispose dropped the retained inputs, so a late access is
+      // a caller bug with a clear message — the build cannot resurrect them.
+      expect(counter.builds()).toBe(0);
+      expect(() => model.candidates).toThrowError(/dispose/);
+    } finally {
+      installCandidates();
+    }
+  });
+
+  it("dispose after a build still returns the built store (pre-change semantics)", () => {
+    const counter = countBuilds();
+    try {
+      const model = runPipeline(spec, size);
+      const store = model.candidates;
+      expect(counter.builds()).toBe(1);
+      model.dispose();
+      expect(model.candidates).toBe(store);
+    } finally {
+      installCandidates();
+    }
+  });
 });

--- a/packages/core/tests/candidate/lazy-interaction.test.ts
+++ b/packages/core/tests/candidate/lazy-interaction.test.ts
@@ -98,16 +98,22 @@ describe("lazy interaction candidates", () => {
     }
   });
 
-  it("dispose releases the retained build inputs (no eager build, no leak)", () => {
+  it("dispose releases the retained build inputs; late interaction is quiet-null", () => {
     const counter = countBuilds();
     try {
       const model = runPipeline(spec, size);
       expect(counter.builds()).toBe(0);
       model.dispose();
-      // Never built: dispose dropped the retained inputs, so a late access is
-      // a caller bug with a clear message — the build cannot resurrect them.
+      // Never built: dispose dropped the retained inputs, and a late hit-test
+      // gets the inert released store (pre-#1421 quiet-null contract), not a
+      // crash and not a resurrected build.
       expect(counter.builds()).toBe(0);
-      expect(() => model.candidates).toThrowError(/dispose/);
+      const store = model.candidates;
+      expect(counter.builds()).toBe(0);
+      expect(store.size).toBe(0);
+      expect(store.nearest(10, 10, { mode: "exact", maxDistance: 20 })).toBeNull();
+      expect(store.candidate(0)).toBeNull();
+      expect(model.candidates).toBe(store);
     } finally {
       installCandidates();
     }

--- a/packages/core/tests/semantic-viewport-band-index.test.ts
+++ b/packages/core/tests/semantic-viewport-band-index.test.ts
@@ -52,7 +52,7 @@ function viewportOver(
     scales: { ...perPanel(0), panels: panels.map((_, i) => perPanel(i)) },
     coordProjectors: [],
     flipped: false,
-    candidates: model.candidates,
+    candidates: () => model.candidates,
     sceneSize: { width: 640, height: 400 },
   });
 }


### PR DESCRIPTION
Closes #1421.

## What

Candidate-store construction moves behind a runtime hook that mirrors the established `temporal-runtime.ts` / `install-temporal.ts` pattern:

- **`candidate-runtime.ts`** (new) — hook registry (`installCandidateRuntime` / `getCandidateRuntime` / `resetCandidateRuntimeForTests`) + the `LazyInteraction` bundle type. `CandidateBuildInput` is `Parameters<typeof buildPipelineCandidates>[0]` via type-only import, so this module stays in the lean graph without dragging in build-candidates.
- **`install-candidates.ts`** (new) — side-effect installer, wired exactly like temporal: bare imports in `index.ts` + `pipeline.ts`, `./dist/install-candidates.js` added to the `sideEffects` whitelist (consumer bundles can't tree-shake it away), `bunfig.toml` test preload.
- **`finalize.ts`** — no longer imports `build-candidates`. It creates the eager-but-empty `LineageStore` and a memoized `ensure()` thunk that builds the store (populating lineage) on first access; without an installed runtime it throws a plain `Error` naming the full entry (temporal-position.ts precedent).
- **`assemble-render-model.ts`** — `model.candidates` / `model.lineage` become lazy getters sharing the one build. Lineage access also ensures, so the store is never observed empty (interval/query.ts reads `model.lineage` directly).
- **`semantic-viewport.ts`** — takes `candidates: () => CandidateStore`, resolved at interaction time.
- **lifecycle** — `dispose()` disposes the store only if it was ever built.

Public types unchanged (getters satisfy the existing property types) → no breaking change for full-entry consumers.

## Payoff (same-tree A/B: stash src → rebuild dist → measure-bundles → restore)

| bundle | gzip before | gzip after | Δ |
|---|---|---|---|
| ggsvelte-svg (all 4 scenarios) | 156.0 KB | 136.1 KB | **−19.9 KB (−12.8%)** |
| ggsvelte-canvas (all 3) | 148.6 KB | 128.6 KB | **−20.0 KB (−13.5%)** |
| ggsvelte-full | 349.3 KB | 349.3 KB | +0.0 |

Raw: −73 KB on both lean entries. Plus the runtime win: `renderToSVGString` (SSR/headless) never builds candidates at all (proven by counting-runtime test).

## Acceptance (#1421)

- [x] Minified render-entry bundle free of candidate-store/hit-geometry symbols — CI guard `benchmarks/competitive/lean-candidates-graph.test.ts` (verified red on pre-change code, green after)
- [x] Full entry keeps `model.candidates` behavior — 2169 core tests + all existing candidate/viewport suites green; public types unchanged
- [ ] ~~Temporal preflight absent from non-temporal bundles~~ — **dropped, intentionally**: the ~27 KB `temporal-preflight-*` is the lean date-parse *decision* path itself, load-bearing for date charts on the lean entry; the polyfill + full planner are already gated via `temporal-runtime`. No honest tree-shake gate exists.
- [x] Competitive bundle bench re-run (numbers above; `results/bundles.json` is gitignored)

## Verification

- `bun test packages/core` — 2169 pass / 0 fail (3 new lazy-interaction tests)
- `bun test benchmarks` — green incl. new lean-graph guard
- `packages/svelte` bun tests: 829 failures **identical pre/post change on this worktree** (pre-existing environment issue, not caused by this PR; CI's unit gate covers spec+core+cli)
- tsc, knip, type-aware oxlint, svelte-check, lifecycle.json, docs routes/search projections — all current/clean

## Plan review

Plan reviewed by grok-4.5 (gated FAIL first round): fixed all 3 P1s before implementing — (1) `candidate-geometry.ts` legitimately stays in the lean graph (`renderPrimitiveCount`/`segmentDistance`), only the store/build graph leaves; (2) `sideEffects` whitelist + `index.ts` bare import are load-bearing, pipeline.ts alone would tree-shake away in consumer bundles; (3) `semantic-viewport-band-index.test.ts` call-site. P2s addressed: plain `Error` (temporal precedent), `reset…ForTests` naming, afterAll restore discipline, counting-runtime attribution for the SSR win.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1442" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->