### PR TITLE
perf(core): further #1468 line-3x10k mount cuts

### DIFF
--- a/.changeset/line-floor-cut.md
+++ b/.changeset/line-floor-cut.md
@@ -1,0 +1,9 @@
+---
+"@ggsvelte/core": patch
+---
+
+# Cut multi-series line / ordinal color mount cost
+
+Migration: none — same marks, group ids, and ordinal color assignments; competitive canvas adapter only changes harness chrome (void + color guide none) and data feed (named ref).
+
+Further #1468 hot-path work: `fieldType` reuses lean parse decisions (no second typeof walk); ordinal color training skips materializing a 30k values array when the source catalog is enough; continuous line geometry can bucket+pixel-map in one normalize pass; solid multi-series canvas strokes take a monomorphic path; identity frames fill `rowIndex` without `Uint32Array.from` callbacks. Competitive canvas mount uses named data + theme_void + `{ type: "none" }` color guide so legend layout is not paid on a marks-only fixture.

--- a/benchmarks/competitive/adapters/ggsvelte-canvas.ts
+++ b/benchmarks/competitive/adapters/ggsvelte-canvas.ts
@@ -2,6 +2,10 @@
  * Canvas-mark ggsvelte mounts (pipeline + planStrata + drawStratum).
  * All imports stay on the lean graph (@ggsvelte/core/render + /dom) so canvas
  * charts never install the Temporal polyfill.
+ *
+ * Spec uses a named data ref (`{ name: "main" }`) so mount/update feed columns
+ * via RunOptions.data without snapshotting 30k cells through toPortable each
+ * draw (same data path product code uses for live updates).
  */
 import { cssColorResolver, drawStratum, sizeCanvasForDpr } from "@ggsvelte/core/dom";
 import { planStrata, runPipeline } from "@ggsvelte/core/render";
@@ -24,23 +28,49 @@ export type MountHandle = {
 
 export type MountResult = { markHint: number; handle: MountHandle };
 
-function scatterSpec(data: ScatterColumns) {
-  return gg(data, aes({ x: "x", y: "y", color: "cls" }))
+const DATA_NAME = "main";
+
+/** Named-data portable specs — built once per scenario, data swapped at run.
+ * theme_void + color/fill guide none: no legend layout (peer canvas fixtures
+ * draw marks only). Keep axis guides on so the panel size stays near the
+ * LayerCake padding box — disabling axes expands the canvas and slowed paint.
+ * Guide form must be `{ type: "none" }` (string `"none"` is not normalized). */
+function scatterPortable() {
+  return gg({ name: DATA_NAME }, aes({ x: "x", y: "y", color: "cls" }))
     .geomPoint({ size: 1.5, alpha: 0.7, render: "canvas" })
+    .theme("void")
+    .guides({ color: { type: "none" } })
     .toPortable();
 }
 
-function lineSpec(data: SeriesColumns) {
-  return gg(data, aes({ x: "x", y: "y", color: "series", group: "series" }))
+function linePortable() {
+  return gg({ name: DATA_NAME }, aes({ x: "x", y: "y", color: "series", group: "series" }))
     .geomLine({ render: "canvas" })
+    .theme("void")
+    .guides({ color: { type: "none" } })
     .toPortable();
 }
 
-function areaSpec(data: SeriesColumns) {
+function areaPortable() {
   // Identity (not stack): competitors overlay series; default geomArea is stack.
-  return gg(data, aes({ x: "x", y: "y", fill: "series", group: "series" }))
+  return gg({ name: DATA_NAME }, aes({ x: "x", y: "y", fill: "series", group: "series" }))
     .geomArea({ position: "identity", render: "canvas" })
+    .theme("void")
+    .guides({ fill: { type: "none" } })
     .toPortable();
+}
+
+function portableFor(scenario: ScenarioId) {
+  switch (scenario) {
+    case "scatter-color":
+      return scatterPortable();
+    case "line-multiseries":
+      return linePortable();
+    case "area-multiseries":
+      return areaPortable();
+    default:
+      throw new Error(`unsupported canvas scenario ${scenario}`);
+  }
 }
 
 export function mountGgsvelteCanvas(
@@ -51,21 +81,12 @@ export function mountGgsvelteCanvas(
   if (scenario === "bars-stacked") {
     throw new Error("ggsvelte-canvas competitive path skips bars-stacked");
   }
-  const specFor = (d: UpdateColumns) => {
-    switch (scenario) {
-      case "scatter-color":
-        return scatterSpec(d as ScatterColumns);
-      case "line-multiseries":
-        return lineSpec(d as SeriesColumns);
-      case "area-multiseries":
-        return areaSpec(d as SeriesColumns);
-      default:
-        throw new Error(`unsupported canvas scenario ${scenario}`);
-    }
-  };
+  // Build the portable once: only columns change on update.
+  const portable = portableFor(scenario);
   root.replaceChildren();
   // Axes/text stay un-drawn in this harness (canvas marks only) so paint cost
-  // isolates mark drawing — documented in README fairness notes.
+  // isolates mark drawing — documented in README fairness notes. theme_void
+  // matches that posture (no axis chrome reserve).
   const canvas = document.createElement("canvas");
   canvas.style.width = `${PLOT_WIDTH}px`;
   canvas.style.height = `${PLOT_HEIGHT}px`;
@@ -76,7 +97,11 @@ export function mountGgsvelteCanvas(
   const resolve = cssColorResolver(canvas);
   let sized = false;
   const draw = (d: UpdateColumns): number => {
-    const model = runPipeline(specFor(d), { width: PLOT_WIDTH, height: PLOT_HEIGHT });
+    const model = runPipeline(portable, {
+      width: PLOT_WIDTH,
+      height: PLOT_HEIGHT,
+      data: { [DATA_NAME]: d },
+    });
     const strata = planStrata(model.scene, model.layerBackends);
     if (!sized) {
       sizeCanvasForDpr(canvas, ctx, model.scene.width, model.scene.height, dpr);
@@ -111,13 +136,25 @@ export function mountGgsvelteCanvas(
 }
 
 export function bundleScatterCanvas(data: ScatterColumns): unknown {
-  return runPipeline(scatterSpec(data), { width: PLOT_WIDTH, height: PLOT_HEIGHT });
+  return runPipeline(scatterPortable(), {
+    width: PLOT_WIDTH,
+    height: PLOT_HEIGHT,
+    data: { [DATA_NAME]: data },
+  });
 }
 
 export function bundleLineCanvas(data: SeriesColumns): unknown {
-  return runPipeline(lineSpec(data), { width: PLOT_WIDTH, height: PLOT_HEIGHT });
+  return runPipeline(linePortable(), {
+    width: PLOT_WIDTH,
+    height: PLOT_HEIGHT,
+    data: { [DATA_NAME]: data },
+  });
 }
 
 export function bundleAreaCanvas(data: SeriesColumns): unknown {
-  return runPipeline(areaSpec(data), { width: PLOT_WIDTH, height: PLOT_HEIGHT });
+  return runPipeline(areaPortable(), {
+    width: PLOT_WIDTH,
+    height: PLOT_HEIGHT,
+    data: { [DATA_NAME]: data },
+  });
 }

--- a/benchmarks/competitive/budgets.json
+++ b/benchmarks/competitive/budgets.json
@@ -7,7 +7,7 @@
       "caseId": "scatter-color-10k",
       "kind": "mount",
       "issue": "https://github.com/ljodea/ggsvelte/issues/1468",
-      "note": "~32ms vs ~27ms after lean parse + color-bucket draw (#1468). Still ~1.15× layercake-canvas on some runners; self-destructs when the gap closes."
+      "note": "~32–34ms vs ~27–30ms after ordinal color collect + named-data adapter + paint path (#1468 follow-up). Gate thr = peer×1.02+2ms; self-destructs when the gap closes."
     },
     {
       "ggsvelte": "ggsvelte-canvas",
@@ -15,7 +15,7 @@
       "caseId": "line-3x10k",
       "kind": "mount",
       "issue": "https://github.com/ljodea/ggsvelte/issues/1468",
-      "note": "~56ms vs ~47ms after lean parse/grouping/builder snapshot (#1468). Node pipeline ~6ms; remaining gap is browser pipeline+paint vs naive loop. Self-destructs when the gap closes."
+      "note": "~55–58ms vs ~44–49ms after one-pass line geometry + ordinal color skip + solid stroke hot path + named-data void adapter (#1468). Relative thr often ~peer+5–7ms still short; self-destructs when the gap closes."
     },
     {
       "ggsvelte": "ggsvelte-svg",

--- a/packages/core/src/dom/canvas-marks-paths.ts
+++ b/packages/core/src/dom/canvas-marks-paths.ts
@@ -123,6 +123,47 @@ export function drawPaths(
   const restoreGlow = applyGlow(ctx, batch.glow);
   const themeColors = { ink: themeVar("ink", theme), accent: themeVar("accent", theme) };
   const needBounds = batch.fillPaint !== undefined || batch.strokePaint !== undefined;
+
+  // Solid multi-series lines (competitive line-3×N): no fills, no per-subpath
+  // alpha/linewidth/linetype, no gradient paint — one monomorphic stroke loop
+  // without resolvePathMark allocations or setLineDash per subpath (#1468).
+  const solidLineHot =
+    !isArea &&
+    !needBounds &&
+    batch.glow === undefined &&
+    batch.alphas === undefined &&
+    batch.linewidths === undefined &&
+    batch.linetypeIndexes === undefined &&
+    (batch.linetype === undefined || batch.linetype === "solid") &&
+    batch.curve === "linear";
+  if (solidLineHot) {
+    const linewidth = batch.linewidth;
+    const linejoin = batch.linejoin ?? "round";
+    const linecap = batch.linecap ?? "round";
+    const ink = themeColors.ink;
+    ctx.lineWidth = linewidth;
+    ctx.lineJoin = linejoin;
+    ctx.lineCap = linecap;
+    if (typeof ctx.setLineDash === "function") ctx.setLineDash([]);
+    for (let s = 0; s < subpaths; s++) {
+      const start = batch.pathOffsets[s]!;
+      const end = batch.pathOffsets[s + 1]!;
+      if (end <= start) continue;
+      const stroke = batch.strokes[s];
+      ctx.strokeStyle = resolve(stroke ?? batch.strokePaint?.fallback ?? ink);
+      ctx.beginPath();
+      // Linear open path: no step corners / ring holes.
+      ctx.moveTo(batch.positions[start * 2]!, batch.positions[start * 2 + 1]!);
+      for (let i = start + 1; i < end; i++) {
+        ctx.lineTo(batch.positions[i * 2]!, batch.positions[i * 2 + 1]!);
+      }
+      ctx.stroke();
+    }
+    restoreGlow();
+    ctx.globalAlpha = baseAlpha;
+    return;
+  }
+
   for (let s = 0; s < subpaths; s++) {
     const start = batch.pathOffsets[s]!;
     const end = batch.pathOffsets[s + 1]!;

--- a/packages/core/src/pipeline/frame-identity.ts
+++ b/packages/core/src/pipeline/frame-identity.ts
@@ -110,7 +110,13 @@ export function buildIdentityFrame(
     groups,
     inputGroups: groups,
     inputSourceRows: null,
-    rowIndex: Uint32Array.from({ length: n }, (_, i) => i),
+    // Identity row map: avoid Uint32Array.from(callback) (alloc + per-index
+    // call) — competitive line-3×10k builds this once per frame (#1468).
+    rowIndex: (() => {
+      const rows = new Uint32Array(n);
+      for (let i = 0; i < n; i++) rows[i] = i;
+      return rows;
+    })(),
     colorValues: binding.color.field === null ? null : table.column(binding.color.field),
     fillValues: binding.fill.field === null ? null : table.column(binding.fill.field),
     sizeValues: binding.size.field === null ? null : table.column(binding.size.field),

--- a/packages/core/src/pipeline/geometry-paths-line-write.ts
+++ b/packages/core/src/pipeline/geometry-paths-line-write.ts
@@ -1,9 +1,9 @@
 /**
  * Write sorted line subpaths into path buffers.
  */
-import type { LayerFrame, ResolvedColorScale } from "./types.js";
+import type { LayerFrame, PipelineWarning, ResolvedColorScale } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
-import { positionOf } from "./geometry-shared.js";
+import { positionOf, removedWarning } from "./geometry-shared.js";
 import { paintVector } from "./geometry-style.js";
 
 export function writeLineSubpaths(input: {
@@ -81,4 +81,103 @@ export function writeLineSubpaths(input: {
     pathOffsets,
     strokes,
   };
+}
+
+/**
+ * Continuous multi-series line: single normalize+pixel pass that also builds
+ * group buckets (replaces bucketByGroup + writeLineSubpaths when no per-vertex
+ * style split applies). Stores pixel coords on the first normalize so write
+ * never re-maps the same vertices.
+ *
+ * Returns null when every row is dropped, or when the scale/data shape is not
+ * continuous (caller falls back to the two-step path).
+ */
+export function writeContinuousLineOnePass(input: {
+  frame: LayerFrame;
+  fx: Frame;
+  color: ResolvedColorScale | null;
+  warnings: PipelineWarning[];
+}): {
+  positions: Float32Array;
+  rowIndex: Uint32Array;
+  pathOffsets: Uint32Array;
+  strokes: (string | null)[];
+  /** Non-empty group row lists (for single-observation warnings / x-sort). */
+  groupRows: number[][];
+} | null {
+  const { frame, fx, color, warnings } = input;
+  const xNum = frame.xNumeric;
+  const yNum = frame.yNumeric;
+  if (fx.xScale.type === "band" || fx.yScale.type === "band" || xNum === null || yNum === null) {
+    return null;
+  }
+  const xScale = fx.xScale;
+  const yScale = fx.yScale;
+  const iw = fx.innerWidth;
+  const ih = fx.innerHeight;
+  const sourceRows = frame.rowIndex;
+  const groups = frame.groups;
+  const n = frame.n;
+
+  let maxG = -1;
+  for (let row = 0; row < n; row++) {
+    const g = groups[row]!;
+    if (g > maxG) maxG = g;
+  }
+  if (maxG < 0) return null;
+
+  // Growable per-group buffers (row indices + pixel pairs). Competitive
+  // multi-series has few groups (3) so Array push is fine.
+  const keptRows: number[][] = Array.from({ length: maxG + 1 }, () => []);
+  const keptPx: number[][] = Array.from({ length: maxG + 1 }, () => []);
+  let removed = 0;
+  let kept = 0;
+  for (let row = 0; row < n; row++) {
+    const xv = xNum[row]!;
+    const yv = yNum[row]!;
+    if (!Number.isFinite(xv) || !Number.isFinite(yv)) {
+      removed++;
+      continue;
+    }
+    const tx = xScale.normalizeTransformed(xv);
+    const ty = yScale.normalizeTransformed(yv);
+    if (Number.isNaN(tx) || Number.isNaN(ty)) {
+      removed++;
+      continue;
+    }
+    const g = groups[row]!;
+    keptRows[g]!.push(row);
+    keptPx[g]!.push(tx * iw, ih - ty * ih);
+    kept++;
+  }
+  removedWarning(removed, frame.binding.index, warnings);
+  if (kept === 0) return null;
+
+  const nonEmpty: number[] = [];
+  for (let g = 0; g <= maxG; g++) {
+    if (keptRows[g]!.length > 0) nonEmpty.push(g);
+  }
+  const pathOffsets = new Uint32Array(nonEmpty.length + 1);
+  const positions = new Float32Array(kept * 2);
+  const rowIndex = new Uint32Array(kept);
+  const styleRows = new Uint32Array(nonEmpty.length);
+  const groupRows: number[][] = [];
+  let cursor = 0;
+  for (let s = 0; s < nonEmpty.length; s++) {
+    const g = nonEmpty[s]!;
+    const rows = keptRows[g]!;
+    const px = keptPx[g]!;
+    pathOffsets[s] = cursor;
+    styleRows[s] = rows[0]!;
+    groupRows.push(rows);
+    for (let i = 0; i < rows.length; i++) {
+      positions[cursor * 2] = px[i * 2]!;
+      positions[cursor * 2 + 1] = px[i * 2 + 1]!;
+      rowIndex[cursor] = sourceRows[rows[i]!]!;
+      cursor++;
+    }
+  }
+  pathOffsets[nonEmpty.length] = cursor;
+  const strokes = paintVector(frame, "color", color, styleRows);
+  return { positions, rowIndex, pathOffsets, strokes, groupRows };
 }

--- a/packages/core/src/pipeline/geometry-paths-line.ts
+++ b/packages/core/src/pipeline/geometry-paths-line.ts
@@ -19,8 +19,16 @@ import {
   sortGroupRowsByX,
   warnSingleObservationGroups,
 } from "./geometry-shared.js";
-import { writeLineSubpaths } from "./geometry-paths-line-write.js";
+import { writeContinuousLineOnePass, writeLineSubpaths } from "./geometry-paths-line-write.js";
 import { splitStyleSubpaths } from "./geometry-paths-style-subpaths.js";
+
+/** True when linewidth/alpha/linetype are not per-vertex mapped (style split free). */
+function hasMappedStrokeStyle(frame: LayerFrame): boolean {
+  return (["linewidth", "alpha", "linetype"] as const).some((aesthetic) => {
+    const style = frame.binding[aesthetic];
+    return style.field !== null || style.statColumn !== null || style.scaledConstant !== null;
+  });
+}
 
 export function lineBatch(
   frame: LayerFrame,
@@ -31,15 +39,6 @@ export function lineBatch(
   options: { sortByX?: boolean } = {},
 ): PathsBatch | null {
   const { binding } = frame;
-  const groupedRows = bucketByGroup(frame, fx, null, warnings);
-  if (groupedRows.length === 0) return null;
-  warnSingleObservationGroups(groupedRows, frame, warnings);
-  // geom_line sorts by x; geom_path keeps data/row order (#788).
-  if (options.sortByX !== false && binding.layer.geom !== "path") {
-    sortGroupRowsByX(groupedRows, frame, fx);
-  }
-  const subpaths = splitStyleSubpaths(frame, groupedRows, styles);
-  const styleSplit = subpaths.length > groupedRows.length;
 
   const paint = layerPaintFromParams(binding.layer.params);
   const strokePaintResolved =
@@ -48,13 +47,82 @@ export function lineBatch(
       : resolveGradientPaint(paint.strokePaint, binding.index, "stroke");
   const glowResolved = paint.glow === null ? undefined : resolveGlow(paint.glow, binding.index);
 
-  const { positions, rowIndex, frameRowIndex, pathOffsets, strokes } = writeLineSubpaths({
-    frame,
-    fx,
-    color,
-    subpaths,
-    includeFrameRows: styleSplit,
-  });
+  // Continuous multi-series hot path (#1468): one normalize+pixel pass that also
+  // buckets by group. Skipped when stroke style is per-vertex (style split) or
+  // scales are band — falls through to the classic bucket → sort → write path.
+  const wantSortByX = options.sortByX !== false && binding.layer.geom !== "path";
+  let positions: Float32Array;
+  let rowIndex: Uint32Array;
+  let frameRowIndex: Uint32Array | undefined;
+  let pathOffsets: Uint32Array;
+  let strokes: (string | null)[];
+  let subpaths: readonly (readonly number[])[];
+
+  const onePass =
+    !hasMappedStrokeStyle(frame) &&
+    fx.xScale.type !== "band" &&
+    fx.yScale.type !== "band" &&
+    frame.xNumeric !== null &&
+    frame.yNumeric !== null
+      ? writeContinuousLineOnePass({ frame, fx, color, warnings })
+      : null;
+
+  if (onePass !== null) {
+    // If x within any group is out of order, fall back so sortGroupRowsByX +
+    // write stay correct (one-pass pixels would desync after a row reorder).
+    let needsSort = false;
+    if (wantSortByX) {
+      const x = frame.xNumeric!;
+      for (const rows of onePass.groupRows) {
+        for (let i = 1; i < rows.length; i++) {
+          if (!(x[rows[i]!]! >= x[rows[i - 1]!]!)) {
+            needsSort = true;
+            break;
+          }
+        }
+        if (needsSort) break;
+      }
+    }
+    if (needsSort) {
+      // Pixels from one-pass discarded; re-write after x-sort.
+      const groupedRows = onePass.groupRows.map((rows) => rows.slice());
+      sortGroupRowsByX(groupedRows, frame, fx);
+      warnSingleObservationGroups(groupedRows, frame, warnings);
+      subpaths = groupedRows;
+      ({ positions, rowIndex, frameRowIndex, pathOffsets, strokes } = writeLineSubpaths({
+        frame,
+        fx,
+        color,
+        subpaths,
+      }));
+    } else {
+      warnSingleObservationGroups(onePass.groupRows, frame, warnings);
+      positions = onePass.positions;
+      rowIndex = onePass.rowIndex;
+      pathOffsets = onePass.pathOffsets;
+      strokes = onePass.strokes;
+      subpaths = onePass.groupRows;
+    }
+  } else {
+    const groupedRows = bucketByGroup(frame, fx, null, warnings);
+    if (groupedRows.length === 0) return null;
+    warnSingleObservationGroups(groupedRows, frame, warnings);
+    // geom_line sorts by x; geom_path keeps data/row order (#788).
+    if (wantSortByX) {
+      sortGroupRowsByX(groupedRows, frame, fx);
+    }
+    subpaths = splitStyleSubpaths(frame, groupedRows, styles);
+    const styleSplit = subpaths.length > groupedRows.length;
+    ({ positions, rowIndex, frameRowIndex, pathOffsets, strokes } = writeLineSubpaths({
+      frame,
+      fx,
+      color,
+      subpaths,
+      includeFrameRows: styleSplit,
+    }));
+  }
+
+  if (subpaths.length === 0) return null;
 
   // Apply strokePaint solid fallback when a stroke is still null/theme-default.
   if (strokePaintResolved !== undefined) {

--- a/packages/core/src/pipeline/geometry-paths-line.ts
+++ b/packages/core/src/pipeline/geometry-paths-line.ts
@@ -30,6 +30,88 @@ function hasMappedStrokeStyle(frame: LayerFrame): boolean {
   });
 }
 
+/** True when any group has x keys out of non-decreasing order. */
+function groupsNeedXSort(
+  groupRows: readonly (readonly number[])[],
+  xNumeric: Float64Array,
+): boolean {
+  for (const rows of groupRows) {
+    for (let i = 1; i < rows.length; i++) {
+      if (xNumeric[rows[i]!]! < xNumeric[rows[i - 1]!]!) return true;
+    }
+  }
+  return false;
+}
+
+type LineBuffers = {
+  positions: Float32Array;
+  rowIndex: Uint32Array;
+  frameRowIndex?: Uint32Array;
+  pathOffsets: Uint32Array;
+  strokes: (string | null)[];
+  subpaths: readonly (readonly number[])[];
+};
+
+/**
+ * Continuous multi-series: one normalize+pixel pass that also buckets by group.
+ * Falls back to bucket → sort → write when stroke style is mapped, scales are
+ * band, or x within a group needs sorting.
+ */
+function buildLineBuffers(
+  frame: LayerFrame,
+  fx: Frame,
+  color: ResolvedColorScale | null,
+  styles: ResolvedStyleScales,
+  warnings: PipelineWarning[],
+  wantSortByX: boolean,
+): LineBuffers | null {
+  const canOnePass =
+    !hasMappedStrokeStyle(frame) &&
+    fx.xScale.type !== "band" &&
+    fx.yScale.type !== "band" &&
+    frame.xNumeric !== null &&
+    frame.yNumeric !== null;
+  const onePass = canOnePass ? writeContinuousLineOnePass({ frame, fx, color, warnings }) : null;
+
+  if (onePass === null) {
+    const groupedRows = bucketByGroup(frame, fx, null, warnings);
+    if (groupedRows.length === 0) return null;
+    warnSingleObservationGroups(groupedRows, frame, warnings);
+    // geom_line sorts by x; geom_path keeps data/row order (#788).
+    if (wantSortByX) sortGroupRowsByX(groupedRows, frame, fx);
+    const subpaths = splitStyleSubpaths(frame, groupedRows, styles);
+    const styleSplit = subpaths.length > groupedRows.length;
+    const written = writeLineSubpaths({
+      frame,
+      fx,
+      color,
+      subpaths,
+      includeFrameRows: styleSplit,
+    });
+    return { ...written, subpaths };
+  }
+
+  // If x within any group is out of order, fall back so sortGroupRowsByX +
+  // write stay correct (one-pass pixels would desync after a row reorder).
+  const needsSort = wantSortByX && groupsNeedXSort(onePass.groupRows, frame.xNumeric!);
+  if (needsSort) {
+    const groupedRows = onePass.groupRows.map((rows) => rows.slice());
+    sortGroupRowsByX(groupedRows, frame, fx);
+    warnSingleObservationGroups(groupedRows, frame, warnings);
+    const written = writeLineSubpaths({ frame, fx, color, subpaths: groupedRows });
+    return { ...written, subpaths: groupedRows };
+  }
+
+  warnSingleObservationGroups(onePass.groupRows, frame, warnings);
+  return {
+    positions: onePass.positions,
+    rowIndex: onePass.rowIndex,
+    pathOffsets: onePass.pathOffsets,
+    strokes: onePass.strokes,
+    subpaths: onePass.groupRows,
+  };
+}
+
 export function lineBatch(
   frame: LayerFrame,
   fx: Frame,
@@ -47,82 +129,10 @@ export function lineBatch(
       : resolveGradientPaint(paint.strokePaint, binding.index, "stroke");
   const glowResolved = paint.glow === null ? undefined : resolveGlow(paint.glow, binding.index);
 
-  // Continuous multi-series hot path (#1468): one normalize+pixel pass that also
-  // buckets by group. Skipped when stroke style is per-vertex (style split) or
-  // scales are band — falls through to the classic bucket → sort → write path.
   const wantSortByX = options.sortByX !== false && binding.layer.geom !== "path";
-  let positions: Float32Array;
-  let rowIndex: Uint32Array;
-  let frameRowIndex: Uint32Array | undefined;
-  let pathOffsets: Uint32Array;
-  let strokes: (string | null)[];
-  let subpaths: readonly (readonly number[])[];
-
-  const onePass =
-    !hasMappedStrokeStyle(frame) &&
-    fx.xScale.type !== "band" &&
-    fx.yScale.type !== "band" &&
-    frame.xNumeric !== null &&
-    frame.yNumeric !== null
-      ? writeContinuousLineOnePass({ frame, fx, color, warnings })
-      : null;
-
-  if (onePass !== null) {
-    // If x within any group is out of order, fall back so sortGroupRowsByX +
-    // write stay correct (one-pass pixels would desync after a row reorder).
-    let needsSort = false;
-    if (wantSortByX) {
-      const x = frame.xNumeric!;
-      for (const rows of onePass.groupRows) {
-        for (let i = 1; i < rows.length; i++) {
-          if (!(x[rows[i]!]! >= x[rows[i - 1]!]!)) {
-            needsSort = true;
-            break;
-          }
-        }
-        if (needsSort) break;
-      }
-    }
-    if (needsSort) {
-      // Pixels from one-pass discarded; re-write after x-sort.
-      const groupedRows = onePass.groupRows.map((rows) => rows.slice());
-      sortGroupRowsByX(groupedRows, frame, fx);
-      warnSingleObservationGroups(groupedRows, frame, warnings);
-      subpaths = groupedRows;
-      ({ positions, rowIndex, frameRowIndex, pathOffsets, strokes } = writeLineSubpaths({
-        frame,
-        fx,
-        color,
-        subpaths,
-      }));
-    } else {
-      warnSingleObservationGroups(onePass.groupRows, frame, warnings);
-      positions = onePass.positions;
-      rowIndex = onePass.rowIndex;
-      pathOffsets = onePass.pathOffsets;
-      strokes = onePass.strokes;
-      subpaths = onePass.groupRows;
-    }
-  } else {
-    const groupedRows = bucketByGroup(frame, fx, null, warnings);
-    if (groupedRows.length === 0) return null;
-    warnSingleObservationGroups(groupedRows, frame, warnings);
-    // geom_line sorts by x; geom_path keeps data/row order (#788).
-    if (wantSortByX) {
-      sortGroupRowsByX(groupedRows, frame, fx);
-    }
-    subpaths = splitStyleSubpaths(frame, groupedRows, styles);
-    const styleSplit = subpaths.length > groupedRows.length;
-    ({ positions, rowIndex, frameRowIndex, pathOffsets, strokes } = writeLineSubpaths({
-      frame,
-      fx,
-      color,
-      subpaths,
-      includeFrameRows: styleSplit,
-    }));
-  }
-
-  if (subpaths.length === 0) return null;
+  const buffers = buildLineBuffers(frame, fx, color, styles, warnings, wantSortByX);
+  if (buffers === null || buffers.subpaths.length === 0) return null;
+  const { positions, rowIndex, frameRowIndex, pathOffsets, strokes, subpaths } = buffers;
 
   // Apply strokePaint solid fallback when a stroke is still null/theme-default.
   if (strokePaintResolved !== undefined) {

--- a/packages/core/src/pipeline/geometry-shared-bucket.ts
+++ b/packages/core/src/pipeline/geometry-shared-bucket.ts
@@ -17,6 +17,8 @@ export function bucketByGroup(
   // filter (no band / column normalize branch). Still call normalizeTransformed
   // so projected panel scales (coord log/sqrt/etc.) that map out-of-range
   // fractions to NaN are dropped with removed-missing — same as positionOf.
+  // Do not short-circuit on type/transform alone: projectors wrap linear
+  // identity scales and override normalizeTransformed.
   if (
     fx.xScale.type !== "band" &&
     fx.yScale.type !== "band" &&

--- a/packages/core/src/pipeline/scale-color-collect.ts
+++ b/packages/core/src/pipeline/scale-color-collect.ts
@@ -46,6 +46,57 @@ export function collectColorChannelValues(
   return { values, anyDiscreteField, anyField };
 }
 
+/**
+ * Frame-level mapping flags without materializing per-row values.
+ * Ordinal training uses the source catalog; sequential still needs the full
+ * values array from {@link collectColorChannelValues}.
+ */
+export function collectColorChannelFlags(
+  name: "color" | "fill",
+  frames: readonly LayerFrame[],
+  table: ColumnTable,
+): { anyDiscreteField: boolean; anyField: boolean } {
+  let anyDiscreteField = false;
+  let anyField = false;
+  for (const frame of frames) {
+    const channel = name === "color" ? frame.binding.color : frame.binding.fill;
+    const frameValues = name === "color" ? frame.colorValues : frame.fillValues;
+    if (frameValues !== null && (channel.field !== null || (channel.statColumn ?? null) !== null)) {
+      anyField = true;
+      if (
+        channel.field !== null &&
+        table.has(channel.field) &&
+        table.discreteness(channel.field) === "discrete"
+      ) {
+        anyDiscreteField = true;
+      }
+    }
+    if (channel.scaledConstant !== null) {
+      anyDiscreteField = true;
+      anyField = true;
+    }
+  }
+  return { anyDiscreteField, anyField };
+}
+
+/** Count null cells on the mapped color/fill channel (NA-color warning). */
+export function countNullColorChannelValues(
+  name: "color" | "fill",
+  frames: readonly LayerFrame[],
+): number {
+  let missing = 0;
+  for (const frame of frames) {
+    const channel = name === "color" ? frame.binding.color : frame.binding.fill;
+    const frameValues = name === "color" ? frame.colorValues : frame.fillValues;
+    if (frameValues !== null && (channel.field !== null || (channel.statColumn ?? null) !== null)) {
+      for (let i = 0; i < frameValues.length; i++) {
+        if (frameValues[i] === null) missing++;
+      }
+    }
+  }
+  return missing;
+}
+
 export interface CollectedColorCatalog {
   /** Distinct channel values from the unfiltered source table, in first-seen
    * order. Empty when no layer maps the channel. */
@@ -67,6 +118,15 @@ export function collectColorCatalogValues(
   const catalogValues: CellValue[] = [];
   const catalogKeys = new Set<string>();
   const addCatalogValue = (value: CellValue): void => {
+    // Monomorphic strings (series labels): Set membership on the string
+    // itself — encodeKey for plain strings is identity, but the call +
+    // startsWith("@") check still costs at 30k cells.
+    if (typeof value === "string" && !value.startsWith("@")) {
+      if (catalogKeys.has(value)) return;
+      catalogKeys.add(value);
+      catalogValues.push(value);
+      return;
+    }
     const key = encodeKey(value);
     if (catalogKeys.has(key)) return;
     catalogKeys.add(key);

--- a/packages/core/src/pipeline/scale-color.ts
+++ b/packages/core/src/pipeline/scale-color.ts
@@ -7,7 +7,12 @@ import type { ScaleState } from "../scales/state.js";
 import type { ColumnTable } from "../table.js";
 import type { EditionDefaults } from "../editions.js";
 
-import { collectColorCatalogValues, collectColorChannelValues } from "./scale-color-collect.js";
+import {
+  collectColorCatalogValues,
+  collectColorChannelFlags,
+  collectColorChannelValues,
+  countNullColorChannelValues,
+} from "./scale-color-collect.js";
 import { resolveBinnedColorScale } from "./scale-color-binned.js";
 import { resolveIdentityColorScale } from "./scale-color-identity.js";
 import { resolveManualColorScale } from "./scale-color-manual.js";
@@ -31,21 +36,47 @@ export function resolveColorScale(
   advisories: Advisory[],
   editionDefaults: EditionDefaults,
 ): ColorResolution {
-  const collected = collectColorChannelValues(name, frames, table);
+  // Catalog first: ordinal multi-series only needs distinct source values
+  // (often 3 labels), not a 30k-element values array. Flags avoid the full
+  // push when type resolves to ordinal (#1468).
   const catalog = collectColorCatalogValues(name, bindings, catalogTable);
-  const values = collected.values;
-  const missingCount = values.filter((value) => value === null).length;
+  const flags = collectColorChannelFlags(name, frames, table);
+  const anyDiscreteField = flags.anyDiscreteField || catalog.anyDiscreteField;
+  const anyField = flags.anyField || catalog.anyField;
+  if (!anyField) return { resolved: null, legendInput: null, guidePlan: null, state: null };
+
+  const type = configuredColorScaleType(config) ?? (anyDiscreteField ? "ordinal" : "sequential");
+
+  // NA-color warning: count nulls without allocating a full values array.
+  const missingCount = countNullColorChannelValues(name, frames);
   if (missingCount > 0) {
     warnings.push({
       code: "color-na-values",
       message: `${String(missingCount)} ${name} value(s) use the NA color.`,
     });
   }
-  const anyDiscreteField = collected.anyDiscreteField || catalog.anyDiscreteField;
-  const anyField = collected.anyField || catalog.anyField;
-  if (!anyField) return { resolved: null, legendInput: null, guidePlan: null, state: null };
 
-  const type = configuredColorScaleType(config) ?? (anyDiscreteField ? "ordinal" : "sequential");
+  // Ordinal: train on the unfiltered source catalog when available.
+  if (type === "ordinal") {
+    let domainValues = catalog.catalogValues;
+    if (domainValues.length === 0) {
+      // No source field (stat-only color): fall back to frame values.
+      domainValues = collectColorChannelValues(name, frames, table).values;
+    }
+    return resolveOrdinalColorScale({
+      name,
+      values: domainValues.filter((value) => value !== null),
+      config,
+      prevState,
+      legendTitle,
+      warnings,
+      advisories,
+      editionDefaults,
+    });
+  }
+
+  // Sequential / binned / manual / identity still need the per-row values.
+  const values = collectColorChannelValues(name, frames, table).values;
 
   if (type === "sequential") {
     return resolveSequentialColorScale({
@@ -80,28 +111,12 @@ export function resolveColorScale(
       warnings,
     });
   }
-  if (type === "identity") {
-    return resolveIdentityColorScale({
-      name,
-      values,
-      config: config ?? { type: "identity" },
-      legendTitle,
-      warnings,
-    });
-  }
-
-  // Ordinal scales train on the unfiltered source catalog when available, so
-  // categorical assignments stay stable while runtime filters change the rows.
-  return resolveOrdinalColorScale({
+  // identity
+  return resolveIdentityColorScale({
     name,
-    values: (catalog.catalogValues.length > 0 ? catalog.catalogValues : values).filter(
-      (value) => value !== null,
-    ),
-    config,
-    prevState,
+    values,
+    config: config ?? { type: "identity" },
     legendTitle,
     warnings,
-    advisories,
-    editionDefaults,
   });
 }

--- a/packages/core/src/table.ts
+++ b/packages/core/src/table.ts
@@ -298,7 +298,7 @@ function stringLooksNumeric(value: string): boolean {
  */
 function fieldTypeFromLiteDecision(
   decision: ParsedColumnView["decision"],
-  raw: readonly CellValue[],
+  getRaw: () => readonly CellValue[],
 ): FieldType | null {
   // Only lean parse keys carry monomorphic classification we can trust.
   if (decision.parserKey !== "lite:auto" && decision.parserKey !== "lite:numeric-only") {
@@ -310,6 +310,7 @@ function fieldTypeFromLiteDecision(
   if (validatedCount === nonNullCount) return "quantitative";
   // No finite semantic: pure labels or all-NaN numbers. One non-null probe.
   if (validatedCount === 0) {
+    const raw = getRaw();
     for (let i = 0; i < raw.length; i++) {
       const value = raw[i]!;
       if (value === null) continue;
@@ -625,7 +626,8 @@ export class ColumnTable {
           : // Lean monomorphic parse already classified the column once
             // (pure numbers / pure labels). Reuse that instead of a second
             // O(n) typeof walk — fieldType was a top bind cost on line-3×10k.
-            (fieldTypeFromLiteDecision(view.decision, this.column(name)) ??
+            // Lazy column() so facet O(n) read-count tests stay bounded (#183).
+            (fieldTypeFromLiteDecision(view.decision, () => this.column(name)) ??
             nonTemporalFieldType(this.column(name)));
     this.#typeCache.set(cacheKey, type);
     return type;

--- a/packages/core/src/table.ts
+++ b/packages/core/src/table.ts
@@ -291,6 +291,36 @@ function stringLooksNumeric(value: string): boolean {
   return (c0 >= 48 && c0 <= 57) || c0 === 43 || c0 === 45 || c0 === 46;
 }
 
+/**
+ * Derive field type from a lean liteParse decision without re-scanning the
+ * column. Returns null when the decision is ambiguous (mixed cells) so the
+ * caller can fall back to {@link nonTemporalFieldType}.
+ */
+function fieldTypeFromLiteDecision(
+  decision: ParsedColumnView["decision"],
+  raw: readonly CellValue[],
+): FieldType | null {
+  // Only lean parse keys carry monomorphic classification we can trust.
+  if (decision.parserKey !== "lite:auto" && decision.parserKey !== "lite:numeric-only") {
+    return null;
+  }
+  const { nonNullCount, validatedCount } = decision;
+  if (nonNullCount === 0) return "quantitative";
+  // Every non-null cell produced a finite semantic → quantitative (pure numbers).
+  if (validatedCount === nonNullCount) return "quantitative";
+  // No finite semantic: pure labels or all-NaN numbers. One non-null probe.
+  if (validatedCount === 0) {
+    for (let i = 0; i < raw.length; i++) {
+      const value = raw[i]!;
+      if (value === null) continue;
+      return typeof value === "number" ? "quantitative" : "nominal";
+    }
+    return "quantitative";
+  }
+  // Partial validation (mixed / numeric-text / ISO fragments) — full scan.
+  return null;
+}
+
 function fallbackNumeric(
   raw: readonly CellValue[],
   inferTemporal: boolean,
@@ -592,7 +622,11 @@ export class ColumnTable {
           : "nominal"
         : view.decision.status === "temporal"
           ? "temporal"
-          : nonTemporalFieldType(this.column(name));
+          : // Lean monomorphic parse already classified the column once
+            // (pure numbers / pure labels). Reuse that instead of a second
+            // O(n) typeof walk — fieldType was a top bind cost on line-3×10k.
+            (fieldTypeFromLiteDecision(view.decision, this.column(name)) ??
+            nonTemporalFieldType(this.column(name)));
     this.#typeCache.set(cacheKey, type);
     return type;
   }

--- a/packages/core/src/table.ts
+++ b/packages/core/src/table.ts
@@ -159,7 +159,9 @@ function liteParseColumn(
       decision: {
         status: "nominal",
         parser: null,
-        parserKey: "lite:auto",
+        // Distinct key so fieldType can classify without re-scanning (and
+        // without a first-cell probe that mis-types Date / mixed columns).
+        parserKey: "lite:numbers",
         kind: null,
         precision: null,
         evidence: [],
@@ -200,7 +202,9 @@ function liteParseColumn(
       decision: {
         status: "nominal",
         parser: null,
-        parserKey: "lite:auto",
+        // lite:labels = pure non-ISO strings; lite:auto = mixed / numeric-text
+        // (fieldType must fall back to nonTemporalFieldType for the latter).
+        parserKey: pureNonIsoLabelStrings ? "lite:labels" : "lite:auto",
         kind: null,
         precision: null,
         evidence: [],
@@ -292,34 +296,21 @@ function stringLooksNumeric(value: string): boolean {
 }
 
 /**
- * Derive field type from a lean liteParse decision without re-scanning the
- * column. Returns null when the decision is ambiguous (mixed cells) so the
- * caller can fall back to {@link nonTemporalFieldType}.
+ * Map monomorphic lean parse keys to field types without re-scanning.
+ * Returns null for `lite:auto` (mixed / numeric-text / Dates) so the caller
+ * runs {@link nonTemporalFieldType} — a first-cell probe would mis-type pure
+ * Date columns as nominal and mixed number/text as quantitative (#1477 review).
  */
-function fieldTypeFromLiteDecision(
-  decision: ParsedColumnView["decision"],
-  getRaw: () => readonly CellValue[],
-): FieldType | null {
-  // Only lean parse keys carry monomorphic classification we can trust.
-  if (decision.parserKey !== "lite:auto" && decision.parserKey !== "lite:numeric-only") {
-    return null;
+function fieldTypeFromLiteDecision(decision: ParsedColumnView["decision"]): FieldType | null {
+  switch (decision.parserKey) {
+    case "lite:numbers":
+    case "lite:numeric-only":
+      return "quantitative";
+    case "lite:labels":
+      return "nominal";
+    default:
+      return null;
   }
-  const { nonNullCount, validatedCount } = decision;
-  if (nonNullCount === 0) return "quantitative";
-  // Every non-null cell produced a finite semantic → quantitative (pure numbers).
-  if (validatedCount === nonNullCount) return "quantitative";
-  // No finite semantic: pure labels or all-NaN numbers. One non-null probe.
-  if (validatedCount === 0) {
-    const raw = getRaw();
-    for (let i = 0; i < raw.length; i++) {
-      const value = raw[i]!;
-      if (value === null) continue;
-      return typeof value === "number" ? "quantitative" : "nominal";
-    }
-    return "quantitative";
-  }
-  // Partial validation (mixed / numeric-text / ISO fragments) — full scan.
-  return null;
 }
 
 function fallbackNumeric(
@@ -623,12 +614,10 @@ export class ColumnTable {
           : "nominal"
         : view.decision.status === "temporal"
           ? "temporal"
-          : // Lean monomorphic parse already classified the column once
-            // (pure numbers / pure labels). Reuse that instead of a second
-            // O(n) typeof walk — fieldType was a top bind cost on line-3×10k.
-            // Lazy column() so facet O(n) read-count tests stay bounded (#183).
-            (fieldTypeFromLiteDecision(view.decision, () => this.column(name)) ??
-            nonTemporalFieldType(this.column(name)));
+          : // Monomorphic lean keys (lite:numbers / lite:labels) skip the
+            // second O(n) typeof walk; mixed/Date fall through to
+            // nonTemporalFieldType so lean and full agree (#1477 review).
+            (fieldTypeFromLiteDecision(view.decision) ?? nonTemporalFieldType(this.column(name)));
     this.#typeCache.set(cacheKey, type);
     return type;
   }

--- a/packages/core/tests/scale-color-collect.test.ts
+++ b/packages/core/tests/scale-color-collect.test.ts
@@ -4,6 +4,8 @@
 import { describe, expect, it } from "bun:test";
 import { fromAny } from "@total-typescript/shoehorn";
 
+import { ColumnTable } from "../src/table.ts";
+
 describe("collectColorChannelValues", () => {
   it("returns empty when no color mapping is present", async () => {
     const { collectColorChannelValues } = await import("../src/pipeline/scale-color-collect.ts");
@@ -23,5 +25,50 @@ describe("collectColorChannelValues", () => {
       anyDiscreteField: false,
       anyField: false,
     });
+  });
+});
+
+describe("collectColorChannelFlags + countNullColorChannelValues", () => {
+  it("flags mapping without materializing per-row values", async () => {
+    const { collectColorChannelFlags, countNullColorChannelValues } =
+      await import("../src/pipeline/scale-color-collect.ts");
+    const table = ColumnTable.fromColumns({
+      series: ["a", "b", null, "a"],
+    });
+    const frames = fromAny([
+      {
+        binding: {
+          color: { field: "series", scaledConstant: null, statColumn: null },
+          fill: { field: null, scaledConstant: null, statColumn: null },
+        },
+        colorValues: table.column("series"),
+        fillValues: null,
+      },
+    ]);
+    expect(collectColorChannelFlags("color", frames, table)).toEqual({
+      anyDiscreteField: true,
+      anyField: true,
+    });
+    expect(countNullColorChannelValues("color", frames)).toBe(1);
+  });
+});
+
+describe("collectColorCatalogValues string monomorph path", () => {
+  it("keeps first-seen order for series labels", async () => {
+    const { collectColorCatalogValues } = await import("../src/pipeline/scale-color-collect.ts");
+    const table = ColumnTable.fromColumns({
+      series: ["s0", "s1", "s0", "s2", "s1"],
+    });
+    const bindings = fromAny([
+      {
+        color: { field: "series", scaledConstant: null },
+        fill: { field: null, scaledConstant: null },
+        sourceTable: table,
+      },
+    ]);
+    const catalog = collectColorCatalogValues("color", bindings, table);
+    expect(catalog.catalogValues).toEqual(["s0", "s1", "s2"]);
+    expect(catalog.anyDiscreteField).toBe(true);
+    expect(catalog.anyField).toBe(true);
   });
 });

--- a/packages/core/tests/table-lean-temporal.test.ts
+++ b/packages/core/tests/table-lean-temporal.test.ts
@@ -78,11 +78,29 @@ describe("lean ColumnTable temporal detection (no runtime)", () => {
     // Pure numbers → quantitative; pure labels → nominal; both paths must
     // agree with nonTemporalFieldType on the same cells (#1468).
     const nums = ColumnTable.fromColumns({ x: [0, 1, 2, null, 3] });
+    expect(nums.parsed("x").decision.parserKey).toBe("lite:numbers");
     expect(nums.fieldType("x")).toBe("quantitative");
     expect(nums.discreteness("x")).toBe("continuous");
     const labels = ColumnTable.fromColumns({ g: ["a", "b", "a"] });
+    expect(labels.parsed("g").decision.parserKey).toBe("lite:labels");
     expect(labels.fieldType("g")).toBe("nominal");
     expect(labels.discreteness("g")).toBe("discrete");
+  });
+
+  it("fieldType still classifies pure Date columns as temporal on the lean path", () => {
+    // Devin #1477: first-cell probe would have returned nominal; nonTemporalFieldType
+    // must still run for lite:auto / Date-only columns.
+    const table = ColumnTable.fromColumns({
+      when: [new Date("2024-01-01T00:00:00Z"), new Date("2024-01-02T00:00:00Z")],
+    });
+    expect(table.parsed("when").decision.parserKey).toBe("lite:auto");
+    expect(table.fieldType("when")).toBe("temporal");
+  });
+
+  it("fieldType still classifies mixed number/text as nominal on the lean path", () => {
+    const table = ColumnTable.fromColumns({ mixed: [1, "a", 2] });
+    expect(table.parsed("mixed").decision.parserKey).toBe("lite:auto");
+    expect(table.fieldType("mixed")).toBe("nominal");
   });
 
   it("still coerces numeric text columns via Number (CSV-ish weights)", () => {

--- a/packages/core/tests/table-lean-temporal.test.ts
+++ b/packages/core/tests/table-lean-temporal.test.ts
@@ -74,6 +74,17 @@ describe("lean ColumnTable temporal detection (no runtime)", () => {
     }
   });
 
+  it("fieldType uses lite decision without a second typeof walk on pure columns", () => {
+    // Pure numbers → quantitative; pure labels → nominal; both paths must
+    // agree with nonTemporalFieldType on the same cells (#1468).
+    const nums = ColumnTable.fromColumns({ x: [0, 1, 2, null, 3] });
+    expect(nums.fieldType("x")).toBe("quantitative");
+    expect(nums.discreteness("x")).toBe("continuous");
+    const labels = ColumnTable.fromColumns({ g: ["a", "b", "a"] });
+    expect(labels.fieldType("g")).toBe("nominal");
+    expect(labels.discreteness("g")).toBe("discrete");
+  });
+
   it("still coerces numeric text columns via Number (CSV-ish weights)", () => {
     // Must not take the all-NaN label fast path — lean and full runtime agree.
     const table = ColumnTable.fromColumns({


### PR DESCRIPTION
## Summary

Next cut on [#1468](https://github.com/ljodea/ggsvelte/issues/1468) after #1475. Product hot-path wins plus a marks-only competitive adapter feed.

### Core
- **`fieldType`**: reuse lean parse decisions for pure number / pure label columns (no second `typeof` walk over 30k cells)
- **Ordinal color**: train from the source catalog without materializing a 30k values array; null NA count without allocating
- **Line geometry**: continuous multi-series one-pass (normalize once while bucketing) when stroke style is constant and x is already sorted
- **Canvas paint**: monomorphic solid multi-series stroke loop (no `resolvePathMark` / per-subpath dash setup)
- **Identity frames**: fill `rowIndex` without `Uint32Array.from` callbacks

### Competitive adapter
- Named data ref (`{ name: "main" }` + `RunOptions.data`) so mount/update does not snapshot 30k cells through `toPortable` every draw
- `theme("void")` + `guides({ color: { type: "none" } })` so marks-only fixtures do not pay legend layout (string `"none"` is **not** normalized — object form required)

## Benchmark (rigorous)

Machine: linux-x64, Chromium via Playwright, median of 11 after 2 warmup, case-outer pairing, paint-inclusive double-rAF.

### Baseline (main @ 5249477b, pre this PR)
| case | ggsvelte-canvas | layercake-canvas | ratio |
|------|----------------:|-----------------:|------:|
| line-3x10k mount | 64.3ms | 47.1ms | 1.36× |
| scatter-color-10k mount | 38.5ms | 29.3ms | 1.31× |

### After this PR (same-run, representative)
| case | ggsvelte-canvas | layercake-canvas | ratio | gate thr (peer×1.02+2) |
|------|----------------:|-----------------:|------:|-----------------------:|
| line-3x10k mount | **~55ms** | ~48ms | ~1.15× | ~51ms — **still knownGap** |
| scatter-color-10k mount | **~33ms** | ~28ms | ~1.18× | ~30ms — **still knownGap** (borderline) |

Triple-run spread (ggsvelte line mount): 55–58ms; layercake 44–49ms. Relative gate not closed; knownGaps kept with updated notes.

Node pipeline (named data + void + color guide none): bind/parse/train/geometry still dominate; floor is largely browser JS + double-rAF (~23ms uplot).

### Angles tried that did **not** close the floor
- Skipping x/y axis guides entirely: larger panel, **slower** paint
- Linear-identity skip of `normalizeTransformed` in `bucketByGroup`: incorrect under projected scales (reverted; test keeps the contract)
- Float64Array columns: slower under current `ColumnTable` path

## Test plan
- [x] `bun test` targeted: table lean, scale-color collect, resolveColorScale, color scales, line hotpath, paint batch
- [x] Competitive browser measure (line-3x10k + scatter-color-10k) vs layercake-canvas
- [ ] CI green
- [ ] Re-check relative gate on CI runner variance
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1477" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->