### PR TITLE
docs(readme): add CI, npm, and license badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # ggsvelte
 
+[![CI](https://img.shields.io/github/actions/workflow/status/ljodea/ggsvelte/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/ljodea/ggsvelte/actions/workflows/ci.yml)
+[![npm](https://img.shields.io/npm/v/%40ggsvelte%2Fsvelte?style=flat-square)](https://www.npmjs.com/package/@ggsvelte/svelte)
 [![codecov](https://codecov.io/gh/ljodea/ggsvelte/branch/main/graph/badge.svg)](https://app.codecov.io/gh/ljodea/ggsvelte)
+[![license](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](LICENSE)
 
 ggsvelte is a fast agent-native implementation of the layered grammar of
 graphics, inspired by ggplot2.


### PR DESCRIPTION
## Summary

- Add CI, npm (`@ggsvelte/svelte`), and MIT license badges next to the existing Codecov badge on the README title row.
- Cap the row at four live signals (green build, published package, coverage, license) and skip stars, downloads, bundle size, and tech-stack fluff.

## Test plan

- [ ] Confirm badge images render on the PR/README preview
- [ ] CI badge links to `ci.yml` on `main`
- [ ] npm badge links to `@ggsvelte/svelte` and shows the current version
- [ ] License badge links to `LICENSE`
- [ ] Codecov badge still works
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1506" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->