### PR TITLE
docs(skill): teach inspect mode selection and multi-layer hit hygiene

### DIFF
--- a/.changeset/skill-inspect-mode-hygiene.md
+++ b/.changeset/skill-inspect-mode-hygiene.md
@@ -1,0 +1,14 @@
+---
+"@ggsvelte/skill": patch
+---
+
+# Teach inspect mode selection and multi-layer hit hygiene
+
+Migration: none — skill reference prose only; no API change.
+
+Expand `references/interactions.md` and the SKILL.md Interactions pointer so
+agents prefer `mode="auto"` when product auto matches geometry, pin
+`mode="exact"` on violin / boxplot / discrete error bars (auto still freescrolls
+those until #1528), mark decorative furniture `inspect={false}` (Minard-class
+multi-layer hits), and verify hover/pin outside the CLI SVG loop. Records
+keep-single skill packaging for #1530.

--- a/packages/skill/SKILL.md
+++ b/packages/skill/SKILL.md
@@ -302,10 +302,17 @@ Override with `identity` on `<Inspect>`, object-form `select`, or
 (for example `<Inspect identity="year" />`). Plot-level `key` is deprecated
 since 0.21. Link plots by sharing one `createPlotInteraction()` controller
 and matching `interactionScope` channels; observe everything through
-`oninteraction` or per-capability handlers. Faceted interval presets, the
-controller API, `Tooltip`, handler payloads, and diagnostics:
-[references/interactions.md](references/interactions.md) — read it before
-writing any interactive or linked-view code.
+`oninteraction` or per-capability handlers.
+
+**Inspect mode and hit hygiene:** prefer `mode="auto"` when library auto matches
+the mark; pin `mode="exact"` on violin, boxplot, and discrete-axis error bars
+(product auto still freescrolls those — do not leave bare `auto`); use
+`x`/`y`/`xy` only for continuous shared-axis or free 2d hits; set
+`inspect={false}` on decorative layers in multi-layer stories. The CLI SVG
+loop cannot validate host inspect mode — hover/pin in a browser after edits.
+Read [references/interactions.md](references/interactions.md) (Choosing inspect
+mode, Multi-layer hit hygiene) before enabling Inspect or writing interactive
+or linked-view code.
 
 ## Pointers
 

--- a/packages/skill/references/interactions.md
+++ b/packages/skill/references/interactions.md
@@ -36,6 +36,82 @@ Layers are inspectable by default. Set `inspect={false}` on a geom (or
 full-panel rects never become tooltip targets (#1065 / #1068). This is portable
 and unrelated to the host `<Inspect>` capability.
 
+## Choosing inspect mode
+
+`mode` is a **host** option on `<Inspect>` (and the dual-read plot `inspect`
+alias). It is **not** a PortableSpec field. Empty `<Inspect />` defaults to
+`mode="auto"`. Auto is safe for many mark families (bar/col → exact; continuous
+lines → x), but **not** for discrete distribution and interval geoms — product
+auto still resolves those to freescrolling `x` (library fix tracked as #1528).
+Until that ships, pin an explicit mode when geometry needs it.
+
+### Default preference
+
+1. Prefer `mode="auto"` when library auto matches the mark (bar, col, tile, point,
+   continuous line/area/freqpoly). Prefer an explicit mode when you know the
+   geometry better than auto, or when auto is still wrong for the mark (below).
+2. Use `mode="x"` only for continuous shared-x series: time series, multi-series
+   lines/areas/freqpolys at a common continuous x, stacked continuous areas.
+3. Use `mode="y"` only when the shared continuous axis is vertical and grouping
+   by y is the product intent.
+4. Use `mode="xy"` for free 2d hits (scatters, paths, maps, jitter clouds) when
+   nearest-point inspection is better than snapping to one axis.
+5. **Pin `mode="exact"`** on violin, boxplot, and discrete-axis errorbar /
+   pointrange / linerange. Do **not** leave `auto` for those marks while product
+   auto still maps them to freescrolling `x` (#1528).
+
+### Anti-patterns (do not ship these)
+
+| Pattern                                                                                          | Why it is wrong                                                                                    | Use instead                                               |
+| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| Violin with `mode="x"` / `"y"` / `"xy"`, or bare `auto`                                          | Categorical run labels get freescrolling axis guides and blank axis tooltip rows; auto still → `x` | Pin `mode="exact"`                                        |
+| Boxplot with `mode="x"` / `"y"` / `"xy"`, or bare `auto`                                         | Same discrete-group problem as violin                                                              | Pin `mode="exact"`                                        |
+| Discrete-axis errorbar / pointrange / linerange with `mode="x"` / `"y"` / `"xy"`, or bare `auto` | Caps and intervals are not continuous shared-x series; auto still → `x`                            | Pin `mode="exact"`                                        |
+| Bar / col with explicit `mode="x"` or `"xy"`                                                     | Vertical guide cuts filled bands; library already advises exact/auto                               | `mode="exact"` or leave `auto` (auto → exact for bar/col) |
+| Copying a gallery family's mode without reading the mark geometry                                | Family-to-mode tables go stale; geometry decides                                                   | Match scale type + mark geometry                          |
+
+Treat **violin, boxplot, and discrete-axis errorbar / pointrange / linerange**
+the same: pin `exact` unless product auto is fixed and this skill is updated in
+lock-step. When in doubt on other geoms, ship `auto`.
+
+## Multi-layer hit hygiene
+
+Every inspectable layer competes for pointer hits. Decorative furniture that
+stays hit-testable steals focus from the data story.
+
+Rules:
+
+1. Mark decorative layers `inspect={false}`: rivers, annotation labels, full-panel
+   rects, value labels that are only visual guides, background rugs, and similar
+   non-primary marks.
+2. For multi-layer maps and stories (**Minard-class** charts), keep **one primary
+   inspectable mark family** on the map panel (troop path only). Furniture stays
+   quiet with `inspect={false}` (rivers, city labels, strength text).
+3. When a summary layer sits on a raw scatter (mean–SE errorbar over points), prefer
+   inspecting the summary and set `inspect={false}` on the background cloud unless
+   both layers are intentional hit targets.
+
+Gallery reference: `examples/path/trajectory` (Minard's 1812 map) keeps rivers and
+city/strength text opted out on the map panel so only the troop path is live; the
+cold panel intentionally keeps both path and point inspectable.
+
+## CLI cannot catch host inspect behaviour
+
+`ggsvelte-render` validates PortableSpec and prints pipeline warnings/advisories
+on stderr. It does **not** validate host Inspect mode, tooltip content, or which
+layers steal hover hits. Layer `"inspect": false` is portable and can appear in
+the JSON loop; **mode is not**. Agents that only re-render SVG never see blank
+x-rows, freescrolling guides, or noisy multi-layer hits.
+
+After changing interaction, verify with a **real hover and pin** (docs site,
+playground, or browser test) — not only `ggsvelte-render` / an SVG dump. Read
+this file before enabling Inspect on any chart.
+
+**Skill packaging decision (#1530):** keep a **single skill** (`@ggsvelte/skill`)
+for both PortableSpec agents and Svelte app agents. Do not split until progressive
+disclosure fails (agents ignore `references/`, or the frontmatter description
+cannot route both audiences).
+
 ## Capability props
 
 | Prop / surface | Input                                                                    | What it enables                                                                                                                                                                                                                                                                                                                                                                            |

--- a/scripts/skill-content.test.ts
+++ b/scripts/skill-content.test.ts
@@ -358,3 +358,103 @@ describe("SKILL.md lead-line scheme/theme inventory matches registries", () => {
     expect(missing).toEqual([]);
   });
 });
+
+/**
+ * #1530: Inspect mode selection + multi-layer hit hygiene.
+ *
+ * API surface (mode options, inspect={false}) is already documented. Agents
+ * still ship wrong modes (violin with mode="x", Minard with hit-testable
+ * rivers) because the skill never said "do not do that." CLI SVG render
+ * cannot catch host Inspect mode — only the skill + a real hover check can.
+ * These contracts lock the design rules so skill content stays the gate.
+ */
+describe("skill teaches inspect mode selection and hit hygiene (#1530)", () => {
+  const skill = readFileSync(join(SKILL_DIR, "SKILL.md"), "utf8");
+  const interactions = FILES.find((f) => f.name === "references/interactions.md");
+
+  it("interactions.md has a Choosing inspect mode section", () => {
+    expect(interactions).toBeDefined();
+    expect(interactions!.markdown).toMatch(/## Choosing inspect mode/i);
+  });
+
+  it("Choosing inspect mode prefers auto when product auto matches geometry", () => {
+    const section = interactions!.markdown.match(/## Choosing inspect mode[\s\S]*?(?=\n## )/)?.[0];
+    expect(section).toBeDefined();
+    expect(section!).toMatch(/Prefer `mode="auto"` when library auto matches/);
+    // Axis-group modes only when continuous shared-x (or y) series justify them.
+    expect(section!).toMatch(/continuous shared-x|time series|multi-series/i);
+  });
+
+  it("pins exact on violin/boxplot/discrete intervals; forbids relying on auto there", () => {
+    const section = interactions!.markdown.match(/## Choosing inspect mode[\s\S]*?(?=\n## )/)?.[0];
+    expect(section).toBeDefined();
+    expect(section!).toMatch(/Anti-patterns/);
+    // Discrete distribution/interval geoms: pin exact; do not leave auto (#1528).
+    expect(section!).toMatch(/Pin `mode="exact"`/);
+    expect(section!).toMatch(/Violin with `mode="x"`/);
+    expect(section!).toMatch(/Boxplot with `mode="x"`/);
+    expect(section!).toMatch(/errorbar/);
+    expect(section!).toMatch(/pointrange/);
+    expect(section!).toMatch(/linerange/);
+    expect(section!).toMatch(/Do \*\*not\*\* leave `auto`|do \*\*not\*\* leave `auto`|#1528/);
+    // Use-instead cells must not recommend bare auto for those geoms.
+    expect(section!).not.toMatch(/Pin `mode="exact"` or leave `auto`/);
+    expect(section!).not.toMatch(/\| `mode="exact"` or leave `auto` \|/);
+  });
+
+  it("documents multi-layer hit hygiene with Minard-class furniture opt-out", () => {
+    const section = interactions!.markdown.match(
+      /## Multi-layer hit hygiene[\s\S]*?(?=\n## )/,
+    )?.[0];
+    expect(section).toBeDefined();
+    expect(section!).toMatch(/inspect=\{false\}/);
+    expect(section!).toMatch(/Minard/);
+    expect(section!).toMatch(/path\/trajectory/);
+    expect(section!).toMatch(/one primary[\s*]+inspectable mark family/);
+    expect(section!).toMatch(/troop path/);
+    expect(section!).toMatch(/summary/i);
+  });
+
+  it("notes that CLI SVG render does not validate host inspect behaviour", () => {
+    const section = interactions!.markdown.match(
+      /## CLI cannot catch host inspect behaviour[\s\S]*?(?=\n## )/,
+    )?.[0];
+    expect(section).toBeDefined();
+    expect(section!).toMatch(/ggsvelte-render/);
+    expect(section!).toMatch(
+      /does \*\*not\*\* validate host Inspect mode|does not validate host Inspect mode/i,
+    );
+  });
+
+  it("requires a real hover/pin check after changing interaction (not SVG-only)", () => {
+    const section = interactions!.markdown.match(
+      /## CLI cannot catch host inspect behaviour[\s\S]*?(?=\n## )/,
+    )?.[0];
+    expect(section).toBeDefined();
+    expect(section!).toMatch(/real hover and pin/i);
+    expect(section!).toMatch(/docs site|playground|browser/i);
+  });
+
+  it("SKILL.md Interactions section points at mode selection and hit hygiene rules", () => {
+    // One short pointer, not a second full copy of the reference.
+    const interactionsSection = skill.match(/## Interactions[\s\S]*?(?=\n## )/)?.[0] ?? "";
+    expect(interactionsSection.length).toBeGreaterThan(100);
+    expect(interactionsSection).toMatch(/references\/interactions\.md/);
+    expect(interactionsSection).toMatch(/Choosing inspect\s+mode/);
+    expect(interactionsSection).toMatch(/pin `mode="exact"` on violin/i);
+    expect(interactionsSection).toMatch(/inspect=\{false\}/);
+    expect(interactionsSection).toMatch(/before enabling Inspect/);
+  });
+
+  it("records keep-single skill (no split) decision for #1530", () => {
+    // Default remains one @ggsvelte/skill until progressive disclosure fails.
+    // Recorded in interactions.md so the decision travels with the package.
+    const section = interactions!.markdown.match(
+      /## CLI cannot catch host inspect behaviour[\s\S]*?(?=\n## )/,
+    )?.[0];
+    expect(section).toBeDefined();
+    expect(section!).toMatch(/Skill packaging decision \(#1530\)/);
+    expect(section!).toMatch(/single skill/);
+    expect(section!).toMatch(/Do not split/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1530. Agents could load `@ggsvelte/skill` and still ship freescrolling `mode="x"` on violin/boxplot or multi-layer maps with hit-testable furniture, because the skill documented Inspect APIs but not when each mode is legitimate. `ggsvelte-render` cannot catch host Inspect mode (not a PortableSpec field).

## Changes

- **`references/interactions.md`:** Choosing inspect mode (prefer auto when product auto matches; pin `exact` on violin/boxplot/discrete intervals while #1528 is open); multi-layer hit hygiene (Minard `path/trajectory`); CLI cannot catch host inspect; keep-single skill decision.
- **`SKILL.md`:** Short Interactions pointer to those rules (not a second full copy).
- **`scripts/skill-content.test.ts`:** Content contracts for the above (#1530 suite).
- **Changeset:** `@ggsvelte/skill` patch.

## Review feedback addressed before open

Subagent adversarial review caught that product `auto` still maps violin/boxplot/errorbar to freescrolling `x` (`candidateAutoMode`). First draft said leave auto; corrected to pin `exact` and name #1528. Minard example fixed to troop path only (no invented strength points). Tests tightened to section-scoped contracts.

## Test plan

- [x] `bun test scripts/skill-content.test.ts scripts/skill-trigger.test.ts scripts/skill-package.test.ts` (76 pass)
- [x] Pre-commit oxfmt / prettier / markdownlint / oxlint
- [ ] CI green on the PR

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1540" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->