### PR TITLE
fix(examples): correct Inspect modes and hit targets after #1523

### DIFF
--- a/apps/docs/static/previews/provenance.json
+++ b/apps/docs/static/previews/provenance.json
@@ -48,12 +48,12 @@
     },
     "boxplot/by-category": {
       "filename": "boxplot-by-category-light.png",
-      "sourceSha256": "73da93d07cc9be59707a4fc0e90d93096ea830880ba16e114db66f28129619d2",
+      "sourceSha256": "1229307401f08687c5cbf9023070404678ae6f6a5f5199d6daddc93985fe3b52",
       "pngSha256": "2ea691d1e47b78191c4afdf04e1dff453811e44503fc2cf71564d6eccac4db8a"
     },
     "boxplot/violin": {
       "filename": "boxplot-violin-light.png",
-      "sourceSha256": "2e414410ff2be2c34b8472f31e3ed51e6b55bdaf3bb69fe323fab36ee8c463dd",
+      "sourceSha256": "0fb638e02d1d638273a80c943749acc340057590e15ee1adb9b8defb9436d7b8",
       "pngSha256": "f46358a2ce5822905cd7bb481003aa139b8ba06f80ca2d1e98294c7c7bc47823"
     },
     "col/basic": {
@@ -123,17 +123,17 @@
     },
     "errorbar/caps": {
       "filename": "errorbar-caps-light.png",
-      "sourceSha256": "94df4cf5017245ec82e5fa0f5141d547ce8c7c1b50c4af812f573275f88da090",
+      "sourceSha256": "9d97f71be8b46f29eb4c8d5b65cc3801864b8d2b933ba5948d1d338e6780ae0a",
       "pngSha256": "f232ca152874d8b4306b1c6439bdfb5dc0328acf66310d21bff65b5a459e6019"
     },
     "errorbar/mean-se": {
       "filename": "errorbar-mean-se-light.png",
-      "sourceSha256": "dc7265d8fe8f96cfa5371dacd1a83907ce9947979dca1a0e013e59fe5df97210",
+      "sourceSha256": "fc7e2c9d0c31d7094d3889040b1d46a9493d780e8350b376a85a83a6e4608f45",
       "pngSha256": "dc0de79b6f2f3269ebf5632b580708609faf09b470fad83a7c089aec00ac2a42"
     },
     "errorbar/summary-bin": {
       "filename": "errorbar-summary-bin-light.png",
-      "sourceSha256": "11dde7cbeabedc34ddc64666c387dff91f47dc0e08b5d1c8c1579d2f7896b6db",
+      "sourceSha256": "234e8ae817ff340a249bd62f8bde712acdec8cc3288f883f9db8e15e881bf94a",
       "pngSha256": "d7976f316ae4950012d6d3cdc93806c00f7145a168f617597123b1b61792adfe"
     },
     "facet/ordered-side-strips": {
@@ -238,7 +238,7 @@
     },
     "linerange/stems": {
       "filename": "linerange-stems-light.png",
-      "sourceSha256": "af2d594680083af373de229a8e3a076903e294c126a38848b73adb0131a986cd",
+      "sourceSha256": "0db971b6b8c5357f732d24f45f3c141371a8b0f4aab4d8df6ad188854f74683a",
       "pngSha256": "0958c1a7195d001f16489ac74d888c375752fa115d1ddf283328c0f0dee2f432"
     },
     "map/choropleth": {
@@ -258,7 +258,7 @@
     },
     "path/trajectory": {
       "filename": "path-trajectory-light.png",
-      "sourceSha256": "fade47e6bf58ddb65a52700da574703745dfb7deff8d5da13507233ba8ece350",
+      "sourceSha256": "506292c16c33bf5e7d821158fc95de53acc1c6b121de9f559d8d3ab26556b90c",
       "pngSha256": "2949dc19048c52de04fced10fa7a563726b70d02b5f091f35f84c7d8a7b7f157"
     },
     "point/abline-identity": {
@@ -333,7 +333,7 @@
     },
     "pointrange/midpoints": {
       "filename": "pointrange-midpoints-light.png",
-      "sourceSha256": "e23196233bdae64e23becabb64345cf1b32e74309167c3a73e5fb5a007ccc035",
+      "sourceSha256": "491bc48136511779595ba9bd583d16c7b7f771eed0bccdb1b711df18b47c9a3b",
       "pngSha256": "5c44493e2ba5b9da11cb83d536a95c567ea220ef9d106365af4e025474c2de91"
     },
     "polygon/regions": {

--- a/apps/docs/static/previews/provenance.json
+++ b/apps/docs/static/previews/provenance.json
@@ -128,12 +128,12 @@
     },
     "errorbar/mean-se": {
       "filename": "errorbar-mean-se-light.png",
-      "sourceSha256": "fc7e2c9d0c31d7094d3889040b1d46a9493d780e8350b376a85a83a6e4608f45",
+      "sourceSha256": "66226eae3a85dd6e98d5375c8344013f8206958c7120962cf3b7ef1eb63f9db4",
       "pngSha256": "dc0de79b6f2f3269ebf5632b580708609faf09b470fad83a7c089aec00ac2a42"
     },
     "errorbar/summary-bin": {
       "filename": "errorbar-summary-bin-light.png",
-      "sourceSha256": "234e8ae817ff340a249bd62f8bde712acdec8cc3288f883f9db8e15e881bf94a",
+      "sourceSha256": "644e0ef05574d7bb910201041f800015730d168566986bc5efdf9eade524665e",
       "pngSha256": "d7976f316ae4950012d6d3cdc93806c00f7145a168f617597123b1b61792adfe"
     },
     "facet/ordered-side-strips": {
@@ -258,7 +258,7 @@
     },
     "path/trajectory": {
       "filename": "path-trajectory-light.png",
-      "sourceSha256": "506292c16c33bf5e7d821158fc95de53acc1c6b121de9f559d8d3ab26556b90c",
+      "sourceSha256": "fae61f571f3751cad5d0b1383126a072d5441e91fac0cf052d9494bbebefb7c1",
       "pngSha256": "2949dc19048c52de04fced10fa7a563726b70d02b5f091f35f84c7d8a7b7f157"
     },
     "point/abline-identity": {

--- a/docs/audits/example-inspect-modes.md
+++ b/docs/audits/example-inspect-modes.md
@@ -1,0 +1,129 @@
+# Gallery Inspect mode inventory
+
+**Date:** 2026-08-07
+**Scope:** every `examples/**/Example.svelte` (live gallery charts)
+**Related:** #1529 (re-audit after #1523), #1528 (library auto-mode advisories)
+
+## Rules used
+
+1. **Mode** matches mark geometry and scale type: `exact` for discrete bars/boxes/intervals; `x` for continuous shared-x series; `xy` for scatters/paths with free 2d hits.
+2. **Layer eligibility:** decorative furniture (`GeomText` labels, map rivers, full-panel rects) sets `inspect={false}`.
+3. **Primary hits:** prefer one primary mark family unless multi-layer inspect is intentional and quiet.
+4. **Guardrail:** `scripts/example-interaction-api.test.ts` forbids freescrolling `mode="x"|"xy"` on the discrete-interval set and requires Minard opt-outs.
+
+## Fixed in this pass
+
+| Example                | Before                           | After                                                             |
+| ---------------------- | -------------------------------- | ----------------------------------------------------------------- |
+| `boxplot/violin`       | `mode="x"`                       | `mode="exact"`                                                    |
+| `boxplot/by-category`  | `mode="x"`                       | `mode="exact"`                                                    |
+| `errorbar/caps`        | `mode="x"`                       | `mode="exact"`                                                    |
+| `errorbar/mean-se`     | `mode="x"` + inspectable jitter  | `mode="exact"` + `inspect={false}` on points                      |
+| `errorbar/summary-bin` | `mode="x"` + inspectable scatter | `mode="exact"` + `inspect={false}` on points                      |
+| `pointrange/midpoints` | `mode="x"`                       | `mode="exact"`                                                    |
+| `linerange/stems`      | `mode="x"`                       | `mode="exact"`                                                    |
+| `path/trajectory`      | all layers hit                   | rivers + text `inspect={false}`; troops/cold path+point stay live |
+
+## Full inventory
+
+| id                            | mode(s)                                                   | pin | inspect=false count | judgment | note                                                     |
+| ----------------------------- | --------------------------------------------------------- | --- | ------------------- | -------- | -------------------------------------------------------- |
+| `area/basic`                  | `x`                                                       | yes | 0                   | pass     |                                                          |
+| `area/stacked`                | `x`                                                       | yes | 0                   | pass     |                                                          |
+| `bar/dodged`                  | `exact`                                                   | yes | 0                   | pass     |                                                          |
+| `bar/horizontal`              | `exact`                                                   | yes | 0                   | pass     |                                                          |
+| `bar/proportions`             | `exact`                                                   | yes | 0                   | pass     |                                                          |
+| `bar/stacked`                 | `exact`                                                   | yes | 0                   | pass     |                                                          |
+| `bin2d/basic`                 | `exact`                                                   | yes | 0                   | pass     |                                                          |
+| `blank/axes-only`             | `—`                                                       | —   | 0                   | n/a      | no hit targets                                           |
+| `blank/domain-expand`         | `xy maxDistance=24`                                       | yes | 0                   | pass     |                                                          |
+| `boxplot/by-category`         | `exact`                                                   | yes | 0                   | fixed    | mode/hit hygiene corrected                               |
+| `boxplot/violin`              | `exact`                                                   | yes | 0                   | fixed    | mode/hit hygiene corrected                               |
+| `col/basic`                   | `exact`                                                   | yes | 0                   | pass     |                                                          |
+| `col/long-labels`             | `exact`                                                   | yes | 0                   | pass     |                                                          |
+| `col/mixed-outlier-labels`    | `exact`                                                   | yes | 0                   | pass     |                                                          |
+| `col/theme-linedraw`          | `exact`                                                   | yes | 0                   | pass     |                                                          |
+| `col/value-labels`            | `exact`                                                   | yes | 0                   | pass     |                                                          |
+| `color/binned`                | `xy maxDistance=24`                                       | yes | 0                   | pass     |                                                          |
+| `contour/basic`               | `x`                                                       | yes | 0                   | pass     |                                                          |
+| `crossbar/boxes`              | `x`                                                       | yes | 0                   | pass     | mode=x allowlisted (category-center snap)                |
+| `curve/connectors`            | `xy maxDistance=24`                                       | yes | 0                   | pass     |                                                          |
+| `density/kde-2d`              | `xy maxDistance=24`                                       | yes | 0                   | pass     |                                                          |
+| `density/kde-2d-filled`       | `xy maxDistance=24`                                       | yes | 0                   | pass     |                                                          |
+| `density/overlay`             | `x`                                                       | yes | 0                   | pass     | continuous multi-series; mode=x is correct comparison UX |
+| `dotplot/histodot`            | `exact`                                                   | yes | 0                   | pass     |                                                          |
+| `errorbar/caps`               | `exact`                                                   | yes | 0                   | fixed    | mode/hit hygiene corrected                               |
+| `errorbar/mean-se`            | `exact`                                                   | yes | 1                   | fixed    | mode/hit hygiene corrected                               |
+| `errorbar/summary-bin`        | `exact`                                                   | yes | 1                   | fixed    | mode/hit hygiene corrected                               |
+| `facet/ordered-side-strips`   | `exact`                                                   | yes | 0                   | pass     |                                                          |
+| `facet/wrap`                  | `exact`                                                   | yes | 0                   | pass     |                                                          |
+| `facet/wrap-free-y`           | `x`                                                       | yes | 0                   | pass     |                                                          |
+| `freqpoly/basic`              | `x`                                                       | yes | 0                   | pass     |                                                          |
+| `hex/basic`                   | `exact`                                                   | yes | 0                   | pass     |                                                          |
+| `histogram/basic`             | `exact`                                                   | yes | 0                   | pass     |                                                          |
+| `hline/threshold`             | `xy maxDistance=24`                                       | yes | 0                   | pass     |                                                          |
+| `interaction/brush-zoom`      | `(default)`                                               | no  | 0                   | pass     |                                                          |
+| `interaction/facet-intervals` | `xy maxDistance=24`                                       | yes | 0                   | pass     |                                                          |
+| `interaction/legend-filter`   | `x`                                                       | yes | 0                   | pass     |                                                          |
+| `interaction/legend-focus`    | `xy maxDistance=24; xy maxDistance=24; xy maxDistance=24` | yes | 0                   | pass     |                                                          |
+| `interaction/linked-views`    | `xy maxDistance=24; xy maxDistance=24`                    | yes | 0                   | pass     |                                                          |
+| `interaction/tooltip`         | `x maxDistance=24`                                        | yes | 0                   | pass     |                                                          |
+| `jitter/basic`                | `xy maxDistance=24`                                       | yes | 0                   | pass     |                                                          |
+| `jitter/spread`               | `xy maxDistance=24`                                       | yes | 0                   | pass     |                                                          |
+| `label/basic`                 | `xy maxDistance=24`                                       | yes | 0                   | pass     |                                                          |
+| `line/ecdf`                   | `x`                                                       | yes | 0                   | pass     |                                                          |
+| `line/function`               | `x`                                                       | yes | 0                   | pass     |                                                          |
+| `line/multi-series`           | `x`                                                       | yes | 0                   | pass     |                                                          |
+| `line/time-axis`              | `x`                                                       | yes | 0                   | pass     |                                                          |
+| `linerange/stems`             | `exact`                                                   | yes | 0                   | fixed    | mode/hit hygiene corrected                               |
+| `map/choropleth`              | `exact`                                                   | yes | 0                   | pass     |                                                          |
+| `path/connect-hv`             | `xy maxDistance=24`                                       | yes | 0                   | pass     |                                                          |
+| `path/ellipse-rings`          | `xy maxDistance=24`                                       | yes | 0                   | pass     |                                                          |
+| `path/trajectory`             | `xy maxDistance=24; xy maxDistance=24`                    | yes | 4                   | fixed    | mode/hit hygiene corrected                               |
+| `point/abline-identity`       | `xy maxDistance=24`                                       | yes | 0                   | pass     |                                                          |
+| `point/count`                 | `exact`                                                   | yes | 0                   | pass     |                                                          |
+| `point/fixed-aspect`          | `xy maxDistance=24`                                       | yes | 0                   | pass     |                                                          |
+| `point/gradient-continuous`   | `xy maxDistance=24`                                       | yes | 0                   | pass     |                                                          |
+| `point/hue-discrete`          | `xy maxDistance=24`                                       | yes | 0                   | pass     |                                                          |
+| `point/jitter`                | `xy maxDistance=24`                                       | yes | 0                   | pass     |                                                          |
+| `point/layer-data-bands`      | `x`                                                       | yes | 0                   | pass     |                                                          |
+| `point/log-scale`             | `xy`                                                      | yes | 0                   | pass     |                                                          |
+| `point/quantile-lines`        | `xy maxDistance=24`                                       | yes | 0                   | pass     |                                                          |
+| `point/scatter-color`         | `xy maxDistance=24`                                       | yes | 0                   | pass     |                                                          |
+| `point/stat-manual-mean`      | `xy maxDistance=24`                                       | yes | 0                   | pass     |                                                          |
+| `point/stat-unique`           | `xy maxDistance=24`                                       | yes | 0                   | pass     |                                                          |
+| `point/steps-binned`          | `xy maxDistance=24`                                       | yes | 0                   | pass     |                                                          |
+| `point/void-chrome`           | `x`                                                       | yes | 0                   | pass     |                                                          |
+| `pointrange/midpoints`        | `exact`                                                   | yes | 0                   | fixed    | mode/hit hygiene corrected                               |
+| `polygon/regions`             | `exact`                                                   | yes | 0                   | pass     |                                                          |
+| `qq_line/match`               | `x`                                                       | yes | 0                   | pass     |                                                          |
+| `qq/cloud`                    | `xy maxDistance=24`                                       | yes | 0                   | pass     |                                                          |
+| `qq/normal`                   | `xy maxDistance=24`                                       | yes | 0                   | pass     |                                                          |
+| `raster/grid`                 | `exact`                                                   | yes | 0                   | pass     |                                                          |
+| `rect/regions`                | `x`                                                       | yes | 0                   | pass     |                                                          |
+| `ribbon/bounds`               | `x`                                                       | yes | 0                   | pass     |                                                          |
+| `ribbon/paint`                | `x`                                                       | yes | 0                   | pass     |                                                          |
+| `rug/ticks`                   | `exact`                                                   | yes | 0                   | pass     |                                                          |
+| `rule/annotation`             | `xy maxDistance=24`                                       | yes | 0                   | pass     |                                                          |
+| `rule/data-driven`            | `x`                                                       | yes | 0                   | pass     |                                                          |
+| `segment/annotations`         | `xy maxDistance=24`                                       | yes | 0                   | pass     |                                                          |
+| `sf/basic`                    | `exact`                                                   | yes | 0                   | pass     |                                                          |
+| `sf/boxed-labels`             | `exact`                                                   | yes | 0                   | pass     |                                                          |
+| `sf/geometry-collection`      | `exact`                                                   | yes | 0                   | pass     |                                                          |
+| `sf/holes`                    | `exact`                                                   | yes | 0                   | pass     |                                                          |
+| `sf/labels`                   | `exact`                                                   | yes | 0                   | pass     |                                                          |
+| `showcase/kyoto-sakura`       | `xy maxDistance=24`                                       | yes | 6                   | pass     |                                                          |
+| `smooth/loess-scatter`        | `xy maxDistance=24`                                       | yes | 0                   | pass     |                                                          |
+| `spoke/rays`                  | `xy maxDistance=24`                                       | yes | 0                   | pass     |                                                          |
+| `spoke/vector-field`          | `xy maxDistance=24`                                       | yes | 0                   | pass     |                                                          |
+| `step/ecdf`                   | `x`                                                       | yes | 0                   | pass     |                                                          |
+| `step/stairs`                 | `x`                                                       | yes | 0                   | pass     |                                                          |
+| `text/labels`                 | `xy maxDistance=24`                                       | yes | 0                   | pass     |                                                          |
+| `tile/heatmap`                | `exact`                                                   | yes | 0                   | pass     |                                                          |
+| `vline/cutoff`                | `xy maxDistance=24`                                       | yes | 0                   | pass     |                                                          |
+
+## Follow-ups
+
+- Library auto-mode + advisories for violin/interval geoms: #1528
+- Density tooltip series-centric field quality (mode kept as `x`; content quality is separate)
+- Skill guidance for mode selection: #1530

--- a/examples/boxplot/by-category/Example.svelte
+++ b/examples/boxplot/by-category/Example.svelte
@@ -17,7 +17,7 @@
   width={640}
   height={400}
 >
-  <Inspect mode="x" pin />
+  <Inspect mode="exact" pin />
   <ThemeFew />
   <ScaleXDiscrete domain={["Jun 5", "Jun 7", "Jun 9", "Jun 12", "Jul 2"]} />
   <Labs

--- a/examples/boxplot/violin/Example.svelte
+++ b/examples/boxplot/violin/Example.svelte
@@ -18,7 +18,7 @@
   width={640}
   height={400}
 >
-  <Inspect mode="x" pin />
+  <Inspect mode="exact" pin />
   <ThemeFew />
   <ScaleXDiscrete domain={["Jun 5", "Jun 7", "Jun 9", "Jun 12", "Jul 2"]} />
   <ScaleFillManual

--- a/examples/errorbar/caps/Example.svelte
+++ b/examples/errorbar/caps/Example.svelte
@@ -18,7 +18,7 @@
   width={640}
   height={400}
 >
-  <Inspect mode="x" pin />
+  <Inspect mode="exact" pin />
   <ThemeMinimal />
   <ScaleXDiscrete domain={["A", "B", "C"]} />
   <ScaleYContinuous limits={[0, 12]} />

--- a/examples/errorbar/mean-se/Example.svelte
+++ b/examples/errorbar/mean-se/Example.svelte
@@ -22,7 +22,7 @@
   width={640}
   height={400}
 >
-  <Inspect mode="x" pin />
+  <Inspect mode="exact" pin />
   <ThemeHrbr />
   <ScaleXDiscrete
     domain={["Control", "L-hyoscyamine", "L-hyoscine", "DL-hyoscine"]}
@@ -38,6 +38,7 @@
     positionParams={{ width: 0.12, height: 0, seed: 7 }}
     alpha={0.4}
     size={2.4}
+    inspect={false}
   />
   <GeomErrorbar stat="summary" width={0.35} linewidth={1.5} />
 </GGPlot>

--- a/examples/errorbar/mean-se/spec.ts
+++ b/examples/errorbar/mean-se/spec.ts
@@ -10,6 +10,7 @@ export default defineExample(
       positionParams: { width: 0.12, height: 0, seed: 7 },
       alpha: 0.4,
       size: 2.4,
+      inspect: false,
     })
     .geomErrorbar({ stat: "summary", width: 0.35, linewidth: 1.5 })
     // Control first, then the three hypnotics in the order Student tabulated

--- a/examples/errorbar/summary-bin/Example.svelte
+++ b/examples/errorbar/summary-bin/Example.svelte
@@ -22,7 +22,7 @@
   width={640}
   height={400}
 >
-  <Inspect mode="x" pin />
+  <Inspect mode="exact" pin />
   <ThemeClassic />
   <Labs
     title="Mean and standard error in each x class"
@@ -30,7 +30,7 @@
     x="Mid-parent height (inches)"
     y="Child height (inches)"
   />
-  <GeomPoint alpha={0.15} size={2.4} />
+  <GeomPoint alpha={0.15} size={2.4} inspect={false} />
   <GeomErrorbar
     stat="summary_bin"
     binwidth={1}

--- a/examples/errorbar/summary-bin/spec.ts
+++ b/examples/errorbar/summary-bin/spec.ts
@@ -7,7 +7,7 @@ export default defineExample(
   // summary_bin collapses each non-empty bin of x to mean ± se; the errorbar
   // and the line share one bin grid, so they mark the same eleven means.
   gg(galtonHeights, aes({ x: "parent", y: "child" }))
-    .geomPoint({ alpha: 0.15, size: 2.4 })
+    .geomPoint({ alpha: 0.15, size: 2.4, inspect: false })
     .geomErrorbar({
       stat: "summary_bin",
       binwidth: 1,

--- a/examples/linerange/stems/Example.svelte
+++ b/examples/linerange/stems/Example.svelte
@@ -18,7 +18,7 @@
   width={640}
   height={400}
 >
-  <Inspect mode="x" pin />
+  <Inspect mode="exact" pin />
   <ThemeMinimal />
   <ScaleXDiscrete domain={["A", "B", "C"]} />
   <ScaleYContinuous limits={[0, 12]} />

--- a/examples/path/trajectory/Example.svelte
+++ b/examples/path/trajectory/Example.svelte
@@ -52,6 +52,7 @@
       aes={{ x: "long", y: "lat", group: "river", color: { value: "#8fa8c0" } }}
       linewidth={0.8}
       alpha={0.7}
+      inspect={false}
     />
     <GeomPath
       data={minardTroops}
@@ -68,11 +69,13 @@
       aes={{ x: "lx", y: "ly", label: "city", color: { value: "#4a4237" } }}
       size={10}
       dy={-9}
+      inspect={false}
     />
     <GeomText
       data={minardStrengthLabels}
       aes={{ x: "long", y: "lat", label: "count", color: { value: "#6b5d4a" } }}
       size={9}
+      inspect={false}
     />
   </GGPlot>
 
@@ -96,6 +99,7 @@
       aes={{ x: "long", y: "temp", label: "date", color: { value: "#374151" } }}
       size={10}
       dy={-11}
+      inspect={false}
     />
   </GGPlot>
 </div>

--- a/examples/path/trajectory/spec.ts
+++ b/examples/path/trajectory/spec.ts
@@ -21,6 +21,7 @@ export default defineExample(
       aes: aes({ group: "river", color: { value: "#8fa8c0" } }),
       linewidth: 0.8,
       alpha: 0.7,
+      inspect: false,
     })
     .geomPath({
       aes: aes({
@@ -34,11 +35,13 @@ export default defineExample(
       aes: aes({ x: "lx", y: "ly", label: "city", color: { value: "#4a4237" } }),
       size: 10,
       dy: -9,
+      inspect: false,
     })
     .geomText({
       data: minardStrengthLabels,
       aes: aes({ label: "count", color: { value: "#6b5d4a" } }),
       size: 9,
+      inspect: false,
     })
     .scales({
       ...scaleXContinuous({ limits: [23.5, 38.2] }),

--- a/examples/pointrange/midpoints/Example.svelte
+++ b/examples/pointrange/midpoints/Example.svelte
@@ -18,7 +18,7 @@
   width={640}
   height={400}
 >
-  <Inspect mode="x" pin />
+  <Inspect mode="exact" pin />
   <ThemeMinimal />
   <ScaleXDiscrete domain={["A", "B", "C"]} />
   <ScaleYContinuous limits={[0, 12]} />

--- a/scripts/example-interaction-api.test.ts
+++ b/scripts/example-interaction-api.test.ts
@@ -118,4 +118,57 @@ describe("example interaction API (v0.20)", () => {
 
     expect(offenders).toEqual([]);
   });
+
+  /**
+   * Discrete / categorical interval and distribution examples must not use
+   * freescrolling axis-guide modes (`x` / `xy`). Those modes freescroll across
+   * category slots and blank x tooltip rows. Hit the mark geometry with
+   * `mode="exact"` instead (#1529).
+   *
+   * Continuous shared-x series (lines, areas, densities) keep `mode="x"`.
+   * `crossbar/boxes` is allowlisted: category-center snap makes `x` feel OK.
+   */
+  const DISCRETE_INTERVAL_EXACT = [
+    "boxplot/violin",
+    "boxplot/by-category",
+    "errorbar/caps",
+    "errorbar/mean-se",
+    "errorbar/summary-bin",
+    "pointrange/midpoints",
+    "linerange/stems",
+  ] as const;
+
+  for (const id of DISCRETE_INTERVAL_EXACT) {
+    it(`${id}: uses mode="exact" (not freescrolling x/xy) on categorical/interval charts`, () => {
+      const path = join(EXAMPLES, id, "Example.svelte");
+      const source = readFileSync(path, "utf8");
+      expect(source).toMatch(/<Inspect\b[^>]*\bmode=["']exact["']/);
+      expect(source).not.toMatch(/<Inspect\b[^>]*\bmode=["']x["']/);
+      expect(source).not.toMatch(/<Inspect\b[^>]*\bmode=["']xy["']/);
+    });
+  }
+
+  it("errorbar/mean-se: jitter background points are not hit targets", () => {
+    const source = readFileSync(join(EXAMPLES, "errorbar/mean-se/Example.svelte"), "utf8");
+    // GeomPoint carries inspect={false}; the summary errorbar remains inspectable.
+    expect(source).toMatch(/<GeomPoint[\s\S]*?inspect=\{false\}/);
+  });
+
+  it("errorbar/summary-bin: raw scatter is not a hit target", () => {
+    const source = readFileSync(join(EXAMPLES, "errorbar/summary-bin/Example.svelte"), "utf8");
+    expect(source).toMatch(/<GeomPoint[\s\S]*?inspect=\{false\}/);
+  });
+
+  it("path/trajectory: decorative rivers and text labels opt out of inspection", () => {
+    const source = readFileSync(join(EXAMPLES, "path/trajectory/Example.svelte"), "utf8");
+    // River furniture (campaignRivers) and every GeomText (city/strength/date labels)
+    // must set inspect={false}. Troop path + cold path/point stay inspectable.
+    const riverBlock = source.match(/<GeomPath[\s\S]*?data=\{campaignRivers\}[\s\S]*?\/>/);
+    expect(riverBlock?.[0] ?? "").toContain("inspect={false}");
+    const textBlocks = source.match(/<GeomText[\s\S]*?\/>/g) ?? [];
+    expect(textBlocks.length).toBeGreaterThanOrEqual(3);
+    for (const block of textBlocks) {
+      expect(block).toContain("inspect={false}");
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #1529.

[#1523](https://github.com/ljodea/ggsvelte/pull/1523) made every live gallery chart interactive with a mechanical family-to-mode table. That left discrete interval and distribution examples on `mode="x"` (freescrolling x-guide over category slots, blank x tooltip rows) and left Minard rivers/labels as hit targets.

### Validation

On `main` before this PR:

| Example | Problem |
|---------|---------|
| `boxplot/violin`, `boxplot/by-category` | `mode="x"` + discrete run labels |
| `errorbar/caps`, `mean-se` | `mode="x"` + discrete groups; raw points steal hits |
| `errorbar/summary-bin` | `mode="x"` + dense raw scatter under summary |
| `pointrange/midpoints`, `linerange/stems` | same discrete interval family |
| `path/trajectory` | rivers + city/strength/date text all inspectable under `mode="xy"` |

Guardrail `scripts/example-interaction-api.test.ts` only asserted that `<Inspect` was present.

### Changes

- Discrete/interval charts use `mode="exact"` so hits land on mark geometry
- `errorbar/mean-se` and `errorbar/summary-bin`: `inspect={false}` on background points so the summary is the primary target
- Minard: `inspect={false}` on rivers and all `GeomText`; troop path and cold path/points stay inspectable
- `density/overlay` keeps `mode="x"` (continuous multi-series comparison UX); inventory notes this as pass
- `crossbar/boxes` keeps `mode="x"` (category-center snap still feels right)
- Guardrail tests lock the discrete-interval set and Minard opt-outs
- Full inventory: `docs/audits/example-inspect-modes.md`
- Rehashed gallery preview provenance source digests only (idle PNGs unchanged; Inspect is hover chrome)

No package runtime changes. No changeset (examples/docs only).

### Test plan

- [x] `bun test scripts/example-interaction-api.test.ts` (199 pass)
- [x] `bun test scripts/example-theme-parity.test.ts` (pass)
- [x] `bun run gallery:previews:check` (current)

### Follow-ups

- #1528 library auto-mode / advisories for violin and interval geoms
- #1530 skill guidance for mode selection
- Density tooltip field content quality (mode is correct; content is separate)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1533" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->