### PR TITLE
test(core): cover cssColorResolver and letterbox gutter rects

### DIFF
--- a/packages/core/tests/dom/canvas-dom-resolver.test.ts
+++ b/packages/core/tests/dom/canvas-dom-resolver.test.ts
@@ -1,0 +1,97 @@
+/**
+ * cssColorResolver: theme var() peel + currentColor for canvas paint (#0006).
+ * sizeCanvasForDpr / drawClippedToPanel live in canvas-barrel.test.ts.
+ */
+import { afterEach, describe, expect, it } from "bun:test";
+
+import { cssColorResolver } from "../../src/dom/canvas-dom.ts";
+
+describe("cssColorResolver", () => {
+  const originalGetComputedStyle = globalThis.getComputedStyle;
+  let propertyReads = 0;
+  let colorReads = 0;
+  let properties: Record<string, string> = {};
+  let color = "rgb(1, 2, 3)";
+
+  afterEach(() => {
+    globalThis.getComputedStyle = originalGetComputedStyle;
+    propertyReads = 0;
+    colorReads = 0;
+    properties = {};
+    color = "rgb(1, 2, 3)";
+  });
+
+  /** getComputedStyle only receives the element; no real DOM needed under bun. */
+  const host = {} as Element;
+
+  function installStyle() {
+    globalThis.getComputedStyle = ((el: Element) => {
+      expect(el).toBe(host);
+      return {
+        getPropertyValue(name: string) {
+          propertyReads += 1;
+          return properties[name] ?? "";
+        },
+        get color() {
+          colorReads += 1;
+          return color;
+        },
+      } as CSSStyleDeclaration;
+    }) as typeof getComputedStyle;
+  }
+
+  it("resolves var(--token, fallback) from computed style", () => {
+    installStyle();
+    properties["--gg-ink"] = "  #111111  ";
+    const resolve = cssColorResolver(host);
+    expect(resolve("var(--gg-ink, black)")).toBe("#111111");
+    expect(propertyReads).toBe(1);
+  });
+
+  it("uses the embedded fallback when the custom property is empty", () => {
+    installStyle();
+    properties["--gg-ink"] = "";
+    const resolve = cssColorResolver(host);
+    expect(resolve("var(--gg-ink, #abcdef)")).toBe("#abcdef");
+  });
+
+  it("maps currentColor to the computed color", () => {
+    installStyle();
+    color = "rgb(9, 8, 7)";
+    const resolve = cssColorResolver(host);
+    expect(resolve("currentColor")).toBe("rgb(9, 8, 7)");
+    expect(colorReads).toBe(1);
+  });
+
+  it("caches resolved colors so style is not re-read for the same input", () => {
+    installStyle();
+    properties["--gg-accent"] = "#ff0000";
+    const resolve = cssColorResolver(host);
+    expect(resolve("var(--gg-accent, red)")).toBe("#ff0000");
+    expect(resolve("var(--gg-accent, red)")).toBe("#ff0000");
+    expect(propertyReads).toBe(1);
+
+    expect(resolve("currentColor")).toBe("rgb(1, 2, 3)");
+    expect(resolve("currentColor")).toBe("rgb(1, 2, 3)");
+    expect(colorReads).toBe(1);
+  });
+
+  it("passes through solid colors without touching computed style", () => {
+    installStyle();
+    const resolve = cssColorResolver(host);
+    expect(resolve("#c0ffee")).toBe("#c0ffee");
+    expect(propertyReads).toBe(0);
+    expect(colorReads).toBe(0);
+  });
+
+  it("falls through whitespace-only custom properties to currentColor fallbacks", () => {
+    installStyle();
+    // Real theme tokens often chain: var(--gg-ink, currentColor).
+    properties["--gg-ink"] = "   ";
+    color = "rgb(4, 5, 6)";
+    const resolve = cssColorResolver(host);
+    expect(resolve("var(--gg-ink, currentColor)")).toBe("rgb(4, 5, 6)");
+    expect(propertyReads).toBe(1);
+    expect(colorReads).toBe(1);
+  });
+});

--- a/packages/core/tests/dom/canvas-dom-resolver.test.ts
+++ b/packages/core/tests/dom/canvas-dom-resolver.test.ts
@@ -25,9 +25,9 @@ describe("cssColorResolver", () => {
   const host = {} as Element;
 
   function installStyle() {
-    globalThis.getComputedStyle = ((el: Element) => {
+    globalThis.getComputedStyle = (el: Element): CSSStyleDeclaration => {
       expect(el).toBe(host);
-      return {
+      const style = {
         getPropertyValue(name: string) {
           propertyReads += 1;
           return properties[name] ?? "";
@@ -36,8 +36,9 @@ describe("cssColorResolver", () => {
           colorReads += 1;
           return color;
         },
-      } as CSSStyleDeclaration;
-    }) as typeof getComputedStyle;
+      };
+      return style as unknown as CSSStyleDeclaration;
+    };
   }
 
   it("resolves var(--token, fallback) from computed style", () => {

--- a/packages/core/tests/letterbox-gutters.test.ts
+++ b/packages/core/tests/letterbox-gutters.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Pure letterbox gutter rects (ADR 0020): unused allocation outside the
+ * fitted data panel. SVG/Svelte paint these with theme.letterboxFill.
+ */
+import { describe, expect, it } from "bun:test";
+
+import { letterboxGutterRects } from "../src/letterbox-gutters.ts";
+
+describe("letterboxGutterRects", () => {
+  it("returns empty when the panel fills the allocation", () => {
+    const box = { x: 10, y: 20, width: 100, height: 80 };
+    expect(letterboxGutterRects(box, box)).toEqual([]);
+  });
+
+  it("emits top and bottom gutters for a vertically letterboxed panel", () => {
+    const allocation = { x: 0, y: 0, width: 100, height: 100 };
+    const panel = { x: 0, y: 10, width: 100, height: 60 };
+    expect(letterboxGutterRects(allocation, panel)).toEqual([
+      { x: 0, y: 0, width: 100, height: 10 },
+      { x: 0, y: 70, width: 100, height: 30 },
+    ]);
+  });
+
+  it("emits left and right gutters for a horizontally letterboxed panel", () => {
+    const allocation = { x: 0, y: 0, width: 100, height: 50 };
+    const panel = { x: 15, y: 0, width: 60, height: 50 };
+    expect(letterboxGutterRects(allocation, panel)).toEqual([
+      { x: 0, y: 0, width: 15, height: 50 },
+      { x: 75, y: 0, width: 25, height: 50 },
+    ]);
+  });
+
+  it("emits all four gutters when the panel is inset on every side", () => {
+    const allocation = { x: 10, y: 20, width: 200, height: 100 };
+    const panel = { x: 30, y: 40, width: 120, height: 50 };
+    expect(letterboxGutterRects(allocation, panel)).toEqual([
+      { x: 10, y: 20, width: 200, height: 20 },
+      { x: 10, y: 90, width: 200, height: 30 },
+      { x: 10, y: 40, width: 20, height: 50 },
+      { x: 150, y: 40, width: 60, height: 50 },
+    ]);
+  });
+
+  it("ignores zero-size edges without fabricating empty rects", () => {
+    const allocation = { x: 0, y: 0, width: 80, height: 40 };
+    // Flush top/left; only right + bottom remain.
+    const panel = { x: 0, y: 0, width: 50, height: 30 };
+    expect(letterboxGutterRects(allocation, panel)).toEqual([
+      { x: 0, y: 30, width: 80, height: 10 },
+      { x: 50, y: 0, width: 30, height: 30 },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Unit-test `cssColorResolver` against stubbed `getComputedStyle`: theme `var()` peel, empty/whitespace fallbacks, `currentColor`, Map cache, solid pass-through.
- Unit-test public `letterboxGutterRects` (ADR 0020): vertical/horizontal/four-side gutters, flush panel, zero-size edges.

## Coverage
| File | Before (lines) | After (related tests) |
|------|----------------|------------------------|
| `packages/core/src/dom/canvas-dom.ts` | ~66% | 100% |
| `packages/core/src/letterbox-gutters.ts` | ~71% | 100% |

Full `packages/core` suite green.

## Test plan
- [x] `bun test packages/core/tests/dom/canvas-dom-resolver.test.ts packages/core/tests/letterbox-gutters.test.ts`
- [x] `bun test packages/core`
- [ ] CI unit job green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1489" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->