### PR TITLE
fix(core): not-registered errors name the family register function (#1420)

### DIFF
--- a/.changeset/register-hint-errors.md
+++ b/.changeset/register-hint-errors.md
@@ -1,0 +1,7 @@
+---
+"@ggsvelte/core": patch
+---
+
+# Not-registered errors name the family register function
+
+When a specialty stat/geom is missing from the build, the thrown error now names the precise fix — `registerSummary()`, `registerViolin()`, `registerHex()`, … (exported from both `@ggsvelte/core` and `@ggsvelte/svelte`) — instead of only the broad `registerAll()` / `registerBasic()` advice, and no longer suggests `registerBasic()` for specialty names it cannot cover. Non-obvious families map correctly (`bin_hex` → `registerHex()`, `ydensity` → `registerViolin()`, `bindot` → `registerDotplot()`). The hint maps are pure strings so the lean `@ggsvelte/core/render` graph stays free of the registration modules, with drift-guard tests keeping them in sync with the `register-*.ts` family modules.

--- a/packages/core/src/pipeline/frame-stats.ts
+++ b/packages/core/src/pipeline/frame-stats.ts
@@ -9,6 +9,7 @@
 import type { ColumnTable } from "../table.js";
 
 import { getStatFrameBuilder } from "./frame-stats-registry.js";
+import { statRegisterHint } from "./register-hints.js";
 import type { Advisory, LayerBinding, LayerFrame, PipelineWarning } from "./types.js";
 import { PipelineError } from "./types.js";
 
@@ -27,10 +28,15 @@ export function buildNonIdentityFrame(
   const build = getStatFrameBuilder(stat);
   if (build === undefined) {
     const path = `/layers/${String(binding.index)}/stat`;
+    const family = statRegisterHint(stat);
+    const fix =
+      family === undefined
+        ? `Call registerAll() (full grammar) or registerBasic() (identity charts) from @ggsvelte/core, render the stat's default <Geom*> component (it self-registers), or call registerStatFrame("${stat}", …).`
+        : `Call ${family}() once at startup (exported from @ggsvelte/svelte and @ggsvelte/core) or registerAll() (full grammar). A <Geom*> component self-registers only its default stat, so a stat override needs the family call. Low-level: registerStatFrame("${stat}", …).`;
     throw new PipelineError(
       "unsupported-param",
       path,
-      `Stat "${stat}" is not registered in this build. Call registerAll() (full grammar) or registerBasic() (identity charts) from @ggsvelte/core, render the stat's default <Geom*> component (it self-registers), or call registerStatFrame("${stat}", …).`,
+      `Stat "${stat}" is not registered in this build. ${fix}`,
     );
   }
   return build(binding, table, groups, warnings, advisories, binRange, functionDomain);

--- a/packages/core/src/pipeline/geometry-dispatch.ts
+++ b/packages/core/src/pipeline/geometry-dispatch.ts
@@ -5,6 +5,7 @@
 import type { GeometryBatch } from "../scene.js";
 
 import { getGeomBatchBuilder } from "./geometry-registry.js";
+import { geomRegisterHint } from "./register-hints.js";
 import type { LayerFrame, PipelineWarning, ResolvedColorScale } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
 import type { ResolvedStyleScales } from "./geometry-style.js";
@@ -21,10 +22,15 @@ export function dispatchGeometryBatch(
   const geom = frame.binding.layer.geom;
   const build = getGeomBatchBuilder(geom);
   if (build === undefined) {
+    const family = geomRegisterHint(geom);
+    const fix =
+      family === undefined
+        ? `Call registerAll() (full grammar) or registerBasic() (identity charts) from @ggsvelte/core, render the geom's <Geom*> component (it self-registers), or call registerGeomBatch("${geom}", …).`
+        : `Call ${family}() once at startup (exported from @ggsvelte/svelte and @ggsvelte/core) or registerAll() (full grammar), or render the geom's <Geom*> component (it self-registers). Low-level: registerGeomBatch("${geom}", …).`;
     throw new PipelineError(
       "unsupported-param",
       `/layers/${String(frame.binding.index)}/geom`,
-      `Geom "${geom}" is not registered in this build. Call registerAll() (full grammar) or registerBasic() (identity charts) from @ggsvelte/core, render the geom's <Geom*> component (it self-registers), or call registerGeomBatch("${geom}", …).`,
+      `Geom "${geom}" is not registered in this build. ${fix}`,
     );
   }
   return build(frame, fx, color, fill, styles, warnings);

--- a/packages/core/src/pipeline/register-hints.ts
+++ b/packages/core/src/pipeline/register-hints.ts
@@ -1,0 +1,82 @@
+/**
+ * Stat/geom name → family register function name, for "not registered in
+ * this build" error hints (#1420). Pure strings by design: importing the
+ * actual register functions here would pull the whole registration graph
+ * into the lean `@ggsvelte/core/render` bundle and undo tree-shaking.
+ *
+ * Coverage mirrors the register-*.ts family modules one-for-one; the drift
+ * guards in tests/register-hints.test.ts fail if a family module lands
+ * without a matching hint entry. Basic-tier names (count/sum stats; point,
+ * line, bar, … geoms) intentionally have NO entry — their fix is
+ * registerBasic(), which the error message already names on the fallback
+ * path.
+ */
+
+/** Specialty stat name → family register function (from @ggsvelte/core or @ggsvelte/svelte). */
+export const STAT_REGISTER_HINTS: Readonly<Record<string, string>> = {
+  align: "registerAlign",
+  bin: "registerBin",
+  bin_2d: "registerBin2d",
+  bin_hex: "registerHex",
+  bindot: "registerDotplot",
+  boxplot: "registerBoxplot",
+  connect: "registerConnect",
+  contour: "registerContour",
+  density: "registerDensity",
+  density_2d: "registerDensity2d",
+  density_2d_filled: "registerDensity2dFilled",
+  ecdf: "registerEcdf",
+  ellipse: "registerEllipse",
+  function: "registerFunction",
+  manual: "registerManual",
+  qq: "registerQq",
+  qq_line: "registerQqLine",
+  quantile: "registerQuantile",
+  sf: "registerSf",
+  sf_coordinates: "registerSfText",
+  smooth: "registerSmooth",
+  summary: "registerSummary",
+  summary_bin: "registerSummaryBin",
+  unique: "registerUnique",
+  ydensity: "registerViolin",
+};
+
+/** Specialty geom name → family register function (from @ggsvelte/core or @ggsvelte/svelte). */
+export const GEOM_REGISTER_HINTS: Readonly<Record<string, string>> = {
+  abline: "registerAbline",
+  bin_2d: "registerBin2d",
+  boxplot: "registerBoxplot",
+  contour: "registerContour",
+  crossbar: "registerCrossbar",
+  curve: "registerCurve",
+  density_2d: "registerDensity2d",
+  density_2d_filled: "registerDensity2dFilled",
+  dotplot: "registerDotplot",
+  errorbar: "registerErrorbar",
+  function: "registerFunction",
+  hex: "registerHex",
+  linerange: "registerLinerange",
+  map: "registerMap",
+  pointrange: "registerPointrange",
+  polygon: "registerPolygon",
+  qq: "registerQq",
+  qq_line: "registerQqLine",
+  quantile: "registerQuantile",
+  raster: "registerRaster",
+  rug: "registerRug",
+  sf: "registerSf",
+  sf_label: "registerSfLabel",
+  sf_text: "registerSfText",
+  smooth: "registerSmooth",
+  spoke: "registerSpoke",
+  tile: "registerTile",
+  violin: "registerViolin",
+};
+
+export function statRegisterHint(stat: string): string | undefined {
+  return STAT_REGISTER_HINTS[stat];
+}
+
+export function geomRegisterHint(geom: string): string | undefined {
+  return GEOM_REGISTER_HINTS[geom];
+}

--- a/packages/core/tests/register-hints.test.ts
+++ b/packages/core/tests/register-hints.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Error-hint contract for "not registered in this build" messages (#1420
+ * follow-up): when a specialty stat/geom is missing, the error must name
+ * the precise family register function (`registerSummary()`, …) — not just
+ * registerAll/registerBasic — because that is the minimal fix for a svelte
+ * app user, and registerBasic() never covers specialty stats/geoms.
+ *
+ * The hint maps in src/pipeline/register-hints.ts are pure strings (the
+ * lean render graph must not import the registration modules); the drift
+ * guards here keep them in sync with the register-*.ts family modules and
+ * the core barrel's actual exports.
+ */
+import { describe, expect, it } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+import * as coreBarrel from "../src/index.js";
+import {
+  GEOM_REGISTER_HINTS,
+  geomRegisterHint,
+  STAT_REGISTER_HINTS,
+  statRegisterHint,
+} from "../src/pipeline/register-hints.js";
+
+describe("register hints: lookup", () => {
+  it("maps specialty stats to their family register function", () => {
+    expect(statRegisterHint("summary")).toBe("registerSummary");
+    expect(statRegisterHint("summary_bin")).toBe("registerSummaryBin");
+    expect(statRegisterHint("ecdf")).toBe("registerEcdf");
+    expect(statRegisterHint("manual")).toBe("registerManual");
+    // Non-obvious families: the hint names the FUNCTION, not the stat.
+    expect(statRegisterHint("bin_hex")).toBe("registerHex");
+    expect(statRegisterHint("ydensity")).toBe("registerViolin");
+    expect(statRegisterHint("bindot")).toBe("registerDotplot");
+    expect(statRegisterHint("sf_coordinates")).toBe("registerSfText");
+  });
+
+  it("maps specialty geoms to their family register function", () => {
+    expect(geomRegisterHint("violin")).toBe("registerViolin");
+    expect(geomRegisterHint("hex")).toBe("registerHex");
+    expect(geomRegisterHint("errorbar")).toBe("registerErrorbar");
+    expect(geomRegisterHint("smooth")).toBe("registerSmooth");
+  });
+
+  it("returns undefined for basic-tier names (registerBasic is the fix)", () => {
+    expect(statRegisterHint("count")).toBeUndefined();
+    expect(statRegisterHint("sum")).toBeUndefined();
+    expect(geomRegisterHint("bar")).toBeUndefined();
+    expect(geomRegisterHint("point")).toBeUndefined();
+  });
+});
+
+describe("register hints: drift guards", () => {
+  it("every hint names a real exported function on the core barrel", () => {
+    const names = new Set([
+      ...Object.values(STAT_REGISTER_HINTS),
+      ...Object.values(GEOM_REGISTER_HINTS),
+    ]);
+    expect(names.size).toBeGreaterThanOrEqual(38);
+    for (const fn of names) {
+      expect(
+        typeof (coreBarrel as Record<string, unknown>)[fn],
+        `${fn} must be exported from @ggsvelte/core`,
+      ).toBe("function");
+    }
+  });
+
+  it("every stat/geom registered by a register-*.ts family module has a hint", () => {
+    const pipelineDir = path.resolve(import.meta.dir, "..", "src", "pipeline");
+    const missing: string[] = [];
+    for (const file of readdirSync(pipelineDir)) {
+      if (!/^register-[a-z0-9-]+\.ts$/.test(file)) continue;
+      const src = readFileSync(path.join(pipelineDir, file), "utf8");
+      for (const match of src.matchAll(/registerStatFrame\("([a-z_0-9]+)"/g)) {
+        if (!(match[1] in STAT_REGISTER_HINTS)) missing.push(`${file}: stat "${match[1]}"`);
+      }
+      for (const match of src.matchAll(/registerGeomBatch\("([a-z_0-9]+)"/g)) {
+        if (!(match[1] in GEOM_REGISTER_HINTS)) missing.push(`${file}: geom "${match[1]}"`);
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+});
+
+describe("register hints: error messages (fresh process)", () => {
+  it("missing-registration errors name the family register function", () => {
+    const coreRoot = path.resolve(import.meta.dir, "..");
+    const script = `
+      import { renderToSVGString } from ${JSON.stringify(path.join(coreRoot, "src", "index.ts"))};
+
+      const rows = [
+        { x: 1, y: 10 }, { x: 2, y: 20 }, { x: 3, y: 15 }, { x: 4, y: 25 }, { x: 5, y: 22 },
+      ];
+      const spec = (layer) => ({
+        data: { values: rows },
+        aes: { x: { field: "x" }, y: { field: "y" } },
+        layers: [layer],
+      });
+      const attempt = (layer) => {
+        try {
+          renderToSVGString(spec(layer), { width: 400, height: 300 });
+          return "rendered";
+        } catch (err) {
+          return String(err instanceof Error ? err.message : err);
+        }
+      };
+
+      console.log(JSON.stringify({
+        summaryStat: attempt({ geom: "point", stat: "summary" }),
+        summaryBinStat: attempt({ geom: "point", stat: "summary_bin" }),
+        violinStat: attempt({ geom: "violin" }),
+        dotplotStat: attempt({ geom: "dotplot", aes: { y: null } }),
+        hexStat: attempt({ geom: "hex" }),
+        sfTextStat: attempt({ geom: "sf_text", aes: { label: { field: "y" } } }),
+        polygonGeom: attempt({ geom: "polygon" }),
+        colGeom: attempt({ geom: "col" }),
+        countStat: attempt({ geom: "bar", aes: { y: null } }),
+      }));
+    `;
+    const proc = spawnSync(process.execPath, ["-e", script], {
+      cwd: coreRoot,
+      encoding: "utf8",
+    });
+    expect(proc.status).toBe(0);
+    const out = JSON.parse(proc.stdout.trim().split("\n").at(-1) ?? "{}") as Record<string, string>;
+
+    // Specialty stat overrides: name the family function, never registerBasic.
+    expect(out.summaryStat).toContain("not registered in this build");
+    expect(out.summaryStat).toContain("registerSummary()");
+    expect(out.summaryStat).toContain("@ggsvelte/svelte");
+    expect(out.summaryStat).not.toContain("registerBasic()");
+    expect(out.summaryBinStat).toContain("registerSummaryBin()");
+    expect(out.violinStat).toContain("registerViolin()");
+    expect(out.dotplotStat).toContain("registerDotplot()");
+    expect(out.hexStat).toContain("registerHex()");
+    expect(out.sfTextStat).toContain("registerSfText()");
+
+    // Specialty geom: name the family function.
+    expect(out.polygonGeom).toContain("not registered in this build");
+    expect(out.polygonGeom).toContain("registerPolygon()");
+    expect(out.polygonGeom).not.toContain("registerBasic()");
+
+    // Basic tier: registerBasic remains the named fix.
+    expect(out.colGeom).toContain("not registered in this build");
+    expect(out.colGeom).toContain("registerBasic()");
+    expect(out.countStat).toContain("not registered in this build");
+    expect(out.countStat).toContain("registerBasic()");
+  }, 60_000);
+});


### PR DESCRIPTION
## Why

Follow-up to #1440. The `not registered in this build` errors (the DX safety net for the tree-shaking change) only pointed at `registerAll()` / `registerBasic()` / `registerStatFrame()` from `@ggsvelte/core`. Two problems:

1. A **svelte-app user** hitting this at runtime needs the **family function** (`registerSummary()`, `registerViolin()`, …) re-exported from `@ggsvelte/svelte` — the minimal, precise fix the skill docs now teach (#1444).
2. The old message **actively misled**: it suggested `registerBasic()` for specialty stats/geoms that `registerBasic()` never covers.

## What

**Before:** `Stat "summary" is not registered in this build. Call registerAll() (full grammar) or registerBasic() (identity charts) from @ggsvelte/core, render the stat's default <Geom*> component (it self-registers), or call registerStatFrame("summary", …).`

**After:** `Stat "summary" is not registered in this build. Call registerSummary() once at startup (exported from @ggsvelte/svelte and @ggsvelte/core) or registerAll() (full grammar). A <Geom*> component self-registers only its default stat, so a stat override needs the family call. Low-level: registerStatFrame("summary", …).`

- `src/pipeline/register-hints.ts`: stat/geom name → family function name. **Pure strings by design** — importing the actual register functions into the dispatch path would pull the registration graph into the lean `@ggsvelte/core/render` bundle and undo the tree-shaking this error exists to teach about. Basic-tier names (count/sum, point/line/bar…) have no entry and keep the `registerBasic()` advice.
- Non-obvious families map to the function, not the stat: `bin_hex` → `registerHex()`, `ydensity` → `registerViolin()`, `bindot` → `registerDotplot()`, `sf_coordinates` → `registerSfText()`.

## Test plan

- [x] New `tests/register-hints.test.ts`: lookup unit tests + **two drift guards** (every hint resolves to a real `@ggsvelte/core` barrel export; every stat/geom registered by a `register-*.ts` family module has a hint, parsed from source — new families fail the suite without one) + fresh-process error-message assertions (red → green)
- [x] Core suite 2181 pass / 0 fail; type-aware oxlint clean; knip clean
- [x] Existing Seam B fresh-process gating test still green (message keeps `not registered` + `registerAll` anchors)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1447" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->