### PR TITLE
docs(readme): shorten LayerCake scale note to d3 scales

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,18 +58,18 @@ and Windows.
 
 ## Why ggsvelte?
 
-| Capability                                 | ggsvelte  | SveltePlot           | LayerCake                    |
-| ------------------------------------------ | --------- | -------------------- | ---------------------------- |
-| **Bundle size** (min+gzip, 1k scatter app) | ⚠️ 138 KB | ✅ 109 KB            | ✅ 41 KB                     |
-| **API stability**                          | ⚠️ v0.30  | ⚠️ v0.14             | ✅ v10                       |
-| **Headless server-side SVG** (no DOM)      | ✅        | ❌ empty shell       | ⚠️ opt-in `ssr` flag         |
-| **Portable JSON spec + schema**            | ✅        | ❌                   | ❌                           |
-| **CLI validator + renderer**               | ✅        | ❌                   | ❌                           |
-| **Agent skill**                            | ✅        | ❌                   | ❌                           |
-| **Automatic temporal detection**           | ✅        | ⚠️ Date objects only | ❌                           |
-| **Built-in interactions**                  | ✅        | ⚠️ tooltip + brush   | ❌                           |
-| **ggplot2 API**                            | ✅        | ❌                   | ❌                           |
-| **Scale, axis & coord control**            | ✅        | ✅                   | ⚠️ hand-configured d3 scales |
+| Capability                                 | ggsvelte  | SveltePlot           | LayerCake            |
+| ------------------------------------------ | --------- | -------------------- | -------------------- |
+| **Bundle size** (min+gzip, 1k scatter app) | ⚠️ 138 KB | ✅ 109 KB            | ✅ 41 KB             |
+| **API stability**                          | ⚠️ v0.30  | ⚠️ v0.14             | ✅ v10               |
+| **Headless server-side SVG** (no DOM)      | ✅        | ❌ empty shell       | ⚠️ opt-in `ssr` flag |
+| **Portable JSON spec + schema**            | ✅        | ❌                   | ❌                   |
+| **CLI validator + renderer**               | ✅        | ❌                   | ❌                   |
+| **Agent skill**                            | ✅        | ❌                   | ❌                   |
+| **Automatic temporal detection**           | ✅        | ⚠️ Date objects only | ❌                   |
+| **Built-in interactions**                  | ✅        | ⚠️ tooltip + brush   | ❌                   |
+| **ggplot2 API**                            | ✅        | ❌                   | ❌                   |
+| **Scale, axis & coord control**            | ✅        | ✅                   | ⚠️ d3 scales         |
 
 ## Reference
 

--- a/apps/docs/src/lib/components/Benchmarks.svelte
+++ b/apps/docs/src/lib/components/Benchmarks.svelte
@@ -99,7 +99,7 @@
       feature: "Scale, axis & coord control",
       gg: yes,
       sp: yes,
-      lc: { mark: "partial", note: "hand-configured d3" },
+      lc: { mark: "partial", note: "d3 scales" },
     },
   ];
 </script>


### PR DESCRIPTION
## Summary

- Shorten the LayerCake cell on **Scale, axis & coord control** from `hand-configured d3 scales` to `d3 scales` (README + docs comparison table).

## Accuracy check (layercake@10.0.3)

- Defaults: `d3.scaleLinear` for x/y/z, `d3.scaleSqrt` for r (`defaultScales.js`).
- Domain/range auto from data and container; override via `xScale` / `yScale` props with an instantiated d3 scale.
- Package exports `LayerCake` + layouts + helpers only — no axis components.

"hand-configured" overstated the default path; `d3 scales` stays accurate for the partial mark.

## Test plan

- [x] Claim checked against installed layercake@10.0.3 source
- [ ] Spot-check README and homepage table on GitHub / docs after merge
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1512" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->