### PR TITLE
docs(geoms): show light gallery illustration on each geom detail page

### DIFF
--- a/apps/docs/src/lib/geom-thumbnails.ts
+++ b/apps/docs/src/lib/geom-thumbnails.ts
@@ -90,8 +90,7 @@ export function illustrationForGeom(
 ): { path: string; exampleId: string } | undefined {
   const exampleId = GEOM_THUMBNAIL_EXAMPLE[geom];
   const path = previewPathById.get(exampleId);
-  if (path === undefined) return undefined;
-  return { path, exampleId };
+  return path === undefined ? undefined : { path, exampleId };
 }
 
 /** Every KNOWN_GEOMS entry must have a resolvable gallery preview. */

--- a/apps/docs/src/lib/geom-thumbnails.ts
+++ b/apps/docs/src/lib/geom-thumbnails.ts
@@ -81,6 +81,19 @@ export function thumbnailPathForGeom(geom: GeomName): string | undefined {
   return previewPathById.get(exampleId);
 }
 
+/**
+ * Full-frame illustration for a geom detail page: the same light-theme gallery
+ * PNG the index crops, plus the example id for a live-chart link.
+ */
+export function illustrationForGeom(
+  geom: GeomName,
+): { path: string; exampleId: string } | undefined {
+  const exampleId = GEOM_THUMBNAIL_EXAMPLE[geom];
+  const path = previewPathById.get(exampleId);
+  if (path === undefined) return undefined;
+  return { path, exampleId };
+}
+
 /** Every KNOWN_GEOMS entry must have a resolvable gallery preview. */
 export function missingGeomThumbnails(): readonly string[] {
   const missing: string[] = [];

--- a/apps/docs/src/routes/reference/geoms/[name]/+page.server.ts
+++ b/apps/docs/src/routes/reference/geoms/[name]/+page.server.ts
@@ -3,6 +3,7 @@ import { error } from "@sveltejs/kit";
 import { GEOM_REFERENCE, type GeomName, KNOWN_GEOMS } from "@ggsvelte/spec";
 
 import { EXAMPLES } from "$lib/examples-manifest";
+import { illustrationForGeom } from "$lib/geom-thumbnails";
 
 import type { EntryGenerator, PageServerLoad } from "./$types";
 
@@ -21,6 +22,22 @@ function relatedExamples(geom: GeomName) {
   ).slice(0, 8);
 }
 
+/** Resolve gallery illustration on the server so the client stays catalog-free. */
+function illustrationData(geom: GeomName, component: string) {
+  const resolved = illustrationForGeom(geom);
+  if (resolved === undefined) {
+    return null;
+  }
+  const example = EXAMPLES.find((ex) => ex.id === resolved.exampleId);
+  return {
+    path: resolved.path,
+    exampleId: resolved.exampleId,
+    title: example?.title ?? component,
+    width: example?.vrWidth ?? 640,
+    height: example?.vrHeight ?? 400,
+  };
+}
+
 export const load: PageServerLoad = ({ params }) => {
   const name = params.name;
   if (!GEOM_SET.has(name)) {
@@ -29,6 +46,7 @@ export const load: PageServerLoad = ({ params }) => {
   const entry = GEOM_REFERENCE[name as GeomName];
   return {
     entry,
+    illustration: illustrationData(entry.name, entry.component),
     examples: relatedExamples(entry.name).map((ex) => ({
       id: ex.id,
       title: ex.title,

--- a/apps/docs/src/routes/reference/geoms/[name]/+page.svelte
+++ b/apps/docs/src/routes/reference/geoms/[name]/+page.svelte
@@ -2,6 +2,8 @@
   import { base } from "$app/paths";
 
   import ReferenceLede from "$lib/components/ReferenceLede.svelte";
+  import { EXAMPLES } from "$lib/examples-manifest";
+  import { illustrationForGeom } from "$lib/geom-thumbnails";
   import {
     buildGeomJsonSnippet,
     buildGeomSvelteSnippet,
@@ -11,6 +13,19 @@
 
   const { data }: PageProps = $props();
   const entry = $derived(data.entry);
+
+  const illustration = $derived.by(() => {
+    const resolved = illustrationForGeom(entry.name);
+    if (resolved === undefined) return undefined;
+    const example = EXAMPLES.find((ex) => ex.id === resolved.exampleId);
+    return {
+      path: resolved.path,
+      exampleId: resolved.exampleId,
+      title: example?.title ?? entry.component,
+      width: example?.vrWidth ?? 640,
+      height: example?.vrHeight ?? 400,
+    };
+  });
 
   const svelteSnippet = $derived(
     buildGeomSvelteSnippet(
@@ -28,6 +43,26 @@
 <article class="geom-detail prose" aria-labelledby="geom-heading">
   <h1 id="geom-heading"><code>{entry.component}</code></h1>
   <ReferenceLede text={entry.summary} />
+
+  {#if illustration !== undefined}
+    <figure class="geom-illustration">
+      <div class="preview-paper">
+        <img
+          src={`${base}${illustration.path}`}
+          alt={`Light-theme example chart for ${entry.component}`}
+          width={illustration.width}
+          height={illustration.height}
+          loading="eager"
+          decoding="async"
+        />
+      </div>
+      <figcaption>
+        <a href={`${base}/examples/${illustration.exampleId}`}
+          >{illustration.title}</a
+        >
+      </figcaption>
+    </figure>
+  {/if}
 
   <h2 id="defaults">Defaults</h2>
   <dl class="defaults">
@@ -141,6 +176,35 @@
 
   h1 {
     margin: 0 0 0.5rem;
+  }
+
+  .geom-illustration {
+    margin: 0 0 1.75rem;
+    max-width: 40rem;
+  }
+
+  .preview-paper {
+    overflow: hidden;
+    border: 1px solid var(--line);
+    border-radius: 0.55rem;
+    background: color-mix(in srgb, var(--ink) 3%, transparent);
+  }
+
+  .preview-paper img {
+    display: block;
+    width: 100%;
+    height: auto;
+  }
+
+  .geom-illustration figcaption {
+    margin-top: 0.55rem;
+    color: var(--muted);
+    font-size: 0.88rem;
+  }
+
+  .geom-illustration figcaption a {
+    color: inherit;
+    text-underline-offset: 0.12em;
   }
 
   .defaults {

--- a/apps/docs/src/routes/reference/geoms/[name]/+page.svelte
+++ b/apps/docs/src/routes/reference/geoms/[name]/+page.svelte
@@ -2,8 +2,6 @@
   import { base } from "$app/paths";
 
   import ReferenceLede from "$lib/components/ReferenceLede.svelte";
-  import { EXAMPLES } from "$lib/examples-manifest";
-  import { illustrationForGeom } from "$lib/geom-thumbnails";
   import {
     buildGeomJsonSnippet,
     buildGeomSvelteSnippet,
@@ -13,19 +11,7 @@
 
   const { data }: PageProps = $props();
   const entry = $derived(data.entry);
-
-  const illustration = $derived.by(() => {
-    const resolved = illustrationForGeom(entry.name);
-    if (resolved === undefined) return undefined;
-    const example = EXAMPLES.find((ex) => ex.id === resolved.exampleId);
-    return {
-      path: resolved.path,
-      exampleId: resolved.exampleId,
-      title: example?.title ?? entry.component,
-      width: example?.vrWidth ?? 640,
-      height: example?.vrHeight ?? 400,
-    };
-  });
+  const illustration = $derived(data.illustration);
 
   const svelteSnippet = $derived(
     buildGeomSvelteSnippet(
@@ -44,7 +30,7 @@
   <h1 id="geom-heading"><code>{entry.component}</code></h1>
   <ReferenceLede text={entry.summary} />
 
-  {#if illustration !== undefined}
+  {#if illustration}
     <figure class="geom-illustration">
       <div class="preview-paper">
         <img

--- a/apps/docs/tests/geom-thumbnails.test.ts
+++ b/apps/docs/tests/geom-thumbnails.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   GEOM_THUMBNAIL_EXAMPLE,
+  illustrationForGeom,
   missingGeomThumbnails,
   thumbnailPathForGeom,
 } from "../src/lib/geom-thumbnails";
@@ -21,6 +22,26 @@ describe("GEOM_THUMBNAIL_EXAMPLE", () => {
     const ids = new Set(GALLERY_PREVIEWS.map((p) => p.id));
     for (const [geom, exampleId] of Object.entries(GEOM_THUMBNAIL_EXAMPLE)) {
       expect(ids.has(exampleId), `${geom} → ${exampleId}`).toBe(true);
+    }
+  });
+
+  it("illustrationForGeom returns path + example id for every known geom", () => {
+    expect(illustrationForGeom("point")).toEqual({
+      path: "/previews/point-scatter-color-light.png",
+      exampleId: "point/scatter-color",
+    });
+    expect(illustrationForGeom("histogram")).toEqual({
+      path: "/previews/histogram-basic-light.png",
+      exampleId: "histogram/basic",
+    });
+    for (const geom of Object.keys(GEOM_THUMBNAIL_EXAMPLE) as Array<
+      keyof typeof GEOM_THUMBNAIL_EXAMPLE
+    >) {
+      const illustration = illustrationForGeom(geom);
+      expect(illustration, geom).toBeDefined();
+      expect(illustration?.exampleId).toBe(GEOM_THUMBNAIL_EXAMPLE[geom]);
+      expect(illustration?.path).toBe(thumbnailPathForGeom(geom));
+      expect(illustration?.path.endsWith("-light.png"), geom).toBe(true);
     }
   });
 });

--- a/scripts/docs-reference-client-thin.test.ts
+++ b/scripts/docs-reference-client-thin.test.ts
@@ -48,6 +48,16 @@ describe("docs reference detail client thin", () => {
     }
   });
 
+  it("keeps detail .svelte free of catalog barrels (EXAMPLES / thumbnails)", () => {
+    for (const dir of DETAIL_DIRS) {
+      const rel = `${dir}/+page.svelte`;
+      const source = read(rel);
+      expect(source, rel).not.toMatch(
+        /from\s*["']\$lib\/(?:examples-manifest|examples|geom-thumbnails|generated\/gallery-previews)["']/,
+      );
+    }
+  });
+
   it("keeps ReferenceLede on the thin known-names catalog", () => {
     const lede = read("lib/components/ReferenceLede.svelte");
     expect(lede).toContain("known-names");


### PR DESCRIPTION
## Summary

- The geoms index already crops a light-theme gallery PNG for every geom; each `/reference/geoms/[name]` page only had prose and code.
- Wire the same mapping as a full-frame figure under the lede, with a caption link to the live gallery example.
- Export `illustrationForGeom()` next to `thumbnailPathForGeom()` and assert every geom resolves to a `*-light.png`.

No new captures: assets live under `apps/docs/static/previews/` from the existing light gallery pipeline.

## Test plan

- [x] `cd apps/docs && bun run test -- tests/geom-thumbnails.test.ts`
- [ ] Spot-check `/reference/geoms/point` and `/reference/geoms/histogram` after `bun run build:docs` (or local dev) — figure shows and caption links to the example
- [ ] Confirm index thumbs still match detail illustrations for a few geoms
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1456" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->