### PR TITLE
docs(ui): restrained shell motion for drawers, press, copy

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -245,8 +245,16 @@ pill shapes.
   being spoken automatically.
 - Under `forced-colors`, remove unreliable translucent fills, map focus/selection outlines
   to system colors, and preserve active-tool, zoom-label, and outline distinctions.
-- Use no decorative entrance or continuous animation. Short opacity feedback is allowed
-  only when reduced motion is not requested; meaning never depends on motion.
+- Chart marks and plot furniture use no decorative entrance or continuous animation.
+  Short opacity feedback is allowed only when reduced motion is not requested; meaning
+  never depends on motion.
+- The documentation shell may use short, functional motion only (not continuous loops):
+  edge-docked drawer enter/exit (`transform` + backdrop opacity), origin-aware popover
+  open (opacity + light scale from the trigger), press scale on controls (`scale(0.97)`),
+  and opacity icon crossfades. Shared tokens live under `:root` in
+  `apps/docs/src/styles/tokens.css` (`--ease-out`, `--ease-drawer`, duration tokens).
+  Under `prefers-reduced-motion: reduce` (and VR / visual-test), durations collapse —
+  including `::backdrop`, which is not matched by `*`. Meaning never depends on motion.
 
 ## Rejected patterns
 
@@ -274,6 +282,7 @@ release evidence, not optional decoration.
 
 | Date       | Decision                                                | Rationale                                                                                                      |
 | ---------- | ------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| 2026-08-06 | Allow restrained functional docs-shell motion only      | Spatial drawers, press feedback, and opacity state crossfades; chart marks stay motion-free                    |
 | 2026-07-14 | Establish quiet editorial data graphics as the system   | Matches the audited ggplot2/hrbrthemes/ggthemes references and makes good defaults the product advantage       |
 | 2026-07-14 | Keep `theme.ts` as executable token truth               | Prevents prose from becoming a parallel styling implementation                                                 |
 | 2026-07-14 | Derive ten interaction roles from each theme foundation | Keeps controls and overlays coherent across light, dark, and custom themes without hard-coded universal colors |

--- a/apps/docs/src/app.css
+++ b/apps/docs/src/app.css
@@ -49,9 +49,11 @@
 html[data-vr] *,
 html[data-vr] *::before,
 html[data-vr] *::after,
+html[data-vr] *::backdrop,
 html[data-visual-test] *,
 html[data-visual-test] *::before,
-html[data-visual-test] *::after {
+html[data-visual-test] *::after,
+html[data-visual-test] *::backdrop {
   transition: none !important;
   animation: none !important;
   caret-color: transparent !important;

--- a/apps/docs/src/lib/CodeTabs.svelte
+++ b/apps/docs/src/lib/CodeTabs.svelte
@@ -93,16 +93,14 @@
     <button
       type="button"
       class="copy"
+      class:copied
       aria-label={copied ? "Copied" : "Copy code"}
       onclick={copy}
     >
-      {#if copied}
-        <!-- eslint-disable-next-line svelte/no-at-html-tags -- trusted static SVG -->
-        {@html CHECK_ICON_SVG}
-      {:else}
-        <!-- eslint-disable-next-line svelte/no-at-html-tags -- trusted static SVG -->
-        {@html COPY_ICON_SVG}
-      {/if}
+      <!-- eslint-disable-next-line svelte/no-at-html-tags -- trusted static SVG -->
+      <span class="icon-copy" aria-hidden="true">{@html COPY_ICON_SVG}</span>
+      <!-- eslint-disable-next-line svelte/no-at-html-tags -- trusted static SVG -->
+      <span class="icon-check" aria-hidden="true">{@html CHECK_ICON_SVG}</span>
     </button>
     <span class="visually-hidden" role="status">{copyStatus}</span>
   </div>
@@ -166,7 +164,8 @@
     font: 600 0.82rem/1 var(--body-font);
     transition:
       background-color 120ms ease,
-      color 120ms ease;
+      color 120ms ease,
+      transform var(--duration-press) var(--ease-out);
   }
 
   /* 36px visual height, 44px hit height (DESIGN.md hit-region floor). */
@@ -176,8 +175,14 @@
     inset: -4px 0;
   }
 
-  .bar button[role="tab"]:hover {
-    color: var(--code-ink);
+  .bar button[role="tab"]:active {
+    transform: scale(0.97);
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    .bar button[role="tab"]:hover {
+      color: var(--code-ink);
+    }
   }
 
   /*
@@ -212,7 +217,8 @@
     cursor: pointer;
     transition:
       background-color 120ms ease,
-      color 120ms ease;
+      color 120ms ease,
+      transform var(--duration-press) var(--ease-out);
   }
 
   /* 32px visual, 44px hit region (DESIGN.md hit-region floor). */
@@ -222,9 +228,39 @@
     inset: -6px;
   }
 
-  .bar .copy:hover {
-    background: color-mix(in srgb, var(--code-ink) 12%, transparent);
-    color: var(--code-ink);
+  .bar .copy:active {
+    transform: scale(0.97);
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    .bar .copy:hover {
+      background: color-mix(in srgb, var(--code-ink) 12%, transparent);
+      color: var(--code-ink);
+    }
+  }
+
+  .bar .copy .icon-copy,
+  .bar .copy .icon-check {
+    grid-area: 1 / 1;
+    display: grid;
+    place-items: center;
+    transition: opacity var(--duration-icon) var(--ease-out);
+  }
+
+  .bar .copy .icon-copy {
+    opacity: 1;
+  }
+
+  .bar .copy .icon-check {
+    opacity: 0;
+  }
+
+  .bar .copy.copied .icon-copy {
+    opacity: 0;
+  }
+
+  .bar .copy.copied .icon-check {
+    opacity: 1;
   }
 
   /*

--- a/apps/docs/src/lib/components/CopyCode.svelte
+++ b/apps/docs/src/lib/components/CopyCode.svelte
@@ -43,32 +43,29 @@
       <button
         type="button"
         class="copy-trigger"
+        class:copied
         aria-label={copied ? "Copied" : accessibleLabel}
         onclick={copy}
       >
-        {#if copied}
-          <!-- eslint-disable-next-line svelte/no-at-html-tags -- trusted static SVG -->
-          {@html CHECK_ICON_SVG}
-        {:else}
-          <!-- eslint-disable-next-line svelte/no-at-html-tags -- trusted static SVG -->
-          {@html COPY_ICON_SVG}
-        {/if}
+        <!-- eslint-disable-next-line svelte/no-at-html-tags -- trusted static SVG -->
+        <span class="icon-copy" aria-hidden="true">{@html COPY_ICON_SVG}</span>
+        <!-- eslint-disable-next-line svelte/no-at-html-tags -- trusted static SVG -->
+        <span class="icon-check" aria-hidden="true">{@html CHECK_ICON_SVG}</span
+        >
       </button>
     </div>
   {:else}
     <button
       type="button"
       class="copy-trigger floating"
+      class:copied
       aria-label={copied ? "Copied" : accessibleLabel}
       onclick={copy}
     >
-      {#if copied}
-        <!-- eslint-disable-next-line svelte/no-at-html-tags -- trusted static SVG -->
-        {@html CHECK_ICON_SVG}
-      {:else}
-        <!-- eslint-disable-next-line svelte/no-at-html-tags -- trusted static SVG -->
-        {@html COPY_ICON_SVG}
-      {/if}
+      <!-- eslint-disable-next-line svelte/no-at-html-tags -- trusted static SVG -->
+      <span class="icon-copy" aria-hidden="true">{@html COPY_ICON_SVG}</span>
+      <!-- eslint-disable-next-line svelte/no-at-html-tags -- trusted static SVG -->
+      <span class="icon-check" aria-hidden="true">{@html CHECK_ICON_SVG}</span>
     </button>
   {/if}
   <div class="code-body" bind:this={source}>
@@ -134,7 +131,8 @@
     cursor: pointer;
     transition:
       background-color 120ms ease,
-      color 120ms ease;
+      color 120ms ease,
+      transform var(--duration-press) var(--ease-out);
   }
 
   /*
@@ -148,9 +146,40 @@
     inset: -6px;
   }
 
-  .copy-trigger:hover {
-    background: color-mix(in srgb, var(--code-ink) 12%, transparent);
-    color: var(--code-ink);
+  .copy-trigger:active {
+    transform: scale(0.97);
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    .copy-trigger:hover {
+      background: color-mix(in srgb, var(--code-ink) 12%, transparent);
+      color: var(--code-ink);
+    }
+  }
+
+  /* Stacked icons; opacity crossfade on copy success (no layout thrash). */
+  .icon-copy,
+  .icon-check {
+    grid-area: 1 / 1;
+    display: grid;
+    place-items: center;
+    transition: opacity var(--duration-icon) var(--ease-out);
+  }
+
+  .icon-copy {
+    opacity: 1;
+  }
+
+  .icon-check {
+    opacity: 0;
+  }
+
+  .copy-trigger.copied .icon-copy {
+    opacity: 0;
+  }
+
+  .copy-trigger.copied .icon-check {
+    opacity: 1;
   }
 
   .copy-trigger.floating {

--- a/apps/docs/src/lib/components/UiButton.svelte
+++ b/apps/docs/src/lib/components/UiButton.svelte
@@ -56,7 +56,8 @@
       background-color 120ms ease,
       border-color 120ms ease,
       color 120ms ease,
-      opacity 120ms ease;
+      opacity 120ms ease,
+      transform var(--duration-press) var(--ease-out);
   }
 
   :global(.ui-button:focus-visible) {
@@ -70,6 +71,10 @@
     opacity: 0.45;
   }
 
+  :global(.ui-button:active:not(:disabled):not([aria-disabled="true"])) {
+    transform: scale(0.97);
+  }
+
   :global(.ui-button--primary),
   :global(a.ui-button--primary:visited) {
     border-color: var(--accent);
@@ -77,11 +82,26 @@
     color: #fff;
   }
 
-  :global(
-    .ui-button--primary:hover:not(:disabled):not([aria-disabled="true"])
-  ) {
-    background: color-mix(in srgb, var(--accent) 88%, var(--ink));
-    border-color: color-mix(in srgb, var(--accent) 88%, var(--ink));
+  @media (hover: hover) and (pointer: fine) {
+    :global(
+      .ui-button--primary:hover:not(:disabled):not([aria-disabled="true"])
+    ) {
+      background: color-mix(in srgb, var(--accent) 88%, var(--ink));
+      border-color: color-mix(in srgb, var(--accent) 88%, var(--ink));
+    }
+
+    :global(
+      .ui-button--secondary:hover:not(:disabled):not([aria-disabled="true"])
+    ) {
+      border-color: color-mix(in srgb, var(--ink) 22%, var(--line));
+      background: var(--wash);
+    }
+
+    :global(
+      .ui-button--ghost:hover:not(:disabled):not([aria-disabled="true"])
+    ) {
+      background: color-mix(in srgb, var(--ink) 6%, transparent);
+    }
   }
 
   :global(.ui-button--secondary) {
@@ -90,21 +110,10 @@
     color: var(--ink);
   }
 
-  :global(
-    .ui-button--secondary:hover:not(:disabled):not([aria-disabled="true"])
-  ) {
-    border-color: color-mix(in srgb, var(--ink) 22%, var(--line));
-    background: var(--wash);
-  }
-
   :global(.ui-button--ghost) {
     border-color: transparent;
     background: transparent;
     color: var(--ink);
-  }
-
-  :global(.ui-button--ghost:hover:not(:disabled):not([aria-disabled="true"])) {
-    background: color-mix(in srgb, var(--ink) 6%, transparent);
   }
 
   :root[data-theme="dark"] :global(.ui-button--primary),

--- a/apps/docs/src/styles/base.css
+++ b/apps/docs/src/styles/base.css
@@ -274,12 +274,19 @@ pre {
   cursor: pointer;
   transition:
     background-color 120ms ease,
-    color 120ms ease;
+    color 120ms ease,
+    transform var(--duration-press) var(--ease-out);
 }
 
-.guide-code-copy button:hover {
-  background: color-mix(in srgb, var(--code-ink) 12%, transparent);
-  color: var(--code-ink);
+.guide-code-copy button:active {
+  transform: scale(0.97);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .guide-code-copy button:hover {
+    background: color-mix(in srgb, var(--code-ink) 12%, transparent);
+    color: var(--code-ink);
+  }
 }
 
 /* 32px visual, 44px hit region (DESIGN.md hit-region floor). */

--- a/apps/docs/src/styles/base.css
+++ b/apps/docs/src/styles/base.css
@@ -355,4 +355,10 @@ pre {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
   }
+
+  /* ::backdrop is not matched by * / ::before / ::after — keep drawers snap-close */
+  *::backdrop {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+  }
 }

--- a/apps/docs/src/styles/shell.css
+++ b/apps/docs/src/styles/shell.css
@@ -136,11 +136,43 @@
   padding: 0;
   border: 0;
   background: transparent;
+  /* Keep display/overlay long enough for exit transforms on close() */
+  transition:
+    overlay var(--duration-drawer-exit) allow-discrete,
+    display var(--duration-drawer-exit) allow-discrete;
+}
+
+.site-menu[open],
+.chapter-dialog[open] {
+  transition:
+    overlay var(--duration-drawer-enter) allow-discrete,
+    display var(--duration-drawer-enter) allow-discrete;
 }
 
 .site-menu::backdrop,
 .chapter-dialog::backdrop {
   background: color-mix(in srgb, #000 42%, transparent);
+  opacity: 0;
+  transition:
+    opacity var(--duration-drawer-exit) var(--ease-out),
+    overlay var(--duration-drawer-exit) allow-discrete,
+    display var(--duration-drawer-exit) allow-discrete;
+}
+
+.site-menu[open]::backdrop,
+.chapter-dialog[open]::backdrop {
+  opacity: 1;
+  transition:
+    opacity var(--duration-backdrop) var(--ease-out),
+    overlay var(--duration-drawer-enter) allow-discrete,
+    display var(--duration-drawer-enter) allow-discrete;
+}
+
+@starting-style {
+  .site-menu[open]::backdrop,
+  .chapter-dialog[open]::backdrop {
+    opacity: 0;
+  }
 }
 
 .site-menu__panel,
@@ -151,6 +183,37 @@
   padding: 1rem 1.25rem 2rem;
   background: var(--paper);
   box-shadow: -12px 0 32px color-mix(in srgb, #000 18%, transparent);
+  /* Site menu docks right; exit faster than enter */
+  transform: translateX(100%);
+  transition: transform var(--duration-drawer-exit) var(--ease-drawer);
+}
+
+.site-menu[open] .site-menu__panel {
+  transform: translateX(0);
+  transition: transform var(--duration-drawer-enter) var(--ease-drawer);
+}
+
+@starting-style {
+  .site-menu[open] .site-menu__panel {
+    transform: translateX(100%);
+  }
+}
+
+/* Chapter dialog docks left (see mobile override on margin) */
+.chapter-dialog__panel {
+  transform: translateX(-100%);
+  box-shadow: 12px 0 32px color-mix(in srgb, #000 18%, transparent);
+}
+
+.chapter-dialog[open] .chapter-dialog__panel {
+  transform: translateX(0);
+  transition: transform var(--duration-drawer-enter) var(--ease-drawer);
+}
+
+@starting-style {
+  .chapter-dialog[open] .chapter-dialog__panel {
+    transform: translateX(-100%);
+  }
 }
 
 .site-menu__heading,
@@ -436,7 +499,7 @@
     position: relative;
   }
 
-  .docs-mobile-tools details[open] .on-this-page {
+  .docs-mobile-tools details .on-this-page {
     position: absolute;
     right: 0;
     z-index: 20;
@@ -447,12 +510,32 @@
     border: 1px solid var(--line);
     background: var(--paper);
     box-shadow: 0 8px 24px color-mix(in srgb, #000 12%, transparent);
+    transform-origin: top right;
+    opacity: 0;
+    transform: scale(0.97);
+    transition:
+      opacity var(--duration-popover-exit) var(--ease-out),
+      transform var(--duration-popover-exit) var(--ease-out);
+  }
+
+  .docs-mobile-tools details[open] .on-this-page {
+    opacity: 1;
+    transform: scale(1);
+    transition:
+      opacity var(--duration-popover) var(--ease-out),
+      transform var(--duration-popover) var(--ease-out);
+  }
+
+  @starting-style {
+    .docs-mobile-tools details[open] .on-this-page {
+      opacity: 0;
+      transform: scale(0.97);
+    }
   }
 
   .chapter-dialog__panel {
     margin-right: auto;
     margin-left: 0;
-    box-shadow: 12px 0 32px color-mix(in srgb, #000 18%, transparent);
   }
 
   .chapter-dialog .docs-sidebar {

--- a/apps/docs/src/styles/shell.css
+++ b/apps/docs/src/styles/shell.css
@@ -136,7 +136,8 @@
   padding: 0;
   border: 0;
   background: transparent;
-  /* Keep display/overlay long enough for exit transforms on close() */
+  /* Exit keeps display for the slide; ignore hits so the page stays tappable */
+  pointer-events: none;
   transition:
     overlay var(--duration-drawer-exit) allow-discrete,
     display var(--duration-drawer-exit) allow-discrete;
@@ -144,6 +145,7 @@
 
 .site-menu[open],
 .chapter-dialog[open] {
+  pointer-events: auto;
   transition:
     overlay var(--duration-drawer-enter) allow-discrete,
     display var(--duration-drawer-enter) allow-discrete;
@@ -175,6 +177,7 @@
   }
 }
 
+/* Default dock: right edge (site menu always; chapter dialog on wide screens) */
 .site-menu__panel,
 .chapter-dialog__panel {
   width: min(88vw, 24rem);
@@ -183,36 +186,20 @@
   padding: 1rem 1.25rem 2rem;
   background: var(--paper);
   box-shadow: -12px 0 32px color-mix(in srgb, #000 18%, transparent);
-  /* Site menu docks right; exit faster than enter */
   transform: translateX(100%);
   transition: transform var(--duration-drawer-exit) var(--ease-drawer);
 }
 
-.site-menu[open] .site-menu__panel {
-  transform: translateX(0);
-  transition: transform var(--duration-drawer-enter) var(--ease-drawer);
-}
-
-@starting-style {
-  .site-menu[open] .site-menu__panel {
-    transform: translateX(100%);
-  }
-}
-
-/* Chapter dialog docks left (see mobile override on margin) */
-.chapter-dialog__panel {
-  transform: translateX(-100%);
-  box-shadow: 12px 0 32px color-mix(in srgb, #000 18%, transparent);
-}
-
+.site-menu[open] .site-menu__panel,
 .chapter-dialog[open] .chapter-dialog__panel {
   transform: translateX(0);
   transition: transform var(--duration-drawer-enter) var(--ease-drawer);
 }
 
 @starting-style {
+  .site-menu[open] .site-menu__panel,
   .chapter-dialog[open] .chapter-dialog__panel {
-    transform: translateX(-100%);
+    transform: translateX(100%);
   }
 }
 
@@ -533,9 +520,22 @@
     }
   }
 
+  /* Docs menu docks left under the mobile layout (matches the Menu control) */
   .chapter-dialog__panel {
     margin-right: auto;
     margin-left: 0;
+    box-shadow: 12px 0 32px color-mix(in srgb, #000 18%, transparent);
+    transform: translateX(-100%);
+  }
+
+  .chapter-dialog[open] .chapter-dialog__panel {
+    transform: translateX(0);
+  }
+
+  @starting-style {
+    .chapter-dialog[open] .chapter-dialog__panel {
+      transform: translateX(-100%);
+    }
   }
 
   .chapter-dialog .docs-sidebar {

--- a/apps/docs/src/styles/tokens.css
+++ b/apps/docs/src/styles/tokens.css
@@ -59,6 +59,17 @@
   --muted: var(--muted-ink);
   --surface: var(--wash);
   --border: var(--line);
+  /* Motion — Emil curves; UI stays under 300ms except drawers */
+  --ease-out: cubic-bezier(0.23, 1, 0.32, 1);
+  --ease-in-out: cubic-bezier(0.77, 0, 0.175, 1);
+  --ease-drawer: cubic-bezier(0.32, 0.72, 0, 1);
+  --duration-press: 140ms;
+  --duration-popover: 160ms;
+  --duration-popover-exit: 120ms;
+  --duration-drawer-enter: 320ms;
+  --duration-drawer-exit: 220ms;
+  --duration-backdrop: 250ms;
+  --duration-icon: 140ms;
   color-scheme: light;
 }
 


### PR DESCRIPTION
## Summary

- Mobile **site menu** and **chapter dialog** drawers slide from their docked edge with backdrop fade (drawer easing, faster exit than enter).
- **Press feedback** (`scale(0.97)`) on UiButton and copy controls; hover washes gated to fine pointers.
- **Copy icons** crossfade (opacity only) on success instead of hard-swapping.
- Mobile **On this page** popover scales in from the top-right trigger.
- Shared motion tokens (`--ease-out`, `--ease-drawer`, durations) in `tokens.css`. Existing reduced-motion and VR `transition: none` still apply.

## Test plan

- [x] `apps/docs` vitest: 36/36 pass
- [x] Browser QA at mobile 375×812: open/close site menu + chapter dialog; On this page open; tokens present; no console errors
- [x] Desktop: copy icon DOM + `.copied` opacity crossfade verified
- [ ] Spot-check press scale on a physical device (optional)

## QA note

Report: `.gstack/qa-reports/qa-report-docs-shell-motion-2026-08-06.md` (local). No functional regressions found.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1507" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->