### PR TITLE
test(core): cover geom_sf frame edges and unregistered dispatch

### DIFF
--- a/packages/core/tests/pipeline-frame/sf-frame-edges.test.ts
+++ b/packages/core/tests/pipeline-frame/sf-frame-edges.test.ts
@@ -1,0 +1,140 @@
+/**
+ * buildSfFrame edges not always hit via pipeline (empty panel, MultiLine expand,
+ * invalid Multi* coords, no-drawable throw). Happy paths live in geom-sf.test.ts.
+ */
+import { describe, expect, it } from "bun:test";
+
+import { bindLayer } from "../../src/pipeline/bind-layer.ts";
+import { buildSfFrame } from "../../src/pipeline/frame-stats-sf.ts";
+import { PipelineError } from "../../src/pipeline/types.ts";
+import { ColumnTable } from "../../src/table.ts";
+
+function geo(g: object): string {
+  return JSON.stringify(g);
+}
+
+function sfBinding(table: ColumnTable) {
+  return bindLayer(
+    {
+      geom: "sf",
+      stat: "sf",
+      aes: { fill: { field: "region" } },
+    },
+    0,
+    table,
+    [],
+  );
+}
+
+describe("buildSfFrame edges", () => {
+  it("returns an empty polygon frame for zero-row tables", () => {
+    const table = ColumnTable.fromColumns({
+      geometry: [] as string[],
+      region: [] as string[],
+    });
+    const frame = buildSfFrame(sfBinding(table), table, [], []);
+    expect(frame.n).toBe(0);
+    expect(frame.xNumeric!.length).toBe(0);
+    expect(frame.sf?.kind).toBe("polygon");
+  });
+
+  it("expands MultiLineString into separate line groups", () => {
+    const table = ColumnTable.fromColumns({
+      geometry: [
+        geo({
+          type: "MultiLineString",
+          coordinates: [
+            [
+              [0, 0],
+              [1, 1],
+            ],
+            [
+              [2, 2],
+              [3, 3],
+            ],
+          ],
+        }),
+      ],
+      region: ["east"],
+    });
+    const frame = buildSfFrame(sfBinding(table), table, [0], []);
+    expect(frame.n).toBe(4);
+    expect(frame.sf?.kind).toBe("line");
+    // Two groups (one per line part), two vertices each
+    expect(new Set(frame.groups).size).toBe(2);
+    expect(frame.fillValues).toEqual(["east", "east", "east", "east"]);
+  });
+
+  it("expands MultiPolygon parts and keeps fill style", () => {
+    const table = ColumnTable.fromColumns({
+      geometry: [
+        geo({
+          type: "MultiPolygon",
+          coordinates: [
+            [
+              [
+                [0, 0],
+                [1, 0],
+                [1, 1],
+                [0, 0],
+              ],
+            ],
+            [
+              [
+                [2, 2],
+                [3, 2],
+                [3, 3],
+                [2, 2],
+              ],
+            ],
+          ],
+        }),
+      ],
+      region: ["west"],
+    });
+    const frame = buildSfFrame(sfBinding(table), table, [0], []);
+    expect(frame.n).toBeGreaterThan(0);
+    expect(frame.sf?.kind).toBe("polygon");
+    expect(frame.fillValues?.every((v) => v === "west")).toBe(true);
+  });
+
+  it("throws sf-geometry-invalid for a MultiLineString with non-array coordinates", () => {
+    const table = ColumnTable.fromColumns({
+      geometry: [geo({ type: "MultiLineString", coordinates: "bad" })],
+      region: ["x"],
+    });
+    expect(() => buildSfFrame(sfBinding(table), table, [0], [])).toThrow(
+      expect.objectContaining({ code: "sf-geometry-invalid" } satisfies Partial<PipelineError>),
+    );
+  });
+
+  it("throws sf-geometry-invalid when MultiPoint has no finite positions", () => {
+    const table = ColumnTable.fromColumns({
+      geometry: [
+        geo({
+          type: "MultiPoint",
+          coordinates: [
+            [Number.NaN, 1],
+            [2, Number.POSITIVE_INFINITY],
+          ],
+        }),
+      ],
+      region: ["x"],
+    });
+    expect(() => buildSfFrame(sfBinding(table), table, [0], [])).toThrow(
+      expect.objectContaining({
+        code: "sf-geometry-invalid",
+        message: expect.stringMatching(/no drawable coordinates/i),
+      } satisfies Partial<PipelineError>),
+    );
+  });
+
+  it("throws sf-geometry-missing when the geometry column is absent", () => {
+    const table = ColumnTable.fromColumns({ region: ["x"] });
+    expect(() =>
+      buildSfFrame(bindLayer({ geom: "sf", stat: "sf", aes: {} }, 0, table, []), table, [], []),
+    ).toThrow(
+      expect.objectContaining({ code: "sf-geometry-missing" } satisfies Partial<PipelineError>),
+    );
+  });
+});

--- a/packages/core/tests/pipeline-frame/sf-frame-edges.test.ts
+++ b/packages/core/tests/pipeline-frame/sf-frame-edges.test.ts
@@ -121,12 +121,14 @@ describe("buildSfFrame edges", () => {
       ],
       region: ["x"],
     });
-    expect(() => buildSfFrame(sfBinding(table), table, [0], [])).toThrow(
-      expect.objectContaining({
-        code: "sf-geometry-invalid",
-        message: expect.stringMatching(/no drawable coordinates/i),
-      } satisfies Partial<PipelineError>),
-    );
+    try {
+      buildSfFrame(sfBinding(table), table, [0], []);
+      expect.unreachable("should throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(PipelineError);
+      expect((error as PipelineError).code).toBe("sf-geometry-invalid");
+      expect((error as PipelineError).message).toMatch(/no drawable coordinates/i);
+    }
   });
 
   it("throws sf-geometry-missing when the geometry column is absent", () => {

--- a/packages/core/tests/pipeline-register-dispatch-unit.test.ts
+++ b/packages/core/tests/pipeline-register-dispatch-unit.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Unit tests for unregistered geom/stat dispatch error messages (#1420).
+ * Spawned process tests exist; these run in-process so coverage attributes.
+ */
+import { describe, expect, it } from "bun:test";
+import { fromPartial } from "@total-typescript/shoehorn";
+
+import { dispatchGeometryBatch } from "../src/pipeline/geometry-dispatch.ts";
+import { buildNonIdentityFrame } from "../src/pipeline/frame-stats.ts";
+import type { LayerBinding, LayerFrame } from "../src/pipeline/types.ts";
+import { PipelineError } from "../src/pipeline/types.ts";
+import { ColumnTable } from "../src/table.ts";
+import type { Frame } from "../src/pipeline/geometry-shared.ts";
+import type { ResolvedStyleScales } from "../src/pipeline/geometry-style.ts";
+
+const table = ColumnTable.fromRows([{ x: 1, y: 2 }]);
+const emptyStyles = fromPartial<ResolvedStyleScales>({});
+const emptyFx = fromPartial<Frame>({});
+
+function fakeFrame(geom: string): LayerFrame {
+  const binding = fromPartial<LayerBinding>({
+    index: 3,
+    layer: { geom, stat: "identity" },
+  });
+  return fromPartial<LayerFrame>({
+    binding,
+    table,
+    n: 0,
+    xNumeric: new Float64Array(0),
+    yNumeric: new Float64Array(0),
+    groups: [],
+    inputGroups: [],
+    rowIndex: new Uint32Array(0),
+  });
+}
+
+function fakeBinding(stat: string): LayerBinding {
+  return fromPartial<LayerBinding>({
+    index: 2,
+    layer: { geom: "point", stat },
+  });
+}
+
+describe("dispatchGeometryBatch unregistered geom", () => {
+  it("names registerBasic/registerAll for an unknown geom", () => {
+    expect(() =>
+      dispatchGeometryBatch(fakeFrame("not_a_real_geom"), emptyFx, null, null, emptyStyles, []),
+    ).toThrow(
+      expect.objectContaining({
+        code: "unsupported-param",
+        path: "/layers/3/geom",
+      } satisfies Partial<PipelineError>),
+    );
+    try {
+      dispatchGeometryBatch(fakeFrame("not_a_real_geom"), emptyFx, null, null, emptyStyles, []);
+    } catch (error) {
+      const message = (error as PipelineError).message;
+      expect(message).toMatch(/not registered in this build/);
+      expect(message).toMatch(/registerAll\(\)|registerBasic\(\)/);
+      expect(message).toMatch(/registerGeomBatch\("not_a_real_geom"/);
+    }
+  });
+});
+
+describe("buildNonIdentityFrame unregistered stat", () => {
+  it("returns null for identity without looking up a builder", () => {
+    expect(buildNonIdentityFrame(fakeBinding("identity"), table, [], [], [])).toBeNull();
+  });
+
+  it("names registerBasic/registerAll for an unknown stat", () => {
+    expect(() => buildNonIdentityFrame(fakeBinding("not_a_real_stat"), table, [], [], [])).toThrow(
+      expect.objectContaining({
+        code: "unsupported-param",
+        path: "/layers/2/stat",
+      } satisfies Partial<PipelineError>),
+    );
+    try {
+      buildNonIdentityFrame(fakeBinding("not_a_real_stat"), table, [], [], []);
+    } catch (error) {
+      const message = (error as PipelineError).message;
+      expect(message).toMatch(/not registered in this build/);
+      expect(message).toMatch(/registerAll\(\)|registerBasic\(\)/);
+      expect(message).toMatch(/registerStatFrame\("not_a_real_stat"/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Unit-test `buildSfFrame` edges: zero-row empty frame, MultiLineString/MultiPolygon expand + style, invalid MultiLineString coords, MultiPoint with no finite positions, missing geometry column.
- Unit-test `dispatchGeometryBatch` / `buildNonIdentityFrame` unregistered geom/stat error messages in-process (so coverage attributes; spawn tests still exist for family-register hints).

Also this fire: merged #1491, #1494, #1497.

## Coverage
| File | Focus |
|------|--------|
| `packages/core/src/pipeline/frame-stats-sf.ts` | empty panel + Multi* edges |
| `packages/core/src/pipeline/geometry-dispatch.ts` | unregistered geom path |
| `packages/core/src/pipeline/frame-stats.ts` | unregistered stat path |

Full `packages/core` suite green.

## Test plan
- [x] `bun test packages/core/tests/pipeline-frame/sf-frame-edges.test.ts packages/core/tests/pipeline-register-dispatch-unit.test.ts`
- [x] `bun test packages/core`
- [ ] CI unit job green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1498" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->