### PR TITLE
docs(site): shorten benchmarks headline; drop hanging table border

### DIFF
--- a/apps/docs/src/lib/components/Benchmarks.svelte
+++ b/apps/docs/src/lib/components/Benchmarks.svelte
@@ -109,8 +109,7 @@
 
 <section class="benchmarks" aria-labelledby="benchmarks-heading">
   <header class="bench-intro">
-    <h2 id="benchmarks-heading">Mounts first</h2>
-    <p>10,000-point charts. Cold start.</p>
+    <h2 id="benchmarks-heading">ggsvelte is Fast</h2>
   </header>
 
   <div class="bench-grid">

--- a/apps/docs/src/styles/shell.css
+++ b/apps/docs/src/styles/shell.css
@@ -645,6 +645,11 @@
   vertical-align: middle;
 }
 
+.benchmarks tbody tr:last-child th,
+.benchmarks tbody tr:last-child td {
+  border-bottom: none;
+}
+
 .benchmarks thead th {
   font-size: 0.8rem;
   font-weight: 600;


### PR DESCRIPTION
## Summary
- Headline: **ggsvelte is Fast** (was "Mounts first")
- Dropped subtitle "10,000-point charts. Cold start."
- Last capability row no longer draws a hanging bottom separator

## Test plan
- [ ] Homepage `/` benchmarks section: headline only, no subtitle
- [ ] Last table row ("Scale, axis & coord control") has no line under it
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1483" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->