### PR TITLE
test(core): cover sf_coordinates empty/drop paths and y after_stat

### DIFF
--- a/packages/core/tests/pipeline-bind-y-stat.test.ts
+++ b/packages/core/tests/pipeline-bind-y-stat.test.ts
@@ -1,0 +1,73 @@
+/**
+ * resolveYChannel: field vs after_stat y mapping for bindLayer.
+ */
+import { describe, expect, it } from "bun:test";
+
+import { resolveYChannel } from "../src/pipeline/bind-layer-y.ts";
+import { PipelineError } from "../src/pipeline/types.ts";
+import { ColumnTable } from "../src/table.ts";
+
+const table = ColumnTable.fromRows([
+  { x: 1, y: 10 },
+  { x: 2, y: 20 },
+]);
+
+describe("resolveYChannel", () => {
+  it("maps a data field onto yField", () => {
+    const got = resolveYChannel({
+      aes: { y: { field: "y" } },
+      stat: "identity",
+      index: 0,
+      table,
+      warnings: [],
+    });
+    expect(got).toEqual({ yField: "y", yStatColumn: null });
+  });
+
+  it("accepts after_stat columns the layer stat actually generates", () => {
+    const got = resolveYChannel({
+      aes: { y: { stat: "count" } },
+      stat: "count",
+      index: 1,
+      table,
+      warnings: [],
+    });
+    expect(got).toEqual({ yField: null, yStatColumn: "count" });
+  });
+
+  it("rejects after_stat y columns the layer stat does not generate", () => {
+    expect(() =>
+      resolveYChannel({
+        aes: { y: { stat: "count" } },
+        stat: "identity",
+        index: 2,
+        table,
+        warnings: [],
+      }),
+    ).toThrow(
+      expect.objectContaining({
+        code: "unknown-stat-column",
+        path: "/layers/2/aes/y",
+      } satisfies Partial<PipelineError>),
+    );
+  });
+
+  it("names generated columns when rejecting a bad after_stat mapping", () => {
+    try {
+      resolveYChannel({
+        aes: { y: { stat: "level" } },
+        stat: "bin",
+        index: 0,
+        table,
+        warnings: [],
+      });
+      expect.unreachable("should throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(PipelineError);
+      const message = (error as PipelineError).message;
+      expect(message).toMatch(/maps stat column "level"/);
+      expect(message).toMatch(/stat \("bin"\)/);
+      expect(message).toMatch(/generates:/);
+    }
+  });
+});

--- a/packages/core/tests/pipeline-frame/sf-coordinates.test.ts
+++ b/packages/core/tests/pipeline-frame/sf-coordinates.test.ts
@@ -74,12 +74,9 @@ describe("buildSfCoordinatesFrame", () => {
     const warnings: PipelineWarning[] = [];
     const frame = buildSfCoordinatesFrame(textBinding(table), table, [0], warnings);
     expect(frame.n).toBe(0);
-    expect(warnings).toEqual([
-      expect.objectContaining({
-        code: "sf-coordinates-dropped",
-        message: expect.stringMatching(/dropped 1 feature/),
-      }),
-    ]);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.code).toBe("sf-coordinates-dropped");
+    expect(warnings[0]?.message).toMatch(/dropped 1 feature/);
   });
 
   it("expands MultiPoint parts and replicates style columns per part", () => {

--- a/packages/core/tests/pipeline-frame/sf-coordinates.test.ts
+++ b/packages/core/tests/pipeline-frame/sf-coordinates.test.ts
@@ -1,0 +1,129 @@
+/**
+ * buildSfCoordinatesFrame unit edges (#809): empty panel, all-dropped features,
+ * drop warning, and style-column expand. Happy-path geometry lives in
+ * pipeline-m2/geom-sf-text.test.ts.
+ */
+import { describe, expect, it } from "bun:test";
+
+import { bindLayer } from "../../src/pipeline/bind-layer.ts";
+import { buildSfCoordinatesFrame } from "../../src/pipeline/frame-stats-sf-coordinates.ts";
+import type { PipelineWarning } from "../../src/pipeline/types.ts";
+import { PipelineError } from "../../src/pipeline/types.ts";
+import { ColumnTable } from "../../src/table.ts";
+
+function geo(g: object): string {
+  return JSON.stringify(g);
+}
+
+function textBinding(table: ColumnTable, warnings: PipelineWarning[] = []) {
+  return bindLayer(
+    {
+      geom: "sf_text",
+      stat: "sf_coordinates",
+      aes: { label: { field: "name" }, color: { field: "region" } },
+    },
+    0,
+    table,
+    warnings,
+  );
+}
+
+describe("buildSfCoordinatesFrame", () => {
+  it("returns an empty frame for zero-row tables", () => {
+    const table = ColumnTable.fromColumns({
+      geometry: [] as string[],
+      name: [] as string[],
+      region: [] as string[],
+    });
+    const warnings: PipelineWarning[] = [];
+    const frame = buildSfCoordinatesFrame(textBinding(table), table, [], warnings);
+    expect(frame.n).toBe(0);
+    expect(frame.xNumeric!.length).toBe(0);
+    expect(frame.yNumeric!.length).toBe(0);
+    expect(frame.rowIndex.length).toBe(0);
+    expect(warnings).toEqual([]);
+  });
+
+  it("throws sf-geometry-missing when the geometry column is absent", () => {
+    const table = ColumnTable.fromColumns({ name: ["a"], region: ["east"] });
+    expect(() =>
+      buildSfCoordinatesFrame(
+        bindLayer(
+          { geom: "sf_text", stat: "sf_coordinates", aes: { label: { field: "name" } } },
+          0,
+          table,
+          [],
+        ),
+        table,
+        [],
+        [],
+      ),
+    ).toThrow(
+      expect.objectContaining({
+        code: "sf-geometry-missing",
+      } satisfies Partial<PipelineError>),
+    );
+  });
+
+  it("drops empty GeometryCollection features with a warning and empty frame", () => {
+    const table = ColumnTable.fromColumns({
+      geometry: [geo({ type: "GeometryCollection", geometries: [] })],
+      name: ["empty"],
+      region: ["west"],
+    });
+    const warnings: PipelineWarning[] = [];
+    const frame = buildSfCoordinatesFrame(textBinding(table), table, [0], warnings);
+    expect(frame.n).toBe(0);
+    expect(warnings).toEqual([
+      expect.objectContaining({
+        code: "sf-coordinates-dropped",
+        message: expect.stringMatching(/dropped 1 feature/),
+      }),
+    ]);
+  });
+
+  it("expands MultiPoint parts and replicates style columns per part", () => {
+    const table = ColumnTable.fromColumns({
+      geometry: [
+        geo({
+          type: "MultiPoint",
+          coordinates: [
+            [1, 2],
+            [3, 4],
+          ],
+        }),
+      ],
+      name: ["mp"],
+      region: ["north"],
+    });
+    const warnings: PipelineWarning[] = [];
+    const frame = buildSfCoordinatesFrame(textBinding(table), table, [7], warnings);
+    expect(frame.n).toBe(2);
+    expect([...frame.xNumeric!]).toEqual([1, 3]);
+    expect([...frame.yNumeric!]).toEqual([2, 4]);
+    expect(frame.groups).toEqual([7, 7]);
+    expect([...frame.rowIndex]).toEqual([0, 0]);
+    expect(frame.labelValues).toEqual(["mp", "mp"]);
+    expect(frame.colorValues).toEqual(["north", "north"]);
+    expect(warnings).toEqual([]);
+  });
+
+  it("keeps usable features while warning about siblings with no points", () => {
+    const table = ColumnTable.fromColumns({
+      geometry: [
+        geo({ type: "Point", coordinates: [9, 8] }),
+        geo({ type: "GeometryCollection", geometries: [] }),
+      ],
+      name: ["ok", "bad"],
+      region: ["a", "b"],
+    });
+    const warnings: PipelineWarning[] = [];
+    const frame = buildSfCoordinatesFrame(textBinding(table), table, [0, 1], warnings);
+    expect(frame.n).toBe(1);
+    expect([...frame.xNumeric!]).toEqual([9]);
+    expect([...frame.yNumeric!]).toEqual([8]);
+    expect(frame.labelValues).toEqual(["ok"]);
+    expect(frame.colorValues).toEqual(["a"]);
+    expect(warnings.some((w) => w.code === "sf-coordinates-dropped")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Unit-test `buildSfCoordinatesFrame`: zero-row empty frame, missing geometry column, empty GeometryCollection drops + warning, MultiPoint part expand with style column replication, mixed ok/dropped features.
- Unit-test `resolveYChannel`: data-field mapping, valid after_stat y, unknown-stat-column rejection (including generated-column listing).

## Coverage
| File | Before (lines) | After (related tests) |
|------|----------------|------------------------|
| `packages/core/src/pipeline/frame-stats-sf-coordinates.ts` | ~69% | high / near-full under unit+sf-text tests |
| `packages/core/src/pipeline/bind-layer-y.ts` | ~74% | 100% under unit tests |

Full `packages/core` suite green.

## Test plan
- [x] `bun test packages/core/tests/pipeline-frame/sf-coordinates.test.ts packages/core/tests/pipeline-bind-y-stat.test.ts`
- [x] `bun test packages/core`
- [ ] CI unit job green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1494" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->