### PR TITLE
fix(theme): Solarized tooltip surfaces for contrast

### DIFF
--- a/.changeset/solarized-tooltip-contrast.md
+++ b/.changeset/solarized-tooltip-contrast.md
@@ -1,0 +1,14 @@
+---
+"@ggsvelte/core": patch
+"@ggsvelte/spec": patch
+"@ggsvelte/svelte": patch
+"@ggsvelte/skill": patch
+"@ggsvelte/cli": patch
+---
+
+# Solarized tooltip surfaces for contrast
+
+Elevate tooltip cards on `solarized`, `solarizeddark`, `solarized_2`, and
+`solarized_2dark` using adjacent Schoonover base steps so tips no longer match
+the chart panel. Tip ink steps stronger than axis ink (base01/base1) for short
+reading chrome. Light solarized tip text is palette-native near-AA (4.39∶1).

--- a/packages/core/src/theme-builtins.ts
+++ b/packages/core/src/theme-builtins.ts
@@ -582,6 +582,11 @@ export const BUILTIN_THEMES: Readonly<Record<ThemeName, ThemeTokens>> = Object.f
     ticksX: true,
     ticksY: true,
     showPanelBorder: true,
+    // Tip package: base2 card; tip ink intentionally stronger than axis ink
+    // (base01 vs base1) for short-lived reading chrome.
+    tooltipPaper: "#eee8d5",
+    tooltipInk: "#586e75",
+    tooltipBorder: "#93a1a1",
   }),
   // ggthemes theme_solarized (light = FALSE): same geometry on the dark
   // rebase — base03 panel (#002b36), base02 grid, base01 chrome. Accents are
@@ -613,6 +618,10 @@ export const BUILTIN_THEMES: Readonly<Record<ThemeName, ThemeTokens>> = Object.f
     ticksX: true,
     ticksY: true,
     showPanelBorder: true,
+    // Tip package: base02 card; tip ink brightens from axis base01 to base1.
+    tooltipPaper: "#073642",
+    tooltipInk: "#93a1a1",
+    tooltipBorder: "#586e75",
   }),
   // ggthemes theme_economist_white (gray_bg = TRUE): the Graphic Detail blog
   // variant of theme_economist — white panel on a light-gray (#ebebeb) plot
@@ -658,6 +667,10 @@ export const BUILTIN_THEMES: Readonly<Record<ThemeName, ThemeTokens>> = Object.f
     gridWidth: 0.5,
     ticksX: true,
     ticksY: true,
+    // Tip package: base3 card (lighter than base2 panel); tip ink base01.
+    tooltipPaper: "#fdf6e3",
+    tooltipInk: "#586e75",
+    tooltipBorder: "#93a1a1",
   }),
   // ggthemes theme_solarized_2 (light = FALSE): same geometry on the dark
   // rebase — base02 panel (#073642), base03 grid (#002b36), base01 chrome.
@@ -681,6 +694,10 @@ export const BUILTIN_THEMES: Readonly<Record<ThemeName, ThemeTokens>> = Object.f
     gridWidth: 0.5,
     ticksX: true,
     ticksY: true,
+    // Tip package: base03 card (darker than base02 panel); tip ink base1.
+    tooltipPaper: "#002b36",
+    tooltipInk: "#93a1a1",
+    tooltipBorder: "#586e75",
   }),
   // ggthemes theme_wsj: Wall Street Journal chrome — "brown" paper (#f8f2e4),
   // dotted black y-grid only, x axis line and ticks, no y line/ticks, big bold

--- a/packages/core/tests/scales-m1/sequential-and-theme.test.ts
+++ b/packages/core/tests/scales-m1/sequential-and-theme.test.ts
@@ -399,4 +399,45 @@ describe("theme registry", () => {
     expect(LEGACY_BUILTIN_THEMES.dark.letterboxFill).toBe("none");
     expect(LEGACY_BUILTIN_THEMES.minimal.letterboxFill).toBe("none");
   });
+
+  it("Solarized family elevates tooltip cards above the reading surface", () => {
+    const PROBLEM_SOLARIZED = [
+      "solarized",
+      "solarizeddark",
+      "solarized_2",
+      "solarized_2dark",
+    ] as const;
+
+    for (const name of PROBLEM_SOLARIZED) {
+      const tokens = BUILTIN_THEMES[name];
+      const readingSurface = tokens.paper === "none" ? tokens.panel : tokens.paper;
+      const viaString = resolveTheme(name);
+      const viaObject = resolveTheme({ name, titleSize: 20 });
+
+      expect(viaString.tooltipPaper, name).toBe(tokens.tooltipPaper);
+      expect(viaObject.tooltipPaper, name).toBe(tokens.tooltipPaper);
+      expect(tokens.tooltipPaper, name).not.toBe(readingSurface);
+      // LEGACY spreads edition-2 Solarized tips.
+      expect(LEGACY_BUILTIN_THEMES[name].tooltipPaper, name).toBe(tokens.tooltipPaper);
+    }
+
+    // Exact Schoonover anchors (tip ink stronger than axis ink on low-contrast bases).
+    expect(BUILTIN_THEMES.solarized.tooltipPaper).toBe("#eee8d5"); // base2
+    expect(BUILTIN_THEMES.solarized.tooltipInk).toBe("#586e75"); // base01
+    expect(BUILTIN_THEMES.solarized.tooltipBorder).toBe("#93a1a1"); // base1
+    expect(BUILTIN_THEMES.solarized.tooltipInk).not.toBe(BUILTIN_THEMES.solarized.ink);
+
+    expect(BUILTIN_THEMES.solarized_2.tooltipPaper).toBe("#fdf6e3"); // base3
+    expect(BUILTIN_THEMES.solarized_2.tooltipInk).toBe("#586e75");
+    expect(BUILTIN_THEMES.solarized_2.tooltipBorder).toBe("#93a1a1");
+
+    expect(BUILTIN_THEMES.solarizeddark.tooltipPaper).toBe("#073642"); // base02
+    expect(BUILTIN_THEMES.solarizeddark.tooltipInk).toBe("#93a1a1"); // base1
+    expect(BUILTIN_THEMES.solarizeddark.tooltipBorder).toBe("#586e75"); // base01
+    expect(BUILTIN_THEMES.solarizeddark.tooltipInk).not.toBe(BUILTIN_THEMES.solarizeddark.ink);
+
+    expect(BUILTIN_THEMES.solarized_2dark.tooltipPaper).toBe("#002b36"); // base03
+    expect(BUILTIN_THEMES.solarized_2dark.tooltipInk).toBe("#93a1a1");
+    expect(BUILTIN_THEMES.solarized_2dark.tooltipBorder).toBe("#586e75");
+  });
 });


### PR DESCRIPTION
## Summary

- Elevate tooltip packages on `solarized`, `solarizeddark`, `solarized_2`, and `solarized_2dark` using adjacent Schoonover base steps (no white/black cards).
- Tip ink is intentionally stronger than axis ink (base01/base1) for short-lived reading chrome.
- String + object `resolveTheme` parity via sticky-when-elevated (PR #1459).
- LEGACY inherits the same tips via `BUILTIN_THEMES` spread.

Depends on #1459 (merged).

## Test plan

- [x] tip ≠ reading surface for all four Solarized names
- [x] exact hex anchors
- [x] string + object resolveTheme parity
- [x] LEGACY spread equality


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1461" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->