### PR TITLE
test(core): cover lean inferFieldType and qq empty-sample frames

### DIFF
--- a/packages/core/tests/pipeline-frame/qq-missing-sample.test.ts
+++ b/packages/core/tests/pipeline-frame/qq-missing-sample.test.ts
@@ -1,0 +1,72 @@
+/**
+ * buildQqFrame / buildQqLineFrame empty-sample defensive path.
+ * Public bind rejects missing sample; these unit tests call the frame
+ * builders with sampleField null so the empty-frame contract stays locked.
+ */
+import { describe, expect, it } from "bun:test";
+
+import { bindLayer } from "../../src/pipeline/bind-layer.ts";
+import { buildQqFrame, buildQqLineFrame } from "../../src/pipeline/frame-stats-qq.ts";
+import type { PipelineWarning } from "../../src/pipeline/types.ts";
+import { ColumnTable } from "../../src/table.ts";
+
+const table = ColumnTable.fromRows([{ y: 1 }, { y: 2 }, { y: 3 }]);
+
+function qqBinding() {
+  return bindLayer({ geom: "qq", aes: { sample: { field: "y" } }, stat: "qq" }, 0, table, []);
+}
+
+function qqLineBinding() {
+  return bindLayer(
+    { geom: "qq_line", aes: { sample: { field: "y" } }, stat: "qq_line" },
+    0,
+    table,
+    [],
+  );
+}
+
+describe("buildQqFrame / buildQqLineFrame missing sample", () => {
+  it("returns an empty qq frame without warnings when sampleField is null", () => {
+    const warnings: PipelineWarning[] = [];
+    const binding = { ...qqBinding(), sampleField: null };
+    const frame = buildQqFrame(binding, table, [], warnings);
+    expect(frame.n).toBe(0);
+    expect(frame.xNumeric).not.toBeNull();
+    expect(frame.xNumeric!.length).toBe(0);
+    expect(frame.yNumeric).not.toBeNull();
+    expect(frame.yNumeric!.length).toBe(0);
+    expect(warnings).toEqual([]);
+  });
+
+  it("returns an empty qq_line frame without warnings when sampleField is null", () => {
+    const warnings: PipelineWarning[] = [];
+    const binding = { ...qqLineBinding(), sampleField: null };
+    const frame = buildQqLineFrame(binding, table, [], warnings);
+    expect(frame.n).toBe(0);
+    expect(frame.xNumeric!.length).toBe(0);
+    expect(frame.yNumeric!.length).toBe(0);
+    expect(warnings).toEqual([]);
+  });
+
+  it("builds theoretical x and sample y for a finite sample", () => {
+    const warnings: PipelineWarning[] = [];
+    const frame = buildQqFrame(qqBinding(), table, [0, 0, 0], warnings);
+    expect(frame.n).toBe(3);
+    expect(frame.xNumeric!.length).toBe(3);
+    expect(frame.yNumeric!.length).toBe(3);
+    // samples are finite; theoretical quantiles span below/above 0 for n=3
+    expect([...frame.yNumeric!].every((v) => Number.isFinite(v))).toBe(true);
+    expect([...frame.xNumeric!].every((v) => Number.isFinite(v))).toBe(true);
+    expect(Math.min(...frame.xNumeric!)).toBeLessThan(0);
+    expect(Math.max(...frame.xNumeric!)).toBeGreaterThan(0);
+  });
+
+  it("qq_line builds a two-point theoretical/sample frame", () => {
+    const frame = buildQqLineFrame(qqLineBinding(), table, [0, 0, 0], []);
+    // Reference line is two endpoints spanning the sample quantiles.
+    expect(frame.n).toBe(2);
+    expect(frame.xNumeric!.length).toBe(2);
+    expect(frame.yNumeric!.length).toBe(2);
+    expect([...frame.xNumeric!, ...frame.yNumeric!].every((v) => Number.isFinite(v))).toBe(true);
+  });
+});

--- a/packages/core/tests/table-coerce-lean.test.ts
+++ b/packages/core/tests/table-coerce-lean.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Lean table-coerce path: inferFieldType without Temporal runtime, plus
+ * cellsToQuantitative edge cases. ColumnTable has its own lite parsed() path;
+ * this locks the public free helpers used by hosts that import them directly.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+
+import { installTemporal } from "../src/install-temporal.ts";
+import { cellsToQuantitative, inferFieldType, nonTemporalFieldType } from "../src/table-coerce.ts";
+import { getTemporalRuntime, resetTemporalRuntimeForTests } from "../src/temporal-runtime.ts";
+
+describe("inferFieldType lean path (no temporal runtime)", () => {
+  beforeAll(() => {
+    resetTemporalRuntimeForTests();
+    expect(getTemporalRuntime()).toBeNull();
+  });
+
+  afterAll(() => {
+    installTemporal();
+    expect(getTemporalRuntime()).not.toBeNull();
+  });
+
+  it("classifies all-ISO string columns as temporal", () => {
+    expect(inferFieldType(["2024-01-01", "2024-01-02", null])).toBe("temporal");
+  });
+
+  it("classifies pure Date columns as temporal", () => {
+    expect(
+      inferFieldType([new Date("2024-01-01T00:00:00Z"), new Date("2024-01-02T00:00:00Z")]),
+    ).toBe("temporal");
+  });
+
+  it("rejects mixed ISO strings and numbers as nominal", () => {
+    expect(inferFieldType(["2024-01-01", 5, "2024-01-03"])).toBe("nominal");
+  });
+
+  it("rejects mixed Dates and numbers as nominal", () => {
+    expect(inferFieldType([new Date("2024-01-01T00:00:00Z"), 1_704_067_200_000])).toBe("nominal");
+  });
+
+  it("classifies non-ISO labels and booleans as nominal", () => {
+    expect(inferFieldType(["s0", "s1", null, "s2"])).toBe("nominal");
+    expect(inferFieldType([true, false])).toBe("nominal");
+  });
+
+  it("classifies pure numbers as quantitative", () => {
+    expect(inferFieldType([1, 2.5, null, 4])).toBe("quantitative");
+    expect(inferFieldType([])).toBe("quantitative");
+  });
+
+  it("returns nominal for unknown object cells", () => {
+    expect(inferFieldType([{ x: 1 } as unknown as never])).toBe("nominal");
+  });
+
+  it("matches nonTemporalFieldType when the lean scan is non-temporal", () => {
+    const labels = ["a", "b", "a"] as const;
+    expect(inferFieldType([...labels])).toBe(nonTemporalFieldType([...labels]));
+    const nums = [0, 1, 2] as const;
+    expect(inferFieldType([...nums])).toBe(nonTemporalFieldType([...nums]));
+  });
+});
+
+describe("cellsToQuantitative", () => {
+  it("keeps numbers, epoch-ms for Dates, and parses non-empty numeric strings", () => {
+    const date = new Date("2024-01-01T00:00:00.000Z");
+    const out = cellsToQuantitative([1, date, "2.5", "  ", null, true]);
+    expect(out[0]).toBe(1);
+    expect(out[1]).toBe(date.getTime());
+    expect(out[2]).toBe(2.5);
+    expect(Number.isNaN(out[3]!)).toBe(true);
+    expect(Number.isNaN(out[4]!)).toBe(true);
+    // booleans are not quantitative under the strict coercer
+    expect(Number.isNaN(out[5]!)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Unit-test public `inferFieldType` on the lean path (no Temporal runtime): ISO strings, Dates, mixed ISO/number and Date/number, labels, booleans, objects, quantitative empties; parity with `nonTemporalFieldType` for non-temporal scans.
- Unit-test `cellsToQuantitative` for numbers, Date epoch-ms, numeric strings, blanks/null/bool → NaN.
- Unit-test `buildQqFrame` / `buildQqLineFrame` empty-sample defensive frames (`sampleField: null`) and happy paths (n=3 points, n=2 qq_line).

## Coverage
| File | Before (lines) | After (related tests) |
|------|----------------|------------------------|
| `packages/core/src/table-coerce.ts` | ~69% | 100% |
| `packages/core/src/pipeline/frame-stats-qq.ts` | ~68% | 100% |

Full `packages/core` suite green.

## Test plan
- [x] `bun test packages/core/tests/table-coerce-lean.test.ts packages/core/tests/pipeline-frame/qq-missing-sample.test.ts`
- [x] `bun test packages/core`
- [ ] CI unit job green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1493" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->