### PR TITLE
docs(site): GitHub icon in header (light/dark)

### DIFF
--- a/apps/docs/src/lib/components/SiteHeader.svelte
+++ b/apps/docs/src/lib/components/SiteHeader.svelte
@@ -105,8 +105,24 @@
       <a
         class="github-link"
         href="https://github.com/ljodea/ggsvelte"
-        rel="external">GitHub <span aria-hidden="true">↗</span></a
+        rel="external"
+        aria-label="GitHub"
+        title="GitHub"
       >
+        <!-- Phosphor GithubLogo fill; currentColor follows light/dark chrome. -->
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="20"
+          height="20"
+          fill="currentColor"
+          viewBox="0 0 256 256"
+          aria-hidden="true"
+        >
+          <path
+            d="M216,104v8a56.06,56.06,0,0,1-48.44,55.47A39.8,39.8,0,0,1,176,192v40a8,8,0,0,1-8,8H104a8,8,0,0,1-8-8V216H72a40,40,0,0,1-40-40A24,24,0,0,0,8,152a8,8,0,0,1,0-16,40,40,0,0,1,40,40,24,24,0,0,0,24,24H96v-8a39.8,39.8,0,0,1,8.44-24.53A56.06,56.06,0,0,1,56,112v-8a58.14,58.14,0,0,1,7.69-28.32A59.78,59.78,0,0,1,69.07,28,8,8,0,0,1,76,24a59.75,59.75,0,0,1,48,24h24a59.75,59.75,0,0,1,48-24,8,8,0,0,1,6.93,4,59.74,59.74,0,0,1,5.37,47.68A58,58,0,0,1,216,104Z"
+          />
+        </svg>
+      </a>
     </div>
 
     <button

--- a/apps/docs/src/styles/shell.css
+++ b/apps/docs/src/styles/shell.css
@@ -89,6 +89,22 @@
   cursor: pointer;
 }
 
+.github-link {
+  justify-content: center;
+  width: 44px;
+  color: var(--chrome-link);
+}
+
+.github-link:hover,
+.github-link:focus-visible {
+  color: var(--ink);
+}
+
+.github-link svg {
+  display: block;
+  flex-shrink: 0;
+}
+
 .mobile-search-trigger,
 .menu-trigger {
   display: none;


### PR DESCRIPTION
## Summary

- Replace the desktop header **GitHub** text link with an icon-only control (Phosphor GithubLogo fill)
- Icon uses `currentColor` so it follows existing light/dark chrome tokens
- Keep text label in the mobile nav sheet (text list pattern); `aria-label` + `title` on the desktop control

## Test plan

- [x] `bun test scripts/docs-search-icons-lazy.test.ts scripts/docs-routes-client-thin.test.ts`
- [ ] Spot-check docs header in light and dark: icon visible, contrast OK, link still opens `ljodea/ggsvelte`
- [ ] Mobile: header actions still hide; menu still shows "GitHub ↗"
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1480" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->