### PR TITLE
docs(home): cap grammar chart at static width, center it

### DIFF
--- a/apps/docs/src/lib/components/GrammarDemo.svelte
+++ b/apps/docs/src/lib/components/GrammarDemo.svelte
@@ -143,6 +143,15 @@
   .grammar-output {
     position: relative;
     min-width: 0;
+    /*
+     * Cap at the static shell width (DOCS_STATIC_PLOT_WIDTH_PX) and center.
+     * The live plot is container-responsive, so an uncapped shell stretched
+     * to the full code-path column on hover intent — far too wide vs its
+     * 400px height. Keep the literal: importing the constant would pull the
+     * headless renderer into the home client bundle.
+     */
+    max-width: 832px;
+    margin-inline: auto;
   }
 
   .grammar-output :global(svg) {

--- a/tests/visual/docs-home-gallery.spec.ts
+++ b/tests/visual/docs-home-gallery.spec.ts
@@ -158,6 +158,30 @@ test("code tabs share the manual-copy fallback", async ({ page }) => {
   );
 });
 
+test("home grammar chart keeps static dimensions through live upgrade", async ({ page }) => {
+  // Wider than the 832px shell cap so an uncapped container-responsive live
+  // plot would visibly stretch (the default 800px viewport cannot show it).
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto("/");
+  const shell = page.locator(".grammar-output");
+  await expect(shell).toBeVisible();
+  const column = await page.locator(".code-path-chart").boundingBox();
+  const before = await shell.boundingBox();
+  expect(before).not.toBeNull();
+  expect(column).not.toBeNull();
+  expect(column!.width).toBeGreaterThan(832);
+  // Cap is DOCS_STATIC_PLOT_WIDTH_PX (832); static svg renders at exactly that.
+  expect(Math.round(before!.width)).toBe(832);
+  // pointerenter intent upgrades the shell to the live plot.
+  await shell.hover();
+  await expect(shell.locator(".gg-plot-root")).toBeVisible({ timeout: 15_000 });
+  const after = await shell.boundingBox();
+  expect(after).not.toBeNull();
+  expect(Math.round(after!.width)).toBe(Math.round(before!.width));
+  expect(Math.round(after!.height)).toBe(Math.round(before!.height));
+  expect(after!.width).toBeLessThan(column!.width);
+});
+
 test("gallery exposes every generated preview exactly once", async ({ page }) => {
   await page.goto("/examples");
   // One meta.json per example under examples/ (grows when new specimens land).


### PR DESCRIPTION
## What

Caps the homepage grammar-demo chart at its static shell width (832px, `DOCS_STATIC_PLOT_WIDTH_PX`) and centers it, so the hover-triggered live upgrade keeps the exact static 832×400 box instead of stretching to the full code-path column.

## Why

`GGPlot` is container-responsive when `width` is omitted. On `pointerenter` intent (`observeUserIntent`), the shell upgraded from the fixed 832×400 static SVG to the full `.code-path-chart` column (~1325px on a 14\" laptop) — the chart became far too wide relative to its 400px height. Reported with screenshots: starts reasonable, elongates to full width on mouse-over.

Bonus: the absolutely-positioned "Load interactive chart" button now anchors to the chart box rather than floating at the far right of the full-width container.

## Verification

- New journeys spec `home grammar chart keeps static dimensions through live upgrade` (1440px viewport so the cap binds): hovers the shell, waits for `.gg-plot-root`, asserts width/height identical to the static shell and below the column width. Passes; would fail pre-fix (shell stretched to ~1325px).
- Full `docs-home-gallery.spec.ts`: 15/15 pass against a fresh `apps/docs` build.
- Browser-verified at 1440×900: static shell 832×400 centered; after hover, live plot svg 832×400 — no layout jump; screenshot taken.

## Verification evidence

SKIPPED-tier: docs CSS + Playwright spec only; evidence above (commands run locally, results in this body).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1518" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->