### PR TITLE
test(core): cover numeric style and color value temporal views

### DIFF
--- a/packages/core/tests/pipeline-style-families/scale-color-values-unit.test.ts
+++ b/packages/core/tests/pipeline-style-families/scale-color-values-unit.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for resolveColorValueView (temporal request + transform conflict).
+ */
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+
+import { installTemporal } from "../../src/install-temporal.ts";
+import { resolveColorValueView } from "../../src/pipeline/scale-color-values.ts";
+import { PipelineError } from "../../src/pipeline/types.ts";
+import type { PipelineWarning } from "../../src/pipeline/types.ts";
+import { getTemporalRuntime, resetTemporalRuntimeForTests } from "../../src/temporal-runtime.ts";
+
+describe("resolveColorValueView (non-temporal)", () => {
+  it("coerces quantitative columns without requesting temporal", () => {
+    const view = resolveColorValueView({
+      name: "color",
+      values: [1, 2, "3"],
+      config: { type: "sequential" },
+      warnings: [],
+    });
+    expect([...view.semantic]).toEqual([1, 2, 3]);
+    expect(view.temporalKind).toBeNull();
+    expect(view.parser).toBeNull();
+    expect(view.semanticOf(2)).toBe(2);
+  });
+});
+
+describe("resolveColorValueView (temporal with runtime)", () => {
+  it("parses temporal color values and exposes semanticOf", () => {
+    const warnings: PipelineWarning[] = [];
+    const view = resolveColorValueView({
+      name: "fill",
+      values: ["2024-01-01", "2024-02-01"],
+      config: { type: "sequential", temporalKind: "date", parse: "ymd" },
+      warnings,
+    });
+    expect(view.temporalKind).toBe("date");
+    expect(view.parser).toBe("ymd");
+    expect(view.semanticOf("2024-01-01")).toBe(view.semantic[0]);
+    expect(warnings).toEqual([]);
+  });
+
+  it("rejects temporal color with a non-identity transform", () => {
+    expect(() =>
+      resolveColorValueView({
+        name: "color",
+        values: ["2024-01-01"],
+        config: { temporalKind: "date", parse: "ymd", transform: "log10" },
+        warnings: [],
+      }),
+    ).toThrow(
+      expect.objectContaining({
+        code: "scale-type-transform-conflict",
+      } satisfies Partial<PipelineError>),
+    );
+  });
+
+  it("throws color-temporal-parse when the column does not parse", () => {
+    expect(() =>
+      resolveColorValueView({
+        name: "color",
+        values: ["2024-01-01", "nope"],
+        config: { temporalKind: "date", parse: "ymd" },
+        warnings: [],
+      }),
+    ).toThrow(
+      expect.objectContaining({ code: "color-temporal-parse" } satisfies Partial<PipelineError>),
+    );
+  });
+
+  it("censors color temporal parse failures when configured", () => {
+    const warnings: PipelineWarning[] = [];
+    resolveColorValueView({
+      name: "fill",
+      values: ["2024-01-01", "nope"],
+      config: { temporalKind: "date", parse: "ymd", parseFailure: "censor" },
+      warnings,
+    });
+    expect(warnings.some((w) => w.code === "color-temporal-censored")).toBe(true);
+  });
+
+  it("throws color-temporal-kind on precision mismatch", () => {
+    expect(() =>
+      resolveColorValueView({
+        name: "color",
+        values: ["2024-01-01T12:00:00", "2024-01-02T12:00:00"],
+        config: { temporalKind: "date", parse: "ymd_hms" },
+        warnings: [],
+      }),
+    ).toThrow(
+      expect.objectContaining({ code: "color-temporal-kind" } satisfies Partial<PipelineError>),
+    );
+  });
+});
+
+describe("resolveColorValueView (lean: no temporal runtime)", () => {
+  beforeAll(() => {
+    resetTemporalRuntimeForTests();
+    expect(getTemporalRuntime()).toBeNull();
+  });
+
+  afterAll(() => {
+    installTemporal();
+    expect(getTemporalRuntime()).not.toBeNull();
+  });
+
+  it("fails temporal color requests loudly without the polyfill", () => {
+    expect(() =>
+      resolveColorValueView({
+        name: "color",
+        values: ["2024-01-01"],
+        config: { temporalKind: "date", parse: "ymd" },
+        warnings: [],
+      }),
+    ).toThrow(
+      expect.objectContaining({ code: "color-temporal-parse" } satisfies Partial<PipelineError>),
+    );
+  });
+});

--- a/packages/core/tests/pipeline-style-families/scale-style-values-unit.test.ts
+++ b/packages/core/tests/pipeline-style-families/scale-style-values-unit.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Unit tests for resolveNumericStyleValueView (#style temporal + lean).
+ */
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+
+import { installTemporal } from "../../src/install-temporal.ts";
+import { resolveNumericStyleValueView } from "../../src/pipeline/scale-style-values.ts";
+import { PipelineError } from "../../src/pipeline/types.ts";
+import type { PipelineWarning } from "../../src/pipeline/types.ts";
+import { getTemporalRuntime, resetTemporalRuntimeForTests } from "../../src/temporal-runtime.ts";
+
+describe("resolveNumericStyleValueView (non-temporal)", () => {
+  it("fast-paths dense number columns", () => {
+    const warnings: PipelineWarning[] = [];
+    const view = resolveNumericStyleValueView({
+      aesthetic: "size",
+      values: [1, 2, 3],
+      config: { type: "sequential" },
+      warnings,
+    });
+    expect([...view.semantic]).toEqual([1, 2, 3]);
+    expect(view.temporalKind).toBeNull();
+    expect(view.semanticOf(2)).toBe(2);
+    expect(view.semanticOf("nope")).toBeUndefined();
+    expect(warnings).toEqual([]);
+  });
+
+  it("falls back to cellToNumber from the first non-number", () => {
+    const date = new Date("2024-01-01T00:00:00.000Z");
+    const view = resolveNumericStyleValueView({
+      aesthetic: "alpha",
+      values: [1, "2.5", date, null],
+      config: undefined,
+      warnings: [],
+    });
+    expect(view.semantic[0]).toBe(1);
+    expect(view.semantic[1]).toBe(2.5);
+    expect(view.semantic[2]).toBe(date.getTime());
+    expect(Number.isNaN(view.semantic[3]!)).toBe(true);
+  });
+});
+
+describe("resolveNumericStyleValueView (temporal with runtime)", () => {
+  it("parses date strings into a temporal semantic view", () => {
+    const warnings: PipelineWarning[] = [];
+    const view = resolveNumericStyleValueView({
+      aesthetic: "size",
+      values: ["2024-01-01", "2024-01-03"],
+      config: { type: "sequential", temporalKind: "date", parse: "ymd" },
+      warnings,
+    });
+    expect(view.temporalKind).toBe("date");
+    expect(view.semantic.length).toBe(2);
+    expect(view.semantic[0]!).toBeLessThan(view.semantic[1]!);
+    expect(view.semanticOf("2024-01-01")).toBe(view.semantic[0]);
+    expect(warnings).toEqual([]);
+  });
+
+  it("throws style-temporal-parse when values fail and censor is off", () => {
+    expect(() =>
+      resolveNumericStyleValueView({
+        aesthetic: "linewidth",
+        values: ["2024-01-01", "not-a-date"],
+        config: { temporalKind: "date", parse: "ymd" },
+        warnings: [],
+      }),
+    ).toThrow(
+      expect.objectContaining({ code: "style-temporal-parse" } satisfies Partial<PipelineError>),
+    );
+  });
+
+  it("censors failed temporal values when parseFailure is censor", () => {
+    const warnings: PipelineWarning[] = [];
+    const view = resolveNumericStyleValueView({
+      aesthetic: "size",
+      values: ["2024-01-01", "not-a-date"],
+      config: { temporalKind: "date", parse: "ymd", parseFailure: "censor" },
+      warnings,
+    });
+    expect(warnings.some((w) => w.code === "style-temporal-censored")).toBe(true);
+    expect(Number.isFinite(view.semantic[0]!)).toBe(true);
+  });
+
+  it("throws style-temporal-kind when parsed precision mismatches temporalKind", () => {
+    expect(() =>
+      resolveNumericStyleValueView({
+        aesthetic: "size",
+        values: ["2024-01-01T10:00:00", "2024-01-02T10:00:00"],
+        config: { temporalKind: "date", parse: "ymd_hms" },
+        warnings: [],
+      }),
+    ).toThrow(
+      expect.objectContaining({ code: "style-temporal-kind" } satisfies Partial<PipelineError>),
+    );
+  });
+
+  it("seeds temporal parse from an authored domain when samples are empty", () => {
+    const warnings: PipelineWarning[] = [];
+    const view = resolveNumericStyleValueView({
+      aesthetic: "size",
+      values: [],
+      config: {
+        type: "sequential",
+        temporalKind: "date",
+        parse: "ymd",
+        domain: ["2024-01-01", "2024-01-31"],
+      },
+      warnings,
+    });
+    expect(view.temporalKind).toBe("date");
+    expect(view.semantic.length).toBe(2);
+    expect(warnings).toEqual([]);
+  });
+
+  it("seeds binned temporal breaks when samples are empty", () => {
+    const view = resolveNumericStyleValueView({
+      aesthetic: "size",
+      values: [],
+      config: {
+        type: "binned",
+        temporalKind: "date",
+        parse: "ymd",
+        breaks: ["2024-01-01", "2024-06-01", "2024-12-31"],
+      },
+      warnings: [],
+    });
+    expect(view.temporalKind).toBe("date");
+    expect(view.semantic.length).toBe(3);
+  });
+});
+
+describe("resolveNumericStyleValueView (lean: no temporal runtime)", () => {
+  beforeAll(() => {
+    resetTemporalRuntimeForTests();
+    expect(getTemporalRuntime()).toBeNull();
+  });
+
+  afterAll(() => {
+    installTemporal();
+    expect(getTemporalRuntime()).not.toBeNull();
+  });
+
+  it("treats temporal requests as non-temporal parse failures without the polyfill", () => {
+    // Lean runtimeParseColumn always reports nominal; explicit temporal
+    // request must still fail loudly instead of inventing epochs.
+    expect(() =>
+      resolveNumericStyleValueView({
+        aesthetic: "size",
+        values: ["2024-01-01", "2024-01-02"],
+        config: { temporalKind: "date", parse: "ymd" },
+        warnings: [],
+      }),
+    ).toThrow(
+      expect.objectContaining({ code: "style-temporal-parse" } satisfies Partial<PipelineError>),
+    );
+  });
+
+  it("censors under lean when parseFailure is censor", () => {
+    const warnings: PipelineWarning[] = [];
+    resolveNumericStyleValueView({
+      aesthetic: "alpha",
+      values: [1, 2, 3],
+      config: { timezone: "UTC", parseFailure: "censor" },
+      warnings,
+    });
+    expect(warnings.some((w) => w.code === "style-temporal-censored")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Unit-test `resolveNumericStyleValueView`: dense numbers, cellToNumber fallback, temporal parse/censor/kind mismatch, empty-sample domain and binned-breaks seeding, lean polyfill-missing failures.
- Unit-test `resolveColorValueView`: quantitative coerce, temporal parse/censor/kind, non-identity transform conflict, lean polyfill-missing failures.

## Coverage
| File | Before (lines) | After (related unit tests) |
|------|----------------|----------------------------|
| `packages/core/src/pipeline/scale-style-values.ts` | ~74% | high / near-full under unit tests |
| `packages/core/src/pipeline/scale-color-values.ts` | ~77% | high / near-full under unit tests |

Full `packages/core` suite green.

## Test plan
- [x] `bun test packages/core/tests/pipeline-style-families/scale-style-values-unit.test.ts packages/core/tests/pipeline-style-families/scale-color-values-unit.test.ts`
- [x] `bun test packages/core`
- [ ] CI unit job green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1495" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->