### PR TITLE
fix(core): unit-aware temporal axisFormatters for pin/tooltip

### DIFF
--- a/.changeset/unit-aware-axis-formatters.md
+++ b/.changeset/unit-aware-axis-formatters.md
@@ -1,0 +1,9 @@
+---
+"@ggsvelte/core": patch
+---
+
+# Unit-aware temporal axisFormatters for pin and tooltip
+
+Migration: none for authored labels — `dateLabels` / `labels` still override. **Default** tooltip header and floating crosshair axis labels now follow column precision (year → `1835`, month → `2024-07`, day → `2024-07-09`) instead of always stamping a calendar day or full datetime. Empty-space pins on year charts no longer show `1835-01-01`.
+
+Axis tick **spacing** is unchanged; only the shared `axisFormatters` default pattern tracks the channel unit.

--- a/packages/core/src/pipeline/finalize-layout-pass.ts
+++ b/packages/core/src/pipeline/finalize-layout-pass.ts
@@ -104,6 +104,17 @@ export function finalizePanelLayoutPass(input: {
     return scale.type === "time" && conversion.requestedTime ? "datetime" : null;
   };
 
+  /** Shared column precision for axisFormatters defaults; mixed precisions → null. */
+  const temporalPrecision = (axis: "x" | "y") => {
+    const precisions = prepared.scaleDecisions
+      .filter((decision) => decision.aesthetic === axis && decision.status === "temporal")
+      .map((decision) => decision.precision)
+      .filter((value): value is NonNullable<typeof value> => value !== null);
+    if (precisions.length === 0) return null;
+    const first = precisions[0]!;
+    return precisions.every((value) => value === first) ? first : null;
+  };
+
   const xGuide = resolveAxisGuide("x", scalesConfig, normalized.guides, theme);
   const yGuide = resolveAxisGuide("y", scalesConfig, normalized.guides, theme);
   const labs = { ...normalized.labs };
@@ -158,6 +169,8 @@ export function finalizePanelLayoutPass(input: {
       yScale: yTraining.scale,
       xTemporalKind: temporalKind("x"),
       yTemporalKind: temporalKind("y"),
+      xTemporalPrecision: temporalPrecision("x"),
+      yTemporalPrecision: temporalPrecision("y"),
       legendInputs,
       legendOrder: normalized.legend?.order ?? "stable-domain",
       theme,

--- a/packages/core/src/pipeline/layout-helpers.ts
+++ b/packages/core/src/pipeline/layout-helpers.ts
@@ -2,7 +2,7 @@
  * Layout/scene assembly helpers used by runPipeline: domain projection,
  * tick formatters, margin max, and warning/advisory dedupe.
  */
-import type { PositionScaleSpec, TemporalScaleKind } from "@ggsvelte/spec";
+import type { PositionScaleSpec, TemporalPrecision, TemporalScaleKind } from "@ggsvelte/spec";
 
 import type {
   BandLayoutDomainContext,
@@ -83,12 +83,63 @@ export function layoutDomain(
   };
 }
 
+/**
+ * Default strftime pattern for tooltip / crosshair axis values.
+ *
+ * Patterns track the **channel unit** (column precision), not tick spacing.
+ * Year data labels as years even when a cursor sits between year ticks;
+ * day data still gets full calendar dates.
+ */
+export function defaultTemporalAxisPattern(
+  kind: TemporalScaleKind,
+  precision: TemporalPrecision | null | undefined,
+  options: { lean: boolean } = { lean: false },
+): string {
+  if (kind === "monthDay") return "%b %e";
+  if (kind === "time") {
+    if (precision === "millisecond") return "%H:%M:%S.%L";
+    if (precision === "minute") return "%H:%M";
+    return "%H:%M:%S";
+  }
+
+  switch (precision) {
+    case "year":
+      return "%Y";
+    case "quarter":
+      // formatTime (lean) has no %q token.
+      return options.lean ? "%Y-%m" : "%Y-Q%q";
+    case "month":
+      return "%Y-%m";
+    case "date":
+      return "%Y-%m-%d";
+    case "minute":
+      return kind === "date" ? "%Y-%m-%d" : options.lean ? "%Y-%m-%d %H:%M" : "%Y-%m-%d %H:%M %Z";
+    case "second":
+      return kind === "date"
+        ? "%Y-%m-%d"
+        : options.lean
+          ? "%Y-%m-%d %H:%M:%S"
+          : "%Y-%m-%d %H:%M:%S %Z";
+    case "millisecond":
+      return kind === "date"
+        ? "%Y-%m-%d"
+        : options.lean
+          ? "%Y-%m-%d %H:%M:%S.%L"
+          : "%Y-%m-%d %H:%M:%S.%L %Z";
+    default:
+      // Unknown precision: prior kind-only defaults.
+      if (kind === "date") return "%Y-%m-%d";
+      return options.lean ? "%Y-%m-%d %H:%M:%S" : "%Y-%m-%d %H:%M:%S %Z";
+  }
+}
+
 export function makeAxisFormatter(
   axis: "x" | "y",
   scale: PositionScale,
   config: PositionScaleSpec | undefined,
   warnings: PipelineWarning[],
   resolvedTemporalKind?: TemporalScaleKind | null,
+  resolvedTemporalPrecision?: TemporalPrecision | null,
 ): TickFormatter | undefined {
   if (config?.breaks !== undefined && config.dateBreaks !== undefined) {
     warnings.push({
@@ -112,23 +163,18 @@ export function makeAxisFormatter(
   if (labels === undefined) {
     if (scale.type !== "time") return undefined;
     const kind = resolvedTemporalKind ?? config?.temporalKind ?? "datetime";
-    const defaultPattern =
-      kind === "date"
-        ? "%Y-%m-%d"
-        : kind === "time"
-          ? "%H:%M:%S"
-          : // The crosshair and tooltip header read through here, so this is
-            // where a month-day axis says "Apr 1" rather than a stamped date.
-            kind === "monthDay"
-            ? "%b %e"
-            : "%Y-%m-%d %H:%M:%S %Z";
+    // Crosshair and tooltip header share this formatter. Unit comes from
+    // column precision (year → %Y), not from how densely ticks are drawn.
     const compile = getTemporalRuntime()?.compileLabelFormat;
     if (compile === undefined) {
-      // formatTime has no %Z; use a zone-free lean default.
-      const leanPattern =
-        kind === "date" ? "%Y-%m-%d" : kind === "time" ? "%H:%M:%S" : "%Y-%m-%d %H:%M:%S";
+      const leanPattern = defaultTemporalAxisPattern(kind, resolvedTemporalPrecision, {
+        lean: true,
+      });
       return (value) => formatTime(value as number, leanPattern);
     }
+    const defaultPattern = defaultTemporalAxisPattern(kind, resolvedTemporalPrecision, {
+      lean: false,
+    });
     const format = compile(defaultPattern, {
       kind,
       locale: config?.locale ?? "en-US",

--- a/packages/core/src/pipeline/layout-helpers.ts
+++ b/packages/core/src/pipeline/layout-helpers.ts
@@ -93,8 +93,9 @@ export function layoutDomain(
 export function defaultTemporalAxisPattern(
   kind: TemporalScaleKind,
   precision: TemporalPrecision | null | undefined,
-  options: { lean: boolean } = { lean: false },
+  options?: { lean?: boolean },
 ): string {
+  const lean = options?.lean === true;
   if (kind === "monthDay") return "%b %e";
   if (kind === "time") {
     if (precision === "millisecond") return "%H:%M:%S.%L";
@@ -107,29 +108,25 @@ export function defaultTemporalAxisPattern(
       return "%Y";
     case "quarter":
       // formatTime (lean) has no %q token.
-      return options.lean ? "%Y-%m" : "%Y-Q%q";
+      return lean ? "%Y-%m" : "%Y-Q%q";
     case "month":
       return "%Y-%m";
     case "date":
       return "%Y-%m-%d";
     case "minute":
-      return kind === "date" ? "%Y-%m-%d" : options.lean ? "%Y-%m-%d %H:%M" : "%Y-%m-%d %H:%M %Z";
+      return kind === "date" ? "%Y-%m-%d" : lean ? "%Y-%m-%d %H:%M" : "%Y-%m-%d %H:%M %Z";
     case "second":
-      return kind === "date"
-        ? "%Y-%m-%d"
-        : options.lean
-          ? "%Y-%m-%d %H:%M:%S"
-          : "%Y-%m-%d %H:%M:%S %Z";
+      return kind === "date" ? "%Y-%m-%d" : lean ? "%Y-%m-%d %H:%M:%S" : "%Y-%m-%d %H:%M:%S %Z";
     case "millisecond":
       return kind === "date"
         ? "%Y-%m-%d"
-        : options.lean
+        : lean
           ? "%Y-%m-%d %H:%M:%S.%L"
           : "%Y-%m-%d %H:%M:%S.%L %Z";
     default:
       // Unknown precision: prior kind-only defaults.
       if (kind === "date") return "%Y-%m-%d";
-      return options.lean ? "%Y-%m-%d %H:%M:%S" : "%Y-%m-%d %H:%M:%S %Z";
+      return lean ? "%Y-%m-%d %H:%M:%S" : "%Y-%m-%d %H:%M:%S %Z";
   }
 }
 

--- a/packages/core/src/pipeline/layout-helpers.ts
+++ b/packages/core/src/pipeline/layout-helpers.ts
@@ -90,7 +90,7 @@ export function layoutDomain(
  * Year data labels as years even when a cursor sits between year ticks;
  * day data still gets full calendar dates.
  */
-export function defaultTemporalAxisPattern(
+function defaultTemporalAxisPattern(
   kind: TemporalScaleKind,
   precision: TemporalPrecision | null | undefined,
   options?: { lean?: boolean },

--- a/packages/core/src/pipeline/panel-layout-chrome.ts
+++ b/packages/core/src/pipeline/panel-layout-chrome.ts
@@ -1,7 +1,7 @@
 /**
  * Panel layout chrome: labs, axis titles (coord flip), formatters, legends.
  */
-import type { PortableSpec, TemporalScaleKind } from "@ggsvelte/spec";
+import type { PortableSpec, TemporalPrecision, TemporalScaleKind } from "@ggsvelte/spec";
 
 import { humanizeFieldTitle } from "../humanize-field.js";
 import { FONT_METRICS } from "../layout/font-metrics.js";
@@ -66,6 +66,8 @@ export interface PanelLayoutChromeInput {
   yScale: PositionScale;
   xTemporalKind: TemporalScaleKind | null;
   yTemporalKind: TemporalScaleKind | null;
+  xTemporalPrecision: TemporalPrecision | null;
+  yTemporalPrecision: TemporalPrecision | null;
   legendInputs: readonly LegendInput[];
   legendOrder: LegendOrder;
   theme: ThemeTokens;
@@ -197,6 +199,8 @@ function resolvePanelLayoutDisplay(input: {
   yScale: PositionScale;
   xTemporalKind: TemporalScaleKind | null;
   yTemporalKind: TemporalScaleKind | null;
+  xTemporalPrecision: TemporalPrecision | null;
+  yTemporalPrecision: TemporalPrecision | null;
   xTitle: string;
   yTitle: string;
   warnings: PipelineWarning[];
@@ -214,8 +218,22 @@ function resolvePanelLayoutDisplay(input: {
     warnings,
   } = input;
 
-  const formatX = makeAxisFormatter("x", xScale, scalesConfig.x, warnings, input.xTemporalKind);
-  const formatY = makeAxisFormatter("y", yScale, scalesConfig.y, warnings, input.yTemporalKind);
+  const formatX = makeAxisFormatter(
+    "x",
+    xScale,
+    scalesConfig.x,
+    warnings,
+    input.xTemporalKind,
+    input.xTemporalPrecision,
+  );
+  const formatY = makeAxisFormatter(
+    "y",
+    yScale,
+    scalesConfig.y,
+    warnings,
+    input.yTemporalKind,
+    input.yTemporalPrecision,
+  );
   const { hTitle, vTitle } = flipDisplayTitles(flip, xTitle, yTitle);
   const { formatH, formatV } = flipDisplayFormatters(flip, formatX, formatY);
   const convertedBreaks = (axis: "x" | "y"): (number | string)[] | undefined => {
@@ -389,6 +407,8 @@ export function resolvePanelLayoutChrome(input: PanelLayoutChromeInput): PanelLa
     yScale: input.yScale,
     xTemporalKind: input.xTemporalKind,
     yTemporalKind: input.yTemporalKind,
+    xTemporalPrecision: input.xTemporalPrecision,
+    yTemporalPrecision: input.yTemporalPrecision,
     xTitle: labsChrome.xTitle,
     yTitle: labsChrome.yTitle,
     warnings: input.warnings,

--- a/packages/core/src/pipeline/panel-layout.ts
+++ b/packages/core/src/pipeline/panel-layout.ts
@@ -6,7 +6,7 @@
  * Owns placement, chrome, and the resolved axis guides for the run so scene
  * assembly does not re-resolve them (ADR-0003 two-pass layout stands).
  */
-import type { PortableSpec, TemporalScaleKind } from "@ggsvelte/spec";
+import type { PortableSpec, TemporalPrecision, TemporalScaleKind } from "@ggsvelte/spec";
 
 import { planBasicAxis } from "../layout/basic-axis.js";
 import {
@@ -52,6 +52,8 @@ export interface PanelLayoutInput {
   yScale: PositionScale;
   xTemporalKind: TemporalScaleKind | null;
   yTemporalKind: TemporalScaleKind | null;
+  xTemporalPrecision: TemporalPrecision | null;
+  yTemporalPrecision: TemporalPrecision | null;
   legendInputs: readonly LegendInput[];
   legendOrder: LegendOrder;
   theme: ThemeTokens;
@@ -148,6 +150,8 @@ export function layoutPanels(input: PanelLayoutInput): PanelLayoutResult {
     yScale: input.yScale,
     xTemporalKind: input.xTemporalKind,
     yTemporalKind: input.yTemporalKind,
+    xTemporalPrecision: input.xTemporalPrecision,
+    yTemporalPrecision: input.yTemporalPrecision,
     legendInputs: input.legendInputs,
     legendOrder: input.legendOrder,
     theme: input.theme,

--- a/packages/core/tests/layout/panels.test.ts
+++ b/packages/core/tests/layout/panels.test.ts
@@ -57,6 +57,8 @@ function baseInput(over: Partial<PanelLayoutInput> = {}): PanelLayoutInput {
     yScale,
     xTemporalKind: null,
     yTemporalKind: null,
+    xTemporalPrecision: null,
+    yTemporalPrecision: null,
     legendInputs: [],
     legendOrder: "stable-domain",
     theme: resolveTheme("default"),

--- a/packages/core/tests/pipeline-layout-helpers.test.ts
+++ b/packages/core/tests/pipeline-layout-helpers.test.ts
@@ -16,11 +16,14 @@ import {
   dedupeWarnings,
   elementwiseMaxMargins,
   layoutDomain,
+  makeAxisFormatter,
   makeAxisValueFormatter,
   scaleDomainSnapshot,
 } from "../src/pipeline/layout-helpers.ts";
 import type { Advisory, PipelineWarning } from "../src/pipeline/types.ts";
 import type { PositionScale } from "../src/scales/train.ts";
+import { installTemporal } from "../src/install-temporal.ts";
+import { getTemporalRuntime } from "../src/temporal-runtime.ts";
 
 describe("layout chrome constants", () => {
   it("keeps title/legend band sizes stable", () => {
@@ -131,6 +134,38 @@ describe("makeAxisValueFormatter", () => {
     const fmt = makeAxisValueFormatter(band);
     expect(fmt("a")).toBe("a");
     expect(fmt(null)).toBe("–");
+  });
+});
+
+describe("makeAxisFormatter temporal unit defaults", () => {
+  const timeScale: PositionScale = {
+    type: "time",
+    domain: [Date.UTC(1835, 0, 1), Date.UTC(2026, 0, 1)],
+    range: [0, 1],
+    normalize: () => 0,
+  };
+
+  it("defaults date-kind labels to the column precision unit", () => {
+    // bunfig preload installs temporal; keep compile path for %Y / %q tokens.
+    if (getTemporalRuntime() === null) installTemporal();
+    const warnings: PipelineWarning[] = [];
+    const year = makeAxisFormatter("x", timeScale, undefined, warnings, "date", "year");
+    const month = makeAxisFormatter("x", timeScale, undefined, warnings, "date", "month");
+    const day = makeAxisFormatter("x", timeScale, undefined, warnings, "date", "date");
+    expect(year).toBeDefined();
+    expect(month).toBeDefined();
+    expect(day).toBeDefined();
+    expect(year!(Date.UTC(1835, 0, 1), 0)).toBe("1835");
+    expect(month!(Date.UTC(2024, 6, 1), 0)).toBe("2024-07");
+    expect(day!(Date.UTC(2024, 6, 9), 0)).toBe("2024-07-09");
+    expect(warnings).toEqual([]);
+  });
+
+  it("keeps calendar-day defaults when precision is unknown", () => {
+    if (getTemporalRuntime() === null) installTemporal();
+    const warnings: PipelineWarning[] = [];
+    const fmt = makeAxisFormatter("x", timeScale, undefined, warnings, "date", null);
+    expect(fmt!(Date.UTC(1835, 0, 1), 0)).toBe("1835-01-01");
   });
 });
 

--- a/packages/core/tests/pipeline-temporal/annotations-preflight.test.ts
+++ b/packages/core/tests/pipeline-temporal/annotations-preflight.test.ts
@@ -285,7 +285,10 @@ describe("temporal pipeline: annotations and preflight", () => {
       portableOverride: { type: "time", temporalKind: "date", parse: "year" },
     });
     expect(model.row(0)).toEqual(yearRows[0]);
-    expect(model.axisFormatters.x("1835")).toBe("1835-01-01");
+    // Year-unit data: empty-space pin / crosshair share axisFormatters with the
+    // tooltip header. Labels must use the channel unit, not a fixed day stamp.
+    expect(model.axisFormatters.x("1835")).toBe("1835");
+    expect(model.axisFormatters.x(Date.UTC(1900, 0, 1))).toBe("1900");
     expect(Object.isFrozen(model.guidePlans)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Tooltip and crosshair axis labels (`RenderModel.axisFormatters`) now default from **column temporal precision** (the channel unit), not a fixed `%Y-%m-%d` / datetime stamp.
- Year data labels as `1835`, month as `2024-07`, day as `2024-07-09`. Tick spacing is unrelated: thinned month ticks on day data still format as days.
- Fixes empty-space pin on annual charts showing `1835-01-01` while point pin showed the year.

## Root cause

`makeAxisFormatter` used only `temporalKind` (`date` → always `%Y-%m-%d`). Year-parsed values sit on Jan 1 instants, so empty-space pin (scale invert + formatter) stamped a day. Exact pin used the source year string.

## Test plan

- [x] RED → GREEN: `axisFormatters.x("1835")` → `"1835"` for year rows
- [x] Unit: `makeAxisFormatter` year / month / date / null precision
- [x] `bun test packages/core/tests/pipeline-temporal packages/core/tests/pipeline-layout-helpers.test.ts packages/core/tests/identity.test.ts packages/core/tests/layout/panels.test.ts`
- [x] `bun run check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1519" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->