### PR TITLE
docs(readme): fast tagline, five benchmark charts up top, Why-ggsvelte table

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,26 @@
 
 [![codecov](https://codecov.io/gh/ljodea/ggsvelte/branch/main/graph/badge.svg)](https://app.codecov.io/gh/ljodea/ggsvelte)
 
-A layered grammar of graphics in Svelte for agents. Inspired by ggplot.
+ggsvelte is a fast agent-native implementation of the layered grammar of
+graphics, inspired by ggplot2.
 
 [Documentation](https://ggsvelte.sh/) · [Examples](https://ggsvelte.sh/examples) ·
 [Getting started](https://ggsvelte.sh/guide/getting-started)
+
+![Bar chart of cold-mount time for a 1,000-point colored scatter: ggsvelte 6.3 ms, LayerCake 13.2 ms, SveltePlot 241.1 ms. Lower is better.](apps/docs/static/benchmarks/bench-scatter-1k-mount.svg)
+
+![Bar chart of cold-mount time for a 10,000-point colored scatter: ggsvelte 34.5 ms, LayerCake 139.7 ms, SveltePlot 3,032 ms. Lower is better.](apps/docs/static/benchmarks/bench-scatter-mount.svg)
+
+![Bar chart of cold-mount time for a 3-series by 10,000-point line chart: ggsvelte 16 ms, LayerCake 26.5 ms, SveltePlot 1,143 ms. Lower is better.](apps/docs/static/benchmarks/bench-line-mount.svg)
+
+![Bar chart of cold-mount time for a 3-series by 1,000-point area chart: ggsvelte 4.2 ms, LayerCake 5.2 ms, SveltePlot 177.4 ms. Lower is better.](apps/docs/static/benchmarks/bench-area-mount.svg)
+
+![Bar chart of cold-mount time for a stacked bar chart of 50 categories by 4 stacks: ggsvelte 3 ms, LayerCake 3.7 ms, SveltePlot 41.6 ms. Lower is better.](apps/docs/static/benchmarks/bench-bars-mount.svg)
+
+Cold-mount milliseconds vs [SveltePlot](https://svelteplot.dev) and
+[LayerCake](https://layercake.graphics); lower is better. Harness and full
+matrix (d3, uPlot, Chart.js, ECharts):
+[`benchmarks/competitive`](benchmarks/competitive).
 
 ## Install
 
@@ -39,18 +55,11 @@ and Windows.
 | [`@ggsvelte/cli`](packages/cli)       | `ggsvelte-render` CLI: validate + render specs in agent sandboxes   |
 | [`@ggsvelte/skill`](packages/skill)   | Agent skill (SKILL.md + references) teaching the grammar            |
 
-## Benchmarks
-
-Cold mount speed vs [SveltePlot](https://svelteplot.dev) and
-[LayerCake](https://layercake.graphics).
-
-![10,000-point colored scatter: ggsvelte 75.5 ms, LayerCake 354.3 ms, SveltePlot 7,193 ms](apps/docs/static/benchmarks/bench-scatter-mount.svg)
-
-![3 × 10,000-point line chart: ggsvelte 52 ms, LayerCake 65 ms, SveltePlot 1,889 ms](apps/docs/static/benchmarks/bench-line-mount.svg)
+## Why ggsvelte?
 
 | Capability                                                 | ggsvelte  | SveltePlot           | LayerCake                    |
 | ---------------------------------------------------------- | --------- | -------------------- | ---------------------------- |
-| **Bundle size** (min+gzip, 1k scatter app)                 | ⚠️ 137 KB | ✅ 109 KB            | ✅ 41 KB                     |
+| **Bundle size** (min+gzip, 1k scatter app)                 | ⚠️ 138 KB | ✅ 109 KB            | ✅ 41 KB                     |
 | **API stability** (pre-1.0 can break)                      | ⚠️ v0.30  | ⚠️ v0.14             | ✅ v10                       |
 | **Headless server-side SVG** (no DOM)                      | ✅        | ❌ empty shell       | ⚠️ opt-in `ssr` flag         |
 | **Portable JSON spec + schema**                            | ✅        | ❌                   | ❌                           |
@@ -58,11 +67,8 @@ Cold mount speed vs [SveltePlot](https://svelteplot.dev) and
 | **Agent skill** (SKILL.md, llms.txt)                       | ✅        | ❌                   | ❌                           |
 | **Automatic temporal detection**                           | ✅        | ⚠️ Date objects only | ❌                           |
 | **Built-in interactions** (tooltip, select, zoom, linking) | ✅        | ⚠️ tooltip + brush   | ❌                           |
-| **ggplot2 API**                                            | ✅        | ❌                   | ❌ hand-written marks        |
+| **ggplot2 API**                                            | ✅        | ❌                   | ❌                           |
 | **Scale, axis & coord control**                            | ✅        | ✅                   | ⚠️ hand-configured d3 scales |
-
-Harness and full matrix (d3, uPlot, Chart.js, ECharts):
-[`benchmarks/competitive`](benchmarks/competitive).
 
 ## Reference
 


### PR DESCRIPTION
**Stacked on #1484** (base: `docs/homepage-bun-bench-tabs`) — the three new chart SVGs (`bench-scatter-1k-mount`, `bench-area-mount`, `bench-bars-mount`) only exist after that PR merges. Merge #1484 first; GitHub will auto-retarget this PR to `main`.

## What

Mirrors the new homepage story in the README:

- Opens with the same line: *"ggsvelte is a fast agent-native implementation of the layered grammar of graphics, inspired by ggplot2."*
- The same **five** cold-mount benchmark charts (1k/10k scatter, 3×10k line, 3×1k area, 50×4 stacked bars) embedded right at the top, with alt text from the generated projection.
- `## Benchmarks` → **`## Why ggsvelte?`**, holding the same capability table as the new homepage (bundle 138 KB to match the fresh measurement; unverified "hand-written marks" note dropped from LayerCake's ggplot2 row).

## Verification

- prettier + markdownlint pass (pre-commit hooks).
- Image paths verified against `apps/docs/static/benchmarks/` on the base branch.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1485" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->