### PR TITLE
perf(bench): Svelte-peer browser cells + CI gate + update scoreboard

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -50,6 +50,14 @@ jobs:
           BUN_INSTALL_CACHE_DIR: ${{ runner.temp }}/bun-install-cache
       - name: build spec/core dist (benchmarks import the packages)
         run: bun run check
+      - name: competitive browser bench (Playwright chromium, writes benchmarks/competitive/results/browser.json)
+        # HOME=/root so Playwright finds the chromium baked into the ci-runner
+        # image (same convention as ci-interaction-perf); no install step needed.
+        run: bun run bench:competitive:browser
+        env:
+          HOME: /root
+      - name: enforce competitive browser budgets + Svelte-peer gate (benchmarks/competitive/budgets.json)
+        run: bun run bench:competitive:check
       - name: bench (writes bench-results.json, customSmallerIsBetter format)
         run: bun run bench:json
       - name: enforce absolute budgets (benchmarks/budgets.json)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,9 @@ repos:
         entry: bun node_modules/.bin/oxlint
         language: system
         files: \.(ts|tsx|mts|cts|js|jsx|mjs|cjs)$
-        exclude: ^spikes/
+        exclude: ^(spikes/|benchmarks/competitive/)
+        # benchmarks/competitive is in .oxlintrc ignorePatterns; passing only
+        # competitive files makes oxlint exit 1 ("No files found to lint").
         # .oxlintrc.json also bans Math.random/Date.now inside examples/**
         # (VR determinism), so staged examples files are guarded here too.
 

--- a/benchmarks/competitive/adapters/chartjs.ts
+++ b/benchmarks/competitive/adapters/chartjs.ts
@@ -42,7 +42,7 @@ Chart.register(
   Legend,
 );
 
-export type UpdateColumns = ScatterColumns | SeriesColumns | BarsColumns;
+type UpdateColumns = ScatterColumns | SeriesColumns | BarsColumns;
 
 export type ChartJsHandle = {
   destroy: () => void;

--- a/benchmarks/competitive/adapters/chartjs.ts
+++ b/benchmarks/competitive/adapters/chartjs.ts
@@ -42,7 +42,13 @@ Chart.register(
   Legend,
 );
 
-export type ChartJsHandle = { destroy: () => void };
+export type UpdateColumns = ScatterColumns | SeriesColumns | BarsColumns;
+
+export type ChartJsHandle = {
+  destroy: () => void;
+  /** Chart.js in-place update: swap datasets/labels on chart.data + update(). */
+  update: (data: UpdateColumns) => void;
+};
 
 function canvasIn(root: HTMLElement): HTMLCanvasElement {
   root.replaceChildren();
@@ -84,26 +90,29 @@ export function mountChartJs(
 ): { markHint: number; handle: ChartJsHandle } {
   const canvas = canvasIn(root);
   if (scenario === "scatter-color") {
-    const scatter = data as ScatterColumns;
-    const bySeries = new Map<string, { x: number; y: number }[]>();
-    for (let i = 0; i < scatter.x.length; i++) {
-      const cls = scatter.cls[i]!;
-      let pts = bySeries.get(cls);
-      if (pts === undefined) {
-        pts = [];
-        bySeries.set(cls, pts);
+    const datasetsFor = (scatter: ScatterColumns) => {
+      const bySeries = new Map<string, { x: number; y: number }[]>();
+      for (let i = 0; i < scatter.x.length; i++) {
+        const cls = scatter.cls[i]!;
+        let pts = bySeries.get(cls);
+        if (pts === undefined) {
+          pts = [];
+          bySeries.set(cls, pts);
+        }
+        pts.push({ x: scatter.x[i]!, y: scatter.y[i]! });
       }
-      pts.push({ x: scatter.x[i]!, y: scatter.y[i]! });
-    }
+      return [...bySeries.entries()].map(([label, pts], i) => ({
+        label,
+        data: pts,
+        backgroundColor: COLORS[i % COLORS.length],
+        pointRadius: 1.5,
+      }));
+    };
+    const scatter = data as ScatterColumns;
     const chart = new Chart(canvas, {
       type: "scatter",
       data: {
-        datasets: [...bySeries.entries()].map(([label, pts], i) => ({
-          label,
-          data: pts,
-          backgroundColor: COLORS[i % COLORS.length],
-          pointRadius: 1.5,
-        })),
+        datasets: datasetsFor(scatter),
       },
       options: {
         animation: false,
@@ -114,28 +123,37 @@ export function mountChartJs(
     });
     return {
       markHint: scatter.x.length,
-      handle: { destroy: () => chart.destroy() },
+      handle: {
+        destroy: () => chart.destroy(),
+        update: (d) => {
+          chart.data.datasets = datasetsFor(d as ScatterColumns);
+          chart.update();
+        },
+      },
     };
   }
 
   if (scenario === "bars-stacked") {
+    const dataFor = (bars: BarsColumns) => {
+      const categories = [...new Set(bars.category)];
+      const stacks = [...new Set(bars.stack)];
+      const datasets = stacks.map((stack, i) => ({
+        label: stack,
+        data: categories.map((cat) => {
+          for (let j = 0; j < bars.category.length; j++) {
+            if (bars.category[j] === cat && bars.stack[j] === stack) return bars.value[j]!;
+          }
+          return 0;
+        }),
+        backgroundColor: COLORS[i % COLORS.length],
+        stack: "total",
+      }));
+      return { labels: categories, datasets };
+    };
     const bars = data as BarsColumns;
-    const categories = [...new Set(bars.category)];
-    const stacks = [...new Set(bars.stack)];
-    const datasets = stacks.map((stack, i) => ({
-      label: stack,
-      data: categories.map((cat) => {
-        for (let j = 0; j < bars.category.length; j++) {
-          if (bars.category[j] === cat && bars.stack[j] === stack) return bars.value[j]!;
-        }
-        return 0;
-      }),
-      backgroundColor: COLORS[i % COLORS.length],
-      stack: "total",
-    }));
     const chart = new Chart(canvas, {
       type: "bar",
-      data: { labels: categories, datasets },
+      data: dataFor(bars),
       options: {
         animation: false,
         responsive: false,
@@ -148,20 +166,31 @@ export function mountChartJs(
     });
     return {
       markHint: bars.category.length,
-      handle: { destroy: () => chart.destroy() },
+      handle: {
+        destroy: () => chart.destroy(),
+        update: (d) => {
+          const next = dataFor(d as BarsColumns);
+          chart.data.labels = next.labels;
+          chart.data.datasets = next.datasets;
+          chart.update();
+        },
+      },
     };
   }
 
   const seriesData = data as SeriesColumns;
-  const { labels, datasets } = seriesFromLong(seriesData);
   const filled = scenario === "area-multiseries";
-  for (const ds of datasets) {
-    ds.fill = filled;
-    if (filled) ds.backgroundColor = `${ds.backgroundColor}55`;
-  }
+  const dataFor = (d: SeriesColumns) => {
+    const { labels, datasets } = seriesFromLong(d);
+    for (const ds of datasets) {
+      ds.fill = filled;
+      if (filled) ds.backgroundColor = `${ds.backgroundColor}55`;
+    }
+    return { labels, datasets };
+  };
   const chart = new Chart(canvas, {
     type: "line",
-    data: { labels, datasets },
+    data: dataFor(seriesData),
     options: {
       animation: false,
       responsive: false,
@@ -175,6 +204,14 @@ export function mountChartJs(
   });
   return {
     markHint: seriesData.x.length,
-    handle: { destroy: () => chart.destroy() },
+    handle: {
+      destroy: () => chart.destroy(),
+      update: (d) => {
+        const next = dataFor(d as SeriesColumns);
+        chart.data.labels = next.labels;
+        chart.data.datasets = next.datasets;
+        chart.update();
+      },
+    },
   };
 }

--- a/benchmarks/competitive/adapters/d3.ts
+++ b/benchmarks/competitive/adapters/d3.ts
@@ -24,9 +24,9 @@ import {
 
 const MARGIN = { top: 20, right: 20, bottom: 40, left: 50 };
 
-export type UpdateColumns = ScatterColumns | SeriesColumns | BarsColumns;
+type UpdateColumns = ScatterColumns | SeriesColumns | BarsColumns;
 
-export type D3Handle = {
+type D3Handle = {
   destroy: () => void;
   update: (data: UpdateColumns) => void;
 };

--- a/benchmarks/competitive/adapters/d3.ts
+++ b/benchmarks/competitive/adapters/d3.ts
@@ -1,5 +1,10 @@
 /**
  * Raw D3 competitive mounts (SVG). Baseline for "hand-rolled" cost.
+ *
+ * Update scoreboard: mount keeps the svg root, axis groups, mark groups and
+ * join selections in closure; update() re-runs the same render with new data
+ * via the proper d3 data-join pattern (no transitions). Scales/axes are
+ * recomputed per render since domains move with the data.
  */
 import { extent, max, rollup } from "d3-array";
 import { axisBottom, axisLeft } from "d3-axis";
@@ -19,6 +24,15 @@ import {
 
 const MARGIN = { top: 20, right: 20, bottom: 40, left: 50 };
 
+export type UpdateColumns = ScatterColumns | SeriesColumns | BarsColumns;
+
+export type D3Handle = {
+  destroy: () => void;
+  update: (data: UpdateColumns) => void;
+};
+
+export type D3MountResult = { markHint: number; handle: D3Handle };
+
 function chartRoot(root: HTMLElement) {
   root.replaceChildren();
   const iw = PLOT_WIDTH - MARGIN.left - MARGIN.right;
@@ -32,7 +46,7 @@ export function mountD3(
   scenario: ScenarioId,
   data: ScatterColumns | SeriesColumns | BarsColumns,
   root: HTMLElement,
-): { markHint: number } {
+): D3MountResult {
   switch (scenario) {
     case "scatter-color":
       return mountScatter(data as ScatterColumns, root);
@@ -45,110 +59,168 @@ export function mountD3(
   }
 }
 
-function mountScatter(data: ScatterColumns, root: HTMLElement) {
+function makeHandle(root: HTMLElement, render: (d: UpdateColumns) => void): D3Handle {
+  return {
+    destroy: () => {
+      root.replaceChildren();
+    },
+    update: render,
+  };
+}
+
+function mountScatter(initial: ScatterColumns, root: HTMLElement): D3MountResult {
   const { g, iw, ih } = chartRoot(root);
-  const rows = data.x.map((x, i) => ({ x, y: data.y[i]!, cls: data.cls[i]! }));
-  const x = scaleLinear()
-    .domain(extent(rows, (d) => d.x) as [number, number])
-    .nice()
-    .range([0, iw]);
-  const y = scaleLinear()
-    .domain(extent(rows, (d) => d.y) as [number, number])
-    .nice()
-    .range([ih, 0]);
   const color = scaleOrdinal<string, string>()
     .domain(["series-0", "series-1", "series-2", "series-3", "series-4"])
     .range([...COLORS]);
-  g.append("g").attr("transform", `translate(0,${ih})`).call(axisBottom(x));
-  g.append("g").call(axisLeft(y));
-  g.selectAll("circle")
-    .data(rows)
-    .join("circle")
-    .attr("cx", (d) => x(d.x))
-    .attr("cy", (d) => y(d.y))
-    .attr("r", 1.5)
-    .attr("fill", (d) => color(d.cls))
-    .attr("fill-opacity", 0.7);
-  return { markHint: rows.length };
+  const xAxisG = g.append("g").attr("transform", `translate(0,${ih})`);
+  const yAxisG = g.append("g");
+  const marksG = g.append("g");
+  const render = (data: ScatterColumns): number => {
+    const rows = data.x.map((x, i) => ({ x, y: data.y[i]!, cls: data.cls[i]! }));
+    const x = scaleLinear()
+      .domain(extent(rows, (d) => d.x) as [number, number])
+      .nice()
+      .range([0, iw]);
+    const y = scaleLinear()
+      .domain(extent(rows, (d) => d.y) as [number, number])
+      .nice()
+      .range([ih, 0]);
+    xAxisG.call(axisBottom(x));
+    yAxisG.call(axisLeft(y));
+    marksG
+      .selectAll("circle")
+      .data(rows)
+      .join("circle")
+      .attr("cx", (d) => x(d.x))
+      .attr("cy", (d) => y(d.y))
+      .attr("r", 1.5)
+      .attr("fill", (d) => color(d.cls))
+      .attr("fill-opacity", 0.7);
+    return rows.length;
+  };
+  const markHint = render(initial);
+  return {
+    markHint,
+    handle: makeHandle(root, (d) => {
+      render(d as ScatterColumns);
+    }),
+  };
 }
 
-function mountLine(data: SeriesColumns, root: HTMLElement, filled: boolean) {
+function mountLine(initial: SeriesColumns, root: HTMLElement, filled: boolean): D3MountResult {
   const { g, iw, ih } = chartRoot(root);
-  const seriesNames = [...new Set(data.series)];
-  const x = scaleLinear()
-    .domain(extent(data.x) as [number, number])
-    .range([0, iw]);
-  const y = scaleLinear()
-    .domain(extent(data.y) as [number, number])
-    .nice()
-    .range([ih, 0]);
-  const color = scaleOrdinal<string, string>()
-    .domain(seriesNames)
-    .range([...COLORS]);
-  g.append("g").attr("transform", `translate(0,${ih})`).call(axisBottom(x).ticks(6));
-  g.append("g").call(axisLeft(y));
-  const bySeries = rollup(
-    data.x.map((xv, i) => ({ x: xv, y: data.y[i]!, series: data.series[i]! })),
-    (v) => v,
-    (d) => d.series,
-  );
-  const lineGen = d3Line<{ x: number; y: number }>()
-    .x((d) => x(d.x))
-    .y((d) => y(d.y));
-  const areaGen = d3Area<{ x: number; y: number }>()
-    .x((d) => x(d.x))
-    .y0(ih)
-    .y1((d) => y(d.y));
-  for (const [name, pts] of bySeries) {
-    const sorted = pts.toSorted((a, b) => a.x - b.x);
+  const xAxisG = g.append("g").attr("transform", `translate(0,${ih})`);
+  const yAxisG = g.append("g");
+  const areaG = g.append("g");
+  const lineG = g.append("g");
+  const render = (data: SeriesColumns): number => {
+    const seriesNames = [...new Set(data.series)];
+    const x = scaleLinear()
+      .domain(extent(data.x) as [number, number])
+      .range([0, iw]);
+    const y = scaleLinear()
+      .domain(extent(data.y) as [number, number])
+      .nice()
+      .range([ih, 0]);
+    const color = scaleOrdinal<string, string>()
+      .domain(seriesNames)
+      .range([...COLORS]);
+    xAxisG.call(axisBottom(x).ticks(6));
+    yAxisG.call(axisLeft(y));
+    const bySeries = rollup(
+      data.x.map((xv, i) => ({ x: xv, y: data.y[i]!, series: data.series[i]! })),
+      (v) => v,
+      (d) => d.series,
+    );
+    const layers = [...bySeries.entries()].map(([name, pts]) => ({
+      name,
+      pts: pts.toSorted((a, b) => a.x - b.x),
+    }));
+    const lineGen = d3Line<{ x: number; y: number }>()
+      .x((d) => x(d.x))
+      .y((d) => y(d.y));
+    const areaGen = d3Area<{ x: number; y: number }>()
+      .x((d) => x(d.x))
+      .y0(ih)
+      .y1((d) => y(d.y));
     if (filled) {
-      g.append("path")
-        .attr("d", areaGen(sorted))
-        .attr("fill", color(name))
+      areaG
+        .selectAll("path")
+        .data(layers, (d) => (d as { name: string }).name)
+        .join("path")
+        .attr("d", (d) => areaGen(d.pts))
+        .attr("fill", (d) => color(d.name))
         .attr("fill-opacity", 0.35)
         .attr("stroke", "none");
     }
-    g.append("path")
-      .attr("d", lineGen(sorted))
+    lineG
+      .selectAll("path")
+      .data(layers, (d) => (d as { name: string }).name)
+      .join("path")
+      .attr("d", (d) => lineGen(d.pts))
       .attr("fill", "none")
-      .attr("stroke", color(name))
+      .attr("stroke", (d) => color(d.name))
       .attr("stroke-width", 1.5);
-  }
-  return { markHint: seriesNames.length * (filled ? 2 : 1) };
+    return seriesNames.length * (filled ? 2 : 1);
+  };
+  const markHint = render(initial);
+  return {
+    markHint,
+    handle: makeHandle(root, (d) => {
+      render(d as SeriesColumns);
+    }),
+  };
 }
 
-function mountBars(data: BarsColumns, root: HTMLElement) {
+function mountBars(initial: BarsColumns, root: HTMLElement): D3MountResult {
   const { g, iw, ih } = chartRoot(root);
-  const categories = [...new Set(data.category)];
-  const stacks = [...new Set(data.stack)];
-  const wide = categories.map((cat) => {
-    const row: Record<string, string | number> = { category: cat };
-    for (let i = 0; i < data.category.length; i++) {
-      if (data.category[i] === cat) row[data.stack[i]!] = data.value[i]!;
-    }
-    return row;
-  });
-  const stackGen = d3Stack<Record<string, string | number>>().keys(stacks);
-  const series = stackGen(wide);
-  const x = scaleBand().domain(categories).range([0, iw]).padding(0.15);
-  const y = scaleLinear()
-    .domain([0, max(series, (s) => max(s, (d) => d[1])) ?? 1])
-    .nice()
-    .range([ih, 0]);
-  const color = scaleOrdinal<string, string>()
-    .domain(stacks)
-    .range([...COLORS]);
-  g.append("g").attr("transform", `translate(0,${ih})`).call(axisBottom(x));
-  g.append("g").call(axisLeft(y));
-  for (const layer of series) {
-    g.selectAll(`rect.${layer.key}`)
-      .data(layer)
+  const xAxisG = g.append("g").attr("transform", `translate(0,${ih})`);
+  const yAxisG = g.append("g");
+  const marksG = g.append("g");
+  const render = (data: BarsColumns): number => {
+    const categories = [...new Set(data.category)];
+    const stacks = [...new Set(data.stack)];
+    const wide = categories.map((cat) => {
+      const row: Record<string, string | number> = { category: cat };
+      for (let i = 0; i < data.category.length; i++) {
+        if (data.category[i] === cat) row[data.stack[i]!] = data.value[i]!;
+      }
+      return row;
+    });
+    const stackGen = d3Stack<Record<string, string | number>>().keys(stacks);
+    const series = stackGen(wide);
+    const x = scaleBand().domain(categories).range([0, iw]).padding(0.15);
+    const y = scaleLinear()
+      .domain([0, max(series, (s) => max(s, (d) => d[1])) ?? 1])
+      .nice()
+      .range([ih, 0]);
+    const color = scaleOrdinal<string, string>()
+      .domain(stacks)
+      .range([...COLORS]);
+    xAxisG.call(axisBottom(x));
+    yAxisG.call(axisLeft(y));
+    const flat = series.flatMap((layer) => layer.map((d) => ({ key: layer.key, d })));
+    marksG
+      .selectAll("rect")
+      .data(
+        flat,
+        (f) =>
+          `${(f as { key: string }).key}:${String((f as { d: { data: Record<string, unknown> } }).d.data["category"])}`,
+      )
       .join("rect")
-      .attr("x", (d) => x(String(d.data["category"])) ?? 0)
-      .attr("y", (d) => y(d[1]))
-      .attr("height", (d) => Math.max(0, y(d[0]) - y(d[1])))
+      .attr("x", (f) => x(String(f.d.data["category"])) ?? 0)
+      .attr("y", (f) => y(f.d[1]))
+      .attr("height", (f) => Math.max(0, y(f.d[0]) - y(f.d[1])))
       .attr("width", x.bandwidth())
-      .attr("fill", color(layer.key));
-  }
-  return { markHint: data.category.length };
+      .attr("fill", (f) => color(f.key));
+    return data.category.length;
+  };
+  const markHint = render(initial);
+  return {
+    markHint,
+    handle: makeHandle(root, (d) => {
+      render(d as BarsColumns);
+    }),
+  };
 }

--- a/benchmarks/competitive/adapters/echarts.ts
+++ b/benchmarks/competitive/adapters/echarts.ts
@@ -26,7 +26,13 @@ echarts.use([
   CanvasRenderer,
 ]);
 
-export type EChartsHandle = { destroy: () => void };
+export type UpdateColumns = ScatterColumns | SeriesColumns | BarsColumns;
+
+export type EChartsHandle = {
+  destroy: () => void;
+  /** ECharts in-place update: setOption with the new series data (merge mode). */
+  update: (data: UpdateColumns) => void;
+};
 
 function hostIn(root: HTMLElement): HTMLDivElement {
   root.replaceChildren();
@@ -62,60 +68,74 @@ export function mountEcharts(
   });
 
   if (scenario === "scatter-color") {
+    const optionFor = (scatter: ScatterColumns) => {
+      const names = [...new Set(scatter.cls)];
+      return {
+        animation: false,
+        grid: { left: 50, right: 20, top: 20, bottom: 40 },
+        xAxis: { type: "value" },
+        yAxis: { type: "value" },
+        series: names.map((name, i) => ({
+          type: "scatter",
+          name,
+          symbolSize: 3,
+          itemStyle: { color: COLORS[i % COLORS.length], opacity: 0.7 },
+          data: scatter.x
+            .map((x, idx) => (scatter.cls[idx] === name ? [x, scatter.y[idx]!] : null))
+            .filter((d): d is [number, number] => d !== null),
+        })),
+      };
+    };
     const scatter = data as ScatterColumns;
-    const names = [...new Set(scatter.cls)];
-    chart.setOption({
-      animation: false,
-      grid: { left: 50, right: 20, top: 20, bottom: 40 },
-      xAxis: { type: "value" },
-      yAxis: { type: "value" },
-      series: names.map((name, i) => ({
-        type: "scatter",
-        name,
-        symbolSize: 3,
-        itemStyle: { color: COLORS[i % COLORS.length], opacity: 0.7 },
-        data: scatter.x
-          .map((x, idx) => (scatter.cls[idx] === name ? [x, scatter.y[idx]!] : null))
-          .filter((d): d is [number, number] => d !== null),
-      })),
-    });
+    chart.setOption(optionFor(scatter));
     return {
       markHint: scatter.x.length,
       handle: {
         destroy: () => {
           chart.dispose();
         },
+        update: (d) => {
+          // Series count is stable across update variants (rotated cls labels
+          // are the same set), so index-merge setOption replaces the data.
+          chart.setOption(optionFor(d as ScatterColumns));
+        },
       },
     };
   }
 
   if (scenario === "bars-stacked") {
+    const optionFor = (bars: BarsColumns) => {
+      const categories = [...new Set(bars.category)];
+      const stacks = [...new Set(bars.stack)];
+      return {
+        animation: false,
+        grid: { left: 50, right: 20, top: 20, bottom: 40 },
+        xAxis: { type: "category", data: categories },
+        yAxis: { type: "value" },
+        series: stacks.map((stack, i) => ({
+          type: "bar",
+          name: stack,
+          stack: "total",
+          itemStyle: { color: COLORS[i % COLORS.length] },
+          data: categories.map((cat) => {
+            for (let j = 0; j < bars.category.length; j++) {
+              if (bars.category[j] === cat && bars.stack[j] === stack) return bars.value[j]!;
+            }
+            return 0;
+          }),
+        })),
+      };
+    };
     const bars = data as BarsColumns;
-    const categories = [...new Set(bars.category)];
-    const stacks = [...new Set(bars.stack)];
-    chart.setOption({
-      animation: false,
-      grid: { left: 50, right: 20, top: 20, bottom: 40 },
-      xAxis: { type: "category", data: categories },
-      yAxis: { type: "value" },
-      series: stacks.map((stack, i) => ({
-        type: "bar",
-        name: stack,
-        stack: "total",
-        itemStyle: { color: COLORS[i % COLORS.length] },
-        data: categories.map((cat) => {
-          for (let j = 0; j < bars.category.length; j++) {
-            if (bars.category[j] === cat && bars.stack[j] === stack) return bars.value[j]!;
-          }
-          return 0;
-        }),
-      })),
-    });
+    chart.setOption(optionFor(bars));
     return {
       markHint: bars.category.length,
       handle: {
         destroy: () => {
           chart.dispose();
+        },
+        update: (d) => {
+          chart.setOption(optionFor(d as BarsColumns));
         },
       },
     };
@@ -123,26 +143,32 @@ export function mountEcharts(
 
   const seriesData = data as SeriesColumns;
   const filled = scenario === "area-multiseries";
-  const datasets = seriesFromLong(seriesData);
-  chart.setOption({
-    animation: false,
-    grid: { left: 50, right: 20, top: 20, bottom: 40 },
-    xAxis: { type: "value" },
-    yAxis: { type: "value" },
-    series: datasets.map((ds, i) => ({
-      type: "line",
-      name: ds.name,
-      showSymbol: false,
-      itemStyle: { color: COLORS[i % COLORS.length] },
-      areaStyle: filled ? { opacity: 0.25 } : undefined,
-      data: ds.pts,
-    })),
-  });
+  const optionFor = (d: SeriesColumns) => {
+    const datasets = seriesFromLong(d);
+    return {
+      animation: false,
+      grid: { left: 50, right: 20, top: 20, bottom: 40 },
+      xAxis: { type: "value" },
+      yAxis: { type: "value" },
+      series: datasets.map((ds, i) => ({
+        type: "line",
+        name: ds.name,
+        showSymbol: false,
+        itemStyle: { color: COLORS[i % COLORS.length] },
+        areaStyle: filled ? { opacity: 0.25 } : undefined,
+        data: ds.pts,
+      })),
+    };
+  };
+  chart.setOption(optionFor(seriesData));
   return {
     markHint: seriesData.x.length,
     handle: {
       destroy: () => {
         chart.dispose();
+      },
+      update: (d) => {
+        chart.setOption(optionFor(d as SeriesColumns));
       },
     },
   };

--- a/benchmarks/competitive/adapters/echarts.ts
+++ b/benchmarks/competitive/adapters/echarts.ts
@@ -26,7 +26,7 @@ echarts.use([
   CanvasRenderer,
 ]);
 
-export type UpdateColumns = ScatterColumns | SeriesColumns | BarsColumns;
+type UpdateColumns = ScatterColumns | SeriesColumns | BarsColumns;
 
 export type EChartsHandle = {
   destroy: () => void;

--- a/benchmarks/competitive/adapters/ggsvelte-canvas.ts
+++ b/benchmarks/competitive/adapters/ggsvelte-canvas.ts
@@ -15,7 +15,14 @@ import {
   type SeriesColumns,
 } from "../scenarios";
 
-export type MountResult = { markHint: number };
+export type UpdateColumns = ScatterColumns | SeriesColumns;
+
+export type MountHandle = {
+  destroy: () => void;
+  update: (data: UpdateColumns) => void;
+};
+
+export type MountResult = { markHint: number; handle: MountHandle };
 
 function scatterSpec(data: ScatterColumns) {
   return gg(data, aes({ x: "x", y: "y", color: "cls" }))
@@ -44,22 +51,18 @@ export function mountGgsvelteCanvas(
   if (scenario === "bars-stacked") {
     throw new Error("ggsvelte-canvas competitive path skips bars-stacked");
   }
-  let spec;
-  switch (scenario) {
-    case "scatter-color":
-      spec = scatterSpec(data as ScatterColumns);
-      break;
-    case "line-multiseries":
-      spec = lineSpec(data as SeriesColumns);
-      break;
-    case "area-multiseries":
-      spec = areaSpec(data as SeriesColumns);
-      break;
-    default:
-      throw new Error(`unsupported canvas scenario ${scenario}`);
-  }
-  const model = runPipeline(spec, { width: PLOT_WIDTH, height: PLOT_HEIGHT });
-  const strata = planStrata(model.scene, model.layerBackends);
+  const specFor = (d: UpdateColumns) => {
+    switch (scenario) {
+      case "scatter-color":
+        return scatterSpec(d as ScatterColumns);
+      case "line-multiseries":
+        return lineSpec(d as SeriesColumns);
+      case "area-multiseries":
+        return areaSpec(d as SeriesColumns);
+      default:
+        throw new Error(`unsupported canvas scenario ${scenario}`);
+    }
+  };
   root.replaceChildren();
   // Axes/text stay un-drawn in this harness (canvas marks only) so paint cost
   // isolates mark drawing — documented in README fairness notes.
@@ -70,15 +73,41 @@ export function mountGgsvelteCanvas(
   const ctx = canvas.getContext("2d");
   if (ctx === null) throw new Error("2d context unavailable");
   const dpr = window.devicePixelRatio || 1;
-  sizeCanvasForDpr(canvas, ctx, model.scene.width, model.scene.height, dpr);
   const resolve = cssColorResolver(canvas);
-  let batches = 0;
-  for (const stratum of strata) {
-    if (stratum.backend !== "canvas") continue;
-    drawStratum(ctx, model.scene, stratum.batches, resolve);
-    batches += stratum.batches.length;
-  }
-  return { markHint: batches };
+  let sized = false;
+  const draw = (d: UpdateColumns): number => {
+    const model = runPipeline(specFor(d), { width: PLOT_WIDTH, height: PLOT_HEIGHT });
+    const strata = planStrata(model.scene, model.layerBackends);
+    if (!sized) {
+      sizeCanvasForDpr(canvas, ctx, model.scene.width, model.scene.height, dpr);
+      sized = true;
+    } else {
+      // Same canvas element on updates: clear the frame (logical coords — the
+      // dpr transform set by sizeCanvasForDpr persists) and redraw.
+      ctx.clearRect(0, 0, model.scene.width, model.scene.height);
+    }
+    let batches = 0;
+    for (const stratum of strata) {
+      if (stratum.backend !== "canvas") continue;
+      drawStratum(ctx, model.scene, stratum.batches, resolve);
+      batches += stratum.batches.length;
+    }
+    return batches;
+  };
+  const markHint = draw(data);
+  return {
+    markHint,
+    handle: {
+      // Full pipeline re-run on the SAME canvas element — ggsvelte's lean
+      // canvas path has no incremental redraw, so update == remount-minus-DOM.
+      update: (d) => {
+        draw(d);
+      },
+      destroy: () => {
+        root.replaceChildren();
+      },
+    },
+  };
 }
 
 export function bundleScatterCanvas(data: ScatterColumns): unknown {

--- a/benchmarks/competitive/adapters/ggsvelte-svg.ts
+++ b/benchmarks/competitive/adapters/ggsvelte-svg.ts
@@ -13,7 +13,14 @@ import {
   type SeriesColumns,
 } from "../scenarios";
 
-export type MountResult = { markHint: number };
+export type UpdateColumns = ScatterColumns | SeriesColumns | BarsColumns;
+
+export type MountHandle = {
+  destroy: () => void;
+  update: (data: UpdateColumns) => void;
+};
+
+export type MountResult = { markHint: number; handle: MountHandle };
 
 function scatterSpec(data: ScatterColumns) {
   return gg(data, aes({ x: "x", y: "y", color: "cls" }))
@@ -45,25 +52,42 @@ export function mountGgsvelteSvg(
   data: ScatterColumns | SeriesColumns | BarsColumns,
   root: HTMLElement,
 ): MountResult {
-  let spec;
-  switch (scenario) {
-    case "scatter-color":
-      spec = scatterSpec(data as ScatterColumns);
-      break;
-    case "line-multiseries":
-      spec = lineSpec(data as SeriesColumns);
-      break;
-    case "area-multiseries":
-      spec = areaSpec(data as SeriesColumns);
-      break;
-    case "bars-stacked":
-      spec = barsSpec(data as BarsColumns);
-      break;
-  }
-  const svg = renderToSVGString(spec, { width: PLOT_WIDTH, height: PLOT_HEIGHT });
-  root.replaceChildren();
-  root.innerHTML = svg;
-  return { markHint: root.querySelectorAll("circle, path, rect, line").length };
+  const render = (d: UpdateColumns): number => {
+    let spec;
+    switch (scenario) {
+      case "scatter-color":
+        spec = scatterSpec(d as ScatterColumns);
+        break;
+      case "line-multiseries":
+        spec = lineSpec(d as SeriesColumns);
+        break;
+      case "area-multiseries":
+        spec = areaSpec(d as SeriesColumns);
+        break;
+      case "bars-stacked":
+        spec = barsSpec(d as BarsColumns);
+        break;
+    }
+    const svg = renderToSVGString(spec, { width: PLOT_WIDTH, height: PLOT_HEIGHT });
+    root.replaceChildren();
+    root.innerHTML = svg;
+    return root.querySelectorAll("circle, path, rect, line").length;
+  };
+  const markHint = render(data);
+  return {
+    markHint,
+    handle: {
+      // Honest update path TODAY: ggsvelte's lean SVG path has no in-place DOM
+      // patching, so an update is a full re-render (new spec +
+      // renderToSVGString) followed by a DOM swap — update == remount here.
+      update: (d) => {
+        render(d);
+      },
+      destroy: () => {
+        root.replaceChildren();
+      },
+    },
+  };
 }
 
 export function bundleScatterSvg(data: ScatterColumns): string {

--- a/benchmarks/competitive/adapters/layercake.ts
+++ b/benchmarks/competitive/adapters/layercake.ts
@@ -27,7 +27,7 @@ import {
   type SeriesColumns,
 } from "../scenarios";
 
-export type UpdateColumns = ScatterColumns | SeriesColumns | BarsColumns;
+type UpdateColumns = ScatterColumns | SeriesColumns | BarsColumns;
 
 export type LayerCakeHandle = {
   destroy: () => void;

--- a/benchmarks/competitive/adapters/layercake.ts
+++ b/benchmarks/competitive/adapters/layercake.ts
@@ -1,9 +1,21 @@
 /**
- * LayerCake competitive mounts (Svelte 5 components, SVG marks).
+ * LayerCake competitive mounts (Svelte 5 components, SVG marks) plus the
+ * Canvas-layout fast path (mountLayerCakeCanvas).
+ *
+ * Update scoreboard: mount passes a $state proxy (fixtures/props.svelte.ts)
+ * as the props object; update() assigns props.rows + flushSync() so Svelte 5
+ * reactive props propagate through <LayerCake> into the mark components —
+ * no remount. Canvas marks additionally re-draw via a $effect on $data (see
+ * components/layercake/*Canvas.svelte).
  */
+import { stack as d3Stack } from "d3-shape";
 import { flushSync, mount, unmount } from "svelte";
 
+import AreaChart from "../components/layercake/AreaChart.svelte";
+import BarsChart from "../components/layercake/BarsChart.svelte";
+import LineCanvasChart from "../components/layercake/LineCanvasChart.svelte";
 import LineChart from "../components/layercake/LineChart.svelte";
+import ScatterCanvasChart from "../components/layercake/ScatterCanvasChart.svelte";
 import ScatterChart from "../components/layercake/ScatterChart.svelte";
 import {
   COLORS,
@@ -15,7 +27,82 @@ import {
   type SeriesColumns,
 } from "../scenarios";
 
-export type LayerCakeHandle = { destroy: () => void };
+export type UpdateColumns = ScatterColumns | SeriesColumns | BarsColumns;
+
+export type LayerCakeHandle = {
+  destroy: () => void;
+  update: (data: UpdateColumns) => void;
+};
+
+type ScatterRow = { x: number; y: number; cls: string };
+type SeriesRow = { x: number; y: number; series: string; color: string };
+type BarRow = { category: string; y0: number; y1: number; stack: string; color: string };
+
+function buildScatterRows(scatter: ScatterColumns): ScatterRow[] {
+  return scatter.x.map((x, i) => ({
+    x,
+    y: scatter.y[i]!,
+    cls: scatter.cls[i]!,
+  }));
+}
+
+function buildSeriesRows(seriesData: SeriesColumns): SeriesRow[] {
+  const seriesIndex = new Map<string, number>();
+  for (const name of seriesData.series) {
+    if (!seriesIndex.has(name)) seriesIndex.set(name, seriesIndex.size);
+  }
+  return seriesData.x.map((x, i) => {
+    const series = seriesData.series[i]!;
+    const sIndex = seriesIndex.get(series)!;
+    return {
+      x,
+      y: seriesData.y[i]!,
+      series,
+      color: COLORS[sIndex % COLORS.length]!,
+    };
+  });
+}
+
+/**
+ * Genuinely stacked bars: mirror the raw d3 adapter — pivot to wide format,
+ * run d3-shape stack(), then flatten to long rows carrying the stacked
+ * offsets (y0/y1) and a precomputed color per stack (same posture as the
+ * line path's color Map).
+ */
+function buildBarRows(bars: BarsColumns): BarRow[] {
+  const categories = [...new Set(bars.category)];
+  const stacks = [...new Set(bars.stack)];
+  const wide = categories.map((cat) => {
+    const row: Record<string, string | number> = { category: cat };
+    for (let i = 0; i < bars.category.length; i++) {
+      if (bars.category[i] === cat) row[bars.stack[i]!] = bars.value[i]!;
+    }
+    return row;
+  });
+  const layers = d3Stack<Record<string, string | number>>().keys(stacks)(wide);
+  return layers.flatMap((layer, s) =>
+    layer.map((d, i) => ({
+      category: categories[i]!,
+      y0: d[0],
+      y1: d[1],
+      stack: layer.key,
+      color: COLORS[s % COLORS.length]!,
+    })),
+  );
+}
+
+function makeHandle(comp: unknown, update: (d: UpdateColumns) => void): LayerCakeHandle {
+  return {
+    destroy: () => {
+      try {
+        void unmount(comp as Parameters<typeof unmount>[0]);
+      } catch {
+        // already unmounted
+      }
+    },
+    update,
+  };
+}
 
 export function mountLayerCake(
   scenario: ScenarioId,
@@ -24,51 +111,105 @@ export function mountLayerCake(
 ): { markHint: number; handle: LayerCakeHandle } {
   root.replaceChildren();
   let comp;
+  let update: (d: UpdateColumns) => void;
   if (scenario === "scatter-color") {
-    const scatter = data as ScatterColumns;
-    const rows = scatter.x.map((x, i) => ({
-      x,
-      y: scatter.y[i]!,
-      cls: scatter.cls[i]!,
-    }));
-    comp = mount(ScatterChart, {
-      target: root,
-      props: { rows, width: PLOT_WIDTH, height: PLOT_HEIGHT },
-    });
+    const props = {
+      rows: buildScatterRows(data as ScatterColumns),
+      width: PLOT_WIDTH,
+      height: PLOT_HEIGHT,
+    };
+    comp = mount(ScatterChart, { target: root, props });
+    update = (d) => {
+      comp.setRows(buildScatterRows(d as ScatterColumns));
+      flushSync();
+    };
   } else if (scenario === "line-multiseries") {
-    const seriesData = data as SeriesColumns;
-    const seriesIndex = new Map<string, number>();
-    for (const name of seriesData.series) {
-      if (!seriesIndex.has(name)) seriesIndex.set(name, seriesIndex.size);
-    }
-    const rows = seriesData.x.map((x, i) => {
-      const series = seriesData.series[i]!;
-      const sIndex = seriesIndex.get(series)!;
-      return {
-        x,
-        y: seriesData.y[i]!,
-        series,
-        color: COLORS[sIndex % COLORS.length],
-      };
-    });
-    comp = mount(LineChart, {
-      target: root,
-      props: { rows, width: PLOT_WIDTH, height: PLOT_HEIGHT },
-    });
+    const props = {
+      rows: buildSeriesRows(data as SeriesColumns),
+      width: PLOT_WIDTH,
+      height: PLOT_HEIGHT,
+    };
+    comp = mount(LineChart, { target: root, props });
+    update = (d) => {
+      comp.setRows(buildSeriesRows(d as SeriesColumns));
+      flushSync();
+    };
+  } else if (scenario === "area-multiseries") {
+    const props = {
+      rows: buildSeriesRows(data as SeriesColumns),
+      width: PLOT_WIDTH,
+      height: PLOT_HEIGHT,
+    };
+    comp = mount(AreaChart, { target: root, props });
+    update = (d) => {
+      comp.setRows(buildSeriesRows(d as SeriesColumns));
+      flushSync();
+    };
+  } else if (scenario === "bars-stacked") {
+    const props = {
+      rows: buildBarRows(data as BarsColumns),
+      width: PLOT_WIDTH,
+      height: PLOT_HEIGHT,
+    };
+    comp = mount(BarsChart, { target: root, props });
+    update = (d) => {
+      comp.setRows(buildBarRows(d as BarsColumns));
+      flushSync();
+    };
   } else {
     throw new Error(`layercake does not implement ${scenario}`);
   }
   flushSync();
   return {
-    markHint: root.querySelectorAll("circle, path").length,
-    handle: {
-      destroy: () => {
-        try {
-          void unmount(comp);
-        } catch {
-          // already unmounted
-        }
-      },
-    },
+    markHint: root.querySelectorAll("circle, path, rect").length,
+    handle: makeHandle(comp, update),
+  };
+}
+
+/**
+ * Canvas-layout fast path (LayerCake's own <Canvas> layout): one 2D-context
+ * draw pass, no per-mark DOM. markHint is the row count — canvas marks leave
+ * no DOM to count, matching how the uplot/echarts canvas adapters report n.
+ */
+export function mountLayerCakeCanvas(
+  scenario: ScenarioId,
+  data: ScatterColumns | SeriesColumns | BarsColumns,
+  root: HTMLElement,
+): { markHint: number; handle: LayerCakeHandle } {
+  root.replaceChildren();
+  let comp;
+  let n: number;
+  let update: (d: UpdateColumns) => void;
+  if (scenario === "scatter-color") {
+    const props = {
+      rows: buildScatterRows(data as ScatterColumns),
+      width: PLOT_WIDTH,
+      height: PLOT_HEIGHT,
+    };
+    n = props.rows.length;
+    comp = mount(ScatterCanvasChart, { target: root, props });
+    update = (d) => {
+      comp.setRows(buildScatterRows(d as ScatterColumns));
+      flushSync();
+    };
+  } else if (scenario === "line-multiseries") {
+    const props = {
+      rows: buildSeriesRows(data as SeriesColumns),
+      width: PLOT_WIDTH,
+      height: PLOT_HEIGHT,
+    };
+    n = props.rows.length;
+    comp = mount(LineCanvasChart, { target: root, props });
+    update = (d) => {
+      comp.setRows(buildSeriesRows(d as SeriesColumns));
+      flushSync();
+    };
+  } else {
+    throw new Error(`layercake-canvas does not implement ${scenario}`);
+  }
+  flushSync();
+  return {
+    markHint: n,
+    handle: makeHandle(comp, update),
   };
 }

--- a/benchmarks/competitive/adapters/layercake.ts
+++ b/benchmarks/competitive/adapters/layercake.ts
@@ -1,0 +1,74 @@
+/**
+ * LayerCake competitive mounts (Svelte 5 components, SVG marks).
+ */
+import { flushSync, mount, unmount } from "svelte";
+
+import LineChart from "../components/layercake/LineChart.svelte";
+import ScatterChart from "../components/layercake/ScatterChart.svelte";
+import {
+  COLORS,
+  PLOT_HEIGHT,
+  PLOT_WIDTH,
+  type BarsColumns,
+  type ScatterColumns,
+  type ScenarioId,
+  type SeriesColumns,
+} from "../scenarios";
+
+export type LayerCakeHandle = { destroy: () => void };
+
+export function mountLayerCake(
+  scenario: ScenarioId,
+  data: ScatterColumns | SeriesColumns | BarsColumns,
+  root: HTMLElement,
+): { markHint: number; handle: LayerCakeHandle } {
+  root.replaceChildren();
+  let comp;
+  if (scenario === "scatter-color") {
+    const scatter = data as ScatterColumns;
+    const rows = scatter.x.map((x, i) => ({
+      x,
+      y: scatter.y[i]!,
+      cls: scatter.cls[i]!,
+    }));
+    comp = mount(ScatterChart, {
+      target: root,
+      props: { rows, width: PLOT_WIDTH, height: PLOT_HEIGHT },
+    });
+  } else if (scenario === "line-multiseries") {
+    const seriesData = data as SeriesColumns;
+    const seriesIndex = new Map<string, number>();
+    for (const name of seriesData.series) {
+      if (!seriesIndex.has(name)) seriesIndex.set(name, seriesIndex.size);
+    }
+    const rows = seriesData.x.map((x, i) => {
+      const series = seriesData.series[i]!;
+      const sIndex = seriesIndex.get(series)!;
+      return {
+        x,
+        y: seriesData.y[i]!,
+        series,
+        color: COLORS[sIndex % COLORS.length],
+      };
+    });
+    comp = mount(LineChart, {
+      target: root,
+      props: { rows, width: PLOT_WIDTH, height: PLOT_HEIGHT },
+    });
+  } else {
+    throw new Error(`layercake does not implement ${scenario}`);
+  }
+  flushSync();
+  return {
+    markHint: root.querySelectorAll("circle, path").length,
+    handle: {
+      destroy: () => {
+        try {
+          void unmount(comp);
+        } catch {
+          // already unmounted
+        }
+      },
+    },
+  };
+}

--- a/benchmarks/competitive/adapters/svelteplot.ts
+++ b/benchmarks/competitive/adapters/svelteplot.ts
@@ -1,0 +1,63 @@
+/**
+ * SveltePlot browser mounts (Svelte components, real DOM).
+ * Mirrors the d3/ggsvelte adapter shape so fixtures/main.ts can dispatch it.
+ */
+import { flushSync, mount, unmount } from "svelte";
+
+import LineChart from "../components/svelteplot/LineChart.svelte";
+import ScatterChart from "../components/svelteplot/ScatterChart.svelte";
+import {
+  PLOT_HEIGHT,
+  PLOT_WIDTH,
+  type BarsColumns,
+  type ScatterColumns,
+  type ScenarioId,
+  type SeriesColumns,
+} from "../scenarios";
+
+export type MountHandle = { destroy: () => void };
+export type MountResult = { markHint: number; handle: MountHandle };
+
+export function mountSveltePlot(
+  scenario: ScenarioId,
+  data: ScatterColumns | SeriesColumns | BarsColumns,
+  root: HTMLElement,
+): MountResult {
+  root.replaceChildren();
+  let component;
+  switch (scenario) {
+    case "scatter-color": {
+      const d = data as ScatterColumns;
+      const rows = d.x.map((x, i) => ({ x, y: d.y[i]!, cls: d.cls[i]! }));
+      component = mount(ScatterChart, {
+        target: root,
+        props: { rows, width: PLOT_WIDTH, height: PLOT_HEIGHT },
+      });
+      break;
+    }
+    case "line-multiseries": {
+      const d = data as SeriesColumns;
+      const rows = d.x.map((x, i) => ({ x, y: d.y[i]!, series: d.series[i]! }));
+      component = mount(LineChart, {
+        target: root,
+        props: { rows, width: PLOT_WIDTH, height: PLOT_HEIGHT },
+      });
+      break;
+    }
+    default:
+      throw new Error(`svelteplot does not implement ${scenario}`);
+  }
+  flushSync();
+  return {
+    markHint: root.querySelectorAll("circle, path").length,
+    handle: {
+      destroy() {
+        try {
+          void unmount(component);
+        } catch {
+          // teardown between samples is best-effort
+        }
+      },
+    },
+  };
+}

--- a/benchmarks/competitive/adapters/svelteplot.ts
+++ b/benchmarks/competitive/adapters/svelteplot.ts
@@ -21,9 +21,9 @@ import {
   type SeriesColumns,
 } from "../scenarios";
 
-export type UpdateColumns = ScatterColumns | SeriesColumns | BarsColumns;
+type UpdateColumns = ScatterColumns | SeriesColumns | BarsColumns;
 
-export type MountHandle = {
+type MountHandle = {
   destroy: () => void;
   update: (data: UpdateColumns) => void;
 };

--- a/benchmarks/competitive/adapters/svelteplot.ts
+++ b/benchmarks/competitive/adapters/svelteplot.ts
@@ -1,9 +1,15 @@
 /**
  * SveltePlot browser mounts (Svelte components, real DOM).
  * Mirrors the d3/ggsvelte adapter shape so fixtures/main.ts can dispatch it.
+ *
+ * Update scoreboard: mount passes a $state proxy (fixtures/props.svelte.ts)
+ * as the props object; update() assigns props.rows + flushSync() so Svelte 5
+ * reactive props re-render the mounted component in place — no remount.
  */
 import { flushSync, mount, unmount } from "svelte";
 
+import AreaChart from "../components/svelteplot/AreaChart.svelte";
+import BarsChart from "../components/svelteplot/BarsChart.svelte";
 import LineChart from "../components/svelteplot/LineChart.svelte";
 import ScatterChart from "../components/svelteplot/ScatterChart.svelte";
 import {
@@ -15,8 +21,33 @@ import {
   type SeriesColumns,
 } from "../scenarios";
 
-export type MountHandle = { destroy: () => void };
+export type UpdateColumns = ScatterColumns | SeriesColumns | BarsColumns;
+
+export type MountHandle = {
+  destroy: () => void;
+  update: (data: UpdateColumns) => void;
+};
 export type MountResult = { markHint: number; handle: MountHandle };
+
+type ScatterRow = { x: number; y: number; cls: string };
+type SeriesRow = { x: number; y: number; series: string };
+type BarRow = { category: string; value: number; stack: string };
+
+function buildScatterRows(d: ScatterColumns): ScatterRow[] {
+  return d.x.map((x, i) => ({ x, y: d.y[i]!, cls: d.cls[i]! }));
+}
+
+function buildSeriesRows(d: SeriesColumns): SeriesRow[] {
+  return d.x.map((x, i) => ({ x, y: d.y[i]!, series: d.series[i]! }));
+}
+
+function buildBarRows(d: BarsColumns): BarRow[] {
+  return d.category.map((category, i) => ({
+    category,
+    value: d.value[i]!,
+    stack: d.stack[i]!,
+  }));
+}
 
 export function mountSveltePlot(
   scenario: ScenarioId,
@@ -25,23 +56,58 @@ export function mountSveltePlot(
 ): MountResult {
   root.replaceChildren();
   let component;
+  let update: (d: UpdateColumns) => void;
   switch (scenario) {
     case "scatter-color": {
-      const d = data as ScatterColumns;
-      const rows = d.x.map((x, i) => ({ x, y: d.y[i]!, cls: d.cls[i]! }));
-      component = mount(ScatterChart, {
-        target: root,
-        props: { rows, width: PLOT_WIDTH, height: PLOT_HEIGHT },
-      });
+      const props = {
+        rows: buildScatterRows(data as ScatterColumns),
+        width: PLOT_WIDTH,
+        height: PLOT_HEIGHT,
+      };
+      component = mount(ScatterChart, { target: root, props });
+      update = (d) => {
+        component.setRows(buildScatterRows(d as ScatterColumns));
+        flushSync();
+      };
       break;
     }
     case "line-multiseries": {
-      const d = data as SeriesColumns;
-      const rows = d.x.map((x, i) => ({ x, y: d.y[i]!, series: d.series[i]! }));
-      component = mount(LineChart, {
-        target: root,
-        props: { rows, width: PLOT_WIDTH, height: PLOT_HEIGHT },
-      });
+      const props = {
+        rows: buildSeriesRows(data as SeriesColumns),
+        width: PLOT_WIDTH,
+        height: PLOT_HEIGHT,
+      };
+      component = mount(LineChart, { target: root, props });
+      update = (d) => {
+        component.setRows(buildSeriesRows(d as SeriesColumns));
+        flushSync();
+      };
+      break;
+    }
+    case "area-multiseries": {
+      const props = {
+        rows: buildSeriesRows(data as SeriesColumns),
+        width: PLOT_WIDTH,
+        height: PLOT_HEIGHT,
+      };
+      component = mount(AreaChart, { target: root, props });
+      update = (d) => {
+        component.setRows(buildSeriesRows(d as SeriesColumns));
+        flushSync();
+      };
+      break;
+    }
+    case "bars-stacked": {
+      const props = {
+        rows: buildBarRows(data as BarsColumns),
+        width: PLOT_WIDTH,
+        height: PLOT_HEIGHT,
+      };
+      component = mount(BarsChart, { target: root, props });
+      update = (d) => {
+        component.setRows(buildBarRows(d as BarsColumns));
+        flushSync();
+      };
       break;
     }
     default:
@@ -49,7 +115,7 @@ export function mountSveltePlot(
   }
   flushSync();
   return {
-    markHint: root.querySelectorAll("circle, path").length,
+    markHint: root.querySelectorAll("circle, path, rect").length,
     handle: {
       destroy() {
         try {
@@ -58,6 +124,7 @@ export function mountSveltePlot(
           // teardown between samples is best-effort
         }
       },
+      update,
     },
   };
 }

--- a/benchmarks/competitive/adapters/uplot.ts
+++ b/benchmarks/competitive/adapters/uplot.ts
@@ -13,7 +13,13 @@ import {
   type SeriesColumns,
 } from "../scenarios";
 
-export type UPlotHandle = { destroy: () => void };
+export type UpdateColumns = ScatterColumns | SeriesColumns;
+
+export type UPlotHandle = {
+  destroy: () => void;
+  /** uPlot's actual in-place update API: setData with same-shape aligned data. */
+  update: (data: UpdateColumns) => void;
+};
 
 function seriesFromLong(data: SeriesColumns): {
   xs: number[];
@@ -42,15 +48,16 @@ export function mountUplot(
 ): { markHint: number; handle: UPlotHandle } {
   root.replaceChildren();
   if (scenario === "scatter-color") {
-    const scatter = data as ScatterColumns;
     // uPlot requires data[0] (x) sorted ascending; it takes x-domain from first/last
     // samples. Sort outside the timed region would need harness changes — sort here
     // so paint cost still covers all N markers (not an off-canvas empty chart).
-    const order = Array.from({ length: scatter.x.length }, (_, i) => i).toSorted(
-      (a, b) => scatter.x[a]! - scatter.x[b]!,
-    );
-    const xs = order.map((i) => scatter.x[i]!);
-    const ys = order.map((i) => scatter.y[i]!);
+    const aligned = (d: ScatterColumns): uPlot.AlignedData => {
+      const order = Array.from({ length: d.x.length }, (_, i) => i).toSorted(
+        (a, b) => d.x[a]! - d.x[b]!,
+      );
+      return [order.map((i) => d.x[i]!), order.map((i) => d.y[i]!)];
+    };
+    const scatter = data as ScatterColumns;
     // uPlot is not a scatter specialist; plot as points with one series of x/y.
     // Fairness: still a cold canvas chart with N markers.
     const opts: uPlot.Options = {
@@ -69,8 +76,16 @@ export function mountUplot(
       axes: [{}, {}],
       legend: { show: false },
     };
-    const u = new uPlot(opts, [xs, ys], root);
-    return { markHint: scatter.x.length, handle: { destroy: () => u.destroy() } };
+    const u = new uPlot(opts, aligned(scatter), root);
+    return {
+      markHint: scatter.x.length,
+      handle: {
+        destroy: () => u.destroy(),
+        update: (d) => {
+          u.setData(aligned(d as ScatterColumns));
+        },
+      },
+    };
   }
 
   const seriesData = data as SeriesColumns;
@@ -109,5 +124,14 @@ export function mountUplot(
   };
   const aligned: uPlot.AlignedData = [xs, ...ys];
   const u = new uPlot(opts, aligned, root);
-  return { markHint: names.length * xs.length, handle: { destroy: () => u.destroy() } };
+  return {
+    markHint: names.length * xs.length,
+    handle: {
+      destroy: () => u.destroy(),
+      update: (d) => {
+        const next = seriesFromLong(d as SeriesColumns);
+        u.setData([next.xs, ...next.ys]);
+      },
+    },
+  };
 }

--- a/benchmarks/competitive/adapters/uplot.ts
+++ b/benchmarks/competitive/adapters/uplot.ts
@@ -13,7 +13,7 @@ import {
   type SeriesColumns,
 } from "../scenarios";
 
-export type UpdateColumns = ScatterColumns | SeriesColumns;
+type UpdateColumns = ScatterColumns | SeriesColumns;
 
 export type UPlotHandle = {
   destroy: () => void;

--- a/benchmarks/competitive/budgets.json
+++ b/benchmarks/competitive/budgets.json
@@ -1,0 +1,121 @@
+{
+  "$comment": "PROVISIONAL competitive browser budgets: measured on linux-x64 (bun 1.3.14) on 2026-08-03 via `bun run measure:browser`; budget = median * ~3 headroom, rounded up to ~2 significant figures, because these are paint-inclusive wall-clock medians (double-rAF mount) inside a CI container with real runner variance. Absolute budgets cover ggsvelte-svg + ggsvelte-canvas cells ONLY \u2014 peer libs (layercake, svelteplot, ...) are third-party and get no absolute budget; the Svelte-peer win is locked by the relative gate in check-budgets.ts instead (same-run same-runner comparison). Keys are '<lib> <caseId> mount' and must exactly match the ggsvelte cells emitted in results/browser.json; check-budgets.ts asserts coverage in both directions so a new ggsvelte cell cannot dodge budgeting and a stale budget cannot linger after a cell is removed. Cells are data-driven from results/browser.json \u2014 peers gaining area/bars cells (or new peer libs) need no edit here.",
+  "knownGaps": [
+    {
+      "ggsvelte": "ggsvelte-canvas",
+      "peer": "layercake-canvas",
+      "caseId": "scatter-color-10k",
+      "kind": "mount",
+      "issue": "https://github.com/ljodea/ggsvelte/issues/1468",
+      "note": "~40ms vs ~28ms. Per-datum pipeline cost above the ~25ms double-rAF floor. Self-destructs when the gap closes."
+    },
+    {
+      "ggsvelte": "ggsvelte-canvas",
+      "peer": "layercake-canvas",
+      "caseId": "line-3x10k",
+      "kind": "mount",
+      "issue": "https://github.com/ljodea/ggsvelte/issues/1468",
+      "note": "~66ms vs ~47ms. Naive canvas line loop beats runPipeline+planStrata+drawStratum at 30k points; both are marks-only (no chrome). Self-destructs when the gap closes."
+    },
+    {
+      "ggsvelte": "ggsvelte-svg",
+      "peer": "layercake",
+      "caseId": "scatter-color-10k",
+      "kind": "update",
+      "issue": "https://github.com/ljodea/ggsvelte/issues/1471",
+      "note": "~90ms vs ~62ms. Our update path is a documented full re-render; layercake updates reactively through $state. Attack: incremental update planning."
+    },
+    {
+      "ggsvelte": "ggsvelte-svg",
+      "peer": "layercake",
+      "caseId": "line-3x10k",
+      "kind": "update",
+      "issue": "https://github.com/ljodea/ggsvelte/issues/1471",
+      "note": "~57ms vs ~31ms. Full re-render vs reactive update at 30k points."
+    },
+    {
+      "ggsvelte": "ggsvelte-canvas",
+      "peer": "layercake-canvas",
+      "caseId": "scatter-color-10k",
+      "kind": "update",
+      "issue": "https://github.com/ljodea/ggsvelte/issues/1471",
+      "note": "~33ms vs ~30ms. Marginal; our update re-runs the whole pipeline on the same canvas."
+    },
+    {
+      "ggsvelte": "ggsvelte-canvas",
+      "peer": "layercake-canvas",
+      "caseId": "line-3x10k",
+      "kind": "update",
+      "issue": "https://github.com/ljodea/ggsvelte/issues/1471",
+      "note": "~68ms vs ~41ms. Full pipeline re-run vs $effect redraw at 30k points."
+    }
+  ],
+  "budgets": {
+    "ggsvelte-canvas area-3x1k mount": {
+      "budgetMs": 81
+    },
+    "ggsvelte-canvas area-3x1k update": {
+      "budgetMs": 93
+    },
+    "ggsvelte-canvas line-3x10k mount": {
+      "budgetMs": 270
+    },
+    "ggsvelte-canvas line-3x10k update": {
+      "budgetMs": 210
+    },
+    "ggsvelte-canvas line-3x1k mount": {
+      "budgetMs": 84
+    },
+    "ggsvelte-canvas line-3x1k update": {
+      "budgetMs": 95
+    },
+    "ggsvelte-canvas scatter-color-10k mount": {
+      "budgetMs": 170
+    },
+    "ggsvelte-canvas scatter-color-10k update": {
+      "budgetMs": 100
+    },
+    "ggsvelte-canvas scatter-color-1k mount": {
+      "budgetMs": 85
+    },
+    "ggsvelte-canvas scatter-color-1k update": {
+      "budgetMs": 95
+    },
+    "ggsvelte-svg area-3x1k mount": {
+      "budgetMs": 91
+    },
+    "ggsvelte-svg area-3x1k update": {
+      "budgetMs": 95
+    },
+    "ggsvelte-svg bars-stacked-50x4 mount": {
+      "budgetMs": 84
+    },
+    "ggsvelte-svg bars-stacked-50x4 update": {
+      "budgetMs": 95
+    },
+    "ggsvelte-svg line-3x10k mount": {
+      "budgetMs": 270
+    },
+    "ggsvelte-svg line-3x10k update": {
+      "budgetMs": 180
+    },
+    "ggsvelte-svg line-3x1k mount": {
+      "budgetMs": 87
+    },
+    "ggsvelte-svg line-3x1k update": {
+      "budgetMs": 94
+    },
+    "ggsvelte-svg scatter-color-10k mount": {
+      "budgetMs": 370
+    },
+    "ggsvelte-svg scatter-color-10k update": {
+      "budgetMs": 280
+    },
+    "ggsvelte-svg scatter-color-1k mount": {
+      "budgetMs": 86
+    },
+    "ggsvelte-svg scatter-color-1k update": {
+      "budgetMs": 93
+    }
+  }
+}

--- a/benchmarks/competitive/check-budgets.ts
+++ b/benchmarks/competitive/check-budgets.ts
@@ -1,0 +1,379 @@
+/**
+ * Competitive browser budget gate: compares results/browser.json (written by
+ * `bun run measure:browser`) against the committed budgets.json, then locks
+ * the Svelte-peer win with a same-run relative gate. Exits 1 on any
+ * violation. Mirrors ../../benchmarks/check-budgets.ts conventions.
+ *
+ *   1. Absolute: every ggsvelte-* ok result's mount median (and update
+ *      median, when measuresUpdate is set) must be <= its budgets.json
+ *      entry. ggsvelte cells and budget keys must cover the SAME set —
+ *      asserted in BOTH directions so a new cell cannot dodge budgeting and
+ *      a stale budget cannot linger after a cell is removed.
+ *   2. Relative: the win this gate locks is against the Svelte ecosystem
+ *      peers, paired by render form factor (scenarios.ts LIBS[].form):
+ *      ggsvelte-svg vs SVG peers (layercake, svelteplot), ggsvelte-canvas
+ *      vs canvas peers (layercake-canvas). General-purpose reference bars
+ *      (d3/uplot/chartjs/echarts) are reported but NEVER gated. Same-run
+ *      same-runner comparison, so no headroom factor. A peer cell that
+ *      errored outright FAILS the gate — we want to know when a fixture
+ *      breaks.
+ *   3. Known gaps (budgets.json "knownGaps"): explicit, issue-tracked
+ *      exemptions to the relative gate. The ratchet is self-destructing —
+ *      if a listed gap CLOSES (ggsvelte median <= peer median), the check
+ *      FAILS until the exemption is removed, so the gate tightens
+ *      automatically as gaps are fixed.
+ *
+ * Cell lists are data-driven from results/browser.json: peers gaining new
+ * cells (area, bars, ...) are picked up automatically.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { LIBS } from "./scenarios";
+
+interface BrowserResult {
+  lib: string;
+  caseId: string;
+  ok: boolean;
+  mountMedianMs?: number;
+  updateMedianMs?: number;
+  error?: string;
+}
+
+interface BrowserFile {
+  generatedAt?: string;
+  /** Set by measure-browser when in-place update medians were measured. */
+  measuresUpdate?: boolean;
+  results: BrowserResult[];
+}
+
+interface KnownGap {
+  /** ggsvelte lib id that currently LOSES the comparison. */
+  ggsvelte: string;
+  /** Peer lib id it loses to. */
+  peer: string;
+  caseId: string;
+  /** "mount" or "update" — which timing the exemption covers. */
+  kind: "mount" | "update";
+  /** Tracking issue URL/number — required so exemptions cannot rot silently. */
+  issue: string;
+  note?: string;
+}
+
+interface BudgetsFile {
+  budgets: Record<string, { budgetMs: number }>;
+  knownGaps?: KnownGap[];
+}
+
+/** General-purpose reference bars, NOT Svelte peers: useful context in the
+ * report, but the win this gate locks is against the Svelte ecosystem peers. */
+const REFERENCE_LIBS = new Set(["d3", "uplot", "chartjs", "echarts"]);
+
+const isGgsvelte = (lib: string) => lib.startsWith("ggsvelte");
+const isPeer = (lib: string) => !isGgsvelte(lib) && !REFERENCE_LIBS.has(lib);
+
+const FORM_BY_LIB = new Map(LIBS.map((l) => [l.id, l.form] as const));
+
+/** Max allowed ggsvelte/peer median ratio in the relative gate. */
+const MAX_RELATIVE_RATIO = 1.0;
+/** Floor-noise tolerance: medians at the ~30ms double-rAF paint floor jitter
+ * by a frame fraction run-to-run, so a strict ratio <= 1.0 flakes on cells
+ * where both sides sit at the floor. Real wins/losses are >= 1.4x — far
+ * outside this band. */
+const REL_EPS = 0.02;
+const ABS_EPS_MS = 2;
+const withinGate = (ggMs: number, peerMs: number) =>
+  ggMs <= peerMs * (MAX_RELATIVE_RATIO + REL_EPS) + ABS_EPS_MS;
+
+function fail(message: string): never {
+  console.error(`check-budgets: ${message}`);
+  process.exit(1);
+}
+
+function readJson(url: URL, what: string): unknown {
+  const path = fileURLToPath(url);
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch {
+    return fail(
+      `missing ${what} at ${path}${what === "results/browser.json" ? " — run `bun run measure:browser` first" : ""}`,
+    );
+  }
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return fail(`${what} at ${path} is not valid JSON`);
+  }
+}
+
+// --- load + validate shapes --------------------------------------------------
+
+const browserJson = readJson(
+  new URL("./results/browser.json", import.meta.url),
+  "results/browser.json",
+) as BrowserFile;
+if (!Array.isArray(browserJson.results) || browserJson.results.length === 0) {
+  fail('results/browser.json must have a non-empty "results" array');
+}
+const results = browserJson.results;
+const measuresUpdate = browserJson.measuresUpdate === true;
+
+type Kind = "mount" | "update";
+const KINDS: readonly Kind[] = measuresUpdate ? ["mount", "update"] : ["mount"];
+const medianOf = (r: BrowserResult, kind: Kind): number | undefined =>
+  kind === "mount" ? r.mountMedianMs : r.updateMedianMs;
+
+for (const r of results) {
+  if (typeof r.lib !== "string" || typeof r.caseId !== "string" || typeof r.ok !== "boolean") {
+    fail(`malformed result entry: ${JSON.stringify(r)}`);
+  }
+  if (!FORM_BY_LIB.has(r.lib as never)) {
+    fail(`result lib "${r.lib}" is not in scenarios.ts LIBS — add it (with a form) first`);
+  }
+  for (const kind of KINDS) {
+    const v = medianOf(r, kind);
+    if (r.ok && (typeof v !== "number" || !Number.isFinite(v))) {
+      fail(`ok result missing ${kind} median: ${JSON.stringify(r)}`);
+    }
+  }
+}
+
+const budgetsJson = readJson(new URL("./budgets.json", import.meta.url), "budgets.json");
+const budgetsFile = budgetsJson as BudgetsFile;
+if (typeof budgetsFile.budgets !== "object" || budgetsFile.budgets === null) {
+  fail('budgets.json must have a "budgets" object');
+}
+const budgets = budgetsFile.budgets;
+for (const [key, entry] of Object.entries(budgets)) {
+  if (!isGgsvelte(key.split(" ")[0]!)) {
+    fail(`budget key "${key}" is not a ggsvelte lib — peers get no absolute budgets`);
+  }
+  if (
+    typeof entry.budgetMs !== "number" ||
+    !Number.isFinite(entry.budgetMs) ||
+    entry.budgetMs <= 0
+  ) {
+    fail(`malformed budget entry for "${key}": ${JSON.stringify(entry)}`);
+  }
+}
+
+const knownGaps = budgetsFile.knownGaps ?? [];
+for (const gap of knownGaps) {
+  if (
+    !isGgsvelte(gap.ggsvelte) ||
+    !isPeer(gap.peer) ||
+    typeof gap.caseId !== "string" ||
+    (gap.kind !== "mount" && gap.kind !== "update") ||
+    typeof gap.issue !== "string" ||
+    gap.issue.length === 0
+  ) {
+    fail(`malformed knownGaps entry: ${JSON.stringify(gap)}`);
+  }
+  if (gap.kind === "update" && !measuresUpdate) {
+    fail(
+      `knownGaps entry covers "update" but results/browser.json has measuresUpdate=false: ${JSON.stringify(gap)}`,
+    );
+  }
+}
+
+// --- 1. absolute budgets (ggsvelte cells only) --------------------------------
+
+const ggsvelteResults = results.filter((r) => isGgsvelte(r.lib));
+const budgetKey = (r: BrowserResult, kind: Kind) => `${r.lib} ${r.caseId} ${kind}`;
+
+const cellKeys = new Set(ggsvelteResults.flatMap((r) => KINDS.map((k) => budgetKey(r, k))));
+const missingBudgets = [...cellKeys].filter((key) => !(key in budgets));
+if (missingBudgets.length > 0) {
+  fail(
+    `ggsvelte cells without a budget (add them to benchmarks/competitive/budgets.json): ${missingBudgets.join(", ")}`,
+  );
+}
+const staleBudgets = Object.keys(budgets).filter((key) => !cellKeys.has(key));
+if (staleBudgets.length > 0) {
+  fail(
+    `budget entries with no result cell (stale? remove or re-run measure:browser): ${staleBudgets.join(", ")}`,
+  );
+}
+
+let failures = 0;
+
+const absNameWidth = Math.max(...[...cellKeys].map((k) => k.length), "cell".length);
+console.log(
+  [
+    "cell".padEnd(absNameWidth),
+    "measured".padStart(13),
+    "budget".padStart(13),
+    "headroom".padStart(9),
+    "",
+  ].join("  "),
+);
+for (const r of ggsvelteResults) {
+  for (const kind of KINDS) {
+    const key = budgetKey(r, kind);
+    const budgetMs = budgets[key]!.budgetMs;
+    if (!r.ok) {
+      failures++;
+      console.log(
+        key.padEnd(absNameWidth),
+        "ERROR".padStart(13),
+        `${budgetMs.toFixed(1).padStart(10)} ms`,
+        "".padStart(9),
+        `OVER BUDGET (cell errored: ${(r.error ?? "").slice(0, 60)})`,
+      );
+      continue;
+    }
+    const measured = medianOf(r, kind)!;
+    const over = measured > budgetMs;
+    if (over) failures++;
+    const headroomPct = ((budgetMs - measured) / budgetMs) * 100;
+    console.log(
+      [
+        key.padEnd(absNameWidth),
+        `${measured.toFixed(1).padStart(10)} ms`,
+        `${budgetMs.toFixed(1).padStart(10)} ms`,
+        `${headroomPct.toFixed(1).padStart(7)} %`,
+        over ? "OVER BUDGET" : "ok",
+      ].join("  "),
+    );
+  }
+}
+
+// --- 2. relative gate: ggsvelte vs Svelte peers, same form factor -------------
+
+const erroredPeers = results.filter((r) => isPeer(r.lib) && !r.ok);
+for (const r of erroredPeers) {
+  failures++;
+  console.error(
+    `check-budgets: peer cell errored outright (fixture broken?): ${r.lib} ${r.caseId}: ${(r.error ?? "").slice(0, 120)}`,
+  );
+}
+
+const okGgsvelte = ggsvelteResults.filter((r) => r.ok);
+const okPeers = results.filter((r) => isPeer(r.lib) && r.ok);
+
+type Comparison = {
+  kind: Kind;
+  caseId: string;
+  ggLib: string;
+  peerLib: string;
+  ggMs: number;
+  peerMs: number;
+  ratio: number;
+  pass: boolean;
+  /** Same-form peer pair that is GATED, vs cross-form context that is not. */
+  gated: boolean;
+  gap?: KnownGap;
+};
+const comparisons: Comparison[] = [];
+for (const gg of okGgsvelte) {
+  for (const peer of okPeers) {
+    if (peer.caseId !== gg.caseId) continue;
+    const sameForm = FORM_BY_LIB.get(gg.lib as never) === FORM_BY_LIB.get(peer.lib as never);
+    for (const kind of KINDS) {
+      const ggMs = medianOf(gg, kind)!;
+      const peerMs = medianOf(peer, kind)!;
+      const ratio = ggMs / peerMs;
+      const pass = withinGate(ggMs, peerMs);
+      const gap = knownGaps.find(
+        (g) =>
+          g.ggsvelte === gg.lib && g.peer === peer.lib && g.caseId === gg.caseId && g.kind === kind,
+      );
+      comparisons.push({
+        kind,
+        caseId: gg.caseId,
+        ggLib: gg.lib,
+        peerLib: peer.lib,
+        ggMs,
+        peerMs,
+        ratio,
+        pass,
+        gated: sameForm,
+        gap,
+      });
+    }
+  }
+}
+
+if (comparisons.length === 0) {
+  fail(
+    "no ggsvelte-vs-peer comparisons possible — are peer cells missing from results/browser.json?",
+  );
+}
+
+const knownGapKeys = new Set(knownGaps.map((g) => `${g.ggsvelte}|${g.peer}|${g.caseId}|${g.kind}`));
+const seenGapKeys = new Set<string>();
+
+for (const c of comparisons) {
+  if (!c.gated) continue; // cross-form context: printed, never gated
+  if (c.gap) {
+    seenGapKeys.add(`${c.gap.ggsvelte}|${c.gap.peer}|${c.gap.caseId}|${c.gap.kind}`);
+    if (c.pass) {
+      // Ratchet: the gap CLOSED — the exemption is now stale and must go.
+      failures++;
+      console.error(
+        `check-budgets: known gap CLOSED (ggsvelte ${c.ggMs.toFixed(1)}ms <= ${c.peerLib} ${c.peerMs.toFixed(1)}ms on ${c.caseId} ${c.kind}) — remove the exemption from budgets.json knownGaps (${c.gap.issue})`,
+      );
+    }
+    continue;
+  }
+  if (!c.pass) failures++;
+}
+for (const key of knownGapKeys) {
+  if (!seenGapKeys.has(key)) {
+    failures++;
+    console.error(
+      `check-budgets: knownGaps entry matched no gated comparison (stale exemption?): ${key}`,
+    );
+  }
+}
+
+const colW = (sel: (c: Comparison) => string, min: string) =>
+  Math.max(...comparisons.map((c) => sel(c).length), min.length);
+
+console.log("\n=== Relative gate: ggsvelte vs Svelte peers (median, same run) ===\n");
+console.log(
+  [
+    "kind".padEnd(6),
+    "case".padEnd(colW((c) => c.caseId, "case")),
+    "ggsvelte".padEnd(colW((c) => c.ggLib, "ggsvelte")),
+    "peer".padEnd(colW((c) => c.peerLib, "peer")),
+    "ggsvelte ms".padStart(12),
+    "peer ms".padStart(12),
+    "ratio".padStart(7),
+    "verdict",
+  ].join("  "),
+);
+for (const c of comparisons) {
+  const verdict = !c.gated
+    ? "info (cross-form)"
+    : c.gap
+      ? c.pass
+        ? `STALE GAP — remove exemption (${c.gap.issue})`
+        : `known gap (${c.gap.issue})`
+      : c.pass
+        ? "PASS"
+        : "FAIL";
+  console.log(
+    [
+      c.kind.padEnd(6),
+      c.caseId.padEnd(colW((x) => x.caseId, "case")),
+      c.ggLib.padEnd(colW((x) => x.ggLib, "ggsvelte")),
+      c.peerLib.padEnd(colW((x) => x.peerLib, "peer")),
+      c.ggMs.toFixed(1).padStart(12),
+      c.peerMs.toFixed(1).padStart(12),
+      c.ratio.toFixed(3).padStart(7),
+      verdict,
+    ].join("  "),
+  );
+}
+
+// --- verdict -----------------------------------------------------------------
+
+if (failures > 0) {
+  console.error(`\ncheck-budgets: ${failures} violation(s)`);
+  process.exit(1);
+}
+console.log(
+  `\ncheck-budgets: ${ggsvelteResults.length} ggsvelte cells within budget; ${comparisons.filter((c) => c.gated).length} gated peer comparison(s) PASS`,
+);

--- a/benchmarks/competitive/components/layercake/AreaChart.svelte
+++ b/benchmarks/competitive/components/layercake/AreaChart.svelte
@@ -1,17 +1,6 @@
 <script>
   import { LayerCake, Svg } from "layercake";
-  import { scaleOrdinal } from "d3-scale";
-  import ScatterSvg from "./ScatterSvg.svelte";
-
-  const COLORS = [
-    "#4e79a7",
-    "#f28e2b",
-    "#e15759",
-    "#76b7b2",
-    "#59a14f",
-    "#edc948",
-    "#b07aa1",
-  ];
+  import AreaSvg from "./AreaSvg.svelte";
 
   let { rows: initialRows, width = 800, height = 500 } = $props();
   // Plain-props mount (zero proxy cost); updates flow through the exported
@@ -28,13 +17,10 @@
     data={rows}
     x="x"
     y="y"
-    z="cls"
-    zScale={scaleOrdinal()}
-    zRange={COLORS}
     padding={{ top: 20, right: 20, bottom: 40, left: 50 }}
   >
     <Svg>
-      <ScatterSvg />
+      <AreaSvg />
     </Svg>
   </LayerCake>
 </div>

--- a/benchmarks/competitive/components/layercake/AreaSvg.svelte
+++ b/benchmarks/competitive/components/layercake/AreaSvg.svelte
@@ -1,0 +1,34 @@
+<script>
+  import { getContext } from "svelte";
+  import { area as d3Area } from "d3-shape";
+
+  const { data, xGet, yGet, height } = getContext("LayerCake");
+
+  // IDENTITY position: baseline is the plot floor ($height), matching the raw
+  // d3 adapter's areaGen.y0(ih) — overlaid areas, NOT stacked (fair vs
+  // competitors; see #1357).
+  const grouped = $derived.by(() => {
+    const bySeries = new Map();
+    for (const d of $data) {
+      let pts = bySeries.get(d.series);
+      if (pts === undefined) {
+        pts = [];
+        bySeries.set(d.series, pts);
+      }
+      pts.push(d);
+    }
+    const gen = d3Area()
+      .x((d) => $xGet(d))
+      .y0($height)
+      .y1((d) => $yGet(d));
+    return [...bySeries.entries()].map(([series, pts]) => ({
+      series,
+      color: pts[0].color,
+      d: gen(pts),
+    }));
+  });
+</script>
+
+{#each grouped as g (g.series)}
+  <path d={g.d} fill={g.color} fill-opacity={0.4} stroke="none" />
+{/each}

--- a/benchmarks/competitive/components/layercake/BarsChart.svelte
+++ b/benchmarks/competitive/components/layercake/BarsChart.svelte
@@ -1,17 +1,7 @@
 <script>
   import { LayerCake, Svg } from "layercake";
-  import { scaleOrdinal } from "d3-scale";
-  import ScatterSvg from "./ScatterSvg.svelte";
-
-  const COLORS = [
-    "#4e79a7",
-    "#f28e2b",
-    "#e15759",
-    "#76b7b2",
-    "#59a14f",
-    "#edc948",
-    "#b07aa1",
-  ];
+  import { scaleBand } from "d3-scale";
+  import StackedBarsSvg from "./StackedBarsSvg.svelte";
 
   let { rows: initialRows, width = 800, height = 500 } = $props();
   // Plain-props mount (zero proxy cost); updates flow through the exported
@@ -26,15 +16,13 @@
 <div style="width:{width}px; height:{height}px; position:relative;">
   <LayerCake
     data={rows}
-    x="x"
-    y="y"
-    z="cls"
-    zScale={scaleOrdinal()}
-    zRange={COLORS}
+    x="category"
+    y={["y0", "y1"]}
+    xScale={scaleBand().padding(0.1)}
     padding={{ top: 20, right: 20, bottom: 40, left: 50 }}
   >
     <Svg>
-      <ScatterSvg />
+      <StackedBarsSvg />
     </Svg>
   </LayerCake>
 </div>

--- a/benchmarks/competitive/components/layercake/LineCanvas.svelte
+++ b/benchmarks/competitive/components/layercake/LineCanvas.svelte
@@ -1,0 +1,45 @@
+<script>
+  import { getContext } from "svelte";
+  import { scaleCanvas } from "layercake";
+
+  const { data, xGet, yGet, width, height } = getContext("LayerCake");
+  const { ctx } = getContext("canvas");
+
+  // Reactive one-pass draw (same pattern as ScatterCanvas): re-runs when the
+  // ctx store appears and on every $data change, stroking one polyline per
+  // series. clearRect resets the frame so updates don't paint over stale
+  // marks.
+  $effect(() => {
+    const c = $ctx;
+    if (c === null) return;
+    const rows = $data;
+    const w = $width;
+    const h = $height;
+    scaleCanvas(c, w, h);
+    c.clearRect(0, 0, w, h);
+    const bySeries = new Map();
+    for (const d of rows) {
+      let pts = bySeries.get(d.series);
+      if (pts === undefined) {
+        pts = [];
+        bySeries.set(d.series, pts);
+      }
+      pts.push(d);
+    }
+    c.lineWidth = 1.5;
+    for (const pts of bySeries.values()) {
+      c.strokeStyle = pts[0].color;
+      c.beginPath();
+      for (let i = 0; i < pts.length; i++) {
+        const px = $xGet(pts[i]);
+        const py = $yGet(pts[i]);
+        if (i === 0) {
+          c.moveTo(px, py);
+        } else {
+          c.lineTo(px, py);
+        }
+      }
+      c.stroke();
+    }
+  });
+</script>

--- a/benchmarks/competitive/components/layercake/LineCanvasChart.svelte
+++ b/benchmarks/competitive/components/layercake/LineCanvasChart.svelte
@@ -1,17 +1,6 @@
 <script>
-  import { LayerCake, Svg } from "layercake";
-  import { scaleOrdinal } from "d3-scale";
-  import ScatterSvg from "./ScatterSvg.svelte";
-
-  const COLORS = [
-    "#4e79a7",
-    "#f28e2b",
-    "#e15759",
-    "#76b7b2",
-    "#59a14f",
-    "#edc948",
-    "#b07aa1",
-  ];
+  import { LayerCake, Canvas } from "layercake";
+  import LineCanvas from "./LineCanvas.svelte";
 
   let { rows: initialRows, width = 800, height = 500 } = $props();
   // Plain-props mount (zero proxy cost); updates flow through the exported
@@ -28,13 +17,10 @@
     data={rows}
     x="x"
     y="y"
-    z="cls"
-    zScale={scaleOrdinal()}
-    zRange={COLORS}
     padding={{ top: 20, right: 20, bottom: 40, left: 50 }}
   >
-    <Svg>
-      <ScatterSvg />
-    </Svg>
+    <Canvas>
+      <LineCanvas />
+    </Canvas>
   </LayerCake>
 </div>

--- a/benchmarks/competitive/components/layercake/LineChart.svelte
+++ b/benchmarks/competitive/components/layercake/LineChart.svelte
@@ -1,0 +1,19 @@
+<script>
+  import { LayerCake, Svg } from "layercake";
+  import MultiLineSvg from "./MultiLineSvg.svelte";
+
+  let { rows, width = 800, height = 500 } = $props();
+</script>
+
+<div style="width:{width}px; height:{height}px; position:relative;">
+  <LayerCake
+    data={rows}
+    x="x"
+    y="y"
+    padding={{ top: 20, right: 20, bottom: 40, left: 50 }}
+  >
+    <Svg>
+      <MultiLineSvg />
+    </Svg>
+  </LayerCake>
+</div>

--- a/benchmarks/competitive/components/layercake/LineChart.svelte
+++ b/benchmarks/competitive/components/layercake/LineChart.svelte
@@ -2,7 +2,14 @@
   import { LayerCake, Svg } from "layercake";
   import MultiLineSvg from "./MultiLineSvg.svelte";
 
-  let { rows, width = 800, height = 500 } = $props();
+  let { rows: initialRows, width = 800, height = 500 } = $props();
+  // Plain-props mount (zero proxy cost); updates flow through the exported
+  // setRows — component exports land on the object returned by svelte's
+  // mount(). $state.raw: 30k-row datasets must NOT be deep-proxied.
+  let rows = $state.raw(initialRows);
+  export function setRows(next) {
+    rows = next;
+  }
 </script>
 
 <div style="width:{width}px; height:{height}px; position:relative;">

--- a/benchmarks/competitive/components/layercake/MultiLineSvg.svelte
+++ b/benchmarks/competitive/components/layercake/MultiLineSvg.svelte
@@ -1,0 +1,32 @@
+<script>
+  import { getContext } from "svelte";
+  import { line as d3line } from "d3-shape";
+
+  const { data, xGet, yGet } = getContext("LayerCake");
+
+  // Group rows by series, then compute one path `d` per series from the
+  // LayerCake getters. Done in a single $derived so $-store reads stay valid.
+  const grouped = $derived.by(() => {
+    const bySeries = new Map();
+    for (const d of $data) {
+      let pts = bySeries.get(d.series);
+      if (pts === undefined) {
+        pts = [];
+        bySeries.set(d.series, pts);
+      }
+      pts.push(d);
+    }
+    const gen = d3line()
+      .x((d) => $xGet(d))
+      .y((d) => $yGet(d));
+    return [...bySeries.entries()].map(([series, pts]) => ({
+      series,
+      color: pts[0].color,
+      d: gen(pts),
+    }));
+  });
+</script>
+
+{#each grouped as g (g.series)}
+  <path d={g.d} stroke={g.color} fill="none" stroke-width={1.5} />
+{/each}

--- a/benchmarks/competitive/components/layercake/ScatterCanvas.svelte
+++ b/benchmarks/competitive/components/layercake/ScatterCanvas.svelte
@@ -1,0 +1,30 @@
+<script>
+  import { getContext } from "svelte";
+  import { scaleCanvas } from "layercake";
+
+  const { data, xGet, yGet, zGet, width, height } = getContext("LayerCake");
+  const { ctx } = getContext("canvas");
+
+  // Reactive one-pass draw: re-runs when the Canvas layout's ctx store first
+  // appears (parent onMount sets it) AND on every later $data change — the
+  // in-place update path for the update scoreboard. scaleCanvas makes the
+  // backing store devicePixelRatio-aware (idempotent — the layout already
+  // called it with the same dims); clearRect resets the frame so updates
+  // don't paint over stale marks.
+  $effect(() => {
+    const c = $ctx;
+    if (c === null) return;
+    const rows = $data;
+    const w = $width;
+    const h = $height;
+    scaleCanvas(c, w, h);
+    c.clearRect(0, 0, w, h);
+    c.globalAlpha = 0.7;
+    for (const d of rows) {
+      c.fillStyle = $zGet(d);
+      c.beginPath();
+      c.arc($xGet(d), $yGet(d), 1.5, 0, Math.PI * 2);
+      c.fill();
+    }
+  });
+</script>

--- a/benchmarks/competitive/components/layercake/ScatterCanvasChart.svelte
+++ b/benchmarks/competitive/components/layercake/ScatterCanvasChart.svelte
@@ -1,7 +1,7 @@
 <script>
-  import { LayerCake, Svg } from "layercake";
+  import { LayerCake, Canvas } from "layercake";
   import { scaleOrdinal } from "d3-scale";
-  import ScatterSvg from "./ScatterSvg.svelte";
+  import ScatterCanvas from "./ScatterCanvas.svelte";
 
   const COLORS = [
     "#4e79a7",
@@ -33,8 +33,8 @@
     zRange={COLORS}
     padding={{ top: 20, right: 20, bottom: 40, left: 50 }}
   >
-    <Svg>
-      <ScatterSvg />
-    </Svg>
+    <Canvas>
+      <ScatterCanvas />
+    </Canvas>
   </LayerCake>
 </div>

--- a/benchmarks/competitive/components/layercake/ScatterChart.svelte
+++ b/benchmarks/competitive/components/layercake/ScatterChart.svelte
@@ -1,0 +1,32 @@
+<script>
+  import { LayerCake, Svg } from "layercake";
+  import { scaleOrdinal } from "d3-scale";
+  import ScatterSvg from "./ScatterSvg.svelte";
+
+  const COLORS = [
+    "#4e79a7",
+    "#f28e2b",
+    "#e15759",
+    "#76b7b2",
+    "#59a14f",
+    "#edc948",
+    "#b07aa1",
+  ];
+
+  let { rows, width = 800, height = 500 } = $props();
+</script>
+
+<div style="width:{width}px; height:{height}px; position:relative;">
+  <LayerCake
+    data={rows}
+    x="x"
+    y="y"
+    z="cls"
+    zScale={scaleOrdinal().range(COLORS)}
+    padding={{ top: 20, right: 20, bottom: 40, left: 50 }}
+  >
+    <Svg>
+      <ScatterSvg />
+    </Svg>
+  </LayerCake>
+</div>

--- a/benchmarks/competitive/components/layercake/ScatterSvg.svelte
+++ b/benchmarks/competitive/components/layercake/ScatterSvg.svelte
@@ -1,0 +1,15 @@
+<script>
+  import { getContext } from "svelte";
+
+  const { data, xGet, yGet, zGet } = getContext("LayerCake");
+</script>
+
+{#each $data as d}
+  <circle
+    cx={$xGet(d)}
+    cy={$yGet(d)}
+    r={1.5}
+    fill={$zGet(d)}
+    fill-opacity={0.7}
+  />
+{/each}

--- a/benchmarks/competitive/components/layercake/StackedBarsSvg.svelte
+++ b/benchmarks/competitive/components/layercake/StackedBarsSvg.svelte
@@ -1,0 +1,20 @@
+<script>
+  import { getContext } from "svelte";
+
+  const { data, xScale, yScale } = getContext("LayerCake");
+
+  // Rows are long-form with stacked offsets precomputed by the adapter via
+  // d3-shape stack(): { category, y0, y1, stack, color }. x is a band scale
+  // (passed as xScale on <LayerCake>); y domain covers the stacked totals
+  // because the y accessor spans [y0, y1].
+</script>
+
+{#each $data as d}
+  <rect
+    x={$xScale(d.category)}
+    y={$yScale(d.y1)}
+    width={$xScale.bandwidth()}
+    height={Math.max(0, $yScale(d.y0) - $yScale(d.y1))}
+    fill={d.color}
+  />
+{/each}

--- a/benchmarks/competitive/components/svelteplot/AreaChart.svelte
+++ b/benchmarks/competitive/components/svelteplot/AreaChart.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Plot, Line, GridX, GridY } from "svelteplot";
+  import { Plot, AreaY, GridX, GridY } from "svelteplot";
 
   type Row = { x: number; y: number; series: string };
   let {
@@ -19,5 +19,10 @@
 <Plot {width} {height}>
   <GridX />
   <GridY />
-  <Line data={rows} x="x" y="y" stroke="series" strokeWidth={1.5} />
+  <!-- IDENTITY position: AreaY implicitly applies stackY only when the y1/y2
+       channels are absent (dist/transforms/stack.js stackXY early-returns when
+       y1 or y2 is set). Passing an explicit baseline y1=0 + topline y2="y"
+       therefore yields overlaid, non-stacked areas — fair vs competitors
+       (#1357). -->
+  <AreaY data={rows} x="x" y1={0} y2="y" fill="series" fillOpacity={0.4} />
 </Plot>

--- a/benchmarks/competitive/components/svelteplot/BarsChart.svelte
+++ b/benchmarks/competitive/components/svelteplot/BarsChart.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import { Plot, Line, GridX, GridY } from "svelteplot";
+  import { Plot, BarY, GridX, GridY } from "svelteplot";
 
-  type Row = { x: number; y: number; series: string };
+  type Row = { category: string; value: number; stack: string };
   let {
     rows: initialRows,
     width,
@@ -19,5 +19,9 @@
 <Plot {width} {height}>
   <GridX />
   <GridY />
-  <Line data={rows} x="x" y="y" stroke="series" strokeWidth={1.5} />
+  <!-- Genuinely stacked: BarY applies stackY by default (dist/marks/BarY.svelte),
+       grouping layers by the fill channel. x gets a band scale automatically
+       (BarY declares requiredScales x: ['band']). Colors come from svelteplot's
+       default categorical range — same posture as the scatter/line fixtures. -->
+  <BarY data={rows} x="category" y="value" fill="stack" />
 </Plot>

--- a/benchmarks/competitive/components/svelteplot/LineChart.svelte
+++ b/benchmarks/competitive/components/svelteplot/LineChart.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import { Plot, Line, GridX, GridY } from "svelteplot";
+
+  type Row = { x: number; y: number; series: string };
+  let { rows, width, height }: { rows: Row[]; width: number; height: number } =
+    $props();
+</script>
+
+<Plot {width} {height}>
+  <GridX />
+  <GridY />
+  <Line data={rows} x="x" y="y" stroke="series" strokeWidth={1.5} />
+</Plot>

--- a/benchmarks/competitive/components/svelteplot/ScatterChart.svelte
+++ b/benchmarks/competitive/components/svelteplot/ScatterChart.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import { Plot, Dot, GridX, GridY } from "svelteplot";
+
+  type Row = { x: number; y: number; cls: string };
+  let { rows, width, height }: { rows: Row[]; width: number; height: number } =
+    $props();
+</script>
+
+<Plot {width} {height}>
+  <GridX />
+  <GridY />
+  <Dot data={rows} x="x" y="y" fill="cls" r={1.5} fillOpacity={0.7} />
+</Plot>

--- a/benchmarks/competitive/components/svelteplot/ScatterChart.svelte
+++ b/benchmarks/competitive/components/svelteplot/ScatterChart.svelte
@@ -2,8 +2,18 @@
   import { Plot, Dot, GridX, GridY } from "svelteplot";
 
   type Row = { x: number; y: number; cls: string };
-  let { rows, width, height }: { rows: Row[]; width: number; height: number } =
-    $props();
+  let {
+    rows: initialRows,
+    width,
+    height,
+  }: { rows: Row[]; width: number; height: number } = $props();
+  // Plain-props mount (zero proxy cost); updates flow through the exported
+  // setRows — component exports land on the object returned by svelte's
+  // mount(). $state.raw: 30k-row datasets must NOT be deep-proxied.
+  let rows = $state.raw(initialRows);
+  export function setRows(next: Row[]) {
+    rows = next;
+  }
 </script>
 
 <Plot {width} {height}>

--- a/benchmarks/competitive/entries/layercake__area-multiseries.ts
+++ b/benchmarks/competitive/entries/layercake__area-multiseries.ts
@@ -1,0 +1,6 @@
+import { LayerCake, Svg } from "layercake";
+import { extent } from "d3-array";
+import { scaleLinear, scaleOrdinal } from "d3-scale";
+import { area as d3Area } from "d3-shape";
+
+export { LayerCake, Svg, d3Area, extent, scaleLinear, scaleOrdinal };

--- a/benchmarks/competitive/entries/layercake__bars-stacked.ts
+++ b/benchmarks/competitive/entries/layercake__bars-stacked.ts
@@ -1,0 +1,6 @@
+import { LayerCake, Svg } from "layercake";
+import { extent } from "d3-array";
+import { scaleBand, scaleLinear, scaleOrdinal } from "d3-scale";
+import { stack as d3Stack } from "d3-shape";
+
+export { LayerCake, Svg, d3Stack, extent, scaleBand, scaleLinear, scaleOrdinal };

--- a/benchmarks/competitive/entries/layercake__line-multiseries.ts
+++ b/benchmarks/competitive/entries/layercake__line-multiseries.ts
@@ -1,0 +1,5 @@
+import { LayerCake, Svg } from "layercake";
+import { extent } from "d3-array";
+import { scaleLinear, scaleOrdinal } from "d3-scale";
+
+export { LayerCake, Svg, extent, scaleLinear, scaleOrdinal };

--- a/benchmarks/competitive/entries/svelteplot__area-multiseries.ts
+++ b/benchmarks/competitive/entries/svelteplot__area-multiseries.ts
@@ -1,0 +1,3 @@
+import { AreaY, GridX, GridY, Plot } from "svelteplot";
+
+export { AreaY, GridX, GridY, Plot };

--- a/benchmarks/competitive/entries/svelteplot__bars-stacked.ts
+++ b/benchmarks/competitive/entries/svelteplot__bars-stacked.ts
@@ -1,0 +1,3 @@
+import { BarY, GridX, GridY, Plot } from "svelteplot";
+
+export { BarY, GridX, GridY, Plot };

--- a/benchmarks/competitive/entries/svelteplot__line-multiseries.ts
+++ b/benchmarks/competitive/entries/svelteplot__line-multiseries.ts
@@ -1,0 +1,3 @@
+import { GridX, GridY, Line, Plot } from "svelteplot";
+
+export { GridX, GridY, Line, Plot };

--- a/benchmarks/competitive/fixtures/main.ts
+++ b/benchmarks/competitive/fixtures/main.ts
@@ -15,6 +15,8 @@ import { mountD3 } from "../adapters/d3";
 import { mountEcharts } from "../adapters/echarts";
 import { mountGgsvelteCanvas } from "../adapters/ggsvelte-canvas";
 import { mountGgsvelteSvg } from "../adapters/ggsvelte-svg";
+import { mountLayerCake } from "../adapters/layercake";
+import { mountSveltePlot } from "../adapters/svelteplot";
 import { mountUplot } from "../adapters/uplot";
 import {
   CASES,
@@ -77,6 +79,14 @@ function mountSync(
     }
     case "echarts": {
       const r = mountEcharts(scenario, data, root);
+      return { markHint: r.markHint, handle: r.handle };
+    }
+    case "svelteplot": {
+      const r = mountSveltePlot(scenario, data, root);
+      return { markHint: r.markHint, handle: r.handle };
+    }
+    case "layercake": {
+      const r = mountLayerCake(scenario, data, root);
       return { markHint: r.markHint, handle: r.handle };
     }
     default:

--- a/benchmarks/competitive/fixtures/main.ts
+++ b/benchmarks/competitive/fixtures/main.ts
@@ -2,6 +2,8 @@
  * Browser harness API for Playwright:
  *   window.competitiveBench.mount(lib, caseId) -> { ms, markHint }
  *   window.competitiveBench.replace(lib, caseId) -> { ms }  // full remount with fresh data seed
+ *   window.competitiveBench.update(lib, caseId) -> { ms }   // IN-PLACE update (second scoreboard)
+ *   window.competitiveBench.endUpdate()                    // teardown the live update cell
  *   window.competitiveBench.list() -> { libs, cases }
  *   window.competitiveBench.clear()
  *
@@ -9,27 +11,50 @@
  * frames so layout/paint can flush (closer to LightningChart-style "visible on
  * screen" than pure JS-only timers). Small cases therefore sit near a ~1–2
  * frame floor; discriminate on denser cases (e.g. line-3x10k, scatter-10k).
+ *
+ * Update axis: the first update(lib, caseId) call for a cell mounts UNTIMED
+ * and keeps the handle alive page-side; later calls time handle.update(data)
+ * with the same double-rAF pattern. Data alternates between two determinis-
+ * tic perturbations of the mount dataset so no lib can no-op on identical
+ * input. Switching cells or calling mount()/replace() destroys the live
+ * update handle first.
  */
 import { mountChartJs } from "../adapters/chartjs";
 import { mountD3 } from "../adapters/d3";
 import { mountEcharts } from "../adapters/echarts";
 import { mountGgsvelteCanvas } from "../adapters/ggsvelte-canvas";
 import { mountGgsvelteSvg } from "../adapters/ggsvelte-svg";
-import { mountLayerCake } from "../adapters/layercake";
+import { mountLayerCake, mountLayerCakeCanvas } from "../adapters/layercake";
 import { mountSveltePlot } from "../adapters/svelteplot";
 import { mountUplot } from "../adapters/uplot";
 import {
   CASES,
   dataForCase,
   LIBS,
+  type BarsColumns,
   type LibId,
   type ScenarioCase,
   type ScenarioId,
+  type ScatterColumns,
+  type SeriesColumns,
 } from "../scenarios";
 
-type Destroyable = { destroy: () => void };
+type UpdateColumns = ScatterColumns | SeriesColumns | BarsColumns;
 
-let liveHandle: Destroyable | null = null;
+type MountHandle = {
+  destroy: () => void;
+  update?: (data: UpdateColumns) => void;
+};
+
+let liveHandle: MountHandle | null = null;
+
+type UpdateSlot = {
+  key: string;
+  caseData: UpdateColumns;
+  calls: number;
+  handle: MountHandle & { update: (data: UpdateColumns) => void };
+};
+let updateSlot: UpdateSlot | null = null;
 
 function caseById(id: string): ScenarioCase {
   const found = CASES.find((c) => c.id === id);
@@ -48,6 +73,61 @@ function destroyLive(): void {
   }
 }
 
+/** Teardown the live update cell (called by the harness after the last sample
+ * of a cell; also automatic on any cell switch / mount / replace). */
+function endUpdate(): void {
+  if (updateSlot !== null) {
+    try {
+      updateSlot.handle.destroy();
+    } catch {
+      // ignore teardown errors between cells
+    }
+    updateSlot = null;
+  }
+}
+
+/** Rotate a trailing numeric label suffix ("series-3" / "stack-1") by shift.
+ * Deterministic; the label SET stays identical so per-name color domains and
+ * series counts don't change across update variants. */
+function rotateLabel(label: string, shift: number, count: number): string {
+  const m = /^(.*?)(\d+)$/.exec(label);
+  if (m === null || count <= 0) return label;
+  const idx = (Number.parseInt(m[2]!, 10) + shift) % count;
+  return `${m[1]}${idx}`;
+}
+
+/**
+ * Deterministic perturbation of the mount dataset for the update scoreboard:
+ * same shape/size, different values (y' = y*0.9 + 5*variant), cls/stack
+ * labels rotated by the variant. Two variants alternate across successive
+ * update calls so no lib can no-op on identical data. Series names for
+ * line/area stay stable (uPlot/Chart.js series counts are fixed at mount).
+ */
+function perturbed(data: UpdateColumns, variant: 1 | 2): UpdateColumns {
+  const bump = variant * 5;
+  if ("cls" in data) {
+    const classes = new Set(data.cls).size;
+    return {
+      x: data.x,
+      y: data.y.map((v) => v * 0.9 + bump),
+      cls: data.cls.map((c) => rotateLabel(c, variant, classes)),
+    };
+  }
+  if ("series" in data) {
+    return {
+      x: data.x,
+      y: data.y.map((v) => v * 0.9 + bump),
+      series: data.series,
+    };
+  }
+  const stacks = new Set(data.stack).size;
+  return {
+    category: data.category,
+    value: data.value.map((v) => v * 0.9 + bump),
+    stack: data.stack.map((s) => rotateLabel(s, variant, stacks)),
+  };
+}
+
 async function afterPaint(): Promise<void> {
   await new Promise<void>((resolve) => {
     requestAnimationFrame(() => {
@@ -61,7 +141,7 @@ function mountSync(
   scenario: ScenarioId,
   data: ReturnType<typeof dataForCase>,
   root: HTMLElement,
-): { markHint: number; handle?: Destroyable } {
+): { markHint: number; handle?: MountHandle } {
   switch (lib) {
     case "ggsvelte-svg":
       return mountGgsvelteSvg(scenario, data, root);
@@ -89,6 +169,10 @@ function mountSync(
       const r = mountLayerCake(scenario, data, root);
       return { markHint: r.markHint, handle: r.handle };
     }
+    case "layercake-canvas": {
+      const r = mountLayerCakeCanvas(scenario, data, root);
+      return { markHint: r.markHint, handle: r.handle };
+    }
     default:
       throw new Error(
         `lib ${lib} has no browser harness (bundle-only peer — see scenarios.ts LIBS)`,
@@ -107,6 +191,7 @@ async function mountLib(lib: string, caseId: string): Promise<{ ms: number; mark
 
   const mountEl = document.querySelector("#mount") as HTMLElement;
   const status = document.querySelector("#status") as HTMLElement;
+  endUpdate();
   destroyLive();
   mountEl.replaceChildren();
 
@@ -126,7 +211,51 @@ async function replaceLib(lib: string, caseId: string): Promise<{ ms: number }> 
   return { ms: result.ms };
 }
 
+/**
+ * IN-PLACE update (second scoreboard axis). First call for a (lib, caseId)
+ * cell mounts once UNTIMED and keeps the handle alive page-side; subsequent
+ * calls time handle.update(variantData) paint-inclusive with the same
+ * double-rAF pattern as mount. Data alternates between two deterministic
+ * perturbations so no lib can no-op on identical input.
+ */
+async function updateLib(lib: string, caseId: string): Promise<{ ms: number }> {
+  const key = `${lib}::${caseId}`;
+  if (updateSlot === null || updateSlot.key !== key) {
+    endUpdate();
+    destroyLive();
+    const c = caseById(caseId);
+    const meta = LIBS.find((l) => l.id === lib);
+    if (meta === undefined) throw new Error(`unknown lib ${lib}`);
+    if (!meta.browser) throw new Error(`${lib} is bundle-only in this harness`);
+    if (!meta.scenarios.includes(c.scenario)) {
+      throw new Error(`${lib} does not support scenario ${c.scenario}`);
+    }
+    const mountEl = document.querySelector("#mount") as HTMLElement;
+    mountEl.replaceChildren();
+    const data = dataForCase(c);
+    // UNTIMED mount — establishes the live handle this cell updates in place.
+    const result = mountSync(lib as LibId, c.scenario, data, mountEl);
+    const handle = result.handle;
+    if (handle === undefined || typeof handle.update !== "function") {
+      throw new Error(`${lib} has no in-place update path (update scoreboard)`);
+    }
+    updateSlot = { key, caseData: data, calls: 0, handle: handle as UpdateSlot["handle"] };
+  }
+  const slot = updateSlot;
+  slot.calls += 1;
+  const variant = (slot.calls % 2 === 1 ? 1 : 2) as 1 | 2;
+  const next = perturbed(slot.caseData, variant);
+  const status = document.querySelector("#status") as HTMLElement;
+  const t0 = performance.now();
+  slot.handle.update(next);
+  await afterPaint();
+  const ms = performance.now() - t0;
+  status.textContent = `${lib} ${caseId} update=${ms.toFixed(2)}ms variant=${variant}`;
+  return { ms };
+}
+
 function clearMount(): void {
+  endUpdate();
   destroyLive();
   document.querySelector("#mount")?.replaceChildren();
 }
@@ -155,8 +284,9 @@ declare global {
     competitiveBench: {
       mount: typeof mountLib;
       replace: typeof replaceLib;
-      /** @deprecated use replace — kept for older measure-browser callers */
-      update: typeof replaceLib;
+      /** In-place update scoreboard (previously a deprecated replace alias). */
+      update: typeof updateLib;
+      endUpdate: typeof endUpdate;
       clear: typeof clearMount;
       list: typeof listCatalog;
     };
@@ -166,7 +296,8 @@ declare global {
 window.competitiveBench = {
   mount: mountLib,
   replace: replaceLib,
-  update: replaceLib,
+  update: updateLib,
+  endUpdate,
   clear: clearMount,
   list: listCatalog,
 };

--- a/benchmarks/competitive/measure-browser.ts
+++ b/benchmarks/competitive/measure-browser.ts
@@ -2,8 +2,10 @@
  * Browser paint competitive bench (Playwright Chromium).
  *
  * Matrix: browser-enabled libs × scenario cases (default subset, or COMPETITIVE_FULL=1).
- * Metrics per cell: cold mount median ms (includes double-rAF). replace* columns
- * mirror mount until in-place setData exists (full remount is not re-sampled).
+ * Metrics per cell: cold mount median ms (includes double-rAF) plus IN-PLACE
+ * update median ms (same medianMs helper, warmup 2 / samples 11, alternating
+ * perturbed data). replace* columns mirror mount until a distinct remount
+ * metric is wanted (full remount is not re-sampled).
  *
  *   bun run measure-browser.ts
  *   COMPETITIVE_FULL=1 bun run measure-browser.ts
@@ -21,12 +23,24 @@ const resultsDir = path.join(root, "results");
 mkdirSync(resultsDir, { recursive: true });
 
 const full = Boolean(process.env["COMPETITIVE_FULL"]);
-const cases = casesForRun(full);
-const browserLibs = LIBS.filter((l) => l.browser);
+// Optional focus filters for debugging contested cells:
+//   COMPETITIVE_LIBS=ggsvelte-svg,layercake COMPETITIVE_CASES=line-3x10k bun run measure-browser.ts
+const onlyLibs = process.env["COMPETITIVE_LIBS"]
+  ?.split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
+const onlyCases = process.env["COMPETITIVE_CASES"]
+  ?.split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
+const cases = casesForRun(full).filter((c) => !onlyCases || onlyCases.includes(c.id));
+const browserLibs = LIBS.filter((l) => l.browser && (!onlyLibs || onlyLibs.includes(l.id)));
 
 type BenchApi = {
   mount: (lib: string, caseId: string) => Promise<{ ms: number; markHint: number }>;
   replace: (lib: string, caseId: string) => Promise<{ ms: number }>;
+  update: (lib: string, caseId: string) => Promise<{ ms: number }>;
+  endUpdate: () => void;
   list: () => {
     libs: { id: string; browser: boolean }[];
     cases: { id: string }[];
@@ -97,6 +111,12 @@ const server = await createServer({
 });
 await server.listen();
 
+// Warm the vite transform graph BEFORE launching Chromium: on a cold
+// node_modules/.vite the first page load compiles the whole import graph
+// (fixture + all lib adapters) and can blow the 120s page timeout.
+// warmupRequest crawls the import graph from the entry module.
+await server.warmupRequest("/main.ts");
+
 const browser = await chromium.launch();
 let page = await browser.newPage();
 page.setDefaultTimeout(120_000);
@@ -124,6 +144,24 @@ async function waitForBenchApi(): Promise<void> {
   });
 }
 
+function isTimeout(err: unknown): boolean {
+  return err instanceof Error && err.name === "TimeoutError";
+}
+
+/** Load the bench page and wait for the API, retrying once on goto timeout
+ * (a cold vite dep-optimize can stall the first load past the page timeout). */
+async function gotoBenchPage(p: Page): Promise<void> {
+  try {
+    await p.goto("http://127.0.0.1:5199/");
+    await waitForBenchApi();
+  } catch (err) {
+    if (!isTimeout(err)) throw err;
+    process.stderr.write("page load timed out; retrying once...\n");
+    await p.goto("http://127.0.0.1:5199/");
+    await waitForBenchApi();
+  }
+}
+
 async function recoverPage(): Promise<void> {
   try {
     await page.reload();
@@ -137,13 +175,11 @@ async function recoverPage(): Promise<void> {
     page = await browser.newPage();
     page.setDefaultTimeout(120_000);
     wirePageDiagnostics(page);
-    await page.goto("http://127.0.0.1:5199/");
-    await waitForBenchApi();
+    await gotoBenchPage(page);
   }
 }
 
-await page.goto("http://127.0.0.1:5199/");
-await waitForBenchApi();
+await gotoBenchPage(page);
 
 for (const cell of matrix) {
   const label = `${cell.lib.id} ${cell.caseId}`;
@@ -160,8 +196,24 @@ for (const cell of matrix) {
       return r.ms;
     });
     // replaceLib is a full remount alias of mountLib today — re-running the
-    // median loop doubles wall time with no new information (#1357). Mirror
-    // mount stats until a real in-place setData metric lands.
+    // median loop doubles wall time with no new information (#1357). replace*
+    // columns below mirror mount stats; update* is the real second axis.
+    const updateStats = await medianMs(async () => {
+      const r = await page.evaluate(
+        async ({ library, caseId }) => {
+          const w = window as unknown as { competitiveBench: BenchApi };
+          return w.competitiveBench.update(library, caseId);
+        },
+        { library: cell.lib.id, caseId: cell.caseId },
+      );
+      return r.ms;
+    });
+    // Teardown the live update handle for this cell (also automatic on the
+    // next cell's first update call — belt and braces, no leaks across cells).
+    await page.evaluate(() => {
+      const w = window as unknown as { competitiveBench: BenchApi };
+      w.competitiveBench.endUpdate();
+    });
     results.push({
       lib: cell.lib.id,
       caseId: cell.caseId,
@@ -174,6 +226,9 @@ for (const cell of matrix) {
       replaceMedianMs: mountStats.median,
       replaceMeanMs: mountStats.mean,
       replaceP95Ms: mountStats.p95,
+      updateMedianMs: updateStats.median,
+      updateMeanMs: updateStats.mean,
+      updateP95Ms: updateStats.p95,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -191,9 +246,15 @@ for (const cell of matrix) {
   }
 }
 
-console.log("\n=== Competitive browser mount / replace (Chromium, median) ===\n");
-console.log("lib".padEnd(18), "case".padEnd(22), "mount".padStart(10), "replace".padStart(10));
-console.log("-".repeat(62));
+console.log("\n=== Competitive browser mount / replace / update (Chromium, median) ===\n");
+console.log(
+  "lib".padEnd(18),
+  "case".padEnd(22),
+  "mount".padStart(10),
+  "replace".padStart(10),
+  "update".padStart(10),
+);
+console.log("-".repeat(72));
 for (const r of results) {
   if (!r["ok"]) {
     console.log(String(r["lib"]).padEnd(18), String(r["caseId"]).padEnd(22), "FAIL");
@@ -204,12 +265,14 @@ for (const r of results) {
     String(r["caseId"]).padEnd(22),
     `${r["mountMedianMs"]}ms`.padStart(10),
     `${r["replaceMedianMs"]}ms`.padStart(10),
+    `${r["updateMedianMs"]}ms`.padStart(10),
   );
 }
 
 const payload = {
   generatedAt: new Date().toISOString(),
   full,
+  measuresUpdate: true,
   caseCatalog: CASES,
   libs: LIBS,
   results,

--- a/benchmarks/competitive/measure-browser.ts
+++ b/benchmarks/competitive/measure-browser.ts
@@ -70,8 +70,12 @@ const server = await createServer({
   plugins: [svelte({ compilerOptions: { css: "injected" }, emitCss: false })],
   resolve: {
     conditions: ["svelte", "browser", "import", "module", "default"],
+    dedupe: ["svelte"],
   },
   optimizeDeps: {
+    // Svelte component libs must share one svelte runtime with the fixture
+    // components (context + flushSync break across duplicated runtimes).
+    exclude: ["svelte", "svelteplot", "layercake"],
     include: [
       "@ggsvelte/core",
       "@ggsvelte/core/render",
@@ -96,6 +100,16 @@ await server.listen();
 const browser = await chromium.launch();
 let page = await browser.newPage();
 page.setDefaultTimeout(120_000);
+
+function wirePageDiagnostics(p: Page): void {
+  p.on("pageerror", (e) => process.stderr.write(`PAGEERROR: ${String(e).slice(0, 800)}\n`));
+  p.on("console", (m) => {
+    if (m.type() === "error") {
+      process.stderr.write(`CONSOLE-ERR: ${m.text().slice(0, 400)}\n`);
+    }
+  });
+}
+wirePageDiagnostics(page);
 
 const results: Record<string, unknown>[] = [];
 const matrix = pairs();
@@ -122,6 +136,7 @@ async function recoverPage(): Promise<void> {
     }
     page = await browser.newPage();
     page.setDefaultTimeout(120_000);
+    wirePageDiagnostics(page);
     await page.goto("http://127.0.0.1:5199/");
     await waitForBenchApi();
   }

--- a/benchmarks/competitive/package.json
+++ b/benchmarks/competitive/package.json
@@ -8,6 +8,7 @@
     "measure:browser:full": "COMPETITIVE_FULL=1 bun run measure-browser.ts",
     "measure:bundles:full": "COMPETITIVE_FULL=1 bun run measure-bundles.ts",
     "measure": "bun run measure:bundles && bun run measure:browser",
+    "check:budgets": "bun run check-budgets.ts",
     "test": "bun test scenarios.test.ts"
   },
   "dependencies": {

--- a/benchmarks/competitive/scenarios.ts
+++ b/benchmarks/competitive/scenarios.ts
@@ -320,18 +320,18 @@ export const LIBS: readonly LibMeta[] = [
   {
     id: "svelteplot",
     label: "SveltePlot",
-    browser: false,
+    browser: true,
     bundle: true,
-    scenarios: ["scatter-color"],
-    note: "Svelte peer — bundle only until component fixture lands",
+    scenarios: ["scatter-color", "line-multiseries"],
+    note: "Svelte peer — <Plot><Dot>/<Line> + default axes via components/svelteplot",
   },
   {
     id: "layercake",
     label: "LayerCake",
-    browser: false,
+    browser: true,
     bundle: true,
-    scenarios: ["scatter-color"],
-    note: "Svelte peer — bundle only until component fixture lands",
+    scenarios: ["scatter-color", "line-multiseries"],
+    note: "Svelte peer — <LayerCake><Svg> + custom marks via components/layercake (no axes: framework ships none)",
   },
 ] as const;
 

--- a/benchmarks/competitive/scenarios.ts
+++ b/benchmarks/competitive/scenarios.ts
@@ -234,6 +234,7 @@ export type LibId =
   | "echarts"
   | "svelteplot"
   | "layercake"
+  | "layercake-canvas"
   | "ggsvelte-ggplot"
   | "ggsvelte-full";
 
@@ -242,6 +243,9 @@ export type LibMeta = {
   readonly label: string;
   /** Browser paint harness implements this lib. */
   readonly browser: boolean;
+  /** Render form factor — the CI relative gate pairs peers with the
+   * same-form ggsvelte adapter (svg vs svg, canvas vs canvas). */
+  readonly form: "svg" | "canvas";
   /** Bundle matrix includes this lib. */
   readonly bundle: boolean;
   readonly scenarios: readonly ScenarioId[];
@@ -256,6 +260,7 @@ export const LIBS: readonly LibMeta[] = [
   {
     id: "ggsvelte-svg",
     label: "ggsvelte SVG (lean)",
+    form: "svg",
     browser: true,
     bundle: true,
     scenarios: ["scatter-color", "line-multiseries", "area-multiseries", "bars-stacked"],
@@ -264,6 +269,7 @@ export const LIBS: readonly LibMeta[] = [
   {
     id: "ggsvelte-canvas",
     label: "ggsvelte canvas (lean pipeline)",
+    form: "canvas",
     browser: true,
     bundle: true,
     scenarios: ["scatter-color", "line-multiseries", "area-multiseries"],
@@ -272,6 +278,7 @@ export const LIBS: readonly LibMeta[] = [
   {
     id: "ggsvelte-full",
     label: "ggsvelte full barrel",
+    form: "svg",
     browser: false,
     bundle: true,
     scenarios: ["scatter-color"],
@@ -280,6 +287,7 @@ export const LIBS: readonly LibMeta[] = [
   {
     id: "ggsvelte-ggplot",
     label: "ggsvelte GGPlot (Svelte)",
+    form: "svg",
     browser: false,
     bundle: true,
     scenarios: ["scatter-color"],
@@ -288,6 +296,7 @@ export const LIBS: readonly LibMeta[] = [
   {
     id: "d3",
     label: "raw D3",
+    form: "svg",
     browser: true,
     bundle: true,
     scenarios: ["scatter-color", "line-multiseries", "area-multiseries", "bars-stacked"],
@@ -296,6 +305,7 @@ export const LIBS: readonly LibMeta[] = [
   {
     id: "uplot",
     label: "uPlot",
+    form: "canvas",
     browser: true,
     bundle: true,
     scenarios: ["scatter-color", "line-multiseries", "area-multiseries"],
@@ -304,6 +314,7 @@ export const LIBS: readonly LibMeta[] = [
   {
     id: "chartjs",
     label: "Chart.js",
+    form: "canvas",
     browser: true,
     bundle: true,
     scenarios: ["scatter-color", "line-multiseries", "area-multiseries", "bars-stacked"],
@@ -312,6 +323,7 @@ export const LIBS: readonly LibMeta[] = [
   {
     id: "echarts",
     label: "Apache ECharts",
+    form: "canvas",
     browser: true,
     bundle: true,
     scenarios: ["scatter-color", "line-multiseries", "area-multiseries", "bars-stacked"],
@@ -320,18 +332,29 @@ export const LIBS: readonly LibMeta[] = [
   {
     id: "svelteplot",
     label: "SveltePlot",
+    form: "svg",
     browser: true,
     bundle: true,
-    scenarios: ["scatter-color", "line-multiseries"],
-    note: "Svelte peer — <Plot><Dot>/<Line> + default axes via components/svelteplot",
+    scenarios: ["scatter-color", "line-multiseries", "area-multiseries", "bars-stacked"],
+    note: "Svelte peer — <Plot><Dot>/<Line>/<AreaY>/<BarY> + default axes via components/svelteplot",
   },
   {
     id: "layercake",
     label: "LayerCake",
+    form: "svg",
     browser: true,
     bundle: true,
-    scenarios: ["scatter-color", "line-multiseries"],
+    scenarios: ["scatter-color", "line-multiseries", "area-multiseries", "bars-stacked"],
     note: "Svelte peer — <LayerCake><Svg> + custom marks via components/layercake (no axes: framework ships none)",
+  },
+  {
+    id: "layercake-canvas",
+    label: "LayerCake (Canvas)",
+    form: "canvas",
+    browser: true,
+    bundle: false,
+    scenarios: ["scatter-color", "line-multiseries"],
+    note: "LayerCake Canvas-layout fast path — one 2D-context draw pass, no per-mark DOM (rebuttal-proofing vs 'SVG-only peer' critique)",
   },
 ] as const;
 

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "bench:competitive": "cd benchmarks/competitive && bun run measure",
     "bench:competitive:bundles": "cd benchmarks/competitive && bun run measure:bundles",
     "bench:competitive:browser": "cd benchmarks/competitive && bun run measure:browser",
+    "bench:competitive:check": "cd benchmarks/competitive && bun run check:budgets",
     "bench:competitive:full": "cd benchmarks/competitive && bun run measure:bundles:full && bun run measure:browser:full",
     "evals": "bun tests/evals/run.ts",
     "render:fresh": "bun scripts/render-fresh.ts",


### PR DESCRIPTION
## Summary

LayerCake and SveltePlot were `browser: false` (bundle-only) in `benchmarks/competitive`. This PR builds the full head-to-head scoreboard: browser fixtures for both Svelte peers, a LayerCake canvas fast-path cell, an extended four-scenario peer matrix, a **CI budget + relative-win gate** (the suite had zero CI wiring), and a second **in-place update** scoreboard alongside mount/replace.

## Final numbers (Chromium, median of 11, paint-inclusive, linux-x64)

**Mount** (gated, form-factor-paired):

| case | gg-svg | LayerCake | SveltePlot | gg-canvas | LayerCake (Canvas) |
|---|---:|---:|---:|---:|---:|
| scatter-1k | **29.9** | 40.2 | 450.9 | **29.5** | 29.0 |
| scatter-10k | **88.4** | 361.1 | 4,941 | 40.6 | **27.4** ⚠️ |
| line-3x1k | **29.9** | 30.9 | 189.6 | **28.5** | 29.4 |
| line-3x10k | **53.8** | 71.8 | 1,741 | 67.6 | **47.3** ⚠️ |
| area-3x1k | **30.8** | 30.8 | 321.8 | **29.2** | — |
| bars-50x4 | 31.3 | **30.6** | 97.2 | — | — |

**Update** (in-place data swap — new scoreboard):

| case | gg-svg | LayerCake | SveltePlot | gg-canvas | LayerCake (Canvas) |
|---|---:|---:|---:|---:|---:|
| scatter-10k | 90.5 | **61.5** ⚠️ | 1,247 | 33.2 | **29.8** ⚠️ |
| line-3x10k | 57.0 | **31.3** ⚠️ | 1,020 | 67.7 | **41.3** ⚠️ |
| scatter-1k | 31.0 | 30.3 | 108.2 | 31.4 | 31.1 |

⚠️ = known gap, declared in `budgets.json` with a tracking issue; the exemption **fails the build when the gap closes**.

## What's here

- **Peer fixtures**: `components/{layercake,svelteplot}/` (SVG scatter/line/area/stacked-bars; LayerCake Canvas scatter/line). Area uses IDENTITY position per the #1357 fairness rule. LayerCake z-scale color bug fixed (`zRange` is overridden by `createScale` unless passed explicitly).
- **CI gate**: `check-budgets.ts` + `budgets.json`, wired into `bench.yml` (`run-bench` label). Absolute budgets (median×3) on all ggsvelte cells both directions of coverage; relative gate pairs peers by **render form factor** (`LIBS[].form`) — svg vs svg, canvas vs canvas; d3/uplot/chartjs/echarts stay informational reference bars; 2ms+2% epsilon absorbs double-rAF floor jitter. Result on this branch: **32 gated comparisons PASS, 6 known gaps tracked**.
- **Update scoreboard**: `handle.update(data)` on every adapter (uplot `setData`, chartjs `update()`, echarts `setOption`, d3 re-join, Svelte peers via exported `setRows` + component-local `$state.raw`). A `$state` props proxy deep-proxied 30k rows and made peer mounts 3–40x slower — caught by A/B probe, fixed by the plain-props + `setRows` design. ggsvelte's update is an honest full re-render, documented.
- **Harness hardening**: vite `warmupRequest` + one retry (cold-cache stall), `COMPETITIVE_LIBS`/`COMPETITIVE_CASES` focus filters, pageerror/console diagnostics, `dedupe: ["svelte"]` (one runtime). Pre-commit oxlint hook excludes `benchmarks/competitive` (already lint-ignored; competitive-only commits died).

## Findings filed as issues

- **#1468** — canvas line mount loses to naive canvas loops at 30k points (67.6 vs 47.3ms); per-datum pipeline cost above the paint floor.
- **#1471** — our update path is a full re-render; peers' reactive updates win at 10k+. Attack: incremental update planning (same scales/geoms, new data → re-map + redraw dirty strata only).

## Fairness notes

- SveltePlot's gap is not an axes artifact: `PlotCore`+`Dot` (zero axes/grids) still runs 465ms @1k / 5.4s @10k — their per-datum mark pipeline is the bottleneck.
- LayerCake SVG fixtures ship no axes (the framework has none) — slightly favored, still loses at scale. Our canvas adapter draws **no chrome** either, so canvas-vs-canvas is like-for-like.
- Small cases sit at a ~27–31ms double-rAF floor where everyone ties; discrimination starts at 10k.

Tree-shaking investigation (separate angle): byte attribution in `benchmarks/competitive/results/treeshake-report.md` — lean canvas is 500KB min / 128KB gz, **zero third-party deps**, top survivors are the scale catalog (~85KB), temporal machinery (~38KB), and geom registration (~42KB); ranked attacks get to ~92–97KB gz. No product code changed in this PR.