### PR TITLE
docs(readme): drop redundant cold-mount caption under charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,6 @@ graphics, inspired by ggplot2.
 
 ![Bar chart of cold-mount time for a stacked bar chart of 50 categories by 4 stacks: ggsvelte 3 ms, LayerCake 3.7 ms, SveltePlot 41.6 ms. Lower is better.](apps/docs/static/benchmarks/bench-bars-mount.svg)
 
-Cold-mount milliseconds vs [SveltePlot](https://svelteplot.dev) and
-[LayerCake](https://layercake.graphics); lower is better.
-
 ## Install
 
 ```sh


### PR DESCRIPTION
## Summary

- Remove the prose caption under the benchmark bar charts ("Cold-mount milliseconds vs SveltePlot and LayerCake; lower is better.").
- The SVGs and alt text already carry the comparison and "lower is better."

## Test plan

- [x] README renders with charts only, no orphan caption between last chart and Install
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1513" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->