### PR TITLE
docs(examples): shrink example page title to homepage scale

### DIFF
--- a/apps/docs/src/routes/examples/[category]/[name]/+page.svelte
+++ b/apps/docs/src/routes/examples/[category]/[name]/+page.svelte
@@ -183,16 +183,18 @@
   }
 
   h1 {
-    max-width: 13ch;
-    margin: 0.25rem 0 1rem;
-    font-size: clamp(3rem, 7vw, 6.5rem);
-    line-height: 0.88;
+    margin: 0.25rem 0 0.75rem;
+    font-size: clamp(1.9rem, 3.4vw, 3.1rem);
+    line-height: 1.04;
+    letter-spacing: -0.035em;
   }
 
   .proof {
-    max-width: 45rem;
+    max-width: 40rem;
+    margin: 0;
     color: var(--muted);
-    font-size: 1.1rem;
+    font-size: 1rem;
+    line-height: 1.45;
   }
 
   .try-it {


### PR DESCRIPTION
## Summary

- Example page `h1` was `clamp(3rem, 7vw, 6.5rem)` — display type that dominated the chart beneath it
- Cap it at the homepage hero size: `clamp(1.9rem, 3.4vw, 3.1rem)` with matching line-height and tracking
- Scale the description (`.proof`) down to `1rem` so it stays subordinate to the title

## Test plan

- [ ] Open any gallery example page (e.g. `/examples/line/series`) and confirm the title is no larger than the homepage hero
- [ ] Confirm the description under the title is readable and proportional
- [ ] Spot-check a long title and a short title at desktop and mobile widths
- [ ] Chart frame still sits clearly as the visual focus under the heading
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1522" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->