### PR TITLE
chore(changeset): list skill and cli on palette purge releases

### DIFF
--- a/.changeset/purge-accent-paired-grey-gdocs.md
+++ b/.changeset/purge-accent-paired-grey-gdocs.md
@@ -2,6 +2,8 @@
 "@ggsvelte/core": minor
 "@ggsvelte/spec": minor
 "@ggsvelte/svelte": minor
+"@ggsvelte/skill": minor
+"@ggsvelte/cli": minor
 ---
 
 # Drop Accent, Paired, Grey, Google Docs, and Tableau multi-hue schemes
@@ -19,3 +21,7 @@ Also remove chart theme `gdocs` and its Svelte shell `ThemeGdocs`.
 greyscale `range` (optional `start`/`end`). They no longer emit
 `scheme: "grey"`. Prefer `Dark2`, `tableau10`, `colorblind`, or `pander` for
 named categorical color; prefer `minimal`, `classic`, or `bw` for themes.
+
+Skill inventory (`SKILL.md`, `references/scales-and-palettes.md`,
+`references/themes.md`) drops the same schemes and theme so agents no longer
+list them.

--- a/.changeset/purge-spreadsheet-stata-hc-palettes.md
+++ b/.changeset/purge-spreadsheet-stata-hc-palettes.md
@@ -2,6 +2,8 @@
 "@ggsvelte/core": minor
 "@ggsvelte/spec": minor
 "@ggsvelte/svelte": minor
+"@ggsvelte/skill": minor
+"@ggsvelte/cli": minor
 ---
 
 # Drop spreadsheet/Stata-extra schemes and Excel/Calc/Stata Mono themes
@@ -16,6 +18,8 @@ Also remove four chart themes (and their Svelte shells): `stata_mono`
 (`ThemeStatamono`), `calc` (`ThemeCalc`), `excel` (`ThemeExcel`), `excel_new`
 (`ThemeExcelnew`). Nothing with "Excel" remains in the product surface.
 
-Switch removed schemes to `stata`, `tableau10`, `grey`, `gdocs`, or `pander`.
+Skill inventory drops the same schemes and themes.
+
+Switch removed schemes to `stata`, `tableau10`, `Dark2`, or `pander`.
 Switch removed themes to `stata`, `stata_s1color`, `bw`, `classic`, or
 `minimal`.


### PR DESCRIPTION
## Summary

The two palette-purge changesets listed only core/spec/svelte. Both PRs also
rewrote `@ggsvelte/skill` inventory, and skill is in the fixed release group
with cli. List skill and cli in the frontmatter so the published skill package
gets an explicit changelog entry and the lock-step set is named completely.

No product code change.

## Test plan

- [x] Frontmatter includes `@ggsvelte/skill` and `@ggsvelte/cli` as minor on both purge changesets
- [ ] Version package PR includes skill when these land
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1450" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->