### PR TITLE
test(core): cover mark-paint pure paths and canvas segment paint

### DIFF
--- a/packages/core/tests/dom/canvas-fixtures.ts
+++ b/packages/core/tests/dom/canvas-fixtures.ts
@@ -13,20 +13,26 @@ export interface RecordedCall {
   name: string;
   args: number[];
   alpha: number;
-  fillStyle: string;
-  strokeStyle: string;
+  fillStyle: string | CanvasGradient;
+  strokeStyle: string | CanvasGradient;
   lineWidth: number;
+  shadowColor?: string;
+  shadowBlur?: number;
+  /** Color stops for createLinearGradient / createRadialGradient calls. */
+  stops?: { offset: number; color: string }[];
 }
 
 export function recordingContext(): { ctx: CanvasRenderingContext2D; calls: RecordedCall[] } {
   const calls: RecordedCall[] = [];
   const target = {
     globalAlpha: 1,
-    fillStyle: "",
-    strokeStyle: "",
+    fillStyle: "" as string | CanvasGradient,
+    strokeStyle: "" as string | CanvasGradient,
     lineWidth: 1,
     lineJoin: "miter",
     lineCap: "butt",
+    shadowColor: "",
+    shadowBlur: 0,
   };
   const methods = new Set([
     "arc",
@@ -45,17 +51,52 @@ export function recordingContext(): { ctx: CanvasRenderingContext2D; calls: Reco
     "strokeRect",
     "translate",
   ]);
+  const snapshot = () => ({
+    alpha: target.globalAlpha,
+    fillStyle: target.fillStyle,
+    strokeStyle: target.strokeStyle,
+    lineWidth: target.lineWidth,
+    shadowColor: target.shadowColor,
+    shadowBlur: target.shadowBlur,
+  });
+  const makeGradient = (kind: "linear" | "radial", args: number[]) => {
+    const stops: { offset: number; color: string }[] = [];
+    calls.push({
+      name: kind === "linear" ? "createLinearGradient" : "createRadialGradient",
+      args: [...args],
+      ...snapshot(),
+      stops,
+    });
+    return {
+      addColorStop(offset: number, color: string) {
+        stops.push({ offset, color });
+      },
+    } as CanvasGradient;
+  };
   const ctx = new Proxy(target, {
     get(object, property): unknown {
+      if (property === "createLinearGradient") {
+        return (...args: number[]) => makeGradient("linear", args);
+      }
+      if (property === "createRadialGradient") {
+        return (...args: number[]) => makeGradient("radial", args);
+      }
+      if (property === "setLineDash") {
+        return (value: number[]) => {
+          calls.push({
+            name: "setLineDash",
+            args: [...value],
+            ...snapshot(),
+          });
+        };
+      }
+      if (property === "getLineDash") return () => [] as number[];
       if (typeof property === "string" && methods.has(property)) {
         return (...args: number[]) => {
           calls.push({
             name: property,
             args,
-            alpha: object.globalAlpha,
-            fillStyle: object.fillStyle,
-            strokeStyle: object.strokeStyle,
-            lineWidth: object.lineWidth,
+            ...snapshot(),
           });
         };
       }

--- a/packages/core/tests/dom/canvas-fixtures.ts
+++ b/packages/core/tests/dom/canvas-fixtures.ts
@@ -71,7 +71,7 @@ export function recordingContext(): { ctx: CanvasRenderingContext2D; calls: Reco
       addColorStop(offset: number, color: string) {
         stops.push({ offset, color });
       },
-    } as CanvasGradient;
+    };
   };
   const ctx = new Proxy(target, {
     get(object, property): unknown {

--- a/packages/core/tests/dom/canvas-segments.test.ts
+++ b/packages/core/tests/dom/canvas-segments.test.ts
@@ -1,8 +1,43 @@
 import { describe, expect, it } from "bun:test";
 
 import { drawStratum } from "../../src/dom/canvas.ts";
+import type { ResolvedGradientPaint, ResolvedGlow } from "../../src/mark-paint.ts";
 import type { SegmentsBatch } from "../../src/scene.ts";
 import { recordingContext, resolve, scene } from "./canvas-fixtures.ts";
+
+const panelLinearStroke: ResolvedGradientPaint = {
+  kind: "linear",
+  space: "panel",
+  x1: 0,
+  y1: 0,
+  x2: 10,
+  y2: 0,
+  cx: 0,
+  cy: 0,
+  r: 0,
+  stops: [
+    { offset: 0, color: "#111111", opacity: 1 },
+    { offset: 1, color: "#eeeeee", opacity: 1 },
+  ],
+  fallback: "#111111",
+  id: "gg-paint-l0-p0-stroke",
+};
+
+const markLinearStroke: ResolvedGradientPaint = {
+  ...panelLinearStroke,
+  space: "mark",
+  x1: 0,
+  y1: 0,
+  x2: 1,
+  y2: 0,
+};
+
+const softGlow: ResolvedGlow = {
+  color: "#0af",
+  radius: 6,
+  opacity: 0.4,
+  id: "gg-paint-l0-p0-glow",
+};
 
 describe("drawStratum segment stroke batching", () => {
   const denseMono: SegmentsBatch = {
@@ -162,5 +197,106 @@ describe("drawStratum segment stroke batching", () => {
     const focused = strokes.filter((c) => c.alpha === 1);
     expect(muted.map((c) => c.strokeStyle)).toEqual(["blue"]);
     expect(focused.map((c) => c.strokeStyle)).toEqual(["red", "red"]);
+  });
+});
+
+describe("drawStratum segment strokePaint and glow", () => {
+  const twoSeg: SegmentsBatch = {
+    kind: "segments",
+    layerIndex: 0,
+    panelIndex: 0,
+    // (0,0)-(10,0) and (0,10)-(20,10)
+    segments: Float32Array.from([0, 0, 10, 0, 0, 10, 20, 10]),
+    rowIndex: Uint32Array.from([0, 1]),
+    stroke: "#111111",
+    linewidth: 2,
+    alpha: 1,
+  };
+
+  it("panel-space mono strokePaint builds one linear gradient for the batch", () => {
+    const batch: SegmentsBatch = { ...twoSeg, strokePaint: panelLinearStroke };
+    const { ctx, calls } = recordingContext();
+    drawStratum(ctx, scene([batch]), [batch], resolve);
+    const creates = calls.filter((c) => c.name === "createLinearGradient");
+    expect(creates).toHaveLength(1);
+    expect(creates[0]?.args).toEqual([0, 0, 10, 0]);
+    expect(creates[0]?.stops).toEqual([
+      { offset: 0, color: "#111111" },
+      { offset: 1, color: "#eeeeee" },
+    ]);
+    const strokes = calls.filter((c) => c.name === "stroke");
+    expect(strokes).toHaveLength(1);
+    // Gradient object, not a solid color string.
+    expect(typeof strokes[0]?.strokeStyle).toBe("object");
+  });
+
+  it("panel-space paint with per-segment strokes still uses one gradient per run", () => {
+    const batch: SegmentsBatch = {
+      ...twoSeg,
+      stroke: null,
+      strokes: ["red", "red"],
+      strokePaint: panelLinearStroke,
+    };
+    const { ctx, calls } = recordingContext();
+    drawStratum(ctx, scene([batch]), [batch], resolve);
+    expect(calls.filter((c) => c.name === "createLinearGradient")).toHaveLength(1);
+    expect(calls.filter((c) => c.name === "stroke")).toHaveLength(1);
+  });
+
+  it("mark-space strokePaint builds one gradient per segment from segment AABB", () => {
+    const batch: SegmentsBatch = { ...twoSeg, strokePaint: markLinearStroke };
+    const { ctx, calls } = recordingContext();
+    drawStratum(ctx, scene([batch]), [batch], resolve);
+    const creates = calls.filter((c) => c.name === "createLinearGradient");
+    expect(creates).toHaveLength(2);
+    // Segment 0: x 0..10, y 0..0 → height clamped to 1e-6; mark x maps 0→0, 1→10.
+    expect(creates[0]?.args[0]).toBeCloseTo(0);
+    expect(creates[0]?.args[2]).toBeCloseTo(10);
+    // Segment 1: x 0..20, y 10..10
+    expect(creates[1]?.args[0]).toBeCloseTo(0);
+    expect(creates[1]?.args[2]).toBeCloseTo(20);
+    expect(calls.filter((c) => c.name === "stroke")).toHaveLength(2);
+  });
+
+  it("mark-space paint with tessellated positions uses path AABB not chord", () => {
+    const batch: SegmentsBatch = {
+      ...twoSeg,
+      segments: Float32Array.from([0, 0, 10, 0]),
+      rowIndex: Uint32Array.from([0]),
+      // Peaks above the chord so AABB height is non-zero.
+      renderPositions: Float32Array.from([0, 0, 5, 8, 10, 0]),
+      renderPathOffsets: Uint32Array.from([0, 3]),
+      strokePaint: markLinearStroke,
+    };
+    const { ctx, calls } = recordingContext();
+    drawStratum(ctx, scene([batch]), [batch], resolve);
+    const creates = calls.filter((c) => c.name === "createLinearGradient");
+    expect(creates).toHaveLength(1);
+    // mark x: bounds.x + v * width → 0 + 1 * 10 = 10 for x2
+    expect(creates[0]?.args[0]).toBeCloseTo(0);
+    expect(creates[0]?.args[2]).toBeCloseTo(10);
+    // y endpoints share y=0; mark y of 0 is bounds.y (0). Height of AABB is 8.
+    expect(creates[0]?.args[1]).toBeCloseTo(0);
+    expect(creates[0]?.args[3]).toBeCloseTo(0);
+    // Topology still traces the tessellated path.
+    expect(calls.filter((c) => c.name === "lineTo").map((c) => c.args)).toEqual([
+      [5, 8],
+      [10, 0],
+    ]);
+  });
+
+  it("glow with opacity < 1 bakes rgba into shadowColor and restores after draw", () => {
+    const batch: SegmentsBatch = { ...twoSeg, glow: softGlow };
+    const { ctx, calls } = recordingContext();
+    drawStratum(ctx, scene([batch]), [batch], resolve);
+    const strokes = calls.filter((c) => c.name === "stroke");
+    // Mono batch: one paint stroke with glow applied for the whole path.
+    expect(strokes).toHaveLength(1);
+    // #0af expands to #00aaff with opacity 0.4
+    expect(strokes[0]?.shadowColor).toBe("rgba(0,170,255,0.4)");
+    expect(strokes[0]?.shadowBlur).toBe(6);
+    // Context restored after the batch so later strata do not inherit glow.
+    expect(ctx.shadowColor).toBe("");
+    expect(ctx.shadowBlur).toBe(0);
   });
 });

--- a/packages/core/tests/mark-paint-unit.test.ts
+++ b/packages/core/tests/mark-paint-unit.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Pure unit tests for mark-paint helpers (#591).
+ * Pipeline/SVG coverage lives in mark-paint.test.ts; this file locks
+ * radial resolve/defs, canvas gradient mapping, and subpath AABB math.
+ */
+import { describe, expect, it } from "bun:test";
+import type { GradientPaint, GlowSpec } from "@ggsvelte/spec";
+
+import {
+  canvasGradientStyle,
+  layerPaintFromParams,
+  paintDefsSvg,
+  paintResourceId,
+  resolveGlow,
+  resolveGradientPaint,
+  subpathBounds,
+  type ResolvedGradientPaint,
+} from "../src/mark-paint.ts";
+
+const linearPaint: GradientPaint = {
+  type: "linear",
+  x1: 0,
+  y1: 0,
+  x2: 1,
+  y2: 0,
+  space: "mark",
+  stops: [
+    { offset: 0, color: "#112233", opacity: 1 },
+    { offset: 1, color: "#aabbcc", opacity: 0.5 },
+  ],
+  fallback: "#112233",
+};
+
+const radialPaint: GradientPaint = {
+  type: "radial",
+  cx: 0.5,
+  cy: 0.5,
+  r: 0.5,
+  space: "mark",
+  stops: [
+    { offset: 0, color: "#fff" },
+    { offset: 1, color: "#000", opacity: 0.25 },
+  ],
+  fallback: "#888888",
+};
+
+function gradientRecordingContext() {
+  const gradients: {
+    kind: "linear" | "radial";
+    args: number[];
+    stops: { offset: number; color: string }[];
+  }[] = [];
+  const ctx = {
+    createLinearGradient(...args: number[]) {
+      const stops: { offset: number; color: string }[] = [];
+      gradients.push({ kind: "linear", args: [...args], stops });
+      return {
+        addColorStop(offset: number, color: string) {
+          stops.push({ offset, color });
+        },
+      };
+    },
+    createRadialGradient(...args: number[]) {
+      const stops: { offset: number; color: string }[] = [];
+      gradients.push({ kind: "radial", args: [...args], stops });
+      return {
+        addColorStop(offset: number, color: string) {
+          stops.push({ offset, color });
+        },
+      };
+    },
+  } as unknown as CanvasRenderingContext2D;
+  return { ctx, gradients };
+}
+
+describe("layerPaintFromParams", () => {
+  it("returns null paints for non-record params", () => {
+    expect(layerPaintFromParams(null)).toEqual({
+      fillPaint: null,
+      strokePaint: null,
+      glow: null,
+    });
+    expect(layerPaintFromParams("nope")).toEqual({
+      fillPaint: null,
+      strokePaint: null,
+      glow: null,
+    });
+  });
+
+  it("rejects glow bags missing color, radius, or opacity", () => {
+    const incomplete = layerPaintFromParams({
+      glow: { color: "#00aaff", radius: 4 },
+    });
+    expect(incomplete.glow).toBeNull();
+
+    const wrongType = layerPaintFromParams({
+      glow: { color: "#00aaff", radius: "wide", opacity: 0.5 },
+    });
+    expect(wrongType.glow).toBeNull();
+  });
+
+  it("extracts validated fillPaint, strokePaint, and glow", () => {
+    const glow: GlowSpec = { color: "#00aaff", radius: 6, opacity: 0.4 };
+    const got = layerPaintFromParams({
+      fillPaint: linearPaint,
+      strokePaint: radialPaint,
+      glow,
+    });
+    expect(got.fillPaint).toEqual(linearPaint);
+    expect(got.strokePaint).toEqual(radialPaint);
+    expect(got.glow).toEqual(glow);
+  });
+});
+
+describe("resolveGradientPaint / resolveGlow", () => {
+  it("resolves radial paint with stable id and default mark space", () => {
+    const noSpace: GradientPaint = {
+      type: "radial",
+      cx: 0.25,
+      cy: 0.75,
+      r: 0.4,
+      stops: [{ offset: 0, color: "#abc" }],
+      fallback: "#abc",
+    };
+    const resolved = resolveGradientPaint(noSpace, 2, "fill", 1);
+    expect(resolved).toMatchObject({
+      kind: "radial",
+      space: "mark",
+      cx: 0.25,
+      cy: 0.75,
+      r: 0.4,
+      x1: 0,
+      y1: 0,
+      x2: 0,
+      y2: 0,
+      id: paintResourceId(2, "fill", 1),
+      fallback: "#abc",
+    });
+    expect(resolved.stops[0]).toEqual({ offset: 0, color: "#abc", opacity: 1 });
+  });
+
+  it("resolves linear paint and glow resource ids", () => {
+    const linear = resolveGradientPaint(linearPaint, 0, "stroke");
+    expect(linear.kind).toBe("linear");
+    expect(linear.id).toBe("gg-paint-l0-p0-stroke");
+    expect(linear.stops[1]?.opacity).toBe(0.5);
+
+    const glow = resolveGlow({ color: "#ff0", radius: 3, opacity: 1 }, 4, 2);
+    expect(glow).toEqual({
+      color: "#ff0",
+      radius: 3,
+      opacity: 1,
+      id: "gg-paint-l4-p2-glow",
+    });
+  });
+});
+
+describe("paintDefsSvg", () => {
+  it("emits radialGradient, stop-opacity only when opacity < 1, and glow filter", () => {
+    const radial = resolveGradientPaint(radialPaint, 0, "fill");
+    const linear = resolveGradientPaint({ ...linearPaint, space: "panel" }, 0, "stroke");
+    const glow = resolveGlow({ color: "#00aaff", radius: 4, opacity: 0.5 }, 0);
+    const svg = paintDefsSvg([radial, linear], [glow]);
+
+    expect(svg).toContain(`id="${radial.id}"`);
+    expect(svg).toContain("radialGradient");
+    expect(svg).toContain('gradientUnits="objectBoundingBox"');
+    expect(svg).toContain(`cx="${String(radial.cx)}"`);
+    expect(svg).toContain(`r="${String(radial.r)}"`);
+    // Full-opacity stop omits stop-opacity; partial keeps it.
+    expect(svg).toContain('stop-color="#fff"');
+    expect(svg).not.toMatch(/stop-color="#fff"[^>]*stop-opacity/);
+    expect(svg).toContain('stop-opacity="0.25"');
+    expect(svg).toContain('gradientUnits="userSpaceOnUse"');
+    expect(svg).toContain(`id="${glow.id}"`);
+    expect(svg).toContain("feGaussianBlur");
+    expect(svg).toContain(`flood-color="${glow.color}"`);
+  });
+});
+
+describe("canvasGradientStyle", () => {
+  const bounds = { x: 10, y: 20, width: 100, height: 50 };
+
+  it("maps mark-space linear coords through bounds", () => {
+    const { ctx, gradients } = gradientRecordingContext();
+    const paint = resolveGradientPaint(linearPaint, 0, "fill");
+    const style = canvasGradientStyle(ctx, paint, bounds);
+    expect(style).not.toBeTypeOf("string");
+    expect(gradients).toHaveLength(1);
+    expect(gradients[0]).toMatchObject({
+      kind: "linear",
+      args: [10, 20, 110, 20],
+    });
+    expect(gradients[0]!.stops).toEqual([
+      { offset: 0, color: "#112233" },
+      { offset: 1, color: "rgba(170,187,204,0.5)" },
+    ]);
+  });
+
+  it("maps mark-space radial coords and radius, baking short hex opacity", () => {
+    const { ctx, gradients } = gradientRecordingContext();
+    const paint = resolveGradientPaint(radialPaint, 0, "fill");
+    canvasGradientStyle(ctx, paint, bounds);
+    expect(gradients[0]).toMatchObject({
+      kind: "radial",
+      // r * max(width, height) = 0.5 * 100 = 50
+      args: [60, 45, 0, 60, 45, 50],
+    });
+    expect(gradients[0]!.stops[1]?.color).toBe("rgba(0,0,0,0.25)");
+  });
+
+  it("uses absolute panel-space coords without remapping", () => {
+    const { ctx, gradients } = gradientRecordingContext();
+    const panel: ResolvedGradientPaint = {
+      kind: "linear",
+      space: "panel",
+      x1: 3,
+      y1: 4,
+      x2: 5,
+      y2: 6,
+      cx: 0,
+      cy: 0,
+      r: 0,
+      stops: [{ offset: 0, color: "#ff0000", opacity: 1 }],
+      fallback: "#ff0000",
+      id: "gg-paint-l0-p0-stroke",
+    };
+    canvasGradientStyle(ctx, panel, bounds);
+    expect(gradients[0]?.args).toEqual([3, 4, 5, 6]);
+    expect(gradients[0]?.stops).toEqual([{ offset: 0, color: "#ff0000" }]);
+  });
+});
+
+describe("subpathBounds", () => {
+  it("returns axis-aligned bounds for a vertex range", () => {
+    const positions = Float32Array.from([0, 0, 10, 2, 4, 8, 1, 1]);
+    expect(subpathBounds(positions, 1, 3)).toEqual({
+      x: 4,
+      y: 2,
+      width: 6,
+      height: 6,
+    });
+  });
+
+  it("returns unit box when the range is empty", () => {
+    const positions = Float32Array.from([1, 2]);
+    expect(subpathBounds(positions, 0, 0)).toEqual({
+      x: 0,
+      y: 0,
+      width: 1,
+      height: 1,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add pure unit tests for `@ggsvelte/core` mark-paint helpers: radial resolve/defs, `canvasGradientStyle` mark vs panel mapping, stop opacity baking, `subpathBounds`, and `layerPaintFromParams` edge cases.
- Extend canvas segment DOM tests for `strokePaint` (panel mono, panel runs, mark-space per-segment AABB, tessellated path bounds) and glow opacity restore.
- Teach `recordingContext` to record gradient factory calls, color stops, shadow state, and `setLineDash` so paint paths can be asserted.

## Coverage
| File | Before (lines) | After (related tests) |
|------|----------------|------------------------|
| `packages/core/src/mark-paint.ts` | ~50% | 100% |
| `packages/core/src/dom/canvas-marks-segments.ts` | ~52% | 100% |

Measured with `bun test --coverage` on the related unit/dom files. Full `packages/core` suite: 2222 pass, 0 fail.

## Test plan
- [x] `bun test packages/core/tests/mark-paint-unit.test.ts packages/core/tests/dom/canvas-segments.test.ts`
- [x] `bun test packages/core` (full package suite green)
- [ ] CI unit job green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1488" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->