### PR TITLE
test(core): cover temporal config assert and geom channel contracts

### DIFF
--- a/packages/core/tests/pipeline-bind.test.ts
+++ b/packages/core/tests/pipeline-bind.test.ts
@@ -233,6 +233,70 @@ describe("bindLayer", () => {
     }
   });
 
+  it("rejects density on a nominal x", () => {
+    try {
+      bindLayer({ geom: "density", aes: { x: { field: "g" } } }, 0, table, []);
+      expect.unreachable("should throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(PipelineError);
+      expect((e as PipelineError).code).toBe("channel-type-mismatch");
+      expect((e as PipelineError).message).toMatch(/density stat needs a continuous x/i);
+      expect((e as PipelineError).path).toContain("x");
+    }
+  });
+
+  it("rejects boxplot with a nominal y", () => {
+    try {
+      bindLayer({ geom: "boxplot", aes: { x: { field: "g" }, y: { field: "g" } } }, 0, table, []);
+      expect.unreachable("should throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(PipelineError);
+      expect((e as PipelineError).code).toBe("channel-type-mismatch");
+      expect((e as PipelineError).message).toMatch(/boxplot stat needs a quantitative y/i);
+      expect((e as PipelineError).path).toContain("y");
+    }
+  });
+
+  it("rejects ellipse on nominal position channels", () => {
+    try {
+      bindLayer(
+        { geom: "path", stat: "ellipse", aes: { x: { field: "g" }, y: { field: "y" } } },
+        0,
+        table,
+        [],
+      );
+      expect.unreachable("should throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(PipelineError);
+      expect((e as PipelineError).code).toBe("channel-type-mismatch");
+      expect((e as PipelineError).message).toMatch(/ellipse stat needs quantitative/i);
+    }
+  });
+
+  it("rejects raster on a nominal y", () => {
+    try {
+      bindLayer({ geom: "raster", aes: { x: { field: "x" }, y: { field: "g" } } }, 0, table, []);
+      expect.unreachable("should throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(PipelineError);
+      expect((e as PipelineError).code).toBe("channel-type-mismatch");
+      expect((e as PipelineError).message).toMatch(/raster geom needs continuous y/i);
+      expect((e as PipelineError).path).toContain("y");
+    }
+  });
+
+  it("rejects spoke on a nominal x", () => {
+    try {
+      bindLayer({ geom: "spoke", aes: { x: { field: "g" }, y: { field: "y" } } }, 0, table, []);
+      expect.unreachable("should throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(PipelineError);
+      expect((e as PipelineError).code).toBe("channel-type-mismatch");
+      expect((e as PipelineError).message).toMatch(/spoke geom needs continuous x/i);
+      expect((e as PipelineError).path).toContain("x");
+    }
+  });
+
   it("requires ymin/ymax for identity errorbar", () => {
     try {
       bindLayer({ geom: "errorbar", aes: { x: { field: "g" } } }, 0, table, []);

--- a/packages/core/tests/pipeline-temporal/assert-temporal-configuration.test.ts
+++ b/packages/core/tests/pipeline-temporal/assert-temporal-configuration.test.ts
@@ -25,17 +25,19 @@ describe("assertTemporalConfiguration", () => {
   });
 
   it("no-ops for forced discrete axes even with an explicit parser", () => {
-    expect(() =>
+    expect(() => {
       assertTemporalConfiguration("x", {
         ...AUTO_POSITION_CONVERSION,
         parser: "ymd",
         forcedDiscrete: true,
-      }),
-    ).not.toThrow();
+      });
+    }).not.toThrow();
   });
 
   it("allows auto parser without the temporal runtime", () => {
-    expect(() => assertTemporalConfiguration("y", AUTO_POSITION_CONVERSION)).not.toThrow();
+    expect(() => {
+      assertTemporalConfiguration("y", AUTO_POSITION_CONVERSION);
+    }).not.toThrow();
   });
 
   it("rejects explicit parsers when the temporal runtime is missing", () => {

--- a/packages/core/tests/pipeline-temporal/assert-temporal-configuration.test.ts
+++ b/packages/core/tests/pipeline-temporal/assert-temporal-configuration.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Unit tests for assertTemporalConfiguration (lean runtime + config errors).
+ * Pipeline timezone preflight is covered in auto-timezone-preflight.test.ts.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+
+import { installTemporal } from "../../src/install-temporal.ts";
+import {
+  assertTemporalConfiguration,
+  temporalPreflightDocs,
+} from "../../src/pipeline/temporal-preflight-shared.ts";
+import { AUTO_POSITION_CONVERSION } from "../../src/pipeline/temporal-position.ts";
+import { PipelineError } from "../../src/pipeline/types.ts";
+import { getTemporalRuntime, resetTemporalRuntimeForTests } from "../../src/temporal-runtime.ts";
+
+describe("assertTemporalConfiguration", () => {
+  beforeAll(() => {
+    resetTemporalRuntimeForTests();
+    expect(getTemporalRuntime()).toBeNull();
+  });
+
+  afterAll(() => {
+    installTemporal();
+    expect(getTemporalRuntime()).not.toBeNull();
+  });
+
+  it("no-ops for forced discrete axes even with an explicit parser", () => {
+    expect(() =>
+      assertTemporalConfiguration("x", {
+        ...AUTO_POSITION_CONVERSION,
+        parser: "ymd",
+        forcedDiscrete: true,
+      }),
+    ).not.toThrow();
+  });
+
+  it("allows auto parser without the temporal runtime", () => {
+    expect(() => assertTemporalConfiguration("y", AUTO_POSITION_CONVERSION)).not.toThrow();
+  });
+
+  it("rejects explicit parsers when the temporal runtime is missing", () => {
+    let caught: unknown;
+    try {
+      assertTemporalConfiguration("x", {
+        ...AUTO_POSITION_CONVERSION,
+        parser: "ymd",
+      });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(PipelineError);
+    const err = caught as PipelineError;
+    expect(err.code).toBe("temporal-parse-failed");
+    expect(err.path).toBe("/scales/x");
+    expect(err.message).toMatch(/explicit temporal parser/i);
+    expect(err.message).toMatch(/@ggsvelte\/core\/temporal|@ggsvelte\/core \(full\)/);
+    expect(err.diagnostic?.documentationUrl).toBe(temporalPreflightDocs("temporal-parse-failed"));
+  });
+
+  it("rejects invalid timezone configuration on auto parse without a runtime", () => {
+    // Timezone validation still runs for auto so mistyped zones fail early.
+    let caught: unknown;
+    try {
+      assertTemporalConfiguration("y", {
+        ...AUTO_POSITION_CONVERSION,
+        options: { timezone: "Not/A_Zone" },
+      });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(PipelineError);
+    const err = caught as PipelineError;
+    expect(err.code).toBe("temporal-parse-failed");
+    expect(err.path).toBe("/scales/y");
+    expect(err.message).toMatch(/invalid temporal parser configuration/i);
+    expect(err.message).toMatch(/Not\/A_Zone|timezone/i);
+    expect(err.diagnostic?.documentationUrl).toBe(temporalPreflightDocs("temporal-parse-failed"));
+  });
+});


### PR DESCRIPTION
## Summary
- Unit-test `assertTemporalConfiguration`: forced-discrete no-op, auto parser without temporal runtime, explicit parser requiring full/temporal entry, invalid timezone on auto without runtime.
- Extend bind-layer characterization for channel-type mismatches: density nominal x, boxplot nominal y, ellipse nominal positions, raster nominal y, spoke nominal x.

## Coverage
| File | Before (lines) | After (related tests) |
|------|----------------|------------------------|
| `packages/core/src/pipeline/temporal-preflight-shared.ts` | ~63% | 100% |
| `packages/core/src/pipeline/bind-layer-type-contracts-geom.ts` | ~67% | ~80% |

Full `packages/core` suite green.

## Test plan
- [x] `bun test packages/core/tests/pipeline-temporal/assert-temporal-configuration.test.ts packages/core/tests/pipeline-bind.test.ts`
- [x] `bun test packages/core`
- [x] `bun test packages/core/tests/pipeline-temporal`
- [ ] CI unit job green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1491" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->