### PR TITLE
test(cli): load package surface so Codecov packages-cli is not unknown

### DIFF
--- a/packages/cli/tests/cli-surface.test.ts
+++ b/packages/cli/tests/cli-surface.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Programmatic surface of @ggsvelte/cli (`src/index.ts`).
+ *
+ * Bin smoke tests only spawn `bin/ggsvelte-render.js`, which imports
+ * `@ggsvelte/core` directly — so they never load this package's entry and
+ * never appear under the Codecov `packages-cli` component. Importing the
+ * re-export here is what puts `packages/cli/src/**` into unit lcov.
+ */
+import { describe, expect, it } from "bun:test";
+import type { CLIIO } from "../src/index.ts";
+import { runCLI } from "../src/index.ts";
+
+const SPEC = {
+  data: {
+    values: [
+      { x: 1, y: 2 },
+      { x: 3, y: 4 },
+    ],
+  },
+  aes: { x: { field: "x" }, y: { field: "y" } },
+  layers: [{ geom: "point" }],
+};
+
+function makeIO(stdin = ""): { io: CLIIO; out: string[]; err: string[] } {
+  const out: string[] = [];
+  const err: string[] = [];
+  return {
+    out,
+    err,
+    io: {
+      readStdin: () => Promise.resolve(stdin),
+      readFile: (path) => {
+        throw new Error(`ENOENT: ${path}`);
+      },
+      writeOut: (text) => {
+        out.push(text);
+      },
+      writeErr: (line) => {
+        err.push(line);
+      },
+    },
+  };
+}
+
+describe("@ggsvelte/cli surface (src/index.ts)", () => {
+  it("re-exports runCLI that renders a point chart to SVG", async () => {
+    expect(typeof runCLI).toBe("function");
+    const { io, out } = makeIO(JSON.stringify(SPEC));
+    const code = await runCLI([], io);
+    expect(code).toBe(0);
+    expect(out.join("")).toStartWith("<svg ");
+    expect(out.join("").trimEnd()).toEndWith("</svg>");
+  });
+
+  it("re-exports runCLI that honors the version option", async () => {
+    const { io, out, err } = makeIO();
+    const code = await runCLI(["--version"], io, { version: "0.0.0-test" });
+    expect(code).toBe(0);
+    expect(out).toEqual(["0.0.0-test\n"]);
+    expect(err).toEqual([]);
+  });
+});

--- a/scripts/release-wiring.test.ts
+++ b/scripts/release-wiring.test.ts
@@ -71,6 +71,10 @@ describe("R0 release wiring", () => {
     expect(ci).toContain("flags: unit");
     expect(ci).toContain("flags: svelte");
     expect(read("codecov.yml")).toContain("component_id: packages-spec");
+    // packages-cli badge goes "unknown" when no unit test loads packages/cli/src
+    // (bin smoke tests spawn a subprocess that imports @ggsvelte/core only).
+    expect(read("codecov.yml")).toContain("component_id: packages-cli");
+    expect(read("packages/cli/tests/cli-surface.test.ts")).toContain('from "../src/index.ts"');
     expect(read(".pre-commit-config.yaml")).not.toContain("bun test packages/spec");
     expect(read(".pre-commit-config.yaml")).not.toContain("pre-push");
   });


### PR DESCRIPTION
## Summary

- **Symptom:** `@ggsvelte/cli` README Codecov badge shows `unknown` while spec/core/svelte show real %.
- **Root cause:** Unit coverage never loaded `packages/cli/src/**`. Bin smoke tests spawn `ggsvelte-render.js`, which imports `@ggsvelte/core` directly. Codecov ignores `packages/cli/bin/**` and `packages/cli/tests/**`, so the `packages-cli` component had no tracked files.
- **Fix:** In-process unit tests import `packages/cli/src/index.ts` (the public re-export surface). Verified locally that unit lcov now includes `SF:packages/cli/src/index.ts` at 100% lines. Release-wiring test guards the Codecov component + surface-test import so the badge cannot go unknown again by accident.

## Test plan

- [x] `bun test packages/cli scripts/release-wiring.test.ts` — pass
- [x] `bun test --coverage --coverage-dir=coverage/unit packages/cli` — lcov contains `SF:packages/cli/src/index.ts`
- [ ] CI unit job uploads coverage; after merge to main, packages-cli badge leaves `unknown`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1500" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->