### PR TITLE
docs(upgrading): put Tableau 10 purge under 0.28 to 0.29

### DIFF
--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -12159,6 +12159,16 @@ export const DOCS_ROUTES = [
         level: 2,
       },
       {
+        id: "0-28-to-0-29",
+        title: "0.28 to 0.29",
+        level: 2,
+      },
+      {
+        id: "removed-tableau-10-summer-winter-and-stone-schemes",
+        title: "Removed Tableau 10, Summer, Winter, and stone schemes",
+        level: 3,
+      },
+      {
         id: "0-27-to-0-28",
         title: "0.27 to 0.28",
         level: 2,
@@ -12171,11 +12181,6 @@ export const DOCS_ROUTES = [
       {
         id: "removed-accent-paired-grey-google-docs-and-tableau-multi-hue-schemes",
         title: "Removed Accent, Paired, Grey, Google Docs, and Tableau multi-hue schemes",
-        level: 3,
-      },
-      {
-        id: "removed-tableau-10-summer-winter-and-stone-schemes",
-        title: "Removed Tableau 10, Summer, Winter, and stone schemes",
         level: 3,
       },
       {

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -20123,6 +20123,26 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["Five-minute path"],
   },
   {
+    id: "heading:guide-upgrading:0-28-to-0-29",
+    kind: "heading",
+    title: "0.28 to 0.29",
+    summary:
+      "0.28 to 0.29 in Upgrade guide. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
+    href: "/guide/upgrading#0-28-to-0-29",
+    keywords: ["Upgrade guide", "Release"],
+    exact: ["0.28 to 0.29"],
+  },
+  {
+    id: "heading:guide-upgrading:removed-tableau-10-summer-winter-and-stone-schemes",
+    kind: "heading",
+    title: "Removed Tableau 10, Summer, Winter, and stone schemes",
+    summary:
+      "Removed Tableau 10, Summer, Winter, and stone schemes in Upgrade guide. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
+    href: "/guide/upgrading#removed-tableau-10-summer-winter-and-stone-schemes",
+    keywords: ["Upgrade guide", "Release"],
+    exact: ["Removed Tableau 10, Summer, Winter, and stone schemes"],
+  },
+  {
     id: "heading:guide-upgrading:0-27-to-0-28",
     kind: "heading",
     title: "0.27 to 0.28",
@@ -20151,16 +20171,6 @@ export const DOCS_SEARCH_INDEX = [
     href: "/guide/upgrading#removed-accent-paired-grey-google-docs-and-tableau-multi-hue-schemes",
     keywords: ["Upgrade guide", "Release"],
     exact: ["Removed Accent, Paired, Grey, Google Docs, and Tableau multi-hue schemes"],
-  },
-  {
-    id: "heading:guide-upgrading:removed-tableau-10-summer-winter-and-stone-schemes",
-    kind: "heading",
-    title: "Removed Tableau 10, Summer, Winter, and stone schemes",
-    summary:
-      "Removed Tableau 10, Summer, Winter, and stone schemes in Upgrade guide. Check versions, apply fixture-backed changes, and verify each 0.x transition.",
-    href: "/guide/upgrading#removed-tableau-10-summer-winter-and-stone-schemes",
-    keywords: ["Upgrade guide", "Release"],
-    exact: ["Removed Tableau 10, Summer, Winter, and stone schemes"],
   },
   {
     id: "heading:guide-upgrading:0-26-to-0-27",

--- a/scripts/gen-llms.test.ts
+++ b/scripts/gen-llms.test.ts
@@ -330,6 +330,30 @@ describe("guide sections cover their catalogs", () => {
     expect(UPGRADING_MD).toContain("Before 0.7, an explicit continuous color domain");
   });
 
+  it("keeps palette-purge migration guidance on the release that owns it", () => {
+    // 0.29 dropped Tableau 10 / season / stone; 0.28 dropped spreadsheet +
+    // Accent/Paired/gdocs multi-hue. H3 anchors stay stable for changesets;
+    // version ownership must not slide the wrong transition.
+    const tableauPurge = UPGRADING_MD.indexOf(
+      "### Removed Tableau 10, Summer, Winter, and stone schemes",
+    );
+    const accentPurge = UPGRADING_MD.indexOf(
+      "### Removed Accent, Paired, Grey, Google Docs, and Tableau multi-hue schemes",
+    );
+    const spreadsheetPurge = UPGRADING_MD.indexOf(
+      "### Removed spreadsheet, Highcharts, and extra Stata schemes and themes",
+    );
+    expect(UPGRADING_MD).toContain("## 0.28 to 0.29");
+    expect(UPGRADING_MD).toContain("## 0.27 to 0.28");
+    expect(renderMarkdown(UPGRADING_MD)).toContain('id="0-28-to-0-29"');
+    expect(renderMarkdown(UPGRADING_MD)).toContain('id="0-27-to-0-28"');
+    expect(tableauPurge).toBeGreaterThan(UPGRADING_MD.indexOf("## 0.28 to 0.29"));
+    expect(tableauPurge).toBeLessThan(UPGRADING_MD.indexOf("## 0.27 to 0.28"));
+    expect(spreadsheetPurge).toBeGreaterThan(UPGRADING_MD.indexOf("## 0.27 to 0.28"));
+    expect(accentPurge).toBeGreaterThan(spreadsheetPurge);
+    expect(accentPurge).toBeLessThan(UPGRADING_MD.indexOf("## 0.26 to 0.27"));
+  });
+
   it("states the 0.1→0.2 upgrade contract: additive, controller optional", () => {
     expect(UPGRADING_MD).toContain("No source changes are required");
     // Controller adoption is optional — both APIs remain supported.

--- a/scripts/llms-guide-content.ts
+++ b/scripts/llms-guide-content.ts
@@ -1965,6 +1965,36 @@ The accepted lifecycle and deprecation policy remains in
 [Lifecycle and editions](/guide/lifecycle#lifecycle-tags); this page applies it
 rather than creating a second policy.
 
+## 0.28 to 0.29
+
+### Removed Tableau 10, Summer, Winter, and stone schemes
+
+Six categorical \`scheme\` names (and matching public \`*_PALETTE\` constants)
+are gone:
+
+- \`tableau10\`
+- \`tableau_summer\`, \`tableau_winter\`
+- \`tableau_miller_stone\`, \`tableau_superfishel_stone\`,
+  \`tableau_nuriel_stone\`
+
+Prefer \`observable10\`, \`colorblind\`, \`Dark2\`, \`pander\`, or another
+remaining Tableau scheme (\`tableau20\`, \`tableau_colorblind\`,
+\`tableau_jewel_bright\`, …), or pass an explicit \`range\`.
+
+\`\`\`json fragment
+// Before
+{
+  "scales": { "color": { "type": "ordinal", "scheme": "tableau10" } }
+}
+\`\`\`
+
+\`\`\`json fragment
+// After
+{
+  "scales": { "color": { "type": "ordinal", "scheme": "observable10" } }
+}
+\`\`\`
+
 ## 0.27 to 0.28
 
 ### Removed spreadsheet, Highcharts, and extra Stata schemes and themes
@@ -2032,34 +2062,6 @@ greyscale \`range\` (optional \`start\`/\`end\`). They no longer emit
 {
   "theme": "minimal",
   "scales": { "color": { "type": "ordinal", "scheme": "Dark2" } }
-}
-\`\`\`
-
-### Removed Tableau 10, Summer, Winter, and stone schemes
-
-Six more categorical \`scheme\` names (and matching public \`*_PALETTE\`
-constants) are gone:
-
-- \`tableau10\`
-- \`tableau_summer\`, \`tableau_winter\`
-- \`tableau_miller_stone\`, \`tableau_superfishel_stone\`,
-  \`tableau_nuriel_stone\`
-
-Prefer \`observable10\`, \`colorblind\`, \`Dark2\`, \`pander\`, or another
-remaining Tableau scheme (\`tableau20\`, \`tableau_colorblind\`,
-\`tableau_jewel_bright\`, …), or pass an explicit \`range\`.
-
-\`\`\`json fragment
-// Before
-{
-  "scales": { "color": { "type": "ordinal", "scheme": "tableau10" } }
-}
-\`\`\`
-
-\`\`\`json fragment
-// After
-{
-  "scales": { "color": { "type": "ordinal", "scheme": "observable10" } }
 }
 \`\`\`
 


### PR DESCRIPTION
## Summary

- **Investigation:** palette/theme purges (#1445, #1446, #1451) already updated `lifecycle.json` and the generated lifecycle page (`bun run lifecycle:check` is green; deleted Theme* / *_PALETTE exports are gone). Migration prose was also written into the upgrade guide.
- **Gap:** the Tableau 10 / Summer / Winter / stone removal (released in **0.29.0**) was nested under `## 0.27 to 0.28` with the earlier spreadsheet and Accent/Paired purges (released in **0.28.0**).
- **Fix:** move that section under a new `## 0.28 to 0.29`, regenerate docs route/search indexes, and add a gen-llms test that pins ownership so it cannot slide again.

H3 anchors used by CHANGELOG / changeset migration links are unchanged.

## Test plan

- [x] `bun test scripts/gen-llms.test.ts`
- [x] `bun run lifecycle:check`
- [x] `bun run docs:routes:gen` / `docs:search:gen` (committed)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1455" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->