### PR TITLE
docs(gallery): curate a stronger featured six for home and examples

### DIFF
--- a/apps/docs/src/lib/catalog/gallery.ts
+++ b/apps/docs/src/lib/catalog/gallery.ts
@@ -11,10 +11,10 @@ export interface GalleryEntry extends ExampleManifestEntry {
 export const FEATURED_EXAMPLES = [
   { id: "line/multi-series" },
   { id: "smooth/loess-scatter" },
-  { id: "point/scatter-color" },
-  { id: "facet/wrap" },
-  { id: "color/continuous" },
-  { id: "point/canvas-scatter" },
+  { id: "density/kde-2d-filled" },
+  { id: "density/overlay" },
+  { id: "path/ellipse-rings" },
+  { id: "color/binned" },
 ] as const;
 
 const featuredIds = new Set<string>(FEATURED_EXAMPLES.map((entry) => entry.id));

--- a/scripts/gallery.test.ts
+++ b/scripts/gallery.test.ts
@@ -23,10 +23,10 @@ describe("gallery editorial catalog", () => {
     expect(FEATURED_EXAMPLES.map((entry) => entry.id)).toEqual([
       "line/multi-series",
       "smooth/loess-scatter",
-      "point/scatter-color",
-      "facet/wrap",
-      "color/continuous",
-      "point/canvas-scatter",
+      "density/kde-2d-filled",
+      "density/overlay",
+      "path/ellipse-rings",
+      "color/binned",
     ]);
     expect(new Set(FEATURED_EXAMPLES.map((entry) => entry.id)).size).toBe(6);
     const ids = new Set(EXAMPLES.map((entry) => entry.id));


### PR DESCRIPTION
## Summary

- Replaces four of the six lead gallery specimens on the docs home page and `/examples` with clearer, better-looking charts.
- Keeps `line/multi-series` and `smooth/loess-scatter`.
- Drops the dark continuous-map and canvas-cloud lead slots (plus the middling scatter/facet leads).
- Adds `density/kde-2d-filled`, `density/overlay`, `path/ellipse-rings`, and `color/binned`.

## Test plan

- [x] `bun test scripts/gallery.test.ts` (13 pass)
- [ ] Confirm home featured strip shows the new six in order
- [ ] Confirm `/examples` leads with the same six, then the rest of the catalog
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1458" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->