### PR TITLE
fix(docs): compact bun-like homepage benchmarks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,20 +41,12 @@ and Windows.
 
 ## Benchmarks
 
-Versus its two direct Svelte peers — [SveltePlot](https://svelteplot.dev) and
-[LayerCake](https://layercake.graphics) — on the benchmarks where ggsvelte
-pulls ahead. Only benchmarks ggsvelte wins outright get a chart; the full
-matrix (d3, uPlot, Chart.js, and ECharts included) and the harness live in
-[`benchmarks/competitive`](benchmarks/competitive).
+Cold mount speed vs [SveltePlot](https://svelteplot.dev) and
+[LayerCake](https://layercake.graphics).
 
-![Mount a 10,000-point colored scatter: ggsvelte 75.5 ms, LayerCake 354.3 ms, SveltePlot 7,193 ms](apps/docs/static/benchmarks/bench-scatter-mount.svg)
+![10,000-point colored scatter: ggsvelte 75.5 ms, LayerCake 354.3 ms, SveltePlot 7,193 ms](apps/docs/static/benchmarks/bench-scatter-mount.svg)
 
-![Mount a 3 × 10,000-point line chart: ggsvelte 52 ms, LayerCake 65 ms, SveltePlot 1,889 ms](apps/docs/static/benchmarks/bench-line-mount.svg)
-
-Canvas render target footnotes: scatter — ggsvelte 33.1 ms, LayerCake 36.7 ms;
-line — ggsvelte 61.3 ms, LayerCake 50.2 ms. Median of 11 cold mounts, Chromium
-(Playwright), Linux x64; charts drawn with ggsvelte's headless renderer.
-Reproduce: `cd benchmarks/competitive && bun run measure:browser`.
+![3 × 10,000-point line chart: ggsvelte 52 ms, LayerCake 65 ms, SveltePlot 1,889 ms](apps/docs/static/benchmarks/bench-line-mount.svg)
 
 | Capability                                                 | ggsvelte  | SveltePlot           | LayerCake                    |
 | ---------------------------------------------------------- | --------- | -------------------- | ---------------------------- |
@@ -66,13 +58,11 @@ Reproduce: `cd benchmarks/competitive && bun run measure:browser`.
 | **Agent skill** (SKILL.md, llms.txt)                       | ✅        | ❌                   | ❌                           |
 | **Automatic temporal detection**                           | ✅        | ⚠️ Date objects only | ❌                           |
 | **Built-in interactions** (tooltip, select, zoom, linking) | ✅        | ⚠️ tooltip + brush   | ❌                           |
-| **Grammar-of-graphics API**                                | ✅        | ✅                   | ❌ hand-written marks        |
+| **ggplot2 API**                                            | ✅        | ❌                   | ❌ hand-written marks        |
 | **Scale, axis & coord control**                            | ✅        | ✅                   | ⚠️ hand-configured d3 scales |
 
-Limitations first, bun-style: ggsvelte pays for its full grammar runtime in
-bundle bytes, and it is pre-1.0. After that: neither peer ships a portable
-spec, schema, CLI validator, or agent skill; LayerCake leaves interactivity
-and mark drawing to you; SveltePlot renders an empty shell server-side.
+Harness and full matrix (d3, uPlot, Chart.js, ECharts):
+[`benchmarks/competitive`](benchmarks/competitive).
 
 ## Reference
 

--- a/apps/docs/src/lib/components/Benchmarks.svelte
+++ b/apps/docs/src/lib/components/Benchmarks.svelte
@@ -16,7 +16,7 @@
 
   interface Row {
     readonly feature: string;
-    readonly desc: string;
+    readonly desc?: string;
     readonly gg: Cell;
     readonly sp: Cell;
     readonly lc: Cell;
@@ -42,90 +42,75 @@
   const rows: readonly Row[] = [
     {
       feature: "Bundle size",
-      desc: "Min+gzip, 1,000-point scatter app — the price of the full grammar runtime",
+      desc: "Min+gzip, 1k scatter app",
       gg: { mark: "partial", note: kb(BENCHMARK_BUNDLE_KB.ggsvelteKb) },
       sp: { mark: "yes", note: kb(BENCHMARK_BUNDLE_KB.svelteplotKb) },
       lc: { mark: "yes", note: kb(BENCHMARK_BUNDLE_KB.layercakeKb) },
     },
     {
       feature: "API stability",
-      desc: "Pre-1.0: minors can still break (lifecycle-tracked)",
+      desc: "Pre-1.0: minors can still break",
       gg: { mark: "partial", note: `v${BENCHMARK_VERSIONS.ggsvelte}` },
       sp: { mark: "partial", note: `v${BENCHMARK_VERSIONS.svelteplot}` },
       lc: { mark: "yes", note: `v${BENCHMARK_VERSIONS.layercake}` },
     },
     {
       feature: "Headless server-side SVG",
-      desc: "data → SVG string in Node/Bun, no DOM",
+      desc: "data → SVG string, no DOM",
       gg: yes,
-      sp: { mark: "no", note: "renders an empty shell" },
-      lc: { mark: "partial", note: "opt-in ssr flag" },
+      sp: { mark: "no", note: "empty shell" },
+      lc: { mark: "partial", note: "opt-in ssr" },
     },
     {
       feature: "Portable JSON spec + schema",
-      desc: "validate() returns machine-applicable fixes",
       gg: yes,
       sp: no,
       lc: no,
     },
     {
       feature: "CLI validator + renderer",
-      desc: "ggsvelte-render spec.json > out.svg",
       gg: yes,
       sp: no,
       lc: no,
     },
     {
       feature: "Agent skill",
-      desc: "SKILL.md + llms.txt corpus for coding agents",
       gg: yes,
       sp: no,
       lc: no,
     },
     {
       feature: "Automatic temporal detection",
-      desc: "ISO dates, year-months, and quarters infer time scales",
       gg: yes,
-      sp: { mark: "partial", note: "Date objects only" },
+      sp: { mark: "partial", note: "Date only" },
       lc: no,
     },
     {
       feature: "Built-in interactions",
-      desc: "Tooltips, selection, zoom, linked views",
+      desc: "Tooltip, select, zoom, link",
       gg: yes,
-      sp: { mark: "partial", note: "tooltip + brush marks" },
+      sp: { mark: "partial", note: "tooltip + brush" },
       lc: { mark: "no", note: "bring your own" },
     },
     {
-      feature: "Grammar-of-graphics API",
-      desc: "Geoms, stats, positions, and facets as composable layers",
+      feature: "ggplot2 API",
       gg: yes,
-      sp: yes,
+      sp: no,
       lc: { mark: "no", note: "hand-written marks" },
     },
     {
       feature: "Scale, axis & coord control",
-      desc: "Transforms, breaks, expansion, and flips declared as data",
       gg: yes,
       sp: yes,
-      lc: { mark: "partial", note: "hand-configured d3 scales" },
+      lc: { mark: "partial", note: "hand-configured d3" },
     },
   ];
 </script>
 
 <section class="benchmarks" aria-labelledby="benchmarks-heading">
   <header class="bench-intro">
-    <h2 id="benchmarks-heading">Benchmarks we win</h2>
-    <p>
-      Against its two direct Svelte peers, ggsvelte mounts real datasets faster
-      — and ships the agent tooling they don't. Only benchmarks ggsvelte wins
-      outright get a chart; the full matrix (d3, uPlot, Chart.js, and ECharts
-      included) lives in
-      <a
-        href="https://github.com/ljodea/ggsvelte/tree/main/benchmarks/competitive"
-        >benchmarks/competitive</a
-      >.
-    </p>
+    <h2 id="benchmarks-heading">Mounts first</h2>
+    <p>10,000-point charts. Cold start.</p>
   </header>
 
   <div class="bench-grid">
@@ -153,13 +138,16 @@
             loading="lazy"
           />
         </div>
-        <p class="bench-foot">{card.footnote}</p>
       </figure>
     {/each}
   </div>
 
   <div class="bench-table-wrap">
     <table>
+      <colgroup>
+        <col class="bench-col-feature" />
+        <col class="bench-col-lib" span="3" />
+      </colgroup>
       <thead>
         <tr>
           <th scope="col">Capability</th>
@@ -173,7 +161,7 @@
           <tr>
             <th scope="row">
               {row.feature}
-              <small>{row.desc}</small>
+              {#if row.desc !== undefined}<small>{row.desc}</small>{/if}
             </th>
             {#each [row.gg, row.sp, row.lc] as cell, i (i)}
               <td>
@@ -188,14 +176,4 @@
       </tbody>
     </table>
   </div>
-
-  <p class="bench-method">
-    ggsvelte {BENCHMARK_VERSIONS.ggsvelte} · SveltePlot {BENCHMARK_VERSIONS.svelteplot}
-    · LayerCake {BENCHMARK_VERSIONS.layercake} · median of 11 cold mounts, Chromium
-    (Playwright), Linux x64 · charts drawn with ggsvelte's headless renderer · reproduce:
-    <code
-      >cd benchmarks/competitive && bun run measure:browser && bun run
-      measure:bundles</code
-    >
-  </p>
 </section>

--- a/apps/docs/src/lib/generated/benchmark-charts.ts
+++ b/apps/docs/src/lib/generated/benchmark-charts.ts
@@ -5,7 +5,6 @@ export interface BenchmarkChartCard {
   readonly id: string;
   readonly title: string;
   readonly subtitle: string;
-  readonly footnote: string;
   readonly path: string;
   /** Dark-site portrait (transparent paper, light ink) — shown under data-theme="dark". */
   readonly darkPath: string;
@@ -18,9 +17,8 @@ export interface BenchmarkChartCard {
 export const BENCHMARK_CHART_CARDS = [
   {
     id: "scatter-mount",
-    title: "Mount a 10,000-point colored scatter",
-    subtitle: "Cold-mount milliseconds · median of 11 · Chromium, Linux x64",
-    footnote: "Canvas render target: ggsvelte 33.1 ms, LayerCake 36.7 ms.",
+    title: "10,000-point colored scatter",
+    subtitle: "Cold-mount milliseconds · lower is better",
     path: "/benchmarks/bench-scatter-mount.svg",
     darkPath: "/benchmarks/bench-scatter-mount-dark-site.svg",
     sha256: "40774c92ec1541f91ddae3b56b351231db469f4779932f0fb516fa8473e4df9b",
@@ -30,9 +28,8 @@ export const BENCHMARK_CHART_CARDS = [
   },
   {
     id: "line-mount",
-    title: "Mount a 3 × 10,000-point line chart",
-    subtitle: "Cold-mount milliseconds · median of 11 · Chromium, Linux x64",
-    footnote: "Canvas render target: ggsvelte 61.3 ms, LayerCake 50.2 ms.",
+    title: "3 × 10,000-point line chart",
+    subtitle: "Cold-mount milliseconds · lower is better",
     path: "/benchmarks/bench-line-mount.svg",
     darkPath: "/benchmarks/bench-line-mount-dark-site.svg",
     sha256: "d14b3b1596bcfaf131487527b0875ae4ad9faacabd48a53ea621e8ff8ca72d63",

--- a/apps/docs/src/styles/shell.css
+++ b/apps/docs/src/styles/shell.css
@@ -554,45 +554,45 @@
 .benchmarks {
   min-width: 0;
   overflow-x: clip;
-  padding-block: clamp(4rem, 8vw, 7rem);
+  padding-block: clamp(2.5rem, 5vw, 4rem);
   border-top: 1px solid var(--line);
 }
 
 .bench-intro h2 {
-  max-width: 14ch;
   margin: 0;
-  font-size: clamp(2.5rem, 5vw, 4.75rem);
-  line-height: 0.94;
+  font-size: clamp(1.75rem, 3.5vw, 2.5rem);
+  line-height: 1.1;
 }
 
 .bench-intro > p {
-  max-width: 56ch;
+  margin: 0.4rem 0 0;
   color: var(--muted);
+  font-size: 0.95rem;
 }
 
 .bench-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 1.25rem;
-  margin-block: 2rem;
+  gap: 2rem;
+  margin-block: 1.5rem;
 }
 
 .bench-card {
   min-width: 0;
   margin: 0;
-  padding: 1.25rem 1.25rem 1rem;
-  border: 1px solid var(--line);
+  padding: 0;
 }
 
 .bench-card figcaption h3 {
   margin: 0;
-  font-size: 1.05rem;
+  font-size: 0.95rem;
+  font-weight: 600;
 }
 
 .bench-card figcaption p {
-  margin: 0.25rem 0 1rem;
+  margin: 0.2rem 0 0.75rem;
   color: var(--muted);
-  font-size: 0.85rem;
+  font-size: 0.8rem;
 }
 
 .bench-chart-img {
@@ -616,12 +616,6 @@
   display: block;
 }
 
-.bench-foot {
-  margin: 0.75rem 0 0;
-  color: var(--muted);
-  font-size: 0.8rem;
-}
-
 .bench-table-wrap {
   display: block;
   max-width: 100%;
@@ -630,31 +624,49 @@
 
 .benchmarks table {
   width: 100%;
+  table-layout: fixed;
   border-collapse: collapse;
   border-top: 1px solid var(--line);
+  font-size: 0.9rem;
+}
+
+.benchmarks .bench-col-feature {
+  width: auto;
+}
+
+.benchmarks .bench-col-lib {
+  width: 18%;
 }
 
 .benchmarks th,
 .benchmarks td {
-  padding: 0.75rem 1rem 0.75rem 0;
+  padding: 0.55rem 0.75rem;
   border-bottom: 1px solid var(--line);
-  text-align: left;
-  vertical-align: top;
+  vertical-align: middle;
 }
 
 .benchmarks thead th {
-  font-size: 0.85rem;
-  letter-spacing: 0.02em;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.benchmarks thead th:not(:first-child),
+.benchmarks tbody td {
+  text-align: center;
 }
 
 .benchmarks tbody th {
+  padding-left: 0;
   font-weight: 600;
+  text-align: left;
 }
 
 .benchmarks tbody th small {
   display: block;
-  margin-top: 0.15rem;
+  margin-top: 0.1rem;
   color: var(--muted);
+  font-size: 0.75rem;
   font-weight: 400;
 }
 
@@ -665,7 +677,7 @@
 .benchmarks td small {
   display: block;
   color: var(--muted);
-  font-size: 0.75rem;
+  font-size: 0.72rem;
   white-space: normal;
 }
 
@@ -685,17 +697,15 @@
   color: #c64747;
 }
 
-.bench-method {
-  margin-top: 1rem;
-  color: var(--muted);
-  font-size: 0.8rem;
-}
-
 @media (max-width: 42rem) {
   .bench-grid {
     /* minmax(0,…) so the wide capability table can't force the track (and the
      * page) wider than a mobile viewport — .bench-table-wrap scrolls instead. */
     grid-template-columns: minmax(0, 1fr);
+  }
+
+  .benchmarks .bench-col-lib {
+    width: 22%;
   }
 }
 

--- a/scripts/gen-benchmark-charts.ts
+++ b/scripts/gen-benchmark-charts.ts
@@ -125,7 +125,6 @@ interface ChartCard {
   readonly id: string;
   readonly title: string;
   readonly subtitle: string;
-  readonly footnote: string;
   readonly chart: BenchmarkChartInput;
 }
 
@@ -134,15 +133,11 @@ function buildCards(browser: BrowserResults): readonly ChartCard[] {
     gg: mountMs(browser, "ggsvelte-svg", "scatter-color-10k"),
     lc: mountMs(browser, "layercake", "scatter-color-10k"),
     sp: mountMs(browser, "svelteplot", "scatter-color-10k"),
-    ggCanvas: mountMs(browser, "ggsvelte-canvas", "scatter-color-10k"),
-    lcCanvas: mountMs(browser, "layercake-canvas", "scatter-color-10k"),
   };
   const line = {
     gg: mountMs(browser, "ggsvelte-svg", "line-3x10k"),
     lc: mountMs(browser, "layercake", "line-3x10k"),
     sp: mountMs(browser, "svelteplot", "line-3x10k"),
-    ggCanvas: mountMs(browser, "ggsvelte-canvas", "line-3x10k"),
-    lcCanvas: mountMs(browser, "layercake-canvas", "line-3x10k"),
   };
 
   // Claim discipline: refuse to publish a chart ggsvelte does not win.
@@ -156,7 +151,7 @@ function buildCards(browser: BrowserResults): readonly ChartCard[] {
     }
   }
 
-  const subtitle = "Cold-mount milliseconds · median of 11 · Chromium, Linux x64";
+  const subtitle = "Cold-mount milliseconds · lower is better";
   const bars = (cell: { gg: number; lc: number; sp: number }) =>
     [
       { lib: "ggsvelte", value: cell.gg, kind: "ggsvelte", label: msLabel(cell.gg) },
@@ -171,9 +166,8 @@ function buildCards(browser: BrowserResults): readonly ChartCard[] {
   return [
     {
       id: "scatter-mount",
-      title: "Mount a 10,000-point colored scatter",
+      title: "10,000-point colored scatter",
       subtitle,
-      footnote: `Canvas render target: ggsvelte ${msLabel(scatter.ggCanvas)}, LayerCake ${msLabel(scatter.lcCanvas)}.`,
       chart: {
         id: "scatter-mount",
         bars: bars(scatter),
@@ -182,9 +176,8 @@ function buildCards(browser: BrowserResults): readonly ChartCard[] {
     },
     {
       id: "line-mount",
-      title: "Mount a 3 × 10,000-point line chart",
+      title: "3 × 10,000-point line chart",
       subtitle,
-      footnote: `Canvas render target: ggsvelte ${msLabel(line.ggCanvas)}, LayerCake ${msLabel(line.lcCanvas)}.`,
       chart: {
         id: "line-mount",
         bars: bars(line),
@@ -215,7 +208,6 @@ function projectionSource(
     id: ${JSON.stringify(card.id)},
     title: ${JSON.stringify(card.title)},
     subtitle: ${JSON.stringify(card.subtitle)},
-    footnote: ${JSON.stringify(card.footnote)},
     path: ${JSON.stringify(`/benchmarks/${light.filename}`)},
     darkPath: ${JSON.stringify(`/benchmarks/${dark.filename}`)},
     sha256: ${JSON.stringify(sha256(light.body))},
@@ -232,7 +224,6 @@ export interface BenchmarkChartCard {
   readonly id: string;
   readonly title: string;
   readonly subtitle: string;
-  readonly footnote: string;
   readonly path: string;
   /** Dark-site portrait (transparent paper, light ink) — shown under data-theme="dark". */
   readonly darkPath: string;


### PR DESCRIPTION
## Summary

- Strip wordy intro, chart card borders, canvas footnotes, method footer, and methodology copy (median/Chromium/Linux)
- Equalize peer table columns; compact Bun-like density
- Correct SveltePlot ggplot2 API claim (✗, not ✓); rename row to ggplot2 API
- Headline/subtitle: **Mounts first** / **10,000-point charts. Cold start.**

## Test plan

- [ ] Homepage benchmarks section: no borders, no footnotes, no method footer
- [ ] Three library columns equal width
- [ ] ggplot2 API row: ggsvelte ✓, SveltePlot ✗, LayerCake ✗
- [ ] Docs CI green (chart projection `--check`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1482" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->