### PR TITLE
test(skill): trigger fixtures and disclosure contracts

### DIFF
--- a/.changeset/skill-trigger-contracts.md
+++ b/.changeset/skill-trigger-contracts.md
@@ -1,0 +1,11 @@
+---
+"@ggsvelte/skill": patch
+---
+
+# Document skill test layers and seed trigger fixtures
+
+Migration: none — package README plus repo-only eval fixtures; no API change.
+
+Document the three-layer skill test story (content contracts, trigger/disclosure
+contracts, held-out NL→spec evals). Repo-only `evals/trigger-cases.json` seeds
+future agent-in-the-loop skill evals and is not packed to npm.

--- a/packages/skill/README.md
+++ b/packages/skill/README.md
@@ -57,7 +57,21 @@ in every sandbox where an agent authors specs.
 
 ## Guarantees
 
-The skill cannot quietly fall behind the library: CI fails any PR that adds a
-geom, stat, position, theme, or color scheme to `@ggsvelte/spec` without
-documenting it here, and every fenced JSON example in the skill is normalized
-and validated against the current spec.
+The skill cannot quietly fall behind the library. CI enforces three layers:
+
+1. **Content contracts** (`scripts/skill-content.test.ts`,
+   `scripts/skill-package.test.ts`) — inventory completeness for every geom,
+   stat, position, theme, and color scheme; every complete JSON fence
+   normalizes and validates; pack shape and lock-step version.
+2. **Trigger / disclosure contracts** (`scripts/skill-trigger.test.ts`) —
+   frontmatter description quality (the loader's selection signal), balanced
+   positive/negative trigger fixtures under `evals/trigger-cases.json`,
+   relative-link integrity, and progressive disclosure of every `references/`
+   file from `SKILL.md`.
+3. **Held-out NL→spec evals** (`tests/evals/`, `bun run evals`) — model
+   capability on PortableSpec authoring with deterministic graders. These do
+   **not** load this skill today; agent-in-the-loop skill evals (with/without
+   skill A/B, multi-trial trigger accuracy) are tracked as follow-up work.
+
+`evals/trigger-cases.json` is not packed to npm (`files` is only `SKILL.md` +
+`references/`). It is the living seed for future skill-loaded agent evals.

--- a/packages/skill/evals/trigger-cases.json
+++ b/packages/skill/evals/trigger-cases.json
@@ -1,0 +1,92 @@
+[
+  {
+    "id": "explicit-skill-name",
+    "should_trigger": true,
+    "prompt": "Use the ggsvelte skill to build a scatter plot of mass vs flipper length colored by species.",
+    "notes": "Direct skill name invocation must keep working after description rewrites."
+  },
+  {
+    "id": "implicit-chart-svelte",
+    "should_trigger": true,
+    "prompt": "In this Svelte app, make a bar chart of signups by region.",
+    "notes": "Everyday chart request in a Svelte project without naming the package."
+  },
+  {
+    "id": "import-ggsvelte-svelte",
+    "should_trigger": true,
+    "prompt": "I'm importing GeomPoint and GGPlot from @ggsvelte/svelte — help me add a smooth layer and a minimal theme.",
+    "notes": "Import path is an explicit frontmatter trigger signal."
+  },
+  {
+    "id": "portable-spec-json",
+    "should_trigger": true,
+    "prompt": "Emit a ggsvelte PortableSpec JSON for a histogram of latency_ms with 30 bins.",
+    "notes": "Agent/headless authoring path: JSON specs."
+  },
+  {
+    "id": "validate-debug",
+    "should_trigger": true,
+    "prompt": "This ggsvelte plot spec fails validation — fix the aes and re-validate.",
+    "notes": "Debugging/validating charts is in the description trigger set."
+  },
+  {
+    "id": "headless-svg",
+    "should_trigger": true,
+    "prompt": "Render this chart server-side to SVG with ggsvelte in Node.",
+    "notes": "Headless/server-side SVG rendering is a primary agent surface."
+  },
+  {
+    "id": "facet-small-multiples",
+    "should_trigger": true,
+    "prompt": "Create faceted small-multiple line charts of temperature by city.",
+    "notes": "Faceted charts are named in the description."
+  },
+  {
+    "id": "boxplot-density",
+    "should_trigger": true,
+    "prompt": "Plot boxplots of score by group, and overlay a density plot for the overall distribution.",
+    "notes": "Named chart types in the description (boxplot, density)."
+  },
+  {
+    "id": "heatmap-map",
+    "should_trigger": true,
+    "prompt": "Draw a heatmap of counts by hour and day, then a simple map choropleth if the data has regions.",
+    "notes": "Heatmaps and maps are listed trigger terms."
+  },
+  {
+    "id": "negative-matplotlib",
+    "should_trigger": false,
+    "prompt": "Write a Python script that reads a CSV and plots a bar chart with matplotlib.",
+    "notes": "Classic false-positive: chart request in an unrelated stack."
+  },
+  {
+    "id": "negative-recharts",
+    "should_trigger": false,
+    "prompt": "Add a Recharts line chart to this React dashboard for weekly revenue.",
+    "notes": "Adjacent charting library must not select ggsvelte solely because the word chart appears."
+  },
+  {
+    "id": "negative-d3-force",
+    "should_trigger": false,
+    "prompt": "Build a D3 force-directed network graph of package dependencies.",
+    "notes": "Network layout is outside ggsvelte grammar; description must not claim graphs in the network sense only."
+  },
+  {
+    "id": "negative-css-layout",
+    "should_trigger": false,
+    "prompt": "Fix the CSS grid layout so the sidebar stops overlapping the main content.",
+    "notes": "Pure layout work should not load a charting skill."
+  },
+  {
+    "id": "negative-sql",
+    "should_trigger": false,
+    "prompt": "Optimize this SQL query that aggregates daily signups by region.",
+    "notes": "Data aggregation without visualization intent."
+  },
+  {
+    "id": "negative-tailwind-existing-app",
+    "should_trigger": false,
+    "prompt": "Add Tailwind styling to my existing Svelte app header and buttons.",
+    "notes": "Svelte mention alone must not fire the skill (OpenAI eval pattern: adjacent false positive)."
+  }
+]

--- a/scripts/skill-trigger.test.ts
+++ b/scripts/skill-trigger.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Trigger-surface and progressive-disclosure contracts for @ggsvelte/skill.
+ *
+ * August 2026 skill-eval practice (OpenAI eval-skills, Anthropic skill-creator,
+ * philschmid testing-skills) splits work into two layers:
+ *
+ * 1. Deterministic static contracts — description quality, negative-scope
+ *    fixtures, link integrity, progressive disclosure. Cheap, CI-gated,
+ *    no model. That is this file.
+ * 2. Agent-in-the-loop evals — load SKILL.md, run prompts, score traces with
+ *    deterministic graders + optional LLM rubrics, multi-trial pass@k.
+ *    Heavier; tracked separately (tests/evals today grades NL→spec without
+ *    loading the skill).
+ *
+ * Fixtures live at packages/skill/evals/trigger-cases.json (not packed —
+ * package.json files only lists SKILL.md + references/).
+ */
+import { describe, expect, it } from "bun:test";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+
+const ROOT = join(import.meta.dir, "..");
+const SKILL_DIR = join(ROOT, "packages", "skill");
+const SKILL_MD = join(SKILL_DIR, "SKILL.md");
+const REFS_DIR = join(SKILL_DIR, "references");
+const FIXTURES = join(SKILL_DIR, "evals", "trigger-cases.json");
+
+interface TriggerCase {
+  id: string;
+  should_trigger: boolean;
+  prompt: string;
+  notes: string;
+}
+
+const skillMd = readFileSync(SKILL_MD, "utf8");
+const frontmatter = skillMd.match(/^---\n([\s\S]*?)\n---/)?.[1] ?? "";
+const descriptionLine = frontmatter.split("\n").find((line) => line.startsWith("description:"));
+const description = descriptionLine?.slice("description:".length).trim() ?? "";
+
+const cases = JSON.parse(readFileSync(FIXTURES, "utf8")) as TriggerCase[];
+
+function markdownFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((name) => {
+    const path = join(dir, name);
+    if (statSync(path).isDirectory()) return markdownFiles(path);
+    return path.endsWith(".md") ? [path] : [];
+  });
+}
+
+/** Relative markdown links: [text](path) or [text](path#hash), not http(s). */
+function relativeMarkdownTargets(markdown: string): string[] {
+  const targets: string[] = [];
+  for (const match of markdown.matchAll(/\[[^\]]*\]\(([^)]+)\)/g)) {
+    const raw = match[1]!.trim();
+    if (raw.startsWith("http://") || raw.startsWith("https://") || raw.startsWith("mailto:")) {
+      continue;
+    }
+    if (raw.startsWith("#")) continue; // same-file anchor
+    targets.push(raw.split("#")[0]!);
+  }
+  return targets;
+}
+
+describe("skill trigger fixtures", () => {
+  it("ships a balanced positive/negative prompt set (10–20 scale)", () => {
+    expect(cases.length).toBeGreaterThanOrEqual(10);
+    expect(cases.length).toBeLessThanOrEqual(40);
+    const positives = cases.filter((c) => c.should_trigger);
+    const negatives = cases.filter((c) => !c.should_trigger);
+    expect(positives.length).toBeGreaterThanOrEqual(5);
+    expect(negatives.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("every case has a stable id, prompt, and notes", () => {
+    const ids = new Set<string>();
+    for (const c of cases) {
+      expect(c.id.length).toBeGreaterThan(0);
+      expect(ids.has(c.id)).toBe(false);
+      ids.add(c.id);
+      expect(c.prompt.length).toBeGreaterThan(10);
+      expect(c.notes.length).toBeGreaterThan(10);
+      expect(typeof c.should_trigger).toBe("boolean");
+    }
+  });
+});
+
+/**
+ * The frontmatter description is the primary trigger signal for Claude Code,
+ * Codex, and other skill loaders. Vague descriptions cause under- or
+ * over-triggering (Langfuse skill-eval postmortem; OpenAI eval-skills §1–4).
+ */
+describe("SKILL.md frontmatter description (trigger surface)", () => {
+  it("is present, non-trivial, and not a multi-line YAML block", () => {
+    expect(description.length).toBeGreaterThan(200);
+    // Keep the description on one YAML scalar so every loader parses it.
+    expect(descriptionLine).toMatch(/^description: \S/);
+    expect(description).not.toMatch(/^\|/);
+  });
+
+  it("names the product and the two authoring skins agents must choose", () => {
+    expect(description.toLowerCase()).toMatch(/ggsvelte/);
+    expect(description).toMatch(/grammar-of-graphics|grammar of graphics/i);
+    expect(description).toMatch(/Svelte/);
+    expect(description).toMatch(/JSON|spec/i);
+  });
+
+  it("lists package import paths agents already have in code", () => {
+    // Import-path triggers are high-precision; losing them is a silent regression.
+    expect(description).toContain("@ggsvelte/svelte");
+    expect(description).toContain("@ggsvelte/spec");
+    expect(description).toContain("@ggsvelte/core");
+  });
+
+  it("lists concrete chart kinds and composition hooks, not only abstract nouns", () => {
+    for (const term of [
+      "scatter",
+      "bar",
+      "histogram",
+      "boxplot",
+      "density",
+      "heatmap",
+      "map",
+      "faceted",
+      "GGPlot",
+      "Geom",
+    ] as const) {
+      expect({ term, hit: description.includes(term) }).toEqual({ term, hit: true });
+    }
+  });
+
+  it("covers validate/debug and headless render intents", () => {
+    expect(description.toLowerCase()).toMatch(/validat/);
+    expect(description.toLowerCase()).toMatch(/debug|editing/);
+    expect(description).toMatch(/SVG|headless|server-side/i);
+  });
+
+  /**
+   * Soft coverage: every *positive* fixture should share at least one
+   * distinctive token with the description (case-insensitive). This is not a
+   * substitute for agent-in-the-loop trigger evals — it only catches description
+   * rewrites that drop the vocabulary the fixtures were written against.
+   */
+  it("positive fixtures share trigger vocabulary with the description", () => {
+    const descLower = description.toLowerCase();
+    // Tokens that are intentionally in the description and useful for routing.
+    const vocab = [
+      "ggsvelte",
+      "chart",
+      "plot",
+      "scatter",
+      "bar",
+      "histogram",
+      "boxplot",
+      "density",
+      "heatmap",
+      "map",
+      "facet",
+      "svelte",
+      "spec",
+      "json",
+      "svg",
+      "validate",
+      "geom",
+      "ggplot",
+      "@ggsvelte/svelte",
+      "@ggsvelte/spec",
+      "@ggsvelte/core",
+    ];
+    const positives = cases.filter((c) => c.should_trigger);
+    for (const c of positives) {
+      const promptLower = c.prompt.toLowerCase();
+      const shared = vocab.filter((t) => promptLower.includes(t) && descLower.includes(t));
+      expect({ id: c.id, shared }).not.toEqual({ id: c.id, shared: [] });
+    }
+  });
+});
+
+/**
+ * Progressive disclosure: SKILL.md is the always-loaded body; references/ are
+ * on-demand. Every reference file must be linked from SKILL.md so agents can
+ * find it, and every relative link in the skill surface must resolve.
+ */
+describe("skill progressive disclosure and link integrity", () => {
+  it("SKILL.md links every references/*.md file", () => {
+    const refFiles = readdirSync(REFS_DIR).filter((n) => n.endsWith(".md"));
+    expect(refFiles.length).toBeGreaterThan(0);
+    for (const file of refFiles) {
+      const linked = skillMd.includes(`references/${file}`) || skillMd.includes(`](${file})`);
+      expect({ file, linked }).toEqual({ file, linked: true });
+    }
+  });
+
+  it("every relative markdown link in SKILL.md + references/ resolves on disk", () => {
+    const files = [SKILL_MD, ...markdownFiles(REFS_DIR)];
+    const broken: string[] = [];
+    for (const file of files) {
+      const markdown = readFileSync(file, "utf8");
+      for (const target of relativeMarkdownTargets(markdown)) {
+        const resolved = join(dirname(file), target);
+        if (!existsSync(resolved)) {
+          broken.push(`${relative(SKILL_DIR, file)} → ${target}`);
+        }
+      }
+    }
+    expect(broken).toEqual([]);
+  });
+});
+
+/**
+ * Directives beat information (philschmid testing-skills §best practices).
+ * The skill must instruct agents to use validate / CLI render, not merely
+ * mention that those tools exist.
+ */
+describe("skill body uses directives for the validation feedback loop", () => {
+  it("teaches validate() and the CLI render path as required steps", () => {
+    expect(skillMd).toMatch(/validate\(spec\)/);
+    expect(skillMd).toMatch(/ggsvelte-render/);
+    // Section title is imperative in spirit ("use it").
+    expect(skillMd).toMatch(/The validation contract \(use it!\)/i);
+  });
+
+  it("states the CLI install contract for agent sandboxes", () => {
+    expect(skillMd).toMatch(/@ggsvelte\/cli/);
+    expect(skillMd).toMatch(/install `@ggsvelte\/cli`|npm i -g @ggsvelte\/cli/);
+  });
+
+  it("documents registerAll for headless / spec-driven surfaces", () => {
+    expect(skillMd).toMatch(/registerAll\(\)/);
+  });
+});


### PR DESCRIPTION
## Summary

Research (August 2026) on agent-skill testing and the first practical slice for `@ggsvelte/skill`.

### What best practice looks like now

Consensus across [OpenAI eval-skills](https://developers.openai.com/blog/eval-skills), [Anthropic demystifying evals](https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents), [philschmid testing-skills](https://www.philschmid.de/testing-skills), and [Langfuse skill evals](https://langfuse.com/blog/2026-02-26-evaluate-ai-agent-skills):

| Layer | Role | Cost |
| --- | --- | --- |
| **Deterministic static contracts** | Description quality, inventory, fence validation, link integrity, progressive disclosure | CI every PR |
| **Agent-in-the-loop evals** | Load the skill, run 10–20 prompts (positive + negative), deterministic graders on traces/outcomes, multi-trial pass@k | Nightly / pre-release |
| **LLM rubrics** | Style / qualitative “did it follow the skill” | Selective |

Key points: start with the **description** (the trigger), use **directives not information**, include **negative trigger** cases, grow fixtures from real failures, grade **outcomes not paths**, isolate runs, multi-trial.

### What we already had

`packages/skill/` itself has no co-located test files, but the monorepo already gates the skill hard:

- `scripts/skill-content.test.ts` — inventory, fences, deprecation, ontology
- `scripts/skill-package.test.ts` — pack shape, lock-step, frontmatter
- `tests/evals/` — held-out NL→spec capability harness (**does not load the skill**)

### Quick wins in this PR

1. `packages/skill/evals/trigger-cases.json` — 15 balanced positive/negative prompts (OpenAI 10–20 pattern)
2. `scripts/skill-trigger.test.ts` — description trigger surface, fixture vocabulary coverage, relative-link integrity, progressive disclosure of every `references/*.md`, directive-style validation feedback loop
3. README — document the three layers so “zero tests in the package dir” is not confused with “untested skill”

### Follow-ups (GitHub issues)

Heavier agent-in-the-loop work (skill-loaded A/B, multi-trial trigger accuracy, optional LLM rubrics) is filed as issues rather than blocked on this PR.

## Test plan

- [x] `bun test scripts/skill-trigger.test.ts scripts/skill-content.test.ts scripts/skill-package.test.ts` (rebuild `packages/spec` first if local `dist/` is stale)
- [ ] CI unit job green
- [ ] Confirm `evals/trigger-cases.json` is not in the npm pack (`files` remains `SKILL.md` + `references/`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1501" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->