### PR TITLE
fix(svelte): recover fill/weight on stat-aggregate bar tooltips

### DIFF
--- a/.changeset/stat-bar-tooltip-fill-weight.md
+++ b/.changeset/stat-bar-tooltip-fill-weight.md
@@ -1,0 +1,5 @@
+---
+"@ggsvelte/svelte": patch
+---
+
+Recover fill/color and single-row weight values from lineage for stat-aggregate bar tooltips so series identity and weights are not blank.

--- a/packages/svelte/src/lib/inspection/resolver.ts
+++ b/packages/svelte/src/lib/inspection/resolver.ts
@@ -254,42 +254,50 @@ function datum<Row extends Record<string, CellValue>, Key extends PropertyKey>(
   };
   /**
    * Recover a non-CandidateFacts field from lineage source rows.
-   * - fill/color/group: first source row only when every lineage row agrees
-   *   (discrete series identity is constant; continuous mappings can disagree).
-   * - Everything else (weight, …): only when lineage has exactly one row so
-   *   we do not invent an arbitrary sample of a multi-row aggregate.
+   * - fill/color/group when discrete (ordinal/manual/identity scale, or group):
+   *   first source row, O(1) — grouping makes the value constant.
+   * - fill/color when continuous (sequential/binned) and multi-row lineage:
+   *   null — continuous channels do not participate in grouping, so values
+   *   can disagree and we refuse to invent a series identity.
+   * - Everything else (weight, …): only when lineage has exactly one row.
    *
    * Indexes + first row are memoized for this datum so multi-field tooltips
    * do not re-materialize the same source row per channel.
    */
   let lineageIndexes: readonly number[] | undefined;
   let firstLineageRow: Record<string, CellValue> | null | undefined;
+  const seriesConstantByConstruction = (channel: string): boolean => {
+    if (channel === "group") return true;
+    if (channel !== "fill" && channel !== "color") return false;
+    const scale = channel === "fill" ? model.scales.fill : model.scales.color;
+    if (scale === null) return true;
+    return scale.kind === "ordinal" || scale.kind === "manual" || scale.kind === "identity";
+  };
   const lineageFieldValue = (channel: string, fieldName: string): CellValue => {
     lineageIndexes ??= model.lineage.keys(candidate.lineage);
     if (lineageIndexes.length === 0) return null;
     const seriesIdentity = channel === "fill" || channel === "color" || channel === "group";
-    if (!seriesIdentity && lineageIndexes.length !== 1) return null;
+    if (seriesIdentity) {
+      if (lineageIndexes.length > 1 && !seriesConstantByConstruction(channel)) return null;
+    } else if (lineageIndexes.length !== 1) {
+      return null;
+    }
     if (firstLineageRow === undefined) {
       firstLineageRow = model.row(lineageIndexes[0]!);
     }
     if (firstLineageRow === null) return null;
-    const first = firstLineageRow[fieldName] ?? null;
-    if (seriesIdentity && lineageIndexes.length > 1) {
-      for (let i = 1; i < lineageIndexes.length; i++) {
-        const other = model.row(lineageIndexes[i]!);
-        if (other === null || (other[fieldName] ?? null) !== first) return null;
-      }
-    }
-    return first;
+    return firstLineageRow[fieldName] ?? null;
   };
   const fields = (model.layerFields[candidate.layerIndex] ?? []).map((field) => {
     if (row !== null) {
       return { ...field, value: row[field.field] ?? null };
     }
     const fromCandidate = candidateValue(field.channel);
-    const value =
-      fromCandidate === undefined ? lineageFieldValue(field.channel, field.field) : fromCandidate;
-    return { ...field, value };
+    if (fromCandidate !== undefined) return { ...field, value: fromCandidate };
+    // Stat outputs are not source-table columns; a same-named source column
+    // would print an unrelated value.
+    if (field.source === "stat") return { ...field, value: null };
+    return { ...field, value: lineageFieldValue(field.channel, field.field) };
   });
   return Object.freeze({
     key,

--- a/packages/svelte/src/lib/inspection/resolver.ts
+++ b/packages/svelte/src/lib/inspection/resolver.ts
@@ -288,7 +288,7 @@ function datum<Row extends Record<string, CellValue>, Key extends PropertyKey>(
     }
     const fromCandidate = candidateValue(field.channel);
     const value =
-      fromCandidate !== undefined ? fromCandidate : lineageFieldValue(field.channel, field.field);
+      fromCandidate === undefined ? lineageFieldValue(field.channel, field.field) : fromCandidate;
     return { ...field, value };
   });
   return Object.freeze({

--- a/packages/svelte/src/lib/inspection/resolver.ts
+++ b/packages/svelte/src/lib/inspection/resolver.ts
@@ -254,18 +254,33 @@ function datum<Row extends Record<string, CellValue>, Key extends PropertyKey>(
   };
   /**
    * Recover a non-CandidateFacts field from lineage source rows.
-   * - Group-constant aesthetics (fill/color/group): first source row (O(1)).
+   * - fill/color/group: first source row only when every lineage row agrees
+   *   (discrete series identity is constant; continuous mappings can disagree).
    * - Everything else (weight, …): only when lineage has exactly one row so
    *   we do not invent an arbitrary sample of a multi-row aggregate.
+   *
+   * Indexes + first row are memoized for this datum so multi-field tooltips
+   * do not re-materialize the same source row per channel.
    */
+  let lineageIndexes: readonly number[] | undefined;
+  let firstLineageRow: Record<string, CellValue> | null | undefined;
   const lineageFieldValue = (channel: string, fieldName: string): CellValue => {
-    const indexes = model.lineage.keys(candidate.lineage);
-    if (indexes.length === 0) return null;
-    const groupConstant = channel === "fill" || channel === "color" || channel === "group";
-    if (!groupConstant && indexes.length !== 1) return null;
-    const src = model.row(indexes[0]!) as Row | null;
-    if (src === null) return null;
-    return (src[fieldName] as CellValue | undefined) ?? null;
+    lineageIndexes ??= model.lineage.keys(candidate.lineage);
+    if (lineageIndexes.length === 0) return null;
+    const seriesIdentity = channel === "fill" || channel === "color" || channel === "group";
+    if (!seriesIdentity && lineageIndexes.length !== 1) return null;
+    if (firstLineageRow === undefined) {
+      firstLineageRow = model.row(lineageIndexes[0]!);
+    }
+    if (firstLineageRow === null) return null;
+    const first = firstLineageRow[fieldName] ?? null;
+    if (seriesIdentity && lineageIndexes.length > 1) {
+      for (let i = 1; i < lineageIndexes.length; i++) {
+        const other = model.row(lineageIndexes[i]!);
+        if (other === null || (other[fieldName] ?? null) !== first) return null;
+      }
+    }
+    return first;
   };
   const fields = (model.layerFields[candidate.layerIndex] ?? []).map((field) => {
     if (row !== null) {

--- a/packages/svelte/src/lib/inspection/resolver.ts
+++ b/packages/svelte/src/lib/inspection/resolver.ts
@@ -229,7 +229,10 @@ function datum<Row extends Record<string, CellValue>, Key extends PropertyKey>(
     model.lineage.keys(candidate.lineage),
     keyAt,
   ) as Key[];
-  const candidateValue = (channel: string): CellValue => {
+  // CandidateFacts only bag position + size channels. Discrete series
+  // aesthetics (fill/color) and weight live on source rows; for stat
+  // aggregates those rows are reachable via lineage only (#1526).
+  const candidateValue = (channel: string): CellValue | undefined => {
     switch (channel) {
       case "x":
         return candidate.xValue;
@@ -246,13 +249,33 @@ function datum<Row extends Record<string, CellValue>, Key extends PropertyKey>(
       case "linetype":
         return candidate.linetypeValue;
       default:
-        return null;
+        return undefined;
     }
   };
-  const fields = (model.layerFields[candidate.layerIndex] ?? []).map((field) => ({
-    ...field,
-    value: row?.[field.field] ?? (row === null ? candidateValue(field.channel) : null),
-  }));
+  /**
+   * Recover a non-CandidateFacts field from lineage source rows.
+   * - Group-constant aesthetics (fill/color/group): first source row (O(1)).
+   * - Everything else (weight, …): only when lineage has exactly one row so
+   *   we do not invent an arbitrary sample of a multi-row aggregate.
+   */
+  const lineageFieldValue = (channel: string, fieldName: string): CellValue => {
+    const indexes = model.lineage.keys(candidate.lineage);
+    if (indexes.length === 0) return null;
+    const groupConstant = channel === "fill" || channel === "color" || channel === "group";
+    if (!groupConstant && indexes.length !== 1) return null;
+    const src = model.row(indexes[0]!) as Row | null;
+    if (src === null) return null;
+    return (src[fieldName] as CellValue | undefined) ?? null;
+  };
+  const fields = (model.layerFields[candidate.layerIndex] ?? []).map((field) => {
+    if (row !== null) {
+      return { ...field, value: row[field.field] ?? null };
+    }
+    const fromCandidate = candidateValue(field.channel);
+    const value =
+      fromCandidate !== undefined ? fromCandidate : lineageFieldValue(field.channel, field.field);
+    return { ...field, value };
+  });
   return Object.freeze({
     key,
     row,

--- a/packages/svelte/tests/inspection/resolve-snapshot.test.ts
+++ b/packages/svelte/tests/inspection/resolve-snapshot.test.ts
@@ -236,6 +236,137 @@ describe("inspection snapshot resolve", () => {
     model.dispose();
   });
 
+  it("recovers fill and weight from lineage for single-row stat bars (#1526)", () => {
+    // geom_bar + weight: candidates are aggregates (rowIndex null) but lineage
+    // still points at the source row that holds fill identity and weight.
+    const model = runPipeline(
+      {
+        data: {
+          values: [
+            { track: "1876", level: "Berks", deaths: 175 },
+            { track: "1876", level: "Herts", deaths: 174 },
+          ],
+        },
+        layers: [
+          {
+            geom: "bar",
+            position: "dodge",
+            aes: {
+              x: { field: "track" },
+              fill: { field: "level" },
+              weight: { field: "deaths" },
+            },
+          },
+        ],
+      },
+      { width: 400, height: 300 },
+    );
+    const seed = model.candidates.candidate(0)!;
+    expect(seed.rowIndex).toBeNull();
+    expect(seed.yValue).toBe(175);
+    const inspection = resolveInspection({
+      model,
+      seed,
+      mode: "exact",
+      state: "transient",
+      source: "pointer",
+      keyOf: () => null,
+    });
+    const byChannel = Object.fromEntries(
+      inspection.focus.fields.map((field) => [field.channel, field.value]),
+    );
+    expect(byChannel.fill).toBe("Berks");
+    expect(byChannel.weight).toBe(175);
+    expect(byChannel.y).toBe(175);
+    model.dispose();
+  });
+
+  it("recovers group-constant fill from multi-row bar lineage (#1526)", () => {
+    const model = runPipeline(
+      {
+        data: {
+          values: [
+            { track: "1876", level: "Berks" },
+            { track: "1876", level: "Berks" },
+            { track: "1876", level: "Herts" },
+          ],
+        },
+        layers: [
+          {
+            geom: "bar",
+            position: "dodge",
+            aes: {
+              x: { field: "track" },
+              fill: { field: "level" },
+            },
+          },
+        ],
+      },
+      { width: 400, height: 300 },
+    );
+    // Berks bar aggregates two rows; fill is still the series identity.
+    const berks = [...Array(model.candidates.size).keys()]
+      .map((id) => model.candidates.candidate(id)!)
+      .find((c) => c.yValue === 2)!;
+    expect(berks.rowIndex).toBeNull();
+    expect(model.lineage.count(berks.lineage)).toBe(2);
+    const inspection = resolveInspection({
+      model,
+      seed: berks,
+      mode: "exact",
+      state: "transient",
+      source: "pointer",
+      keyOf: () => null,
+    });
+    const fill = inspection.focus.fields.find((f) => f.channel === "fill");
+    expect(fill?.value).toBe("Berks");
+    model.dispose();
+  });
+
+  it("does not invent a weight when multi-row lineage weights differ (#1526)", () => {
+    // Prefer y (the aggregate) over a single arbitrary source weight.
+    const model = runPipeline(
+      {
+        data: {
+          values: [
+            { track: "1876", level: "Berks", deaths: 100 },
+            { track: "1876", level: "Berks", deaths: 75 },
+          ],
+        },
+        layers: [
+          {
+            geom: "bar",
+            aes: {
+              x: { field: "track" },
+              fill: { field: "level" },
+              weight: { field: "deaths" },
+            },
+          },
+        ],
+      },
+      { width: 400, height: 300 },
+    );
+    const seed = model.candidates.candidate(0)!;
+    expect(seed.rowIndex).toBeNull();
+    expect(model.lineage.count(seed.lineage)).toBe(2);
+    expect(seed.yValue).toBe(175);
+    const inspection = resolveInspection({
+      model,
+      seed,
+      mode: "exact",
+      state: "transient",
+      source: "pointer",
+      keyOf: () => null,
+    });
+    const byChannel = Object.fromEntries(
+      inspection.focus.fields.map((field) => [field.channel, field.value]),
+    );
+    expect(byChannel.fill).toBe("Berks");
+    expect(byChannel.weight).toBeNull();
+    expect(byChannel.y).toBe(175);
+    model.dispose();
+  });
+
   it("reads non-position candidate channels when the seed has no source row", () => {
     // Stat bins have null rowIndex; tooltip fields must still surface size /
     // linewidth / alpha / shape / linetype from the candidate bag, and map

--- a/packages/svelte/tests/inspection/resolve-snapshot.test.ts
+++ b/packages/svelte/tests/inspection/resolve-snapshot.test.ts
@@ -367,6 +367,50 @@ describe("inspection snapshot resolve", () => {
     model.dispose();
   });
 
+  it("does not invent fill when multi-row lineage fill values disagree (#1526)", () => {
+    // Continuous fill never participates in grouping, so a histogram bin's
+    // lineage can span rows with different fill values. Tooltip must not
+    // pick the first row's fill as if it described the whole bin.
+    const model = runPipeline(
+      {
+        data: {
+          values: [
+            { x: 1.1, heat: 10 },
+            { x: 1.2, heat: 90 },
+            { x: 5.0, heat: 40 },
+          ],
+        },
+        layers: [
+          {
+            geom: "histogram",
+            params: { bins: 2 },
+            aes: {
+              x: { field: "x" },
+              fill: { field: "heat" },
+            },
+          },
+        ],
+      },
+      { width: 400, height: 300 },
+    );
+    const multi = [...Array(model.candidates.size).keys()]
+      .map((id) => model.candidates.candidate(id)!)
+      .find((c) => model.lineage.count(c.lineage) > 1);
+    expect(multi).toBeDefined();
+    expect(multi!.rowIndex).toBeNull();
+    const inspection = resolveInspection({
+      model,
+      seed: multi!,
+      mode: "exact",
+      state: "transient",
+      source: "pointer",
+      keyOf: () => null,
+    });
+    const fill = inspection.focus.fields.find((f) => f.channel === "fill");
+    expect(fill?.value).toBeNull();
+    model.dispose();
+  });
+
   it("reads non-position candidate channels when the seed has no source row", () => {
     // Stat bins have null rowIndex; tooltip fields must still surface size /
     // linewidth / alpha / shape / linetype from the candidate bag, and map

--- a/packages/svelte/tests/inspection/resolve-snapshot.test.ts
+++ b/packages/svelte/tests/inspection/resolve-snapshot.test.ts
@@ -305,9 +305,9 @@ describe("inspection snapshot resolve", () => {
       { width: 400, height: 300 },
     );
     // Berks bar aggregates two rows; fill is still the series identity.
-    const berks = [...Array(model.candidates.size).keys()]
-      .map((id) => model.candidates.candidate(id)!)
-      .find((c) => c.yValue === 2)!;
+    const berks = Array.from({ length: model.candidates.size }, (_, id) =>
+      model.candidates.candidate(id)!,
+    ).find((c) => c.yValue === 2)!;
     expect(berks.rowIndex).toBeNull();
     expect(model.lineage.count(berks.lineage)).toBe(2);
     const inspection = resolveInspection({
@@ -393,9 +393,9 @@ describe("inspection snapshot resolve", () => {
       },
       { width: 400, height: 300 },
     );
-    const multi = [...Array(model.candidates.size).keys()]
-      .map((id) => model.candidates.candidate(id)!)
-      .find((c) => model.lineage.count(c.lineage) > 1);
+    const multi = Array.from({ length: model.candidates.size }, (_, id) =>
+      model.candidates.candidate(id)!,
+    ).find((c) => model.lineage.count(c.lineage) > 1);
     expect(multi).toBeDefined();
     expect(multi!.rowIndex).toBeNull();
     const inspection = resolveInspection({


### PR DESCRIPTION
## Summary

Fixes #1526. Stat-aggregate bars (`geom_bar` + `weight` / count) publish candidates with `rowIndex: null`. Tooltip field resolution only read CandidateFacts channels (`x`/`y`/`size`/…), so `fill` and `weight` from `layerFields` printed as `–` even when lineage still pointed at the source row that holds county and deaths.

### Validation

Minimal pipeline repro:

- layerFields: `fill→level`, `weight→deaths`, `y→count`
- candidate: `rowIndex: null`, `yValue: 175`, lineage → `{ level: "Berks", deaths: 175 }`
- before: fill/weight null; after: fill `"Berks"`, weight `175`

### Change

In `packages/svelte/src/lib/inspection/resolver.ts` `datum()`:

- Keep CandidateFacts channels as the primary source for aggregates
- Recover `fill` / `color` / `group` from the first lineage source row (group-constant by construction)
- Recover other non-fact channels (e.g. `weight`) only when lineage has exactly one source row — multi-row aggregates already expose the summed reading on `y`

## Test plan

- [x] `cd packages/svelte && bun x vitest run --project chromium tests/inspection/resolve-snapshot.test.ts` (17 pass)
- [x] Related inspection suites: lineage-source-keys, display-members, coordinator (46 pass)
- [ ] CI green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1532" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->