### PR TITLE
docs(home): feature path/trajectory (Minard) in the gallery strip

### DIFF
--- a/apps/docs/src/lib/catalog/gallery.ts
+++ b/apps/docs/src/lib/catalog/gallery.ts
@@ -10,7 +10,7 @@ export interface GalleryEntry extends ExampleManifestEntry {
 /** Featured strip order on home and gallery. Identity only — titles come from the manifest. */
 export const FEATURED_EXAMPLES = [
   { id: "line/multi-series" },
-  { id: "smooth/loess-scatter" },
+  { id: "path/trajectory" },
   { id: "density/kde-2d-filled" },
   { id: "density/overlay" },
   { id: "path/ellipse-rings" },

--- a/scripts/gallery.test.ts
+++ b/scripts/gallery.test.ts
@@ -22,7 +22,7 @@ describe("gallery editorial catalog", () => {
   test("curates exactly six unique real examples in the approved order", () => {
     expect(FEATURED_EXAMPLES.map((entry) => entry.id)).toEqual([
       "line/multi-series",
-      "smooth/loess-scatter",
+      "path/trajectory",
       "density/kde-2d-filled",
       "density/overlay",
       "path/ellipse-rings",


### PR DESCRIPTION
## Summary
- Swaps `path/trajectory` (the rebuilt Minard 1869 flow map, #1460) into the featured six shown on the home page and the top of the gallery page, replacing `smooth/loess-scatter`
- `smooth/loess-scatter` keeps its gallery tile in normal manifest order — only its featured slot moves
- Updates the curated-order assertion in `scripts/gallery.test.ts`

## Test plan
- [x] `gallery.test.ts` passes (13 tests)
- [x] Verified locally: Minard tile renders in slot 2 on `/` and `/examples` (light theme)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1465" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->