### PR TITLE
docs(theme): note elevated tooltip chrome on low-contrast built-ins

### DIFF
--- a/apps/docs/src/routes/reference/themes/+page.svelte
+++ b/apps/docs/src/routes/reference/themes/+page.svelte
@@ -111,6 +111,17 @@
     <code>tooltipInk</code> and <code>interactionInk</code> contrasty so
     recovery controls like legend <strong>Clear</strong> stay readable on dark bases.
   </p>
+  <p>
+    Named bases that share paper and panel paint elevated tooltip chrome so tips
+    read as a card off the chart surface:
+    <code>solarized</code>, <code>solarized_2</code>,
+    <code>solarizeddark</code>, <code>solarized_2dark</code>,
+    <code>dark</code>, <code>hcdark</code>, <code>fivethirtyeight</code>, and
+    <code>economist</code>. A <code>ThemeSpec</code> object or named shell that
+    only overrides non-tip roles keeps that elevated package unless
+    <code>tooltipPaper</code>, <code>tooltipInk</code>, or
+    <code>tooltipBorder</code> is set.
+  </p>
   <div class="table-wrap">
     <table>
       <thead>

--- a/scripts/theme-palette-reference.test.ts
+++ b/scripts/theme-palette-reference.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
 import { describe, expect, it } from "bun:test";
 
 import {
@@ -16,6 +19,11 @@ import {
   SEQUENTIAL_SCHEME_NAMES,
   THEME_NAMES,
 } from "../packages/spec/src/schema-names.ts";
+
+const THEMES_PAGE = readFileSync(
+  join(import.meta.dir, "../apps/docs/src/routes/reference/themes/+page.svelte"),
+  "utf8",
+);
 
 describe("theme reference catalog", () => {
   it("lists a shell for every registered theme name", () => {
@@ -43,6 +51,27 @@ describe("theme reference catalog", () => {
       expect(names.has(role), role).toBe(true);
     }
     expect(ALL_THEME_ROLES.length).toBeGreaterThan(THEME_COLOR_ROLES.length);
+  });
+
+  it("documents elevated tooltip chrome on low-contrast built-ins", () => {
+    // Author-facing contract from tooltip-contrast-defaults PR 4: these named
+    // bases ship tip roles off the chart surface; object ThemeSpecs keep that
+    // package unless tip roles are set.
+    const elevated = [
+      "solarized",
+      "solarized_2",
+      "solarizeddark",
+      "solarized_2dark",
+      "dark",
+      "hcdark",
+      "fivethirtyeight",
+      "economist",
+    ] as const;
+    for (const name of elevated) {
+      expect(THEMES_PAGE.includes(name), name).toBe(true);
+    }
+    expect(THEMES_PAGE).toMatch(/elevated tooltip/i);
+    expect(THEMES_PAGE).toMatch(/elevated package unless[\s\S]*tooltipPaper/i);
   });
 });
 


### PR DESCRIPTION
## Summary

- Documents elevated default tooltip chrome on Solarized×4, `dark`, `hcdark`, `fivethirtyeight`, and `economist` on the Themes reference page.
- States that ThemeSpec objects and named shells keep that package when only non-tip roles are overridden; set `tooltipPaper` / `tooltipInk` / `tooltipBorder` to replace tip chrome.
- Locks the author-facing copy with a source-level assertion in `scripts/theme-palette-reference.test.ts`.

Closes the docs follow-up from the tooltip-contrast-defaults plan after #1459 / #1461 / #1463.

## Test plan

- [x] `bun test scripts/theme-palette-reference.test.ts`
- [ ] CI green
- [ ] Skim Themes reference “Color and interaction roles” for the new paragraph
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1467" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->