### PR TITLE
fix(core): align radial axis ticks with expand:false scales

### DIFF
--- a/.changeset/coord-radial-tick-expand-false.md
+++ b/.changeset/coord-radial-tick-expand-false.md
@@ -1,0 +1,5 @@
+---
+"@ggsvelte/core": patch
+---
+
+Remap radial layout axis ticks through `scalesForCoordExpand` so expand:false / theta·r limits match sector fill (not the padded trained domain).

--- a/packages/core/src/pipeline/finalize-layout-pass.ts
+++ b/packages/core/src/pipeline/finalize-layout-pass.ts
@@ -5,6 +5,7 @@ import type { CellValue, CoordRadialSpec, PortableSpec } from "@ggsvelte/spec";
 import { getTemporalRuntime } from "../temporal-runtime.js";
 
 import { buildPolarProjector } from "../coord-polar.js";
+import { scalesForCoordExpand } from "../coord-projector.js";
 import { perfMark, perfMeasure } from "../perf.js";
 import type { ThemeTokens } from "../theme.js";
 
@@ -138,6 +139,28 @@ export function finalizePanelLayoutPass(input: {
     guides: normalized.guides,
   });
 
+  // Radial expand:false / theta·r limits remaps geometry via scalesForCoordExpand
+  // (assemble-geometry-batches). Layout ticks and displayScales must use the same
+  // remapped domains so cartesian chrome describes the arc that sectors fill
+  // (#1514). Polar-aware guide_axis_theta remains deferred v1 work.
+  const radialCoord = normalized.coord?.type === "radial" ? normalized.coord : undefined;
+  const panelScalesForLayout =
+    radialCoord === undefined
+      ? panelScales
+      : panelScales.map((scales) =>
+          scalesForCoordExpand(scales, radialCoord.expand !== false, {
+            theta: radialCoord.theta === "y" ? "y" : "x",
+            ...(radialCoord.thetaLimits !== undefined &&
+              radialCoord.thetaLimits.length === 2 && {
+                thetaLimits: [radialCoord.thetaLimits[0]!, radialCoord.thetaLimits[1]!] as const,
+              }),
+            ...(radialCoord.rLimits !== undefined &&
+              radialCoord.rLimits.length === 2 && {
+                rLimits: [radialCoord.rLimits[0]!, radialCoord.rLimits[1]!] as const,
+              }),
+          }),
+        );
+
   perfMark("ggsvelte:layout:start");
   let panelLayout: PanelLayoutResult;
   try {
@@ -159,7 +182,7 @@ export function finalizePanelLayoutPass(input: {
       ncol,
       facetPanels,
       strip,
-      panelScales,
+      panelScales: panelScalesForLayout,
       allFrames,
       hGuide: flip ? yGuide : xGuide,
       vGuide: flip ? xGuide : yGuide,

--- a/packages/core/tests/pipeline-coord-radial.test.ts
+++ b/packages/core/tests/pipeline-coord-radial.test.ts
@@ -192,6 +192,8 @@ describe("coord_radial pipeline", () => {
     // Stacked pie: y evidence is [0, 6]. expand:false remaps geometry and
     // panel domains to that span; cartesian chrome must not still tick the
     // padded trained domain (e.g. [-0.3, 6.3]) with inset endpoint positions.
+    // Explicit breaks pin endpoints so the assertion does not depend on the
+    // continuous break algorithm choosing 0 and 6.
     const model = runPipeline(
       gg(
         [
@@ -202,6 +204,7 @@ describe("coord_radial pipeline", () => {
         aes({ x: "pie", y: "n", fill: "cat" }),
       )
         .geomCol({ width: 1, position: "stack" })
+        .scales({ y: { breaks: [0, 6] } })
         .coordRadial({ theta: "y", expand: false })
         .spec(),
       size,

--- a/packages/core/tests/pipeline-coord-radial.test.ts
+++ b/packages/core/tests/pipeline-coord-radial.test.ts
@@ -187,4 +187,43 @@ describe("coord_radial pipeline", () => {
     expect(inverted.x).toBeUndefined();
     expect(inverted.y).toBeUndefined();
   });
+
+  it("aligns expand:false axis ticks with evidence domain (not padded range)", () => {
+    // Stacked pie: y evidence is [0, 6]. expand:false remaps geometry and
+    // panel domains to that span; cartesian chrome must not still tick the
+    // padded trained domain (e.g. [-0.3, 6.3]) with inset endpoint positions.
+    const model = runPipeline(
+      gg(
+        [
+          { pie: "all", cat: "a", n: 1 },
+          { pie: "all", cat: "b", n: 2 },
+          { pie: "all", cat: "c", n: 3 },
+        ],
+        aes({ x: "pie", y: "n", fill: "cat" }),
+      )
+        .geomCol({ width: 1, position: "stack" })
+        .coordRadial({ theta: "y", expand: false })
+        .spec(),
+      size,
+    );
+    const panel = model.scene.panels[0]!;
+    const panelDomainY = model.domains.effective.panels[0]?.y;
+    expect(panelDomainY).toEqual([0, 6]);
+
+    const ticksY = panel.axisY ?? [];
+    expect(ticksY.length).toBeGreaterThan(0);
+    for (const tick of ticksY) {
+      if (typeof tick.value !== "number") continue;
+      expect(tick.value).toBeGreaterThanOrEqual(0);
+      expect(tick.value).toBeLessThanOrEqual(6);
+    }
+
+    const lo = ticksY.find((t) => t.value === 0);
+    const hi = ticksY.find((t) => t.value === 6);
+    expect(lo).toBeDefined();
+    expect(hi).toBeDefined();
+    // fromEnd y: value 0 → bottom edge, value 6 → top edge under remapped scale.
+    expect(lo!.pos).toBeCloseTo(panel.height, 0);
+    expect(hi!.pos).toBeCloseTo(0, 0);
+  });
 });


### PR DESCRIPTION
## Summary

- Layout was building axis ticks from padded trained panel scales while polar geometry remapped through `scalesForCoordExpand`. With `coordRadial({ expand: false })` (or theta/r limits), cartesian chrome endpoints no longer sat at the evidence-domain edges that sectors fill.
- Pass the same remapped panel scales into `layoutPanels` so tick values and positions match panel domains and geometry.
- Polar-aware `guide_axis_theta` remains deferred v1 work (as scoped in #1514).

Fixes #1514

## Test plan

- [x] `bun test packages/core/tests/pipeline-coord-radial.test.ts` — includes new expand:false tick vs domain agreement test
- [x] Related coord suite (fixed / transform / radial projector) green
- [ ] CI green

## Review

Subagent adversarial + testing/maintainability reviews: ship. DRY triple call-site of `scalesForCoordExpand` noted as follow-up debt; free facets still rejected for radial; expand:true remains a no-op.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1537" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->