### PR TITLE
docs(examples): shorten path/trajectory gallery title

### DIFF
--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -12921,7 +12921,7 @@ export const DOCS_ROUTES = [
   },
   {
     path: "/examples/path/trajectory",
-    title: "Minard's march on Moscow, map and all — ggsvelte gallery",
+    title: "Minard's march on Moscow — ggsvelte gallery",
     description:
       "The full 1869 flow map: band width is the army's surviving strength over the rivers it crossed, with the towns Minard named and the cold he plotted beneath the retreat.",
     canonicalPath: "/examples/path/trajectory",

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -21451,12 +21451,12 @@ export const DOCS_SEARCH_INDEX = [
   {
     id: "example:path:trajectory",
     kind: "example",
-    title: "Minard's march on Moscow, map and all",
+    title: "Minard's march on Moscow",
     summary:
       "The full 1869 flow map: band width is the army's surviving strength over the rivers it crossed, with the towns Minard named and the cold he plotted beneath the retreat.",
     href: "/examples/path/trajectory",
     keywords: [
-      "Minard's march on Moscow, map and all",
+      "Minard's march on Moscow",
       "Maps & polygons",
       "path",
       "map",
@@ -21465,7 +21465,7 @@ export const DOCS_SEARCH_INDEX = [
       "text",
       "data-order",
     ],
-    exact: ["Minard's march on Moscow, map and all"],
+    exact: ["Minard's march on Moscow"],
   },
   {
     id: "example:point:abline-identity",

--- a/apps/docs/static/previews/provenance.json
+++ b/apps/docs/static/previews/provenance.json
@@ -263,7 +263,7 @@
     },
     "path/trajectory": {
       "filename": "path-trajectory-light.png",
-      "sourceSha256": "50f80c841ddd1ed4b2eff4a050ca79013187fc6964b2f7e619e48252d7565d7c",
+      "sourceSha256": "c7c7c6488150935617cc1a623bcf882141cfbc81e4d272846680a264cd62f0aa",
       "pngSha256": "2949dc19048c52de04fced10fa7a563726b70d02b5f091f35f84c7d8a7b7f157"
     },
     "point/abline-identity": {

--- a/examples/manifest.ts
+++ b/examples/manifest.ts
@@ -639,7 +639,7 @@ export const EXAMPLES: readonly ExampleManifestEntry[] = [
     id: "path/trajectory",
     category: "path",
     name: "trajectory",
-    title: "Minard's march on Moscow, map and all",
+    title: "Minard's march on Moscow",
     description: "The full 1869 flow map: band width is the army's surviving strength over the rivers it crossed, with the towns Minard named and the cold he plotted beneath the retreat.",
     tags: ["path", "map", "linewidth", "annotation", "text", "data-order"],
     docsSection: "Maps & polygons",

--- a/examples/path/trajectory/meta.json
+++ b/examples/path/trajectory/meta.json
@@ -1,5 +1,5 @@
 {
-  "title": "Minard's march on Moscow, map and all",
+  "title": "Minard's march on Moscow",
   "description": "The full 1869 flow map: band width is the army's surviving strength over the rivers it crossed, with the towns Minard named and the cold he plotted beneath the retreat.",
   "tags": ["path", "map", "linewidth", "annotation", "text", "data-order"],
   "docsSection": "Maps & polygons",


### PR DESCRIPTION
## Summary

- Drop ", map and all" from the `path/trajectory` example page title so it is just "Minard's march on Moscow".
- Regenerate `examples/manifest.ts`, docs routes, and the search index from `meta.json`.

## Test plan

- [x] `bun run manifest:gen` / routes / search regenerate cleanly
- [ ] CI green
- [ ] Docs example page title shows "Minard's march on Moscow"
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1473" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->