### PR TITLE
feat(cli): emit interaction inspect advisories via --inspect

### DIFF
--- a/.changeset/cli-inspect-intent.md
+++ b/.changeset/cli-inspect-intent.md
@@ -12,10 +12,11 @@ Agents that only run `ggsvelte-render` never saw inspect×geom advisories
 `ondiagnostic`. Inspect mode stays host-only (not PortableSpec).
 
 - `ggsvelte-render --inspect auto|exact|x|y|xy` declares host intent and emits
-  the same pure collector codes on stderr with `source: "interaction"`.
+  bar/col x-guide pure-collector codes on stderr with `source: "interaction"`.
 - Pure collectors and catalog messages for those codes live in `@ggsvelte/core`
   (`collectInspectIntentDiagnostics`, `INSPECT_GEOM_DIAGNOSTIC_CATALOG`); the
   Svelte host re-exports them so host and CLI share one implementation.
+- Alias geoms (`histogram`→`bar`) are rewritten so CLI matches host normalize.
 - Skill + CLI README document what the CLI covers vs host-only interaction.
 
 Migration: none — additive. Default render without `--inspect` is unchanged.

--- a/.changeset/cli-inspect-intent.md
+++ b/.changeset/cli-inspect-intent.md
@@ -1,0 +1,21 @@
+---
+"@ggsvelte/core": minor
+"@ggsvelte/cli": minor
+"@ggsvelte/svelte": minor
+"@ggsvelte/skill": minor
+---
+
+# CLI host inspect intent (`--inspect`) closes the agent interaction gap
+
+Agents that only run `ggsvelte-render` never saw inspect×geom advisories
+(`INTERACTION_INSPECT_X_ON_COL`, …) because those fired only through Svelte
+`ondiagnostic`. Inspect mode stays host-only (not PortableSpec).
+
+- `ggsvelte-render --inspect auto|exact|x|y|xy` declares host intent and emits
+  the same pure collector codes on stderr with `source: "interaction"`.
+- Pure collectors and catalog messages for those codes live in `@ggsvelte/core`
+  (`collectInspectIntentDiagnostics`, `INSPECT_GEOM_DIAGNOSTIC_CATALOG`); the
+  Svelte host re-exports them so host and CLI share one implementation.
+- Skill + CLI README document what the CLI covers vs host-only interaction.
+
+Migration: none — additive. Default render without `--inspect` is unchanged.

--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -607,6 +607,11 @@ export const DOCS_ROUTES = [
         level: 3,
       },
       {
+        id: "inspect",
+        title: "--inspect",
+        level: 3,
+      },
+      {
         id: "version",
         title: "--version",
         level: 3,
@@ -11044,6 +11049,11 @@ export const DOCS_ROUTES = [
         level: 3,
       },
       {
+        id: "interaction-inspect-high-cardinality-discrete",
+        title: "INTERACTION_INSPECT_HIGH_CARDINALITY_DISCRETE",
+        level: 3,
+      },
+      {
         id: "interaction-inspect-identity-dropped",
         title: "INTERACTION_INSPECT_IDENTITY_DROPPED",
         level: 3,
@@ -11051,11 +11061,6 @@ export const DOCS_ROUTES = [
       {
         id: "interaction-duplicate-inspect-capability",
         title: "INTERACTION_DUPLICATE_INSPECT_CAPABILITY",
-        level: 3,
-      },
-      {
-        id: "interaction-inspect-high-cardinality-discrete",
-        title: "INTERACTION_INSPECT_HIGH_CARDINALITY_DISCRETE",
         level: 3,
       },
       {
@@ -12107,6 +12112,11 @@ export const DOCS_ROUTES = [
         level: 3,
       },
       {
+        id: "interaction-inspect-high-cardinality-discrete",
+        title: "INTERACTION_INSPECT_HIGH_CARDINALITY_DISCRETE",
+        level: 3,
+      },
+      {
         id: "interaction-inspect-identity-dropped",
         title: "INTERACTION_INSPECT_IDENTITY_DROPPED",
         level: 3,
@@ -12114,11 +12124,6 @@ export const DOCS_ROUTES = [
       {
         id: "interaction-duplicate-inspect-capability",
         title: "INTERACTION_DUPLICATE_INSPECT_CAPABILITY",
-        level: 3,
-      },
-      {
-        id: "interaction-inspect-high-cardinality-discrete",
-        title: "INTERACTION_INSPECT_HIGH_CARDINALITY_DISCRETE",
         level: 3,
       },
       {
@@ -12346,8 +12351,8 @@ export const DOCS_ROUTES = [
         level: 2,
       },
       {
-        id: "experimental-368",
-        title: "experimental (368)",
+        id: "experimental-380",
+        title: "experimental (380)",
         level: 3,
       },
       {

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -17857,6 +17857,16 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["INTERACTION_INSPECT_X_BISECTS_BAR_LABELS"],
   },
   {
+    id: "heading:guide-interaction-reference:interaction-inspect-high-cardinality-discrete",
+    kind: "heading",
+    title: "INTERACTION_INSPECT_HIGH_CARDINALITY_DISCRETE",
+    summary:
+      "INTERACTION_INSPECT_HIGH_CARDINALITY_DISCRETE in Interaction reference. Search interaction props, callbacks, event phases, and diagnostic codes.",
+    href: "/guide/interaction-reference#interaction-inspect-high-cardinality-discrete",
+    keywords: ["Interaction reference", "documentation"],
+    exact: ["INTERACTION_INSPECT_HIGH_CARDINALITY_DISCRETE"],
+  },
+  {
     id: "heading:guide-interaction-reference:interaction-inspect-identity-dropped",
     kind: "heading",
     title: "INTERACTION_INSPECT_IDENTITY_DROPPED",
@@ -17875,16 +17885,6 @@ export const DOCS_SEARCH_INDEX = [
     href: "/guide/interaction-reference#interaction-duplicate-inspect-capability",
     keywords: ["Interaction reference", "documentation"],
     exact: ["INTERACTION_DUPLICATE_INSPECT_CAPABILITY"],
-  },
-  {
-    id: "heading:guide-interaction-reference:interaction-inspect-high-cardinality-discrete",
-    kind: "heading",
-    title: "INTERACTION_INSPECT_HIGH_CARDINALITY_DISCRETE",
-    summary:
-      "INTERACTION_INSPECT_HIGH_CARDINALITY_DISCRETE in Interaction reference. Search interaction props, callbacks, event phases, and diagnostic codes.",
-    href: "/guide/interaction-reference#interaction-inspect-high-cardinality-discrete",
-    keywords: ["Interaction reference", "documentation"],
-    exact: ["INTERACTION_INSPECT_HIGH_CARDINALITY_DISCRETE"],
   },
   {
     id: "heading:guide-interaction-reference:accessibility",
@@ -19956,6 +19956,16 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["INTERACTION_INSPECT_X_BISECTS_BAR_LABELS"],
   },
   {
+    id: "heading:guide-errors:interaction-inspect-high-cardinality-discrete",
+    kind: "heading",
+    title: "INTERACTION_INSPECT_HIGH_CARDINALITY_DISCRETE",
+    summary:
+      "INTERACTION_INSPECT_HIGH_CARDINALITY_DISCRETE in Errors reference. Understand validation, render, interaction, and CLI diagnostics and recover safely.",
+    href: "/guide/errors#interaction-inspect-high-cardinality-discrete",
+    keywords: ["Errors reference", "Reference"],
+    exact: ["INTERACTION_INSPECT_HIGH_CARDINALITY_DISCRETE"],
+  },
+  {
     id: "heading:guide-errors:interaction-inspect-identity-dropped",
     kind: "heading",
     title: "INTERACTION_INSPECT_IDENTITY_DROPPED",
@@ -19974,16 +19984,6 @@ export const DOCS_SEARCH_INDEX = [
     href: "/guide/errors#interaction-duplicate-inspect-capability",
     keywords: ["Errors reference", "Reference"],
     exact: ["INTERACTION_DUPLICATE_INSPECT_CAPABILITY"],
-  },
-  {
-    id: "heading:guide-errors:interaction-inspect-high-cardinality-discrete",
-    kind: "heading",
-    title: "INTERACTION_INSPECT_HIGH_CARDINALITY_DISCRETE",
-    summary:
-      "INTERACTION_INSPECT_HIGH_CARDINALITY_DISCRETE in Errors reference. Understand validation, render, interaction, and CLI diagnostics and recover safely.",
-    href: "/guide/errors#interaction-inspect-high-cardinality-discrete",
-    keywords: ["Errors reference", "Reference"],
-    exact: ["INTERACTION_INSPECT_HIGH_CARDINALITY_DISCRETE"],
   },
   {
     id: "heading:guide-errors:cli-diagnostics-ggsvelte-render",
@@ -20384,14 +20384,14 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["@ggsvelte/core"],
   },
   {
-    id: "heading:guide-lifecycle:experimental-368",
+    id: "heading:guide-lifecycle:experimental-380",
     kind: "heading",
-    title: "experimental (368)",
+    title: "experimental (380)",
     summary:
-      "experimental (368) in Lifecycle & editions. API stability tags per export, and the defaults-edition mechanism.",
-    href: "/guide/lifecycle#experimental-368",
+      "experimental (380) in Lifecycle & editions. API stability tags per export, and the defaults-edition mechanism.",
+    href: "/guide/lifecycle#experimental-380",
     keywords: ["Lifecycle & editions", "Reference"],
-    exact: ["experimental (368)"],
+    exact: ["experimental (380)"],
   },
   {
     id: "heading:guide-lifecycle:stable-intent-2",
@@ -31937,6 +31937,33 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["GuidePlan"],
   },
   {
+    id: "api:ggsvelte-core:HIGH_CARDINALITY_DISCRETE_THRESHOLD",
+    kind: "api",
+    title: "HIGH_CARDINALITY_DISCRETE_THRESHOLD",
+    summary: "@ggsvelte/core · value · experimental.",
+    href: "/guide/lifecycle#ggsvelte-core",
+    keywords: ["@ggsvelte/core", ".", "value", "experimental"],
+    exact: ["HIGH_CARDINALITY_DISCRETE_THRESHOLD"],
+  },
+  {
+    id: "api:ggsvelte-core:INSPECT_GEOM_DIAGNOSTIC_CATALOG",
+    kind: "api",
+    title: "INSPECT_GEOM_DIAGNOSTIC_CATALOG",
+    summary: "@ggsvelte/core · value · experimental.",
+    href: "/guide/lifecycle#ggsvelte-core",
+    keywords: ["@ggsvelte/core", ".", "value", "experimental"],
+    exact: ["INSPECT_GEOM_DIAGNOSTIC_CATALOG"],
+  },
+  {
+    id: "api:ggsvelte-core:INSPECT_INTENT_MODES",
+    kind: "api",
+    title: "INSPECT_INTENT_MODES",
+    summary: "@ggsvelte/core · value · experimental.",
+    href: "/guide/lifecycle#ggsvelte-core",
+    keywords: ["@ggsvelte/core", ".", "value", "experimental"],
+    exact: ["INSPECT_INTENT_MODES"],
+  },
+  {
     id: "api:ggsvelte-core:IPSUM_PALETTE",
     kind: "api",
     title: "IPSUM_PALETTE",
@@ -31944,6 +31971,33 @@ export const DOCS_SEARCH_INDEX = [
     href: "/guide/lifecycle#ggsvelte-core",
     keywords: ["@ggsvelte/core", ".", "value", "experimental"],
     exact: ["IPSUM_PALETTE"],
+  },
+  {
+    id: "api:ggsvelte-core:InspectGeomAdvisory",
+    kind: "api",
+    title: "InspectGeomAdvisory",
+    summary: "@ggsvelte/core · type · experimental.",
+    href: "/guide/lifecycle#ggsvelte-core",
+    keywords: ["@ggsvelte/core", ".", "type", "experimental"],
+    exact: ["InspectGeomAdvisory"],
+  },
+  {
+    id: "api:ggsvelte-core:InspectGeomAdvisoryCode",
+    kind: "api",
+    title: "InspectGeomAdvisoryCode",
+    summary: "@ggsvelte/core · type · experimental.",
+    href: "/guide/lifecycle#ggsvelte-core",
+    keywords: ["@ggsvelte/core", ".", "type", "experimental"],
+    exact: ["InspectGeomAdvisoryCode"],
+  },
+  {
+    id: "api:ggsvelte-core:InspectIntentMode",
+    kind: "api",
+    title: "InspectIntentMode",
+    summary: "@ggsvelte/core · type · experimental.",
+    href: "/guide/lifecycle#ggsvelte-core",
+    keywords: ["@ggsvelte/core", ".", "type", "experimental"],
+    exact: ["InspectIntentMode"],
   },
   {
     id: "api:ggsvelte-core:LEGEND_ROW_HEIGHT",
@@ -33314,6 +33368,15 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["cellsToNumeric"],
   },
   {
+    id: "api:ggsvelte-core:collectInspectIntentDiagnostics",
+    kind: "api",
+    title: "collectInspectIntentDiagnostics",
+    summary: "@ggsvelte/core · value · experimental.",
+    href: "/guide/lifecycle#ggsvelte-core",
+    keywords: ["@ggsvelte/core", ".", "value", "experimental"],
+    exact: ["collectInspectIntentDiagnostics"],
+  },
+  {
     id: "api:ggsvelte-core:compileRuntimeRowIndexFilter",
     kind: "api",
     title: "compileRuntimeRowIndexFilter",
@@ -33402,6 +33465,15 @@ export const DOCS_SEARCH_INDEX = [
     href: "/guide/lifecycle#ggsvelte-core",
     keywords: ["@ggsvelte/core", ".", "value", "experimental"],
     exact: ["disambiguatedLabels"],
+  },
+  {
+    id: "api:ggsvelte-core:discreteColorFillDomainSizes",
+    kind: "api",
+    title: "discreteColorFillDomainSizes",
+    summary: "@ggsvelte/core · value · experimental.",
+    href: "/guide/lifecycle#ggsvelte-core",
+    keywords: ["@ggsvelte/core", ".", "value", "experimental"],
+    exact: ["discreteColorFillDomainSizes"],
   },
   {
     id: "api:ggsvelte-core:discretenessOf",
@@ -33512,6 +33584,24 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["inferFieldType"],
   },
   {
+    id: "api:ggsvelte-core:inspectAxisOnBarColDiagnostics",
+    kind: "api",
+    title: "inspectAxisOnBarColDiagnostics",
+    summary: "@ggsvelte/core · value · experimental.",
+    href: "/guide/lifecycle#ggsvelte-core",
+    keywords: ["@ggsvelte/core", ".", "value", "experimental"],
+    exact: ["inspectAxisOnBarColDiagnostics"],
+  },
+  {
+    id: "api:ggsvelte-core:inspectHighCardinalityDiagnostics",
+    kind: "api",
+    title: "inspectHighCardinalityDiagnostics",
+    summary: "@ggsvelte/core · value · experimental.",
+    href: "/guide/lifecycle#ggsvelte-core",
+    keywords: ["@ggsvelte/core", ".", "value", "experimental"],
+    exact: ["inspectHighCardinalityDiagnostics"],
+  },
+  {
     id: "api:ggsvelte-core:installCandidates",
     kind: "api",
     title: "installCandidates",
@@ -33537,6 +33627,24 @@ export const DOCS_SEARCH_INDEX = [
     href: "/guide/lifecycle#ggsvelte-core",
     keywords: ["@ggsvelte/core", ".", "value", "experimental"],
     exact: ["isISODateString"],
+  },
+  {
+    id: "api:ggsvelte-core:isInspectIntentMode",
+    kind: "api",
+    title: "isInspectIntentMode",
+    summary: "@ggsvelte/core · value · experimental.",
+    href: "/guide/lifecycle#ggsvelte-core",
+    keywords: ["@ggsvelte/core", ".", "value", "experimental"],
+    exact: ["isInspectIntentMode"],
+  },
+  {
+    id: "api:ggsvelte-core:layerGeomsFromSpecLayers",
+    kind: "api",
+    title: "layerGeomsFromSpecLayers",
+    summary: "@ggsvelte/core · value · experimental.",
+    href: "/guide/lifecycle#ggsvelte-core",
+    keywords: ["@ggsvelte/core", ".", "value", "experimental"],
+    exact: ["layerGeomsFromSpecLayers"],
   },
   {
     id: "api:ggsvelte-core:layout",
@@ -44576,6 +44684,23 @@ export const DOCS_SEARCH_INDEX = [
     ],
   },
   {
+    id: "diagnostic:interaction:INTERACTION_INSPECT_HIGH_CARDINALITY_DISCRETE",
+    kind: "diagnostic",
+    title: "INTERACTION_INSPECT_HIGH_CARDINALITY_DISCRETE · interaction",
+    summary:
+      "Inspect is enabled with a high-cardinality discrete color/fill domain; the default tooltip shows the focused series, the largest contributors at that x (or y), a stack total, and an overflow line — not every series.",
+    href: "/guide/errors#interaction-inspect-high-cardinality-discrete",
+    keywords: [
+      "interaction",
+      "advisory",
+      "Prep top-n data before plotting if only the largest series matter; Pass a custom content snippet on <Inspect content={…} /> for a full multi-series listing; Pin the tooltip to scroll the full group when every series must be readable",
+    ],
+    exact: [
+      "INTERACTION_INSPECT_HIGH_CARDINALITY_DISCRETE",
+      "interaction:INTERACTION_INSPECT_HIGH_CARDINALITY_DISCRETE",
+    ],
+  },
+  {
     id: "diagnostic:interaction:INTERACTION_INSPECT_IDENTITY_DROPPED",
     kind: "diagnostic",
     title: "INTERACTION_INSPECT_IDENTITY_DROPPED · interaction",
@@ -44607,23 +44732,6 @@ export const DOCS_SEARCH_INDEX = [
     exact: [
       "INTERACTION_DUPLICATE_INSPECT_CAPABILITY",
       "interaction:INTERACTION_DUPLICATE_INSPECT_CAPABILITY",
-    ],
-  },
-  {
-    id: "diagnostic:interaction:INTERACTION_INSPECT_HIGH_CARDINALITY_DISCRETE",
-    kind: "diagnostic",
-    title: "INTERACTION_INSPECT_HIGH_CARDINALITY_DISCRETE · interaction",
-    summary:
-      "Inspect is enabled with a high-cardinality discrete color/fill domain; the default tooltip shows the focused series, the largest contributors at that x (or y), a stack total, and an overflow line — not every series.",
-    href: "/guide/errors#interaction-inspect-high-cardinality-discrete",
-    keywords: [
-      "interaction",
-      "advisory",
-      "Prep top-n data before plotting if only the largest series matter; Pass a custom content snippet on <Inspect content={…} /> for a full multi-series listing; Pin the tooltip to scroll the full group when every series must be readable",
-    ],
-    exact: [
-      "INTERACTION_INSPECT_HIGH_CARDINALITY_DISCRETE",
-      "interaction:INTERACTION_INSPECT_HIGH_CARDINALITY_DISCRETE",
     ],
   },
   {
@@ -44731,6 +44839,15 @@ export const DOCS_SEARCH_INDEX = [
     href: "/reference/cli#max-marks",
     keywords: ["N"],
     exact: ["--max-marks"],
+  },
+  {
+    id: "cli:inspect",
+    kind: "cli",
+    title: "--inspect",
+    summary: "Host inspect intent for interaction advisories",
+    href: "/reference/cli#inspect",
+    keywords: ["MODE", "auto|exact|x|y|xy — host-only; not a PortableSpec field"],
+    exact: ["--inspect"],
   },
   {
     id: "cli:version",

--- a/docs/decisions/0024-cli-interaction-intent.md
+++ b/docs/decisions/0024-cli-interaction-intent.md
@@ -1,0 +1,63 @@
+# 0024 — CLI host interaction intent (`--inspect`)
+
+Date: 2026-08-08. Status: accepted. Closes the agent-loop half of #1531.
+
+## Problem
+
+Interaction diagnostics (`INTERACTION_DIAGNOSTIC_CATALOG`, composition,
+deprecation) fire through Svelte `ondiagnostic` at plot bind/render time. The
+agent feedback loop the CLI was built for (`ggsvelte-render` → stderr JSONL →
+fix → re-render) never saw them.
+
+An agent that follows the skill's "use the CLI" path can ship a schema-valid
+chart with a disastrous inspect mode and get **zero** interaction diagnostics.
+Expanding advisories only helps hosts that already listen on `ondiagnostic`.
+
+Inspect mode is intentionally **not** a PortableSpec field (host capability).
+Putting it on the wire would couple headless SVG render to browser interaction
+chrome.
+
+## Decision
+
+1. **Document the contract.** The CLI covers PortableSpec validation, pipeline
+   warnings/advisories, scale diagnostics, and `lintSpec`. Host interaction
+   quality is **opt-in** via a declared host intent flag — not automatic on
+   every render.
+2. **Delivery path: host interaction intent on the CLI.**
+   `ggsvelte-render --inspect <mode>` where `mode` is
+   `auto|exact|x|y|xy`. The flag does not change SVG output. It runs the same
+   pure collectors the host uses (`inspectAxisOnBarColDiagnostics` /
+   `collectInspectIntentDiagnostics`) and writes matching codes to stderr with
+   `source: "interaction"`.
+3. **Single implementation.** Pure collectors and their catalog messages live
+   in `@ggsvelte/core`. The Svelte host re-exports them and spreads
+   `INSPECT_GEOM_DIAGNOSTIC_CATALOG` into `INTERACTION_DIAGNOSTIC_CATALOG`. No
+   prose-only fork of the rules.
+4. **Default remains silent.** Without `--inspect`, the CLI does not invent
+   host intent. Headless SVG-only charts stay free of false interaction
+   advisories.
+
+## Non-goals (unchanged from #1531)
+
+- Moving Inspect mode into PortableSpec.
+- Full browser visual regression for every tooltip string.
+- Emitting every runtime interaction diagnostic (keys, lineage, wiring) from
+  the CLI — those still need a live host. This decision covers the
+  **inspect×geom pure path** that agents can declare intent for.
+
+## Deferred (still useful, separate work)
+
+- Spec-lint hygiene for portable `inspect: false` on decorative layers when
+  siblings stay inspectable.
+- Docs/gallery CI that mounts examples with inspect on and asserts no
+  interaction advisories of severity advisory+.
+- CLI emission of high-cardinality discrete advisories (needs trained ordinal
+  domain sizes from the pipeline; collectors already exist).
+
+## Acceptance evidence
+
+- ADR (this file).
+- `ggsvelte-render --inspect xy` on a col-layer spec emits
+  `INTERACTION_INSPECT_X_ON_COL` on stderr with `source: "interaction"`.
+- Skill + CLI README state what the CLI covers and does not cover for
+  interaction.

--- a/lifecycle.json
+++ b/lifecycle.json
@@ -4194,8 +4194,32 @@
           "kind": "type",
           "lifecycle": "experimental"
         },
+        "HIGH_CARDINALITY_DISCRETE_THRESHOLD": {
+          "kind": "value",
+          "lifecycle": "experimental"
+        },
+        "INSPECT_GEOM_DIAGNOSTIC_CATALOG": {
+          "kind": "value",
+          "lifecycle": "experimental"
+        },
+        "INSPECT_INTENT_MODES": {
+          "kind": "value",
+          "lifecycle": "experimental"
+        },
         "IPSUM_PALETTE": {
           "kind": "value",
+          "lifecycle": "experimental"
+        },
+        "InspectGeomAdvisory": {
+          "kind": "type",
+          "lifecycle": "experimental"
+        },
+        "InspectGeomAdvisoryCode": {
+          "kind": "type",
+          "lifecycle": "experimental"
+        },
+        "InspectIntentMode": {
+          "kind": "type",
           "lifecycle": "experimental"
         },
         "LEGEND_ROW_HEIGHT": {
@@ -4806,6 +4830,10 @@
           "kind": "value",
           "lifecycle": "experimental"
         },
+        "collectInspectIntentDiagnostics": {
+          "kind": "value",
+          "lifecycle": "experimental"
+        },
         "compileRuntimeRowIndexFilter": {
           "kind": "value",
           "lifecycle": "experimental"
@@ -4843,6 +4871,10 @@
           "lifecycle": "experimental"
         },
         "disambiguatedLabels": {
+          "kind": "value",
+          "lifecycle": "experimental"
+        },
+        "discreteColorFillDomainSizes": {
           "kind": "value",
           "lifecycle": "experimental"
         },
@@ -4894,6 +4926,14 @@
           "kind": "value",
           "lifecycle": "experimental"
         },
+        "inspectAxisOnBarColDiagnostics": {
+          "kind": "value",
+          "lifecycle": "experimental"
+        },
+        "inspectHighCardinalityDiagnostics": {
+          "kind": "value",
+          "lifecycle": "experimental"
+        },
         "installCandidates": {
           "kind": "value",
           "lifecycle": "experimental"
@@ -4903,6 +4943,14 @@
           "lifecycle": "experimental"
         },
         "isISODateString": {
+          "kind": "value",
+          "lifecycle": "experimental"
+        },
+        "isInspectIntentMode": {
+          "kind": "value",
+          "lifecycle": "experimental"
+        },
+        "layerGeomsFromSpecLayers": {
           "kind": "value",
           "lifecycle": "experimental"
         },

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -42,7 +42,10 @@ ggsvelte-render --inspect xy spec.json > out.svg
 
 Modes: `auto`, `exact`, `x`, `y`, `xy` (same enum as the host). Without
 `--inspect`, interaction codes are not invented — headless SVG-only charts
-stay quiet. See [ADR 0024](../../docs/decisions/0024-cli-interaction-intent.md).
+stay quiet. Today this path covers bar/col x-guide pure collectors (including
+alias rewrite so `geom: "histogram"` matches host `normalize`); high-cardinality
+and runtime key/lineage diagnostics still need a mounted host. See
+[ADR 0024](../../docs/decisions/0024-cli-interaction-intent.md).
 
 ## Install
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -45,7 +45,7 @@ Modes: `auto`, `exact`, `x`, `y`, `xy` (same enum as the host). Without
 stay quiet. Today this path covers bar/col x-guide pure collectors (including
 alias rewrite so `geom: "histogram"` matches host `normalize`); high-cardinality
 and runtime key/lineage diagnostics still need a mounted host. See
-[ADR 0024](../../docs/decisions/0024-cli-interaction-intent.md).
+[ADR 0024](https://github.com/ljodea/ggsvelte/blob/main/docs/decisions/0024-cli-interaction-intent.md).
 
 ## Install
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -20,6 +20,30 @@ the spec before anyone sees it.
 If you embed spec-writing agents, treat this package as part of the install
 contract, not an option.
 
+## What the CLI covers (and what it does not)
+
+| Covered on every render                         | Opt-in / host-side                                    |
+| ----------------------------------------------- | ----------------------------------------------------- |
+| Schema validation (`validate`)                  | Host inspect **mode** and most interaction wiring     |
+| Pipeline warnings and advisories                | Runtime key/lineage errors (need a live plot)         |
+| Scale-inference diagnostics (`source: "scale"`) | Composition/deprecation `ondiagnostic` without a host |
+| Spec-lint advisories (`source: "spec-lint"`)    | Full tooltip visual QA                                |
+
+Inspect mode is a **host** capability (`<Inspect mode="xy" />` / plot
+`inspect`), not a PortableSpec field. To surface the same inspect×geom
+advisories agents would only see via `ondiagnostic` in a browser, declare host
+intent:
+
+```sh
+ggsvelte-render --inspect xy spec.json > out.svg
+# stderr may include:
+# {"kind":"advisory","source":"interaction","code":"INTERACTION_INSPECT_X_ON_COL",…}
+```
+
+Modes: `auto`, `exact`, `x`, `y`, `xy` (same enum as the host). Without
+`--inspect`, interaction codes are not invented — headless SVG-only charts
+stay quiet. See [ADR 0024](../../docs/decisions/0024-cli-interaction-intent.md).
+
 ## Install
 
 ```sh
@@ -46,12 +70,15 @@ ggsvelte-render spec.json > out.svg          # spec from a file
 ggsvelte-render < spec.json > out.svg        # spec from stdin
 ggsvelte-render spec.json --data data.json   # named datasets from a file
 ggsvelte-render spec.json --width 832 --height 400
+ggsvelte-render --inspect xy spec.json > out.svg   # host inspect intent
 ```
 
 - SVG goes to stdout. Nothing else ever does.
 - Diagnostics go to stderr as JSON lines:
   `{"kind":"error",…}` | `{"kind":"warning",…}` | `{"kind":"advisory",…}`.
-  Scale-inference diagnostics set `source: "scale"` so hosts can filter.
+  Scale-inference diagnostics set `source: "scale"`; spec-lint sets
+  `source: "spec-lint"`; interaction intent (`--inspect`) sets
+  `source: "interaction"`.
 
 ## Exit codes
 

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -5,17 +5,21 @@
  *
  * Contract:
  *   ggsvelte-render [spec.json] [--width N] [--height N] [--data file.json]
- *                   [--max-marks N]
+ *                   [--max-marks N] [--inspect MODE]
  *
  *   - The spec is read from the file argument, or from stdin when omitted.
  *   - --data file.json provides NAMED datasets: the file is an object mapping
  *     dataset names to inline data ({values}/{columns}/rows/columns).
+ *   - --inspect MODE declares host inspect intent (auto|exact|x|y|xy). Inspect
+ *     mode is host-only, not a PortableSpec field; the flag lets agents run the
+ *     same pure inspect×geom collectors that feed ondiagnostic (#1531).
  *   - SVG goes to stdout. Nothing else ever does.
  *   - Errors and advisories go to stderr as JSON LINES:
  *       {"kind":"error","code",...} | {"kind":"warning",...} |
  *       {"kind":"advisory",...}
  *     Scale inference diagnostics reuse those same `kind` values (mapped from
  *     their internal severity) and set `source: "scale"` so hosts can filter.
+ *     Interaction intent diagnostics set `source: "interaction"`.
  *
  * Exit codes (documented contract):
  *   0  rendered
@@ -27,6 +31,11 @@ import type { SpecInput } from "@ggsvelte/spec";
 import { lintSpec, SpecValidationError, validate } from "@ggsvelte/spec";
 
 import type { CLIDiagnosticCode } from "./diagnostics.js";
+import {
+  collectInspectIntentDiagnostics,
+  isInspectIntentMode,
+  type InspectIntentMode,
+} from "./inspect-geom-advisories.js";
 import type { NamedData } from "./pipeline.js";
 import { PipelineError, runPipeline } from "./pipeline.js";
 import { registerAll } from "./register.js";
@@ -82,6 +91,15 @@ export const CLI_OPTIONS = [
     target: "maxMarks",
   },
   {
+    anchor: "inspect",
+    flag: "--inspect",
+    value: "MODE",
+    description: "Host inspect intent for interaction advisories",
+    detail: "auto|exact|x|y|xy — host-only; not a PortableSpec field",
+    kind: "inspectMode",
+    target: "inspectMode",
+  },
+  {
     anchor: "version",
     flag: "--version",
     value: "",
@@ -126,6 +144,7 @@ interface ParsedArgs {
   height: number | null;
   dataPath: string | null;
   maxMarks: number | null;
+  inspectMode: InspectIntentMode | null;
   help: boolean;
   version: boolean;
 }
@@ -139,6 +158,7 @@ function parseArgs(argv: readonly string[]): ParsedArgs {
     height: null,
     dataPath: null,
     maxMarks: null,
+    inspectMode: null,
     help: false,
     version: false,
   };
@@ -156,6 +176,15 @@ function parseArgs(argv: readonly string[]): ParsedArgs {
     }
     return n;
   };
+  const inspectFlag = (raw: string | undefined): InspectIntentMode => {
+    if (raw === undefined) {
+      throw new UsageError("--inspect needs a mode (auto|exact|x|y|xy)");
+    }
+    if (!isInspectIntentMode(raw)) {
+      throw new UsageError(`--inspect mode must be auto|exact|x|y|xy (got ${JSON.stringify(raw)})`);
+    }
+    return raw;
+  };
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i]!;
     const option = optionByFlag.get(arg);
@@ -164,6 +193,8 @@ function parseArgs(argv: readonly string[]): ParsedArgs {
         out[option.target] = true;
       } else if (option.kind === "number") {
         out[option.target] = numberFlag(option.flag, argv[++i]);
+      } else if (option.kind === "inspectMode") {
+        out[option.target] = inspectFlag(argv[++i]);
       } else {
         const path = argv[++i];
         if (path === undefined) throw new UsageError(`${option.flag} needs a file path`);
@@ -231,7 +262,8 @@ export async function runCLI(
       args.width !== null ||
       args.height !== null ||
       args.dataPath !== null ||
-      args.maxMarks !== null;
+      args.maxMarks !== null ||
+      args.inspectMode !== null;
     if (hasOtherArguments || options.version === undefined) {
       cliError(
         io,
@@ -325,6 +357,26 @@ export async function runCLI(
     // Distinguished from pipeline heuristics by source: "spec-lint".
     for (const advisory of lintSpec(spec)) {
       errLine(io, { kind: "advisory", source: "spec-lint", ...advisory });
+    }
+    // Host interaction intent (#1531): pure inspect×geom collectors. Opt-in
+    // via --inspect because inspect.mode is host-only, not PortableSpec.
+    if (args.inspectMode !== null) {
+      const layers =
+        typeof spec === "object" && spec !== null
+          ? (spec as { layers?: unknown }).layers
+          : undefined;
+      for (const diagnostic of collectInspectIntentDiagnostics(layers, args.inspectMode)) {
+        errLine(io, {
+          kind: diagnostic.severity,
+          source: "interaction",
+          code: diagnostic.code,
+          message: diagnostic.message,
+          prop: diagnostic.prop,
+          suggestions: diagnostic.suggestions,
+          docUrl: diagnostic.docUrl,
+          ...(diagnostic.actual !== undefined && { actual: diagnostic.actual }),
+        });
+      }
     }
     const limit = args.maxMarks ?? 100_000;
     const marks = countMarks(model.scene);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -452,5 +452,23 @@ export type { ResolvedGlow, ResolvedGradientPaint } from "./mark-paint.js";
 export { runCLI } from "./cli.js";
 export type { CLIIO } from "./cli.js";
 
+// Inspect×geom pure collectors (host ondiagnostic + CLI --inspect, #1531)
+export {
+  collectInspectIntentDiagnostics,
+  discreteColorFillDomainSizes,
+  HIGH_CARDINALITY_DISCRETE_THRESHOLD,
+  INSPECT_GEOM_DIAGNOSTIC_CATALOG,
+  INSPECT_INTENT_MODES,
+  inspectAxisOnBarColDiagnostics,
+  inspectHighCardinalityDiagnostics,
+  isInspectIntentMode,
+  layerGeomsFromSpecLayers,
+} from "./inspect-geom-advisories.js";
+export type {
+  InspectGeomAdvisory,
+  InspectGeomAdvisoryCode,
+  InspectIntentMode,
+} from "./inspect-geom-advisories.js";
+
 // Instrumentation
 export { perfMark, perfMeasure } from "./perf.js";

--- a/packages/core/src/inspect-geom-advisories.ts
+++ b/packages/core/src/inspect-geom-advisories.ts
@@ -12,7 +12,7 @@
  * Auto/exact modes never fire the bar/col axis-guide codes: auto already picks
  * exact for bar/col (candidateAutoMode).
  */
-// @lifecycle stable
+// @lifecycle experimental
 
 import { GEOM_ALIASES } from "@ggsvelte/spec";
 

--- a/packages/core/src/inspect-geom-advisories.ts
+++ b/packages/core/src/inspect-geom-advisories.ts
@@ -14,6 +14,8 @@
  */
 // @lifecycle stable
 
+import { GEOM_ALIASES } from "@ggsvelte/spec";
+
 /** Codes owned by this pure collector surface (subset of host interaction codes). */
 export type InspectGeomAdvisoryCode =
   | "INTERACTION_INSPECT_X_ON_COL"
@@ -166,14 +168,24 @@ export function inspectAxisOnBarColDiagnostics(
   return list;
 }
 
-/** Layer geom names from a PortableSpec-like layers array. */
+/**
+ * Layer geom names from a PortableSpec-like layers array.
+ * Alias geoms (`histogram`→`bar`, …) are rewritten to the same canonical names
+ * `normalize()` stamps, so CLI host-intent lint matches host ondiagnostic
+ * (assembled layers are already normalized; raw JSON layers are not).
+ */
 export function layerGeomsFromSpecLayers(layers: unknown): readonly string[] {
   if (!Array.isArray(layers)) return [];
   const geoms: string[] = [];
   for (const layer of layers) {
     if (layer === null || typeof layer !== "object" || Array.isArray(layer)) continue;
     const geom = (layer as { geom?: unknown }).geom;
-    if (typeof geom === "string" && geom.length > 0) geoms.push(geom);
+    if (typeof geom !== "string" || geom.length === 0) continue;
+    if (Object.hasOwn(GEOM_ALIASES, geom)) {
+      geoms.push(GEOM_ALIASES[geom as keyof typeof GEOM_ALIASES]);
+    } else {
+      geoms.push(geom);
+    }
   }
   return geoms;
 }

--- a/packages/core/src/inspect-geom-advisories.ts
+++ b/packages/core/src/inspect-geom-advisories.ts
@@ -1,0 +1,237 @@
+/**
+ * Inspect-mode × geom advisories: pure collectors shared by the host
+ * (plot-engine → ondiagnostic) and the headless CLI (`--inspect MODE`).
+ *
+ * Vertical axis guides that fight bar/col geometry or bisect on-mark value
+ * labels, plus high-cardinality discrete color/fill + inspect (#1274).
+ *
+ * Host inspect mode is intentionally not a PortableSpec field. Agents declare
+ * the host's intended mode via `ggsvelte-render --inspect <mode>` so the same
+ * codes reach the CLI/agent JSONL loop (#1531).
+ *
+ * Auto/exact modes never fire the bar/col axis-guide codes: auto already picks
+ * exact for bar/col (candidateAutoMode).
+ */
+// @lifecycle stable
+
+/** Codes owned by this pure collector surface (subset of host interaction codes). */
+export type InspectGeomAdvisoryCode =
+  | "INTERACTION_INSPECT_X_ON_COL"
+  | "INTERACTION_INSPECT_X_ON_BAR"
+  | "INTERACTION_INSPECT_X_BISECTS_COL_LABELS"
+  | "INTERACTION_INSPECT_X_BISECTS_BAR_LABELS"
+  | "INTERACTION_INSPECT_HIGH_CARDINALITY_DISCRETE";
+
+export interface InspectGeomAdvisory {
+  readonly severity: "error" | "warning" | "advisory";
+  readonly code: InspectGeomAdvisoryCode;
+  readonly message: string;
+  readonly prop: string;
+  readonly actual?: unknown;
+  readonly suggestions: ReadonlyArray<string>;
+  readonly docUrl: string;
+}
+
+/**
+ * Catalog slice for inspect×geom advisories. Host INTERACTION_DIAGNOSTIC_CATALOG
+ * re-exports these entries so messages stay single-sourced.
+ */
+export const INSPECT_GEOM_DIAGNOSTIC_CATALOG: Readonly<
+  Record<InspectGeomAdvisoryCode, Omit<InspectGeomAdvisory, "actual">>
+> = Object.freeze({
+  INTERACTION_INSPECT_X_ON_COL: {
+    severity: "advisory",
+    code: "INTERACTION_INSPECT_X_ON_COL",
+    message:
+      "inspect.mode draws a vertical guide through column marks; columns already encode x as a filled band, so the guide cuts the bar body and rarely adds information.",
+    prop: "inspect.mode",
+    suggestions: [
+      'Use inspect={{ mode: "exact" }} (or leave mode as "auto") for GeomCol',
+      "Prefer muteSiblings for sibling de-emphasis instead of an axis guide",
+    ],
+    docUrl: "https://ggsvelte.sh/guide/interaction-reference#interaction-inspect-x-on-col",
+  },
+  INTERACTION_INSPECT_X_ON_BAR: {
+    severity: "advisory",
+    code: "INTERACTION_INSPECT_X_ON_BAR",
+    message:
+      "inspect.mode draws a vertical guide through bar marks; bars already encode the band axis as a filled region, so the guide cuts the bar body and rarely adds information.",
+    prop: "inspect.mode",
+    suggestions: [
+      'Use inspect={{ mode: "exact" }} (or leave mode as "auto") for GeomBar',
+      "Prefer muteSiblings for sibling de-emphasis instead of an axis guide",
+    ],
+    docUrl: "https://ggsvelte.sh/guide/interaction-reference#interaction-inspect-x-on-bar",
+  },
+  INTERACTION_INSPECT_X_BISECTS_COL_LABELS: {
+    severity: "warning",
+    code: "INTERACTION_INSPECT_X_BISECTS_COL_LABELS",
+    message:
+      "inspect.mode draws a vertical guide through GeomCol marks that also carry GeomText/GeomLabel values; the guide bisects the on-bar totals and makes them hard to read.",
+    prop: "inspect.mode",
+    suggestions: [
+      'Use inspect={{ mode: "exact" }} (or leave mode as "auto") when columns have value labels',
+      "Keep value labels; drop the x/xy guide rather than dropping the labels",
+    ],
+    docUrl:
+      "https://ggsvelte.sh/guide/interaction-reference#interaction-inspect-x-bisects-col-labels",
+  },
+  INTERACTION_INSPECT_X_BISECTS_BAR_LABELS: {
+    severity: "warning",
+    code: "INTERACTION_INSPECT_X_BISECTS_BAR_LABELS",
+    message:
+      "inspect.mode draws a vertical guide through GeomBar marks that also carry GeomText/GeomLabel values; the guide bisects the on-bar totals and makes them hard to read.",
+    prop: "inspect.mode",
+    suggestions: [
+      'Use inspect={{ mode: "exact" }} (or leave mode as "auto") when bars have value labels',
+      "Keep value labels; drop the x/xy guide rather than dropping the labels",
+    ],
+    docUrl:
+      "https://ggsvelte.sh/guide/interaction-reference#interaction-inspect-x-bisects-bar-labels",
+  },
+  INTERACTION_INSPECT_HIGH_CARDINALITY_DISCRETE: {
+    severity: "advisory",
+    code: "INTERACTION_INSPECT_HIGH_CARDINALITY_DISCRETE",
+    message:
+      "Inspect is enabled with a high-cardinality discrete color/fill domain; the default tooltip shows the focused series, the largest contributors at that x (or y), a stack total, and an overflow line — not every series.",
+    prop: "inspect",
+    suggestions: [
+      "Prep top-n data before plotting if only the largest series matter",
+      "Pass a custom content snippet on <Inspect content={…} /> for a full multi-series listing",
+      "Pin the tooltip to scroll the full group when every series must be readable",
+    ],
+    docUrl:
+      "https://ggsvelte.sh/guide/interaction-reference#interaction-inspect-high-cardinality-discrete",
+  },
+});
+
+/**
+ * Discrete color/fill domain size that triggers the default-tooltip content
+ * policy advisory when inspect is enabled (#1274).
+ */
+export const HIGH_CARDINALITY_DISCRETE_THRESHOLD = 16;
+
+/** Modes that draw a vertical (x) crosshair guide in non-flipped coords. */
+const X_GUIDE_MODES = new Set(["x", "xy"]);
+
+const VALUE_LABEL_GEOMS = new Set(["text", "label", "sf_text", "sf_label"]);
+
+/** Host inspect modes accepted by `ggsvelte-render --inspect`. */
+export const INSPECT_INTENT_MODES = ["auto", "exact", "x", "y", "xy"] as const;
+export type InspectIntentMode = (typeof INSPECT_INTENT_MODES)[number];
+
+export function isInspectIntentMode(value: string): value is InspectIntentMode {
+  return (INSPECT_INTENT_MODES as readonly string[]).includes(value);
+}
+
+/**
+ * Advisories when inspect.mode draws an x-axis guide through bar/col marks.
+ * Labels present → stronger bisect warning replaces the plain-geom advisory.
+ */
+export function inspectAxisOnBarColDiagnostics(
+  inspectMode: string | null | undefined,
+  geoms: readonly string[],
+): InspectGeomAdvisory[] {
+  if (inspectMode === null || inspectMode === undefined || !X_GUIDE_MODES.has(inspectMode)) {
+    return [];
+  }
+
+  let hasCol = false;
+  let hasBar = false;
+  let hasValueLabels = false;
+  for (const geom of geoms) {
+    if (geom === "col") hasCol = true;
+    else if (geom === "bar") hasBar = true;
+    if (VALUE_LABEL_GEOMS.has(geom)) hasValueLabels = true;
+  }
+  if (!hasCol && !hasBar) return [];
+
+  const list: InspectGeomAdvisory[] = [];
+  if (hasCol) {
+    list.push({
+      ...(hasValueLabels
+        ? INSPECT_GEOM_DIAGNOSTIC_CATALOG.INTERACTION_INSPECT_X_BISECTS_COL_LABELS
+        : INSPECT_GEOM_DIAGNOSTIC_CATALOG.INTERACTION_INSPECT_X_ON_COL),
+      actual: inspectMode,
+    });
+  }
+  if (hasBar) {
+    list.push({
+      ...(hasValueLabels
+        ? INSPECT_GEOM_DIAGNOSTIC_CATALOG.INTERACTION_INSPECT_X_BISECTS_BAR_LABELS
+        : INSPECT_GEOM_DIAGNOSTIC_CATALOG.INTERACTION_INSPECT_X_ON_BAR),
+      actual: inspectMode,
+    });
+  }
+  return list;
+}
+
+/** Layer geom names from a PortableSpec-like layers array. */
+export function layerGeomsFromSpecLayers(layers: unknown): readonly string[] {
+  if (!Array.isArray(layers)) return [];
+  const geoms: string[] = [];
+  for (const layer of layers) {
+    if (layer === null || typeof layer !== "object" || Array.isArray(layer)) continue;
+    const geom = (layer as { geom?: unknown }).geom;
+    if (typeof geom === "string" && geom.length > 0) geoms.push(geom);
+  }
+  return geoms;
+}
+
+/**
+ * Headless entry: given PortableSpec layers + declared host inspect intent,
+ * return the same inspect×geom codes the host fires via ondiagnostic.
+ */
+export function collectInspectIntentDiagnostics(
+  layers: unknown,
+  inspectMode: string | null | undefined,
+): InspectGeomAdvisory[] {
+  return inspectAxisOnBarColDiagnostics(inspectMode, layerGeomsFromSpecLayers(layers));
+}
+
+/**
+ * Advisory when inspect is on and a discrete color/fill domain is large enough
+ * that the default tooltip content policy (top-k + total + overflow) matters.
+ *
+ * `domainSizes` is the trained ordinal domain length per channel; continuous
+ * ramps are omitted by the caller. Fires once per channel over the threshold.
+ */
+export function inspectHighCardinalityDiagnostics(input: {
+  readonly inspectEnabled: boolean;
+  readonly domainSizes: ReadonlyArray<{
+    readonly channel: "color" | "fill";
+    readonly size: number;
+  }>;
+  readonly threshold?: number;
+}): InspectGeomAdvisory[] {
+  if (!input.inspectEnabled) return [];
+  const threshold = input.threshold ?? HIGH_CARDINALITY_DISCRETE_THRESHOLD;
+  const list: InspectGeomAdvisory[] = [];
+  for (const { channel, size } of input.domainSizes) {
+    if (size < threshold) continue;
+    list.push({
+      ...INSPECT_GEOM_DIAGNOSTIC_CATALOG.INTERACTION_INSPECT_HIGH_CARDINALITY_DISCRETE,
+      prop: channel,
+      actual: size,
+    });
+  }
+  return list;
+}
+
+/** Ordinal color/fill domain lengths from a TrainedScales-like bag. */
+export function discreteColorFillDomainSizes(scales: {
+  readonly color: { readonly kind: string; readonly scale: unknown } | null;
+  readonly fill: { readonly kind: string; readonly scale: unknown } | null;
+}): ReadonlyArray<{ readonly channel: "color" | "fill"; readonly size: number }> {
+  const out: { channel: "color" | "fill"; size: number }[] = [];
+  for (const channel of ["color", "fill"] as const) {
+    const resolved = scales[channel];
+    if (resolved === null || resolved.kind !== "ordinal") continue;
+    const scale = resolved.scale;
+    if (scale === null || typeof scale !== "object") continue;
+    const domain = (scale as { readonly domain?: unknown }).domain;
+    if (!Array.isArray(domain)) continue;
+    out.push({ channel, size: domain.length });
+  }
+  return out;
+}

--- a/packages/core/tests/cli.test.ts
+++ b/packages/core/tests/cli.test.ts
@@ -302,4 +302,49 @@ describe("runCLI", () => {
     expect(await runCLI(["--inspect", "nearest"], io)).toBe(2);
     expect(err.join("\n")).toContain("--inspect");
   });
+
+  it("rewrites histogram→bar so --inspect xy matches host ondiagnostic", async () => {
+    // Host assembled layers run through normalize(); raw CLI JSON does not.
+    // Alias rewrite in layerGeomsFromSpecLayers keeps the agent path honest.
+    const histogramSpec = {
+      data: {
+        values: [{ measure: 1 }, { measure: 2 }, { measure: 2 }, { measure: 3 }],
+      },
+      aes: { x: { field: "measure" } },
+      layers: [{ geom: "histogram" }],
+    };
+    const { io, err } = makeIO(JSON.stringify(histogramSpec));
+    expect(await runCLI(["--inspect", "xy"], io)).toBe(0);
+    const lines = err.map((l) => JSON.parse(l) as Record<string, unknown>);
+    expect(
+      lines.some(
+        (l) => l["source"] === "interaction" && l["code"] === "INTERACTION_INSPECT_X_ON_BAR",
+      ),
+    ).toBe(true);
+  });
+
+  it("maps bisect severity to kind warning on stderr", async () => {
+    const labeledCol = {
+      data: {
+        values: [
+          { category: "a", amount: 3 },
+          { category: "b", amount: 5 },
+        ],
+      },
+      aes: { x: { field: "category" }, y: { field: "amount" } },
+      layers: [{ geom: "col" }, { geom: "text", aes: { label: { field: "amount" } } }],
+    };
+    const { io, err } = makeIO(JSON.stringify(labeledCol));
+    expect(await runCLI(["--inspect", "xy"], io)).toBe(0);
+    const lines = err.map((l) => JSON.parse(l) as Record<string, unknown>);
+    const bisect = lines.find(
+      (l) =>
+        l["source"] === "interaction" && l["code"] === "INTERACTION_INSPECT_X_BISECTS_COL_LABELS",
+    );
+    expect(bisect).toMatchObject({
+      kind: "warning",
+      source: "interaction",
+      code: "INTERACTION_INSPECT_X_BISECTS_COL_LABELS",
+    });
+  });
 });

--- a/packages/core/tests/cli.test.ts
+++ b/packages/core/tests/cli.test.ts
@@ -54,10 +54,12 @@ describe("runCLI", () => {
       "--height",
       "--data",
       "--max-marks",
+      "--inspect",
       "--version",
       "--help",
     ]);
     expect(CLI_OPTIONS.find((option) => option.flag === "--max-marks")?.anchor).toBe("max-marks");
+    expect(CLI_OPTIONS.find((option) => option.flag === "--inspect")?.anchor).toBe("inspect");
     const { io, err } = makeIO();
     expect(await runCLI(["--help"], io)).toBe(0);
     for (const option of CLI_OPTIONS) expect(err.join("\n")).toContain(option.flag);
@@ -228,5 +230,76 @@ describe("runCLI", () => {
     if (dataOption && "detail" in dataOption) {
       expect(help).toContain(dataOption.detail);
     }
+  });
+
+  it("emits INTERACTION_INSPECT_X_ON_COL on stderr when --inspect xy meets a col layer", async () => {
+    // Host inspect mode is not PortableSpec; agents declare intent so the
+    // same pure collectors that feed ondiagnostic reach the CLI JSONL loop.
+    const colSpec = {
+      data: {
+        values: [
+          { category: "a", amount: 3 },
+          { category: "b", amount: 5 },
+        ],
+      },
+      aes: { x: { field: "category" }, y: { field: "amount" } },
+      layers: [{ geom: "col" }],
+    };
+    const { io, out, err } = makeIO(JSON.stringify(colSpec));
+    const code = await runCLI(["--inspect", "xy"], io);
+    expect(code).toBe(0);
+    expect(out.join("")).toStartWith("<svg ");
+    const lines = err.map((l) => JSON.parse(l) as Record<string, unknown>);
+    const interaction = lines.find(
+      (l) => l["source"] === "interaction" && l["code"] === "INTERACTION_INSPECT_X_ON_COL",
+    );
+    expect(interaction).toMatchObject({
+      kind: "advisory",
+      source: "interaction",
+      code: "INTERACTION_INSPECT_X_ON_COL",
+      prop: "inspect.mode",
+      actual: "xy",
+    });
+    expect(typeof interaction?.["message"]).toBe("string");
+  });
+
+  it("does not emit interaction inspect advisories without --inspect", async () => {
+    const colSpec = {
+      data: {
+        values: [
+          { category: "a", amount: 3 },
+          { category: "b", amount: 5 },
+        ],
+      },
+      aes: { x: { field: "category" }, y: { field: "amount" } },
+      layers: [{ geom: "col" }],
+    };
+    const { io, err } = makeIO(JSON.stringify(colSpec));
+    expect(await runCLI([], io)).toBe(0);
+    const lines = err.map((l) => JSON.parse(l) as Record<string, unknown>);
+    expect(lines.some((l) => l["source"] === "interaction")).toBe(false);
+  });
+
+  it("is silent for --inspect exact on col (auto/exact never fire x-guide codes)", async () => {
+    const colSpec = {
+      data: {
+        values: [
+          { category: "a", amount: 3 },
+          { category: "b", amount: 5 },
+        ],
+      },
+      aes: { x: { field: "category" }, y: { field: "amount" } },
+      layers: [{ geom: "col" }],
+    };
+    const { io, err } = makeIO(JSON.stringify(colSpec));
+    expect(await runCLI(["--inspect", "exact"], io)).toBe(0);
+    const lines = err.map((l) => JSON.parse(l) as Record<string, unknown>);
+    expect(lines.some((l) => l["code"] === "INTERACTION_INSPECT_X_ON_COL")).toBe(false);
+  });
+
+  it("exit 2 for an unknown --inspect mode", async () => {
+    const { io, err } = makeIO(JSON.stringify(SPEC));
+    expect(await runCLI(["--inspect", "nearest"], io)).toBe(2);
+    expect(err.join("\n")).toContain("--inspect");
   });
 });

--- a/packages/core/tests/inspect-geom-advisories.test.ts
+++ b/packages/core/tests/inspect-geom-advisories.test.ts
@@ -103,12 +103,24 @@ describe("layerGeomsFromSpecLayers", () => {
       ]),
     ).toEqual(["col", "text"]);
   });
+
+  it("rewrites alias geoms the same way normalize does (histogram→bar)", () => {
+    expect(layerGeomsFromSpecLayers([{ geom: "histogram" }, { geom: "jitter" }])).toEqual([
+      "bar",
+      "point",
+    ]);
+  });
 });
 
 describe("collectInspectIntentDiagnostics", () => {
   it("emits INTERACTION_INSPECT_X_ON_COL from PortableSpec layers + host intent", () => {
     const list = collectInspectIntentDiagnostics([{ geom: "col" }], "xy");
     expect(list.map((d) => d.code)).toEqual(["INTERACTION_INSPECT_X_ON_COL"]);
+  });
+
+  it("emits INTERACTION_INSPECT_X_ON_BAR for authoring alias geom histogram", () => {
+    const list = collectInspectIntentDiagnostics([{ geom: "histogram" }], "xy");
+    expect(list.map((d) => d.code)).toEqual(["INTERACTION_INSPECT_X_ON_BAR"]);
   });
 
   it("is silent without host intent or for auto/exact", () => {

--- a/packages/core/tests/inspect-geom-advisories.test.ts
+++ b/packages/core/tests/inspect-geom-advisories.test.ts
@@ -28,27 +28,25 @@ describe("inspectAxisOnBarColDiagnostics", () => {
 
   it("advises when col is inspected with a vertical (x) guide", () => {
     const list = inspectAxisOnBarColDiagnostics("xy", ["col"]);
-    expect(list).toEqual([
-      expect.objectContaining({
-        code: "INTERACTION_INSPECT_X_ON_COL",
-        severity: "advisory",
-        prop: "inspect.mode",
-        actual: "xy",
-      }),
-    ]);
+    expect(list).toHaveLength(1);
+    expect(list[0]).toMatchObject({
+      code: "INTERACTION_INSPECT_X_ON_COL",
+      severity: "advisory",
+      prop: "inspect.mode",
+      actual: "xy",
+    });
     expect(INSPECT_GEOM_DIAGNOSTIC_CATALOG.INTERACTION_INSPECT_X_ON_COL).toBeDefined();
   });
 
   it("advises when bar is inspected with a vertical (x) guide", () => {
     const list = inspectAxisOnBarColDiagnostics("x", ["bar"]);
-    expect(list).toEqual([
-      expect.objectContaining({
-        code: "INTERACTION_INSPECT_X_ON_BAR",
-        severity: "advisory",
-        prop: "inspect.mode",
-        actual: "x",
-      }),
-    ]);
+    expect(list).toHaveLength(1);
+    expect(list[0]).toMatchObject({
+      code: "INTERACTION_INSPECT_X_ON_BAR",
+      severity: "advisory",
+      prop: "inspect.mode",
+      actual: "x",
+    });
   });
 
   it("warns when col value labels sit under the vertical guide", () => {
@@ -87,7 +85,6 @@ describe("inspectAxisOnBarColDiagnostics", () => {
 
 describe("layerGeomsFromSpecLayers", () => {
   it("extracts geom names and skips non-objects", () => {
-    expect(layerGeomsFromSpecLayers(undefined)).toEqual([]);
     expect(layerGeomsFromSpecLayers(null)).toEqual([]);
     expect(layerGeomsFromSpecLayers("col")).toEqual([]);
     expect(layerGeomsFromSpecLayers({})).toEqual([]);
@@ -139,13 +136,12 @@ describe("inspectHighCardinalityDiagnostics", () => {
         { channel: "fill", size: HIGH_CARDINALITY_DISCRETE_THRESHOLD - 1 },
       ],
     });
-    expect(list).toEqual([
-      expect.objectContaining({
-        code: "INTERACTION_INSPECT_HIGH_CARDINALITY_DISCRETE",
-        prop: "color",
-        actual: HIGH_CARDINALITY_DISCRETE_THRESHOLD,
-      }),
-    ]);
+    expect(list).toHaveLength(1);
+    expect(list[0]).toMatchObject({
+      code: "INTERACTION_INSPECT_HIGH_CARDINALITY_DISCRETE",
+      prop: "color",
+      actual: HIGH_CARDINALITY_DISCRETE_THRESHOLD,
+    });
   });
 
   it("is silent when inspect is off", () => {

--- a/packages/core/tests/inspect-geom-advisories.test.ts
+++ b/packages/core/tests/inspect-geom-advisories.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Pure inspect×geom collectors — shared by host ondiagnostic and CLI --inspect.
+ */
+import { describe, expect, it } from "bun:test";
+
+import {
+  collectInspectIntentDiagnostics,
+  HIGH_CARDINALITY_DISCRETE_THRESHOLD,
+  INSPECT_GEOM_DIAGNOSTIC_CATALOG,
+  inspectAxisOnBarColDiagnostics,
+  inspectHighCardinalityDiagnostics,
+  isInspectIntentMode,
+  layerGeomsFromSpecLayers,
+} from "../src/inspect-geom-advisories.ts";
+
+describe("inspectAxisOnBarColDiagnostics", () => {
+  it("is empty when inspect is off or mode is auto/exact/y", () => {
+    expect(inspectAxisOnBarColDiagnostics(null, ["col"])).toEqual([]);
+    expect(inspectAxisOnBarColDiagnostics("auto", ["col", "bar"])).toEqual([]);
+    expect(inspectAxisOnBarColDiagnostics("exact", ["col"])).toEqual([]);
+    expect(inspectAxisOnBarColDiagnostics("y", ["bar"])).toEqual([]);
+  });
+
+  it("is empty when mode is x/xy but no bar/col layers exist", () => {
+    expect(inspectAxisOnBarColDiagnostics("xy", ["point", "text"])).toEqual([]);
+    expect(inspectAxisOnBarColDiagnostics("x", ["line", "area"])).toEqual([]);
+  });
+
+  it("advises when col is inspected with a vertical (x) guide", () => {
+    const list = inspectAxisOnBarColDiagnostics("xy", ["col"]);
+    expect(list).toEqual([
+      expect.objectContaining({
+        code: "INTERACTION_INSPECT_X_ON_COL",
+        severity: "advisory",
+        prop: "inspect.mode",
+        actual: "xy",
+      }),
+    ]);
+    expect(INSPECT_GEOM_DIAGNOSTIC_CATALOG.INTERACTION_INSPECT_X_ON_COL).toBeDefined();
+  });
+
+  it("advises when bar is inspected with a vertical (x) guide", () => {
+    const list = inspectAxisOnBarColDiagnostics("x", ["bar"]);
+    expect(list).toEqual([
+      expect.objectContaining({
+        code: "INTERACTION_INSPECT_X_ON_BAR",
+        severity: "advisory",
+        prop: "inspect.mode",
+        actual: "x",
+      }),
+    ]);
+  });
+
+  it("warns when col value labels sit under the vertical guide", () => {
+    const list = inspectAxisOnBarColDiagnostics("xy", ["col", "text"]);
+    expect(list.map((d) => d.code)).toEqual(["INTERACTION_INSPECT_X_BISECTS_COL_LABELS"]);
+    expect(list[0]).toMatchObject({
+      severity: "warning",
+      prop: "inspect.mode",
+      actual: "xy",
+    });
+  });
+
+  it("warns when bar value labels sit under the vertical guide", () => {
+    const list = inspectAxisOnBarColDiagnostics("x", ["bar", "label"]);
+    expect(list.map((d) => d.code)).toEqual(["INTERACTION_INSPECT_X_BISECTS_BAR_LABELS"]);
+    expect(list[0]?.severity).toBe("warning");
+  });
+
+  it("prefers the labels warning over the plain bar/col advisory", () => {
+    const list = inspectAxisOnBarColDiagnostics("xy", ["col", "bar", "text"]);
+    expect(list.map((d) => d.code)).toEqual([
+      "INTERACTION_INSPECT_X_BISECTS_COL_LABELS",
+      "INTERACTION_INSPECT_X_BISECTS_BAR_LABELS",
+    ]);
+  });
+
+  it("treats sf_text / sf_label as value-label geoms for the bisect warning", () => {
+    expect(inspectAxisOnBarColDiagnostics("xy", ["col", "sf_text"]).map((d) => d.code)).toEqual([
+      "INTERACTION_INSPECT_X_BISECTS_COL_LABELS",
+    ]);
+    expect(inspectAxisOnBarColDiagnostics("xy", ["bar", "sf_label"]).map((d) => d.code)).toEqual([
+      "INTERACTION_INSPECT_X_BISECTS_BAR_LABELS",
+    ]);
+  });
+});
+
+describe("layerGeomsFromSpecLayers", () => {
+  it("extracts geom names and skips non-objects", () => {
+    expect(layerGeomsFromSpecLayers(undefined)).toEqual([]);
+    expect(layerGeomsFromSpecLayers(null)).toEqual([]);
+    expect(layerGeomsFromSpecLayers("col")).toEqual([]);
+    expect(layerGeomsFromSpecLayers({})).toEqual([]);
+    expect(layerGeomsFromSpecLayers([])).toEqual([]);
+    expect(
+      layerGeomsFromSpecLayers([
+        { geom: "col" },
+        { geom: "text" },
+        null,
+        { geom: 1 },
+        { notGeom: "bar" },
+        "skip",
+      ]),
+    ).toEqual(["col", "text"]);
+  });
+});
+
+describe("collectInspectIntentDiagnostics", () => {
+  it("emits INTERACTION_INSPECT_X_ON_COL from PortableSpec layers + host intent", () => {
+    const list = collectInspectIntentDiagnostics([{ geom: "col" }], "xy");
+    expect(list.map((d) => d.code)).toEqual(["INTERACTION_INSPECT_X_ON_COL"]);
+  });
+
+  it("is silent without host intent or for auto/exact", () => {
+    expect(collectInspectIntentDiagnostics([{ geom: "col" }], null)).toEqual([]);
+    expect(collectInspectIntentDiagnostics([{ geom: "col" }], "auto")).toEqual([]);
+    expect(collectInspectIntentDiagnostics([{ geom: "col" }], "exact")).toEqual([]);
+  });
+});
+
+describe("inspectHighCardinalityDiagnostics", () => {
+  it("fires once per channel over the threshold when inspect is enabled", () => {
+    const list = inspectHighCardinalityDiagnostics({
+      inspectEnabled: true,
+      domainSizes: [
+        { channel: "color", size: HIGH_CARDINALITY_DISCRETE_THRESHOLD },
+        { channel: "fill", size: HIGH_CARDINALITY_DISCRETE_THRESHOLD - 1 },
+      ],
+    });
+    expect(list).toEqual([
+      expect.objectContaining({
+        code: "INTERACTION_INSPECT_HIGH_CARDINALITY_DISCRETE",
+        prop: "color",
+        actual: HIGH_CARDINALITY_DISCRETE_THRESHOLD,
+      }),
+    ]);
+  });
+
+  it("is silent when inspect is off", () => {
+    expect(
+      inspectHighCardinalityDiagnostics({
+        inspectEnabled: false,
+        domainSizes: [{ channel: "color", size: 100 }],
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe("isInspectIntentMode", () => {
+  it("accepts the host inspect mode enum", () => {
+    for (const mode of ["auto", "exact", "x", "y", "xy"]) {
+      expect(isInspectIntentMode(mode)).toBe(true);
+    }
+    expect(isInspectIntentMode("nearest")).toBe(false);
+    expect(isInspectIntentMode("")).toBe(false);
+  });
+});

--- a/packages/skill/SKILL.md
+++ b/packages/skill/SKILL.md
@@ -252,6 +252,21 @@ strip runtime-only fields. CLIs: `ggsvelte-render spec.json > out.svg`
 validation errors, exit 0 with stderr output means quality warnings worth
 fixing) and `ggsvelte-codemod [--write] src` (ships with `@ggsvelte/svelte`).
 
+**CLI coverage for interaction:** the CLI always covers PortableSpec validation,
+pipeline warnings/advisories, scale diagnostics (`source: "scale"`), and
+spec-lint (`source: "spec-lint"`). Host inspect **mode** is not a PortableSpec
+field — without intent the agent loop never sees inspect×geom codes such as
+`INTERACTION_INSPECT_X_ON_COL`. When the host will enable inspect, declare it:
+
+```sh fragment
+ggsvelte-render --inspect xy spec.json > out.svg
+# stderr: kind advisory|warning, source "interaction", same codes as ondiagnostic
+```
+
+Modes match the host enum (`auto|exact|x|y|xy`). Runtime-only interaction
+diagnostics (keys, lineage, wiring without a mounted plot) still require the
+Svelte host's `ondiagnostic`.
+
 ## Recipes (spec JSON — the everyday twelve)
 
 All specs assume inline `"data": {"values": [...]}` or a named dataset.

--- a/packages/skill/SKILL.md
+++ b/packages/skill/SKILL.md
@@ -255,17 +255,19 @@ fixing) and `ggsvelte-codemod [--write] src` (ships with `@ggsvelte/svelte`).
 **CLI coverage for interaction:** the CLI always covers PortableSpec validation,
 pipeline warnings/advisories, scale diagnostics (`source: "scale"`), and
 spec-lint (`source: "spec-lint"`). Host inspect **mode** is not a PortableSpec
-field — without intent the agent loop never sees inspect×geom codes such as
-`INTERACTION_INSPECT_X_ON_COL`. When the host will enable inspect, declare it:
+field — without intent the agent loop never sees inspect×geom bar/col guide
+codes such as `INTERACTION_INSPECT_X_ON_COL`. When the host will enable inspect,
+declare it:
 
 ```sh fragment
 ggsvelte-render --inspect xy spec.json > out.svg
-# stderr: kind advisory|warning, source "interaction", same codes as ondiagnostic
+# stderr: kind advisory|warning, source "interaction", bar/col x-guide codes
 ```
 
-Modes match the host enum (`auto|exact|x|y|xy`). Runtime-only interaction
-diagnostics (keys, lineage, wiring without a mounted plot) still require the
-Svelte host's `ondiagnostic`.
+Modes match the host enum (`auto|exact|x|y|xy`). This path covers the pure
+bar/col axis-guide collectors only (same codes as host for that slice).
+High-cardinality discrete and runtime key/lineage/wiring diagnostics still
+require a mounted host's `ondiagnostic`.
 
 ## Recipes (spec JSON — the everyday twelve)
 

--- a/packages/skill/references/interactions.md
+++ b/packages/skill/references/interactions.md
@@ -227,7 +227,14 @@ custom content snippet.
 ## Diagnostics
 
 `ondiagnostic` receives `PlotDiagnostic`, the union of three catalogs (each
-entry has `severity`, `code`, `message`, `prop`, `suggestions`, `docUrl`):
+entry has `severity`, `code`, `message`, `prop`, `suggestions`, `docUrl`).
+
+**Agent/CLI path:** inspect mode is host-only. `ggsvelte-render --inspect MODE`
+runs the same pure inspect×geom collectors and emits matching codes on stderr
+with `source: "interaction"` (for example `INTERACTION_INSPECT_X_ON_COL` when
+`MODE` is `x`/`xy` and the spec has a `col` layer). Without `--inspect`, the
+CLI does not invent host intent. Full wiring/key/lineage diagnostics still need
+a mounted plot.
 
 - `INTERACTION_DIAGNOSTIC_CATALOG` — capability/key/lineage checks, e.g.
   `INTERACTION_POINT_REQUIRES_KEY`, `INTERACTION_DUPLICATE_KEY`,

--- a/packages/svelte/src/lib/interaction/inspect-geom-advisories.ts
+++ b/packages/svelte/src/lib/interaction/inspect-geom-advisories.ts
@@ -1,126 +1,23 @@
 /**
- * Inspect-mode × geom advisories: vertical axis guides that fight bar/col
- * geometry or bisect on-mark value labels, plus high-cardinality discrete
- * color/fill + inspect (#1274).
+ * Inspect-mode × geom advisories — re-export pure collectors from @ggsvelte/core
+ * so host plot-engine and the headless CLI share one implementation (#1531).
  *
- * Pure collection — plot-engine delivers once per code:prop when inspect.mode
- * is explicit x/xy and the assembled layers include bar/col (and optionally
- * text/label). Auto/exact modes never fire: auto already picks exact for
- * bar/col (candidateAutoMode).
+ * Catalog messages for these codes also live in core
+ * (`INSPECT_GEOM_DIAGNOSTIC_CATALOG`); INTERACTION_DIAGNOSTIC_CATALOG spreads them.
  */
-import {
-  INTERACTION_DIAGNOSTIC_CATALOG,
-  type InteractionDiagnostic,
-} from "./interaction-diagnostics.js";
-
-/**
- * Discrete color/fill domain size that triggers the default-tooltip content
- * policy advisory when inspect is enabled (#1274).
- */
-export const HIGH_CARDINALITY_DISCRETE_THRESHOLD = 16;
-
-/** Modes that draw a vertical (x) crosshair guide in non-flipped coords. */
-const X_GUIDE_MODES = new Set(["x", "xy"]);
-
-const VALUE_LABEL_GEOMS = new Set(["text", "label", "sf_text", "sf_label"]);
-
-/**
- * Advisories when inspect.mode draws an x-axis guide through bar/col marks.
- * Labels present → stronger bisect warning replaces the plain-geom advisory.
- */
-export function inspectAxisOnBarColDiagnostics(
-  inspectMode: string | null | undefined,
-  geoms: readonly string[],
-): InteractionDiagnostic[] {
-  if (inspectMode === null || inspectMode === undefined || !X_GUIDE_MODES.has(inspectMode)) {
-    return [];
-  }
-
-  let hasCol = false;
-  let hasBar = false;
-  let hasValueLabels = false;
-  for (const geom of geoms) {
-    if (geom === "col") hasCol = true;
-    else if (geom === "bar") hasBar = true;
-    if (VALUE_LABEL_GEOMS.has(geom)) hasValueLabels = true;
-  }
-  if (!hasCol && !hasBar) return [];
-
-  const list: InteractionDiagnostic[] = [];
-  if (hasCol) {
-    list.push({
-      ...(hasValueLabels
-        ? INTERACTION_DIAGNOSTIC_CATALOG.INTERACTION_INSPECT_X_BISECTS_COL_LABELS
-        : INTERACTION_DIAGNOSTIC_CATALOG.INTERACTION_INSPECT_X_ON_COL),
-      actual: inspectMode,
-    });
-  }
-  if (hasBar) {
-    list.push({
-      ...(hasValueLabels
-        ? INTERACTION_DIAGNOSTIC_CATALOG.INTERACTION_INSPECT_X_BISECTS_BAR_LABELS
-        : INTERACTION_DIAGNOSTIC_CATALOG.INTERACTION_INSPECT_X_ON_BAR),
-      actual: inspectMode,
-    });
-  }
-  return list;
-}
-
-/** Layer geom names from a PortableSpec-like layers array. */
-export function layerGeomsFromSpecLayers(layers: unknown): readonly string[] {
-  if (!Array.isArray(layers)) return [];
-  const geoms: string[] = [];
-  for (const layer of layers) {
-    if (layer === null || typeof layer !== "object" || Array.isArray(layer)) continue;
-    const geom = (layer as { geom?: unknown }).geom;
-    if (typeof geom === "string" && geom.length > 0) geoms.push(geom);
-  }
-  return geoms;
-}
-
-/**
- * Advisory when inspect is on and a discrete color/fill domain is large enough
- * that the default tooltip content policy (top-k + total + overflow) matters.
- *
- * `domainSizes` is the trained ordinal domain length per channel; continuous
- * ramps are omitted by the caller. Fires once per channel over the threshold.
- */
-export function inspectHighCardinalityDiagnostics(input: {
-  readonly inspectEnabled: boolean;
-  readonly domainSizes: ReadonlyArray<{
-    readonly channel: "color" | "fill";
-    readonly size: number;
-  }>;
-  readonly threshold?: number;
-}): InteractionDiagnostic[] {
-  if (!input.inspectEnabled) return [];
-  const threshold = input.threshold ?? HIGH_CARDINALITY_DISCRETE_THRESHOLD;
-  const list: InteractionDiagnostic[] = [];
-  for (const { channel, size } of input.domainSizes) {
-    if (size < threshold) continue;
-    list.push({
-      ...INTERACTION_DIAGNOSTIC_CATALOG.INTERACTION_INSPECT_HIGH_CARDINALITY_DISCRETE,
-      prop: channel,
-      actual: size,
-    });
-  }
-  return list;
-}
-
-/** Ordinal color/fill domain lengths from a TrainedScales-like bag. */
-export function discreteColorFillDomainSizes(scales: {
-  readonly color: { readonly kind: string; readonly scale: unknown } | null;
-  readonly fill: { readonly kind: string; readonly scale: unknown } | null;
-}): ReadonlyArray<{ readonly channel: "color" | "fill"; readonly size: number }> {
-  const out: { channel: "color" | "fill"; size: number }[] = [];
-  for (const channel of ["color", "fill"] as const) {
-    const resolved = scales[channel];
-    if (resolved === null || resolved.kind !== "ordinal") continue;
-    const scale = resolved.scale;
-    if (scale === null || typeof scale !== "object") continue;
-    const domain = (scale as { readonly domain?: unknown }).domain;
-    if (!Array.isArray(domain)) continue;
-    out.push({ channel, size: domain.length });
-  }
-  return out;
-}
+export {
+  collectInspectIntentDiagnostics,
+  discreteColorFillDomainSizes,
+  HIGH_CARDINALITY_DISCRETE_THRESHOLD,
+  INSPECT_GEOM_DIAGNOSTIC_CATALOG,
+  INSPECT_INTENT_MODES,
+  inspectAxisOnBarColDiagnostics,
+  inspectHighCardinalityDiagnostics,
+  isInspectIntentMode,
+  layerGeomsFromSpecLayers,
+} from "@ggsvelte/core";
+export type {
+  InspectGeomAdvisory,
+  InspectGeomAdvisoryCode,
+  InspectIntentMode,
+} from "@ggsvelte/core";

--- a/packages/svelte/src/lib/interaction/inspect-geom-advisories.ts
+++ b/packages/svelte/src/lib/interaction/inspect-geom-advisories.ts
@@ -4,20 +4,13 @@
  *
  * Catalog messages for these codes also live in core
  * (`INSPECT_GEOM_DIAGNOSTIC_CATALOG`); INTERACTION_DIAGNOSTIC_CATALOG spreads them.
+ * CLI-only helpers (`collectInspectIntentDiagnostics`, intent modes) stay on
+ * `@ggsvelte/core` — do not re-export them here (knip).
  */
 export {
-  collectInspectIntentDiagnostics,
   discreteColorFillDomainSizes,
   HIGH_CARDINALITY_DISCRETE_THRESHOLD,
-  INSPECT_GEOM_DIAGNOSTIC_CATALOG,
-  INSPECT_INTENT_MODES,
   inspectAxisOnBarColDiagnostics,
   inspectHighCardinalityDiagnostics,
-  isInspectIntentMode,
   layerGeomsFromSpecLayers,
-} from "@ggsvelte/core";
-export type {
-  InspectGeomAdvisory,
-  InspectGeomAdvisoryCode,
-  InspectIntentMode,
 } from "@ggsvelte/core";

--- a/packages/svelte/src/lib/interaction/interaction-diagnostics.ts
+++ b/packages/svelte/src/lib/interaction/interaction-diagnostics.ts
@@ -4,7 +4,11 @@
  *
  * Extracted from interaction.ts so pure catalog data is not mixed with event
  * types and normalizeInteractionConfig.
+ *
+ * Inspect×geom advisories (bar/col x-guide + high-cardinality) are owned by
+ * @ggsvelte/core so the CLI --inspect path reuses the same messages (#1531).
  */
+import { INSPECT_GEOM_DIAGNOSTIC_CATALOG } from "@ggsvelte/core";
 
 export type InteractionDiagnosticCode =
   | "INTERACTION_INTERVAL_FACET_UNSUPPORTED"
@@ -189,56 +193,7 @@ export const INTERACTION_DIAGNOSTIC_CATALOG: Readonly<
     docUrl:
       "https://ggsvelte.sh/guide/interaction-reference#interaction-handler-without-capability",
   },
-  INTERACTION_INSPECT_X_ON_COL: {
-    severity: "advisory",
-    code: "INTERACTION_INSPECT_X_ON_COL",
-    message:
-      "inspect.mode draws a vertical guide through column marks; columns already encode x as a filled band, so the guide cuts the bar body and rarely adds information.",
-    prop: "inspect.mode",
-    suggestions: [
-      'Use inspect={{ mode: "exact" }} (or leave mode as "auto") for GeomCol',
-      "Prefer muteSiblings for sibling de-emphasis instead of an axis guide",
-    ],
-    docUrl: "https://ggsvelte.sh/guide/interaction-reference#interaction-inspect-x-on-col",
-  },
-  INTERACTION_INSPECT_X_ON_BAR: {
-    severity: "advisory",
-    code: "INTERACTION_INSPECT_X_ON_BAR",
-    message:
-      "inspect.mode draws a vertical guide through bar marks; bars already encode the band axis as a filled region, so the guide cuts the bar body and rarely adds information.",
-    prop: "inspect.mode",
-    suggestions: [
-      'Use inspect={{ mode: "exact" }} (or leave mode as "auto") for GeomBar',
-      "Prefer muteSiblings for sibling de-emphasis instead of an axis guide",
-    ],
-    docUrl: "https://ggsvelte.sh/guide/interaction-reference#interaction-inspect-x-on-bar",
-  },
-  INTERACTION_INSPECT_X_BISECTS_COL_LABELS: {
-    severity: "warning",
-    code: "INTERACTION_INSPECT_X_BISECTS_COL_LABELS",
-    message:
-      "inspect.mode draws a vertical guide through GeomCol marks that also carry GeomText/GeomLabel values; the guide bisects the on-bar totals and makes them hard to read.",
-    prop: "inspect.mode",
-    suggestions: [
-      'Use inspect={{ mode: "exact" }} (or leave mode as "auto") when columns have value labels',
-      "Keep value labels; drop the x/xy guide rather than dropping the labels",
-    ],
-    docUrl:
-      "https://ggsvelte.sh/guide/interaction-reference#interaction-inspect-x-bisects-col-labels",
-  },
-  INTERACTION_INSPECT_X_BISECTS_BAR_LABELS: {
-    severity: "warning",
-    code: "INTERACTION_INSPECT_X_BISECTS_BAR_LABELS",
-    message:
-      "inspect.mode draws a vertical guide through GeomBar marks that also carry GeomText/GeomLabel values; the guide bisects the on-bar totals and makes them hard to read.",
-    prop: "inspect.mode",
-    suggestions: [
-      'Use inspect={{ mode: "exact" }} (or leave mode as "auto") when bars have value labels',
-      "Keep value labels; drop the x/xy guide rather than dropping the labels",
-    ],
-    docUrl:
-      "https://ggsvelte.sh/guide/interaction-reference#interaction-inspect-x-bisects-bar-labels",
-  },
+  ...INSPECT_GEOM_DIAGNOSTIC_CATALOG,
   INTERACTION_INSPECT_IDENTITY_DROPPED: {
     severity: "advisory",
     code: "INTERACTION_INSPECT_IDENTITY_DROPPED",
@@ -263,19 +218,5 @@ export const INTERACTION_DIAGNOSTIC_CATALOG: Readonly<
     ],
     docUrl:
       "https://ggsvelte.sh/guide/interaction-reference#interaction-duplicate-inspect-capability",
-  },
-  INTERACTION_INSPECT_HIGH_CARDINALITY_DISCRETE: {
-    severity: "advisory",
-    code: "INTERACTION_INSPECT_HIGH_CARDINALITY_DISCRETE",
-    message:
-      "Inspect is enabled with a high-cardinality discrete color/fill domain; the default tooltip shows the focused series, the largest contributors at that x (or y), a stack total, and an overflow line — not every series.",
-    prop: "inspect",
-    suggestions: [
-      "Prep top-n data before plotting if only the largest series matter",
-      "Pass a custom content snippet on <Inspect content={…} /> for a full multi-series listing",
-      "Pin the tooltip to scroll the full group when every series must be readable",
-    ],
-    docUrl:
-      "https://ggsvelte.sh/guide/interaction-reference#interaction-inspect-high-cardinality-discrete",
   },
 });

--- a/packages/svelte/src/lib/interaction/interaction.ts
+++ b/packages/svelte/src/lib/interaction/interaction.ts
@@ -11,14 +11,10 @@ export type {
   InteractionDiagnosticCode,
 } from "./interaction-diagnostics.js";
 export {
-  collectInspectIntentDiagnostics,
   discreteColorFillDomainSizes,
   HIGH_CARDINALITY_DISCRETE_THRESHOLD,
-  INSPECT_GEOM_DIAGNOSTIC_CATALOG,
-  INSPECT_INTENT_MODES,
   inspectAxisOnBarColDiagnostics,
   inspectHighCardinalityDiagnostics,
-  isInspectIntentMode,
   layerGeomsFromSpecLayers,
 } from "./inspect-geom-advisories.js";
 

--- a/packages/svelte/src/lib/interaction/interaction.ts
+++ b/packages/svelte/src/lib/interaction/interaction.ts
@@ -11,10 +11,14 @@ export type {
   InteractionDiagnosticCode,
 } from "./interaction-diagnostics.js";
 export {
+  collectInspectIntentDiagnostics,
   discreteColorFillDomainSizes,
   HIGH_CARDINALITY_DISCRETE_THRESHOLD,
+  INSPECT_GEOM_DIAGNOSTIC_CATALOG,
+  INSPECT_INTENT_MODES,
   inspectAxisOnBarColDiagnostics,
   inspectHighCardinalityDiagnostics,
+  isInspectIntentMode,
   layerGeomsFromSpecLayers,
 } from "./inspect-geom-advisories.js";
 


### PR DESCRIPTION
## Summary

Closes #1531. Interaction inspect×geom advisories (`INTERACTION_INSPECT_X_ON_COL`, bar/col bisect warnings, …) only fired through Svelte `ondiagnostic`, so the agent `ggsvelte-render` loop never saw them.

- **`ggsvelte-render --inspect auto|exact|x|y|xy`** declares host inspect intent (host-only capability, not PortableSpec)
- Pure collectors + catalog messages live in `@ggsvelte/core`; Svelte re-exports and spreads into `INTERACTION_DIAGNOSTIC_CATALOG`
- stderr JSONL uses `source: "interaction"` with the same codes/messages as the host for the bar/col x-guide slice
- Alias geoms (`histogram`→`bar`) rewritten so CLI matches host `normalize`
- ADR 0024 + skill + CLI README document coverage vs host-only gaps

Default without `--inspect` is unchanged (no invented host intent).

## Acceptance (#1531)

- [x] Written decision: [ADR 0024](docs/decisions/0024-cli-interaction-intent.md)
- [x] Automated path emits `INTERACTION_INSPECT_X_ON_COL` without manual `ondiagnostic`
- [x] Skill + CLI README describe what the CLI does/does not cover for interaction

## Test plan

- [x] `bun test packages/core/tests/inspect-geom-advisories.test.ts`
- [x] `bun test packages/core/tests/cli.test.ts` (inspect + histogram alias + bisect warning)
- [x] Svelte browser `inspect-geom-advisories` re-export suite
- [x] skill fence / docs search / lifecycle regen
- [x] Subagent review: histogram normalize parity fixed; docs scope tightened

## Deferred (ADR 0024)

- High-cardinality discrete on CLI (needs trained ordinal domains)
- `coord: flip` vertical-guide mode pairing (pre-existing collector limitation)
- Gallery CI that mounts examples with inspect on
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1542" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->