### PR TITLE
perf(svelte): expand lineages once on precise-bounds recompute

### DIFF
--- a/.changeset/precise-bounds-lineage-once.md
+++ b/.changeset/precise-bounds-lineage-once.md
@@ -1,0 +1,9 @@
+---
+"@ggsvelte/svelte": patch
+---
+
+# Expand shared lineages once on precise-bounds recompute
+
+Migration: none — internal precise-bounds apply path only; same interval keys and lineageCount.
+
+Precise-bounds apply now domain-filters candidates before expanding `lineage.keys()`, and expands each lineage id once among matches (smooth/aggregate eval grids no longer re-spread the same bag once per mark). Semantic keys resolve only for in-interval candidates.

--- a/packages/svelte/src/lib/interval/consumption.ts
+++ b/packages/svelte/src/lib/interval/consumption.ts
@@ -204,7 +204,10 @@ export function nextLocalIntervalRecords<Key extends PropertyKey>(
  * Single-pass panel recompute after an exact bounds edit: unique semantic keys
  * and optional lineage row count. Callers that need both keys and lineageCount
  * must supply `sourceRows` on each candidate so the store is not scanned twice
- * (interval-state precise-bounds path).
+ * (interval-state precise-bounds path). Prefer
+ * {@link recomputePanelIntervalFromLookup} when scanning a live candidate
+ * store — it domain-filters before lineage expansion and expands each
+ * lineage id once.
  */
 export function recomputePanelIntervalProjection<Key extends PropertyKey>(
   input: RecomputePanelIntervalProjectionInput<Key>,
@@ -223,5 +226,55 @@ export function recomputePanelIntervalProjection<Key extends PropertyKey>(
   return {
     keys: Object.freeze([...keys]),
     lineageCount: trackRows ? rows.size : 0,
+  };
+}
+
+/**
+ * Candidate facts for store-backed precise-bounds recompute. `keys` may be a
+ * getter so hosts pay semantic-key resolution only for domain matches.
+ */
+export type PanelIntervalLookupCandidate<Key extends PropertyKey> =
+  IntervalConsumptionCandidate<Key> & {
+    readonly lineage: number;
+    readonly rowIndex: number | null;
+  };
+
+export type RecomputePanelIntervalFromLookupInput<Key extends PropertyKey> = {
+  readonly panelId: string;
+  readonly domains: ReadonlyIntervalDomains;
+  readonly size: number;
+  candidate(id: number): PanelIntervalLookupCandidate<Key> | null;
+  lineageKeys(lineageId: number): Iterable<number>;
+};
+
+/**
+ * Precise-bounds panel recompute from a candidate store.
+ *
+ * Domain membership is tested before lineage expansion. Each lineage id among
+ * matching candidates is expanded once (smooth / aggregate eval grids share
+ * membership — not once per mark). Candidate-local `rowIndex` outside the
+ * shared bag still unions into lineageCount.
+ */
+export function recomputePanelIntervalFromLookup<Key extends PropertyKey>(
+  input: RecomputePanelIntervalFromLookupInput<Key>,
+): { readonly keys: readonly Key[]; readonly lineageCount: number } {
+  const inInterval = prepareCandidateInInterval(input.domains);
+  const keys = new Set<Key>();
+  const rows = new Set<number>();
+  const expandedLineages = new Set<number>();
+  for (let id = 0; id < input.size; id++) {
+    const candidate = input.candidate(id);
+    if (candidate === null || candidate.panelId !== input.panelId) continue;
+    if (!inInterval(candidate)) continue;
+    for (const key of candidate.keys) keys.add(key);
+    if (!expandedLineages.has(candidate.lineage)) {
+      expandedLineages.add(candidate.lineage);
+      for (const rowIndex of input.lineageKeys(candidate.lineage)) rows.add(rowIndex);
+    }
+    if (candidate.rowIndex !== null) rows.add(candidate.rowIndex);
+  }
+  return {
+    keys: Object.freeze([...keys]),
+    lineageCount: rows.size,
   };
 }

--- a/packages/svelte/src/lib/interval/interval-state.svelte.ts
+++ b/packages/svelte/src/lib/interval/interval-state.svelte.ts
@@ -45,10 +45,9 @@ import {
 } from "./interval.js";
 import {
   consumeIntervalKeys,
-  recomputePanelIntervalProjection,
+  recomputePanelIntervalFromLookup,
   sameIntervalRecord,
   type IntervalConsumptionCandidate,
-  type RecomputePanelIntervalProjectionInput,
 } from "./consumption.js";
 import { boundsEditorInputForScale, semanticAxisFromBounds } from "./precise-bounds.js";
 
@@ -385,9 +384,9 @@ export function createIntervalState(
 
   /**
    * One full-store pass for precise-bounds apply: semantic keys + lineage row
-   * count for the target panel/domains. Projects the live CandidateStore into
-   * the pure consumption port (always with sourceRows so lineageCount tracks
-   * unique rows — the live path never omits them).
+   * count for the target panel/domains. Domain-filters before lineage
+   * expansion and expands each lineage id once among matches (shared smooth /
+   * aggregate bags — not once per mark).
    */
   function recomputePanelIntervalSelection(
     targetPanelId: string,
@@ -395,28 +394,26 @@ export function createIntervalState(
   ): { readonly keys: readonly PropertyKey[]; readonly lineageCount: number } {
     const model = context.model();
     if (model === null) return { keys: Object.freeze([]), lineageCount: 0 };
-    type ProjectionCandidate =
-      RecomputePanelIntervalProjectionInput<PropertyKey>["candidates"][number];
-    const candidates: ProjectionCandidate[] = [];
-    for (let id = 0; id < model.candidates.size; id++) {
-      const candidate = model.candidates.candidate(id);
-      if (candidate === null || candidate.panelId !== targetPanelId) continue;
-      const sourceRows = [
-        ...model.lineage.keys(candidate.lineage),
-        ...(candidate.rowIndex === null ? [] : [candidate.rowIndex]),
-      ];
-      candidates.push({
-        panelId: candidate.panelId,
-        xValue: candidate.xValue,
-        yValue: candidate.yValue,
-        keys: context.candidateSemanticKeys(candidate),
-        sourceRows,
-      });
-    }
-    return recomputePanelIntervalProjection({
+    return recomputePanelIntervalFromLookup({
       panelId: targetPanelId,
       domains,
-      candidates,
+      size: model.candidates.size,
+      candidate: (id) => {
+        const candidate = model.candidates.candidate(id);
+        if (candidate === null) return null;
+        return {
+          panelId: candidate.panelId,
+          xValue: candidate.xValue,
+          yValue: candidate.yValue,
+          lineage: candidate.lineage,
+          rowIndex: candidate.rowIndex,
+          // Lazy: pay key resolution only after domain membership passes.
+          get keys() {
+            return context.candidateSemanticKeys(candidate);
+          },
+        };
+      },
+      lineageKeys: (lineageId) => model.lineage.keys(lineageId),
     });
   }
 

--- a/packages/svelte/tests/interval/consumption.test.ts
+++ b/packages/svelte/tests/interval/consumption.test.ts
@@ -3,9 +3,11 @@ import { describe, expect, it } from "vitest";
 import {
   consumeIntervalKeys,
   nextLocalIntervalRecords,
+  recomputePanelIntervalFromLookup,
   recomputePanelIntervalProjection,
   sameIntervalRecord,
   type IntervalConsumptionCandidate,
+  type PanelIntervalLookupCandidate,
 } from "../../src/lib/interval/consumption.js";
 import type { PlotInteractionInterval } from "../../src/lib/interaction/interaction.js";
 
@@ -501,5 +503,126 @@ describe("facet interval consumption", () => {
       ...Array.from({ length: 150 }, (_, i) => `p${300 + i}`),
     ];
     expect(keys).toEqual(expected);
+  });
+
+  it("recomputePanelIntervalFromLookup matches projection keys and unique lineage rows", () => {
+    const store: Array<PanelIntervalLookupCandidate<string> | null> = [
+      {
+        panelId: "south",
+        xValue: 2,
+        yValue: "low",
+        keys: ["s2", "shared"],
+        lineage: 1,
+        rowIndex: 10,
+      },
+      {
+        panelId: "south",
+        xValue: 2,
+        yValue: "low",
+        keys: ["s3"],
+        lineage: 1,
+        rowIndex: null,
+      },
+      {
+        panelId: "south",
+        xValue: 9,
+        yValue: "low",
+        keys: ["out"],
+        lineage: 2,
+        rowIndex: 50,
+      },
+      {
+        panelId: "north",
+        xValue: 2,
+        yValue: "low",
+        keys: ["n1"],
+        lineage: 3,
+        rowIndex: 99,
+      },
+      {
+        panelId: "south",
+        xValue: 2,
+        yValue: "low",
+        keys: ["extra-row"],
+        lineage: 1,
+        rowIndex: 12,
+      },
+    ];
+    const lineages = new Map<number, readonly number[]>([
+      [1, [10, 11]],
+      [2, [50, 51]],
+      [3, [99]],
+    ]);
+    const projection = recomputePanelIntervalFromLookup({
+      panelId: "south",
+      domains: {
+        x: { kind: "linear", domain: [1, 3] },
+        y: { kind: "band", values: ["low"] },
+      },
+      size: store.length,
+      candidate: (id) => store[id] ?? null,
+      lineageKeys: (lineageId) => lineages.get(lineageId) ?? [],
+    });
+    expect(projection.keys).toEqual(["s2", "shared", "s3", "extra-row"]);
+    // Lineage 1 → 10,11; matching candidate also contributes rowIndex 12.
+    expect(projection.lineageCount).toBe(3);
+  });
+
+  it("recomputePanelIntervalFromLookup expands each lineage once among matching candidates", () => {
+    const sharedLineage = 7;
+    const markCount = 80;
+    const store: Array<PanelIntervalLookupCandidate<string> | null> = Array.from(
+      { length: markCount + 2 },
+      (_, i) => {
+        if (i < markCount) {
+          return {
+            panelId: "south",
+            xValue: 2,
+            yValue: "low",
+            keys: [`m${i}`],
+            lineage: sharedLineage,
+            rowIndex: null,
+          };
+        }
+        if (i === markCount) {
+          // In-panel but outside domain — must not expand lineage 99.
+          return {
+            panelId: "south",
+            xValue: 99,
+            yValue: "low",
+            keys: ["outside"],
+            lineage: 99,
+            rowIndex: null,
+          };
+        }
+        return {
+          panelId: "north",
+          xValue: 2,
+          yValue: "low",
+          keys: ["other-panel"],
+          lineage: 100,
+          rowIndex: null,
+        };
+      },
+    );
+    const lineageCalls = new Map<number, number>();
+    const projection = recomputePanelIntervalFromLookup({
+      panelId: "south",
+      domains: {
+        x: { kind: "linear", domain: [1, 3] },
+        y: { kind: "band", values: ["low"] },
+      },
+      size: store.length,
+      candidate: (id) => store[id] ?? null,
+      lineageKeys: (lineageId) => {
+        lineageCalls.set(lineageId, (lineageCalls.get(lineageId) ?? 0) + 1);
+        return lineageId === sharedLineage ? [0, 1, 2, 3, 4] : [lineageId];
+      },
+    });
+    expect(projection.keys).toHaveLength(markCount);
+    expect(projection.lineageCount).toBe(5);
+    expect(lineageCalls.get(sharedLineage)).toBe(1);
+    expect(lineageCalls.has(99)).toBe(false);
+    expect(lineageCalls.has(100)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- Precise-bounds apply rebuilt `sourceRows` by spreading `lineage.keys()` for **every** panel candidate **before** domain filtering, so shared smooth/aggregate lineages were re-expanded once per mark (`O(C·L)`).
- New pure `recomputePanelIntervalFromLookup` domain-filters first, expands each lineage id once among matches, and unions candidate-local `rowIndex` — same keys / lineageCount contract as the brush path's once-per-lineage expand.
- Host pays `candidateSemanticKeys` only for in-interval candidates (lazy `keys` getter).

## Complexity

| | Before | After |
|---|--------|-------|
| Shared lineage expand | `O(C·L)` per precise-bounds apply | `O(C + L)` among matching candidates |
| What n is | `C` = candidates on panel (eval-grid marks), `L` = source rows in shared lineage | same |

## Test plan

- [x] `cd packages/svelte && bunx vitest run tests/interval/ --project chromium` (92 tests)
- [x] New cases: projection parity + `lineageKeys` called once per shared lineage; out-of-domain / other-panel lineages never expanded

## Follow-ups

None deferred from this pass.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1490" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->