### PR TITLE
docs(skill): teach stat-override registration contract (#1420)

### DIFF
--- a/.changeset/skill-stat-override-registration.md
+++ b/.changeset/skill-stat-override-registration.md
@@ -1,0 +1,7 @@
+---
+"@ggsvelte/skill": patch
+---
+
+# Skill teaches the stat-override registration contract
+
+docs(skill): teach the stat-override registration contract (#1420). `<Geom*>` children self-register only their DEFAULT stat; the stat usage patterns, the errorbar `stat="summary"` recipe, and the SKILL.md preamble now name the matching `register<Family>()` calls from `@ggsvelte/svelte` (and `registerAll()` for spec-driven surfaces). Agents following the skill previously produced apps that threw "not registered in this build" for `stat="…"` overrides.

--- a/packages/skill/SKILL.md
+++ b/packages/skill/SKILL.md
@@ -15,7 +15,10 @@ same grammar — never build SVG or canvas output yourself:
   (Node-safe; call `registerAll()` once first — the core barrel is
   side-effect-free since 0.27), `ggsvelte-render spec.json > out.svg` (CLI),
   or `<GGPlot spec>` (spec-driven GGPlot also needs one `registerAll()` for
-  specialty geoms/stats; `<Geom*>` children self-register).
+  specialty geoms/stats). `<Geom*>` children self-register their DEFAULT
+  stat only: a `stat="…"` override on a child additionally needs the
+  matching `register<Family>()` call (from `@ggsvelte/svelte`) — e.g.
+  `<GeomErrorbar stat="summary" />` → `registerSummary()`.
   A third skin, the `gg()` builder, produces the same spec in TypeScript.
   The CLI is part of the install contract for agent-driven chart generation:
   install `@ggsvelte/cli` in every sandbox where an agent authors specs

--- a/packages/skill/references/geoms-and-stats.md
+++ b/packages/skill/references/geoms-and-stats.md
@@ -151,6 +151,19 @@ after-stat column, so usually map nothing at all.
 
 Non-default stats go on the layer; their params share the layer's `params` object.
 
+**Component-form registration:** a `<Geom*>` child self-registers only its
+DEFAULT stat. Any `stat="…"` override below needs the matching family
+register call once at app startup, imported from `@ggsvelte/svelte`:
+`stat="summary"` → `registerSummary()`, `stat="summary_bin"` →
+`registerSummaryBin()`, `stat="ecdf"` → `registerEcdf()`, `stat="manual"` →
+`registerManual()`, `stat="unique"` → `registerUnique()`, `stat="connect"` →
+`registerConnect()`, `stat="align"` → `registerAlign()`, `stat="ellipse"` →
+`registerEllipse()`. (One `registerAll()` covers all of them.) Spec-driven
+surfaces — JSON spec, `layers` prop, `runPipeline`, `renderToSVGString` —
+register nothing per layer: call `registerAll()` once instead. Missing
+registration fails loudly: 'Stat "…" is not registered in this build.',
+naming the fix.
+
 ```json fragment
 {
   "geom": "errorbar",

--- a/packages/skill/references/recipes.md
+++ b/packages/skill/references/recipes.md
@@ -47,6 +47,10 @@ Raw observations per group; the summary stat computes mean ± se, no preaggregat
 </GGPlot>
 ```
 
+The `stat="summary"` override needs one call at app startup:
+`import { registerSummary } from "@ggsvelte/svelte"; registerSummary();`
+(or `registerAll()`; the JSON spec twin needs `registerAll()` regardless).
+
 ## Value labels on columns
 
 `dy`/`dx` are PIXEL offsets (negative dy = up); `position: "nudge"` + `positionParams` offsets in DATA units instead.


### PR DESCRIPTION
## Why

Post-merge audit of #1440 (side-effect registration removal): do `packages/skill` and `packages/cli` need changes?

**CLI: no.** `runCLI` already calls `registerAll()` (packages/core/src/cli.ts:218, fixed in #1440 itself); `@ggsvelte/cli` is a thin re-export of that surface. CLI tests green.

**Skill: yes — three gaps** where the skill taught code that now throws at runtime:

1. **`recipes.md`** — the errorbar recipe (adapted from `examples/errorbar/mean-se/`) shows `<GeomErrorbar stat="summary" />` with no registration. An agent following it writes an app that fails with `Stat "summary" is not registered in this build`. This is the same class of bug Devin Review caught in 7 shipped examples during #1440 review — the skill was teaching it.
2. **`geoms-and-stats.md`** — "Stat usage patterns" teaches five `stat=` override JSON patterns with no mention that component form needs the matching family register call. Added the full `register<Family>()` mapping (`@ggsvelte/svelte` re-exports) plus the `registerAll()` story for spec-driven surfaces.
3. **`SKILL.md` preamble** — said "`<Geom*>` children self-register" — true only for the DEFAULT stat. Now states the override caveat.

## Test plan

- [x] `skill-content.test.ts` + `changeset-check.test.ts`: 78 tests green (fence validation unaffected — additions are prose)
- [x] Exact error message quoted in docs verified against `frame-stats.ts`
- [x] Register function names verified against `packages/svelte/src/lib/index.ts` re-exports
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1444" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->