### PR TITLE
docs(site): bun-like code blocks — soft dark surface, ghost copy, header titles

### DIFF
--- a/apps/docs/src/lib/CodeTabs.svelte
+++ b/apps/docs/src/lib/CodeTabs.svelte
@@ -159,7 +159,7 @@
     flex: 0 0 auto;
     padding: 0.3rem 0.65rem;
     border: 0;
-    border-radius: 7px;
+    border-radius: var(--radius);
     background: none;
     color: color-mix(in srgb, var(--code-ink) 55%, transparent);
     cursor: pointer;
@@ -196,7 +196,7 @@
     margin-left: auto;
     padding: 0;
     border: 0;
-    border-radius: 7px;
+    border-radius: var(--radius);
     background: none;
     color: color-mix(in srgb, var(--code-ink) 55%, transparent);
     cursor: pointer;

--- a/apps/docs/src/lib/CodeTabs.svelte
+++ b/apps/docs/src/lib/CodeTabs.svelte
@@ -180,6 +180,16 @@
     color: var(--code-ink);
   }
 
+  /*
+   * The card clips overflow for the rounded corners, so pull the global
+   * 3px/3px-offset focus indicator inside the bar padding (same
+   * compensation as .scroll-region below).
+   */
+  .bar button[role="tab"]:focus-visible,
+  .bar .copy:focus-visible {
+    outline-offset: -1px;
+  }
+
   .bar button[role="tab"].active {
     background: color-mix(in srgb, var(--code-ink) 10%, transparent);
     color: var(--code-ink);

--- a/apps/docs/src/lib/CodeTabs.svelte
+++ b/apps/docs/src/lib/CodeTabs.svelte
@@ -113,7 +113,7 @@
   >
     <!-- svelte-ignore a11y_no_noninteractive_tabindex (scrollable code must be keyboard reachable) -->
     <div
-      class="scroll-region code-surface"
+      class="scroll-region"
       role="region"
       aria-label="Code example"
       tabindex="0"
@@ -129,8 +129,11 @@
   .code-tabs {
     min-width: 0;
     margin: 1.5rem 0;
-    border-top: 1px solid var(--border);
-    border-bottom: 1px solid var(--border);
+    overflow: hidden;
+    border: 1px solid color-mix(in srgb, var(--code-ink) 10%, transparent);
+    border-radius: var(--code-radius);
+    background: var(--code-paper);
+    color: var(--code-ink);
   }
 
   .bar {
@@ -138,9 +141,9 @@
     min-width: 0;
     align-items: center;
     gap: 0.25rem;
-    padding: 0 0.35rem;
-    border-bottom: 1px solid var(--border);
-    background: var(--bg);
+    padding: 0.15rem 0.5rem 0.15rem 0.75rem;
+    border-bottom: 1px solid
+      color-mix(in srgb, var(--code-ink) 10%, transparent);
   }
 
   .tabs {
@@ -151,41 +154,51 @@
   }
 
   .bar button[role="tab"] {
-    min-height: 44px;
+    min-height: 2.25rem;
     flex: 0 0 auto;
-    padding: 0.35rem 0.65rem;
+    padding: 0.3rem 0.65rem;
     border: 0;
-    border-bottom: 2px solid transparent;
-    border-radius: 0;
+    border-radius: 7px;
     background: none;
-    color: var(--muted);
+    color: color-mix(in srgb, var(--code-ink) 55%, transparent);
     cursor: pointer;
     font: 600 0.82rem/1 var(--body-font);
+    transition:
+      background-color 120ms ease,
+      color 120ms ease;
+  }
+
+  .bar button[role="tab"]:hover {
+    color: var(--code-ink);
   }
 
   .bar button[role="tab"].active {
-    border-bottom-color: var(--accent);
-    color: var(--fg);
+    background: color-mix(in srgb, var(--code-ink) 10%, transparent);
+    color: var(--code-ink);
   }
 
   .bar .copy {
     display: grid;
     place-items: center;
-    width: 2.5rem;
-    height: 2.5rem;
-    min-width: 2.5rem;
-    min-height: 2.5rem;
+    width: 2rem;
+    height: 2rem;
+    min-width: 2rem;
+    min-height: 2rem;
     margin-left: auto;
     padding: 0;
     border: 0;
-    border-radius: 2px;
+    border-radius: 7px;
     background: none;
-    color: var(--accent);
+    color: color-mix(in srgb, var(--code-ink) 55%, transparent);
     cursor: pointer;
+    transition:
+      background-color 120ms ease,
+      color 120ms ease;
   }
 
   .bar .copy:hover {
-    background: color-mix(in srgb, var(--accent) 12%, transparent);
+    background: color-mix(in srgb, var(--code-ink) 12%, transparent);
+    color: var(--code-ink);
   }
 
   /*
@@ -196,6 +209,7 @@
   .scroll-region {
     max-width: 100%;
     padding: 0;
+    outline-offset: -2px;
   }
 
   .scroll-region :global(pre.hljs),
@@ -205,7 +219,9 @@
     padding: 1rem;
     background: transparent !important;
     color: inherit;
-    font: inherit;
+    font-family: var(--code-font);
+    font-size: 0.85rem;
+    line-height: 1.6;
   }
 
   .scroll-region :global(code.hljs),

--- a/apps/docs/src/lib/CodeTabs.svelte
+++ b/apps/docs/src/lib/CodeTabs.svelte
@@ -154,6 +154,7 @@
   }
 
   .bar button[role="tab"] {
+    position: relative; /* anchors the extended hit region */
     min-height: 2.25rem;
     flex: 0 0 auto;
     padding: 0.3rem 0.65rem;
@@ -168,6 +169,13 @@
       color 120ms ease;
   }
 
+  /* 36px visual height, 44px hit height (DESIGN.md hit-region floor). */
+  .bar button[role="tab"]::after {
+    content: "";
+    position: absolute;
+    inset: -4px 0;
+  }
+
   .bar button[role="tab"]:hover {
     color: var(--code-ink);
   }
@@ -178,6 +186,7 @@
   }
 
   .bar .copy {
+    position: relative; /* anchors the extended hit region */
     display: grid;
     place-items: center;
     width: 2rem;
@@ -194,6 +203,13 @@
     transition:
       background-color 120ms ease,
       color 120ms ease;
+  }
+
+  /* 32px visual, 44px hit region (DESIGN.md hit-region floor). */
+  .bar .copy::after {
+    content: "";
+    position: absolute;
+    inset: -6px;
   }
 
   .bar .copy:hover {

--- a/apps/docs/src/lib/components/CopyCode.svelte
+++ b/apps/docs/src/lib/components/CopyCode.svelte
@@ -128,7 +128,7 @@
     min-height: 2rem;
     padding: 0;
     border: 0;
-    border-radius: 7px;
+    border-radius: var(--radius);
     background: transparent;
     color: color-mix(in srgb, var(--code-ink) 55%, transparent);
     cursor: pointer;

--- a/apps/docs/src/lib/components/CopyCode.svelte
+++ b/apps/docs/src/lib/components/CopyCode.svelte
@@ -119,6 +119,7 @@
   }
 
   .copy-trigger {
+    position: relative; /* anchors the extended hit region */
     display: grid;
     place-items: center;
     width: 2rem;
@@ -134,6 +135,17 @@
     transition:
       background-color 120ms ease,
       color 120ms ease;
+  }
+
+  /*
+   * DESIGN.md: free-standing controls keep a 44px hit region even when the
+   * visual footprint is smaller (bun-style ghost icon). The pseudo-element
+   * extends the target without growing the hover wash.
+   */
+  .copy-trigger::after {
+    content: "";
+    position: absolute;
+    inset: -6px;
   }
 
   .copy-trigger:hover {

--- a/apps/docs/src/lib/components/CopyCode.svelte
+++ b/apps/docs/src/lib/components/CopyCode.svelte
@@ -6,6 +6,8 @@
   const {
     code,
     language = "",
+    /** Optional header-bar title (file name or label), bun.com style. */
+    title,
     /** @deprecated Prefer `accessibleLabel`. Kept as an aria-label alias. */
     label,
     accessibleLabel = label ?? "Copy code",
@@ -13,6 +15,7 @@
   }: {
     code: string;
     language?: string;
+    title?: string;
     label?: string;
     accessibleLabel?: string;
     class?: string;
@@ -33,21 +36,41 @@
   }
 </script>
 
-<div class={`copy-code ${className}`}>
-  <button
-    type="button"
-    class="copy-trigger"
-    aria-label={copied ? "Copied" : accessibleLabel}
-    onclick={copy}
-  >
-    {#if copied}
-      <!-- eslint-disable-next-line svelte/no-at-html-tags -- trusted static SVG -->
-      {@html CHECK_ICON_SVG}
-    {:else}
-      <!-- eslint-disable-next-line svelte/no-at-html-tags -- trusted static SVG -->
-      {@html COPY_ICON_SVG}
-    {/if}
-  </button>
+<div class={`copy-code ${className}`} class:titled={title !== undefined}>
+  {#if title !== undefined}
+    <div class="copy-header">
+      <span class="copy-title">{title}</span>
+      <button
+        type="button"
+        class="copy-trigger"
+        aria-label={copied ? "Copied" : accessibleLabel}
+        onclick={copy}
+      >
+        {#if copied}
+          <!-- eslint-disable-next-line svelte/no-at-html-tags -- trusted static SVG -->
+          {@html CHECK_ICON_SVG}
+        {:else}
+          <!-- eslint-disable-next-line svelte/no-at-html-tags -- trusted static SVG -->
+          {@html COPY_ICON_SVG}
+        {/if}
+      </button>
+    </div>
+  {:else}
+    <button
+      type="button"
+      class="copy-trigger floating"
+      aria-label={copied ? "Copied" : accessibleLabel}
+      onclick={copy}
+    >
+      {#if copied}
+        <!-- eslint-disable-next-line svelte/no-at-html-tags -- trusted static SVG -->
+        {@html CHECK_ICON_SVG}
+      {:else}
+        <!-- eslint-disable-next-line svelte/no-at-html-tags -- trusted static SVG -->
+        {@html COPY_ICON_SVG}
+      {/if}
+    </button>
+  {/if}
   <div class="code-body" bind:this={source}>
     <!-- eslint-disable-next-line svelte/no-at-html-tags -- highlight.js token spans; plaintext is escaped -->
     {@html highlighted}
@@ -64,34 +87,65 @@
     max-width: 100%;
     min-width: 0;
     overflow: hidden;
-    border: 1px solid var(--line);
-    border-radius: 2px;
+    border: 1px solid color-mix(in srgb, var(--code-ink) 10%, transparent);
+    border-radius: var(--code-radius);
     background: var(--code-paper);
     color: var(--code-ink);
   }
 
+  /* Titled blocks read as a small window: header bar, divider, then code. */
+  .copy-code.titled {
+    width: 100%;
+  }
+
+  .copy-header {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    padding: 0.3rem 0.5rem 0.3rem 1rem;
+    border-bottom: 1px solid
+      color-mix(in srgb, var(--code-ink) 10%, transparent);
+  }
+
+  .copy-title {
+    overflow: hidden;
+    color: color-mix(in srgb, var(--code-ink) 55%, transparent);
+    font-family: var(--code-font);
+    font-size: 0.75rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
   .copy-trigger {
-    position: absolute;
-    z-index: 1;
-    top: 0.45rem;
-    right: 0.45rem;
     display: grid;
     place-items: center;
-    width: 2.5rem;
-    height: 2.5rem;
-    min-width: 2.5rem;
-    min-height: 2.5rem;
+    width: 2rem;
+    height: 2rem;
+    min-width: 2rem;
+    min-height: 2rem;
     padding: 0;
-    border: 1px solid color-mix(in srgb, var(--code-ink) 28%, transparent);
-    border-radius: 2px;
-    background: color-mix(in srgb, var(--code-paper) 88%, transparent);
-    color: var(--code-ink);
+    border: 0;
+    border-radius: 7px;
+    background: transparent;
+    color: color-mix(in srgb, var(--code-ink) 55%, transparent);
     cursor: pointer;
+    transition:
+      background-color 120ms ease,
+      color 120ms ease;
   }
 
   .copy-trigger:hover {
-    border-color: color-mix(in srgb, var(--code-ink) 55%, transparent);
-    background: color-mix(in srgb, var(--code-paper) 70%, var(--code-ink) 8%);
+    background: color-mix(in srgb, var(--code-ink) 12%, transparent);
+    color: var(--code-ink);
+  }
+
+  .copy-trigger.floating {
+    position: absolute;
+    z-index: 1;
+    top: 0.5rem;
+    right: 0.5rem;
   }
 
   .code-body {
@@ -102,12 +156,17 @@
   .code-body :global(pre.hljs),
   .code-body :global(pre) {
     margin: 0;
-    padding: 0.85rem 3.25rem 0.85rem 1rem;
+    padding: 0.9rem 2.75rem 0.9rem 1rem;
     background: transparent !important;
     color: inherit;
     font-family: var(--code-font);
     font-size: 0.85rem;
-    line-height: 1.55;
+    line-height: 1.6;
+  }
+
+  .titled .code-body :global(pre.hljs),
+  .titled .code-body :global(pre) {
+    padding-right: 1rem;
   }
 
   .code-body :global(code.hljs),

--- a/apps/docs/src/lib/components/GettingStartedGuide.svelte
+++ b/apps/docs/src/lib/components/GettingStartedGuide.svelte
@@ -50,25 +50,20 @@
 
   <h2 id="start-with-a-basic-plot">Start with a basic plot</h2>
   <div class="lesson-block">
-    <section class="lesson-code">
-      <div class="lesson-label">Svelte</div>
-      <CopyCode
-        class="lesson-source lesson-source--file"
-        language="svelte"
-        accessibleLabel="Copy complete file"
-        code={QUICKSTART_PAGE_SVELTE}
-      />
-    </section>
-    <section class="lesson-output">
-      <div class="lesson-label">Output</div>
-      <img
-        class="lesson-chart"
-        src={chartSrc(-1)}
-        width={LESSON_CHART_WIDTH}
-        height={LESSON_CHART_HEIGHT}
-        alt="Peak cherry-blossom dates in Kyoto, 812 to 2026, as a scatter"
-      />
-    </section>
+    <CopyCode
+      class="lesson-source lesson-source--file"
+      language="svelte"
+      title="Example.svelte"
+      accessibleLabel="Copy complete file"
+      code={QUICKSTART_PAGE_SVELTE}
+    />
+    <img
+      class="lesson-chart"
+      src={chartSrc(-1)}
+      width={LESSON_CHART_WIDTH}
+      height={LESSON_CHART_HEIGHT}
+      alt="Peak cherry-blossom dates in Kyoto, 812 to 2026, as a scatter"
+    />
   </div>
 
   <h2 id="add-layers">Add layers</h2>
@@ -95,15 +90,13 @@
         {#if isFinish}
           <LessonFinishedChart placeholderSrc={chartSrc(index)} />
         {:else}
-          <div class="lesson-output">
-            <img
-              class="lesson-chart"
-              src={chartSrc(index)}
-              width={LESSON_CHART_WIDTH}
-              height={LESSON_CHART_HEIGHT}
-              alt={`Kyoto cherry blossom after step ${index + 1}: ${step.title}`}
-            />
-          </div>
+          <img
+            class="lesson-chart"
+            src={chartSrc(index)}
+            width={LESSON_CHART_WIDTH}
+            height={LESSON_CHART_HEIGHT}
+            alt={`Kyoto cherry blossom after step ${index + 1}: ${step.title}`}
+          />
         {/if}
       </section>
     {/each}
@@ -113,6 +106,7 @@
   <CopyCode
     class="lesson-source lesson-source--file"
     language="svelte"
+    title="Sakura.svelte"
     accessibleLabel="Copy finished file"
     code={SAKURA_FINISHED_SVELTE}
   />
@@ -121,6 +115,7 @@
   <CopyCode
     class="lesson-source"
     language="json"
+    title="spec.json"
     accessibleLabel="Copy Spec (JSON) fragment"
     code={QUICKSTART_PORTABLE_SPEC_FRAGMENT}
   />
@@ -143,55 +138,31 @@
 <style>
   /*
    * Code on top, chart below — never side-by-side. Side-by-side crushes the
-   * plot on every viewport and is banned on this docs site.
+   * plot on every viewport and is banned on this docs site. Code blocks stand
+   * on their own (bun-like dark cards); no shaded casing panels around them.
    */
   .lesson-block,
   .progressive-step {
     display: grid;
+    gap: 1.25rem;
     margin: 1.5rem 0 3rem;
-    border-block: 1px solid var(--line);
   }
 
   /*
-   * Static step panels are plain divs in this component. The finished chart is
-   * a child component whose root carries .finished-chart — style it with
-   * :global so scoped CSS still pads and separates that slot.
+   * The finished chart is a child component whose root carries
+   * .finished-chart — style it with :global so scoped CSS still reaches that
+   * slot.
    */
-  .lesson-block > section,
-  .progressive-step > div,
+  .lesson-block > *,
+  .progressive-step > *,
   .progressive-step > :global(.finished-chart) {
     min-width: 0;
-    padding: 1rem;
-  }
-
-  .lesson-block > section + section,
-  .progressive-step > div + div,
-  .progressive-step > div + :global(.finished-chart) {
-    border-top: 1px solid var(--line);
   }
 
   .lesson-chart {
     display: block;
     width: 100%;
     height: auto;
-  }
-
-  .lesson-output {
-    min-width: 0;
-    overflow: hidden;
-    background: #fff;
-    color: #172033;
-  }
-
-  .lesson-label {
-    margin-bottom: 0.75rem;
-    color: var(--muted);
-    font-size: 0.72rem;
-  }
-
-  .lesson-code,
-  .step-copy {
-    background: var(--wash);
   }
 
   .step-copy h3 {
@@ -218,16 +189,5 @@
 
   .lesson-footnote p {
     margin: 0;
-  }
-
-  /*
-   * Translucent band fills do not survive forced-colors mode. Epoch names
-   * remain available via the bottom legend (and the aria-label on the live
-   * chart). The live finished chart carries the same rule in its own file.
-   */
-  @media (forced-colors: active) {
-    .lesson-output :global(.gg-marks rect) {
-      fill: none;
-    }
   }
 </style>

--- a/apps/docs/src/routes/examples/[category]/[name]/+page.svelte
+++ b/apps/docs/src/routes/examples/[category]/[name]/+page.svelte
@@ -237,14 +237,8 @@
     border-bottom: 1px solid var(--line);
   }
 
-  /* CodeTabs already draws a top rule — keep one separator, not a double line. */
-  .code-section .section-heading {
-    padding-bottom: 0.35rem;
-    border-bottom: none;
-  }
-
   .code-section :global(.code-tabs) {
-    margin-top: 0.75rem;
+    margin-top: 1.25rem;
   }
 
   .section-heading h2,

--- a/apps/docs/src/styles/base.css
+++ b/apps/docs/src/styles/base.css
@@ -268,7 +268,7 @@ pre {
   min-height: 2rem;
   padding: 0;
   border: 0;
-  border-radius: 7px;
+  border-radius: var(--radius);
   background: transparent;
   color: color-mix(in srgb, var(--code-ink) 55%, transparent);
   cursor: pointer;

--- a/apps/docs/src/styles/base.css
+++ b/apps/docs/src/styles/base.css
@@ -282,6 +282,13 @@ pre {
   color: var(--code-ink);
 }
 
+/* 32px visual, 44px hit region (DESIGN.md hit-region floor). */
+.guide-code-copy button::after {
+  content: "";
+  position: absolute;
+  inset: -6px;
+}
+
 .guide-code-copy button svg {
   display: block;
   pointer-events: none;

--- a/apps/docs/src/styles/base.css
+++ b/apps/docs/src/styles/base.css
@@ -207,6 +207,20 @@ pre {
   font-style: italic;
 }
 
+/*
+ * atom-one-dark's #e06c75 group (section/name/selector-tag/deletion/subst)
+ * sits at 4.4:1 on the softened --code-paper (#282c34). Lift to ~5:1 so axe
+ * color-contrast stays clean.
+ */
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-deletion,
+.hljs-subst,
+.hljs-tag {
+  color: #ec767f !important;
+}
+
 /* Wide fences scroll locally; never expand the document width. */
 .copy-code,
 .guide-code-copy,

--- a/apps/docs/src/styles/base.css
+++ b/apps/docs/src/styles/base.css
@@ -167,19 +167,21 @@ pre {
 
 /*
  * Shared host code surface (#696): one radius/type/padding for docs pre
- * blocks. Call sites: .prose pre, CodeTabs,
- * CodeTabs. Layout-only extras (max-height, margin, white-space) stay local.
+ * blocks (CopyCode and CodeTabs draw their own card chrome on top of the
+ * same tokens). Layout-only extras (max-height, margin, white-space) stay
+ * local.
  */
 .code-surface,
 .prose pre {
   overflow-x: auto;
   padding: 1rem;
-  border-radius: var(--radius);
+  border: 1px solid color-mix(in srgb, var(--code-ink) 10%, transparent);
+  border-radius: var(--code-radius);
   background: var(--code-paper);
   color: var(--code-ink);
   font-family: var(--code-font);
-  font-size: 0.8rem;
-  line-height: 1.5;
+  font-size: 0.85rem;
+  line-height: 1.6;
 }
 
 .prose pre {
@@ -236,7 +238,7 @@ pre {
 
 .guide-code-copy pre {
   margin: 0;
-  padding: 1rem 3.25rem 1rem 1rem;
+  padding: 1rem 2.75rem 1rem 1rem;
 }
 
 .guide-code-copy button {
@@ -246,21 +248,24 @@ pre {
   right: 0.5rem;
   display: grid;
   place-items: center;
-  width: 2.5rem;
-  height: 2.5rem;
-  min-width: 2.5rem;
-  min-height: 2.5rem;
+  width: 2rem;
+  height: 2rem;
+  min-width: 2rem;
+  min-height: 2rem;
   padding: 0;
-  border: 1px solid color-mix(in srgb, var(--code-ink) 28%, transparent);
-  border-radius: 2px;
-  background: color-mix(in srgb, var(--code-paper) 88%, transparent);
-  color: var(--code-ink);
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: color-mix(in srgb, var(--code-ink) 55%, transparent);
   cursor: pointer;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease;
 }
 
 .guide-code-copy button:hover {
-  border-color: color-mix(in srgb, var(--code-ink) 55%, transparent);
-  background: color-mix(in srgb, var(--code-paper) 70%, var(--code-ink) 8%);
+  background: color-mix(in srgb, var(--code-ink) 12%, transparent);
+  color: var(--code-ink);
 }
 
 .guide-code-copy button svg {

--- a/apps/docs/src/styles/tokens.css
+++ b/apps/docs/src/styles/tokens.css
@@ -42,7 +42,7 @@
   --warning: #8a5a00;
   --error: #b42318;
   --visited: #665980;
-  --code-paper: #172033;
+  --code-paper: #282c34;
   --code-ink: #f4f6fa;
   --display-font: "Roboto Condensed", "Arial Narrow", Arial, sans-serif;
   --body-font: "Noto Sans Display", Arial, sans-serif;
@@ -52,6 +52,8 @@
   --sidebar-width: 15.5rem;
   --contents-width: 14rem;
   --radius: 4px;
+  /* Docs-site code surfaces borrow the softer, rounded bun.com block look. */
+  --code-radius: 10px;
   --bg: var(--paper);
   --fg: var(--ink);
   --muted: var(--muted-ink);
@@ -71,7 +73,7 @@
   --warning: #efc46d;
   --error: #ff8a80;
   --visited: #c2afe8;
-  --code-paper: #0b0e14;
+  --code-paper: #1a1f29;
   --code-ink: #f0f3f8;
   color-scheme: dark;
 }

--- a/scripts/code-surface-design-tokens.test.ts
+++ b/scripts/code-surface-design-tokens.test.ts
@@ -2,8 +2,8 @@
  * Shared docs code-surface treatment (issue #696 point 2).
  *
  * Call sites used to diverge on radius, font-size, padding, and line-height.
- * One `.code-surface` rule in base.css is the source of truth; remaining
- * sites must use it instead of re-stating surface tokens.
+ * One `.code-surface` rule in base.css is the source of truth for prose pre
+ * blocks; CodeTabs draws its own card chrome from the same tokens.
  */
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -15,10 +15,10 @@ const BASE = join(ROOT, "apps/docs/src/styles/base.css");
 const TABS = join(ROOT, "apps/docs/src/lib/CodeTabs.svelte");
 
 const SURFACE_PROPS = [
-  "border-radius: var(--radius)",
+  "border-radius: var(--code-radius)",
   "padding: 1rem",
-  "font-size: 0.8rem",
-  "line-height: 1.5",
+  "font-size: 0.85rem",
+  "line-height: 1.6",
   "background: var(--code-paper)",
   "color: var(--code-ink)",
   "font-family: var(--code-font)",
@@ -50,15 +50,16 @@ describe("shared .code-surface in base.css (#696)", () => {
   });
 });
 
-describe("code-block call sites use .code-surface (#696)", () => {
+describe("code-block call sites share the code tokens (#696)", () => {
   const tabs = readFileSync(TABS, "utf8");
 
-  it("CodeTabs scroll region applies code-surface and inherits type from it", () => {
-    expect(tabs).toMatch(/class="[^"]*\bcode-surface\b[^"]*"/);
+  it("CodeTabs draws its card from the shared code tokens", () => {
     const css = styleBlock(tabs);
-    // Surface type/ink come from .code-surface; do not re-fork font-size or paper.
-    expect(css).not.toMatch(/font-size\s*:\s*0\.8rem/);
-    expect(css).not.toMatch(/\.scroll-region[^{]*\{[^}]*background\s*:\s*var\(--code-paper\)/s);
+    // The whole tab card is the code surface: same paper/ink/radius tokens as
+    // .code-surface, never a re-forked hardcoded value.
+    expect(css).toMatch(/\.code-tabs[^{]*\{[^}]*border-radius\s*:\s*var\(--code-radius\)/s);
+    expect(css).toMatch(/\.code-tabs[^{]*\{[^}]*background\s*:\s*var\(--code-paper\)/s);
+    expect(css).toMatch(/\.code-tabs[^{]*\{[^}]*color\s*:\s*var\(--code-ink\)/s);
     // Padding must live on the scrollable pre (not only the scrollport) so
     // inline-end gap survives horizontal scroll of wide samples.
     expect(css).toMatch(/\.scroll-region[^{]*\{[^}]*padding\s*:\s*0\b/s);

--- a/tests/visual/docs-progressive-search.spec.ts
+++ b/tests/visual/docs-progressive-search.spec.ts
@@ -162,7 +162,7 @@ test("prerendered Docs and lesson source remain useful without JavaScript", asyn
   );
   // Every chart is a build-time SVG without JS: first render + four steps
   // (Make it interactive keeps its static fallback until hydrate near-viewport, #972).
-  await expect(page.locator(".lesson-block .lesson-output")).toBeVisible();
+  await expect(page.locator(".lesson-block img.lesson-chart")).toBeVisible();
   await expect(page.locator("img.lesson-chart")).toHaveCount(5);
   await expect(
     page.getByRole("heading", {
@@ -320,12 +320,16 @@ test("mobile lesson stacks code above chart and remains contained", async ({ pag
 
   // Side-by-side is banned: code always above the chart, on every viewport.
   const order = await page
-    .locator(".lesson-block > section")
-    .evaluateAll((sections) => sections.map((section) => section.getAttribute("class")));
-  expect(order[0]).toContain("lesson-code");
-  expect(order[1]).toContain("lesson-output");
+    .locator(".lesson-block > *")
+    .evaluateAll((children) =>
+      children.map(
+        (child) => `${child.tagName.toLowerCase()}.${child.getAttribute("class") ?? ""}`,
+      ),
+    );
+  expect(order[0]).toContain("copy-code");
+  expect(order[1]).toContain("img.lesson-chart");
   await expect(page.getByRole("tablist", { name: "First chart surfaces" })).toHaveCount(0);
-  await expect(page.locator(".lesson-block .lesson-code")).toBeVisible();
-  await expect(page.locator(".lesson-block .lesson-output")).toBeVisible();
+  await expect(page.locator(".lesson-block .copy-code")).toBeVisible();
+  await expect(page.locator(".lesson-block img.lesson-chart")).toBeVisible();
   await expectNoDocumentOverflow(page);
 });


### PR DESCRIPTION
## What

Restyles every code surface on the docs site after bun.com's code blocks:

- **Soft dark grey card** — `--code-paper` moves from harsh navy (`#172033`) / near-black (`#0b0e14`) to atom-one-dark's native `#282c34` (light theme) and a soft `#1a1f29` (dark theme), so the highlight.js theme sits on the background it was designed for. New `--code-radius: 10px` for code surfaces; DESIGN.md's 4px host-control radius is untouched.
- **Ghost copy button** — the 2.5rem bordered blocky square becomes a small transparent icon (55% ink ≈ 5:1 contrast on the code surface, WCAG non-text OK) with a subtle hover wash. Applied to `CopyCode`, `CodeTabs`, and markdown fence copy buttons.
- **Header bar with title** — `CopyCode` gains an optional `title` prop rendering a bun-style header (muted mono title, hairline divider, copy button in the bar). Untitled blocks (e.g. the install command) stay compact with a floating ghost trigger.
- **CodeTabs** becomes one dark rounded card: pill tabs in the header instead of page-chrome rules + accent underlines.
- **Getting-started casing removed** — the shaded `--wash` wrapper panels, border rules, and redundant "Svelte"/"Output" labels are gone. Full-file blocks carry header titles instead: `Example.svelte`, `Sakura.svelte`, `spec.json`. Code and chart stack with plain whitespace, ending the cramped wrapping the casing caused.

## Verification

- `svelte-check --fail-on-warnings`: 0 errors, 0 warnings
- `oxlint`, `prettier` clean on touched files; `bun test apps/docs` passes except one pre-existing `vi.hoisted` failure that reproduces on clean `main`
- Headless-browser screenshots checked: getting-started (light, dark, 420px mobile), homepage triptych, example-detail CodeTabs, markdown guide fences — rounded soft-dark cards everywhere, code scrolls horizontally instead of wrapping, copy → check feedback works

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1479" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->