### PR TITLE
test(svelte): mount-level composition advisory delivery tests (#1408)

### DIFF
--- a/packages/svelte/tests/diagnostics/composition-diagnostics.test.ts
+++ b/packages/svelte/tests/diagnostics/composition-diagnostics.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Composition advisory delivery through a mounted <GGPlot> (#1408):
+ * pure collectors in composition.ts are unit-tested in
+ * composition-collect.test.ts; this file pins the plot-engine wire-up —
+ * registry.layers → collectCompositionDiagnostics → deliverAdvisoriesOnce
+ * (compositionAdvisoryDedupKey) → ondiagnostic.
+ *
+ * Family-specific assembly suites (scale-children, labs-guides-legend-children,
+ * coord-facet-children) also touch these codes while asserting last-wins merge
+ * behaviour. This file is the dedicated delivery pin: exact codes + severity,
+ * silence for clean compositions, multi-key compositionAdvisoryDedupKey, and
+ * once-per-instance dedup — matching the #1206 pattern for inspect advisories.
+ *
+ * Browser lane on purpose: every delivery path runs inside $effect, which
+ * svelte/server render() never executes, so these assertions would be
+ * vacuous in the SSR lane.
+ */
+import { flushSync } from "svelte";
+import { describe, expect, it } from "vitest";
+
+import CoordFacetChildrenPlot from "../fixtures/CoordFacetChildrenPlot.svelte";
+import LabsGuidesLegendPlot from "../fixtures/LabsGuidesLegendPlot.svelte";
+import ScaleChildrenPlot from "../fixtures/ScaleChildrenPlot.svelte";
+import { render } from "../helpers/render.js";
+import { collect, settled } from "../interaction/diagnostic-harness.js";
+
+const COMPOSITION_CODES = [
+  "DUPLICATE_SCALE_CHANNEL",
+  "DUPLICATE_MERGE_KEY",
+  "DUPLICATE_PLOT_LAYER",
+] as const;
+
+describe("composition advisories through GGPlot ondiagnostic (#1408)", () => {
+  it("fires DUPLICATE_SCALE_CHANNEL for two scale children on the same channel", async () => {
+    const { diagnostics, ondiagnostic } = collect();
+    render(ScaleChildrenPlot, {
+      useScaleColorDiscrete: true,
+      colorScheme: "colorblind",
+      useScaleColourContinuous: true,
+      ondiagnostic,
+    });
+    await expect
+      .poll(() => diagnostics.find((d) => d.code === "DUPLICATE_SCALE_CHANNEL"))
+      .toMatchObject({
+        severity: "advisory",
+        code: "DUPLICATE_SCALE_CHANNEL",
+        channel: "color",
+        kind: "scale",
+      });
+  });
+
+  it("fires DUPLICATE_MERGE_KEY for two Labs children on the same key", async () => {
+    const { diagnostics, ondiagnostic } = collect();
+    render(LabsGuidesLegendPlot, {
+      useLabs: true,
+      labsTitle: "First",
+      useSecondLabs: true,
+      secondLabsTitle: "Second",
+      ondiagnostic,
+    });
+    await expect
+      .poll(() => diagnostics.find((d) => d.code === "DUPLICATE_MERGE_KEY"))
+      .toMatchObject({
+        severity: "advisory",
+        code: "DUPLICATE_MERGE_KEY",
+        kind: "labs",
+        key: "title",
+      });
+  });
+
+  it("fires DUPLICATE_MERGE_KEY for two guide children on the same channel", async () => {
+    const { diagnostics, ondiagnostic } = collect();
+    render(LabsGuidesLegendPlot, {
+      useGuideLegend: true,
+      guideChannel: "color",
+      useSecondGuideNone: true,
+      secondGuideChannel: "color",
+      ondiagnostic,
+    });
+    await expect
+      .poll(() => diagnostics.find((d) => d.code === "DUPLICATE_MERGE_KEY"))
+      .toMatchObject({
+        severity: "advisory",
+        code: "DUPLICATE_MERGE_KEY",
+        kind: "guides",
+        key: "color",
+      });
+  });
+
+  it("fires DUPLICATE_MERGE_KEY for two Legend children on the same key", async () => {
+    const { diagnostics, ondiagnostic } = collect();
+    render(LabsGuidesLegendPlot, {
+      useLegend: true,
+      legendOrder: "sorted",
+      useSecondLegend: true,
+      secondLegendOrder: "stable-domain",
+      ondiagnostic,
+    });
+    await expect
+      .poll(() => diagnostics.find((d) => d.code === "DUPLICATE_MERGE_KEY"))
+      .toMatchObject({
+        severity: "advisory",
+        code: "DUPLICATE_MERGE_KEY",
+        kind: "legend",
+        key: "order",
+      });
+  });
+
+  it("fires DUPLICATE_PLOT_LAYER for two coord children", async () => {
+    const { diagnostics, ondiagnostic } = collect();
+    render(CoordFacetChildrenPlot, {
+      useCoordFlip: true,
+      useCoordFixed: true,
+      fixedRatio: 2,
+      ondiagnostic,
+    });
+    await expect
+      .poll(() => diagnostics.find((d) => d.code === "DUPLICATE_PLOT_LAYER"))
+      .toMatchObject({
+        severity: "advisory",
+        code: "DUPLICATE_PLOT_LAYER",
+        kind: "coord",
+      });
+  });
+
+  it("fires DUPLICATE_PLOT_LAYER for FacetWrap + FacetGrid", async () => {
+    const { diagnostics, ondiagnostic } = collect();
+    render(CoordFacetChildrenPlot, {
+      useFacetWrap: true,
+      useFacetGrid: true,
+      facetField: "g",
+      facetRows: "a",
+      facetCols: "b",
+      ondiagnostic,
+    });
+    await expect
+      .poll(() => diagnostics.find((d) => d.code === "DUPLICATE_PLOT_LAYER"))
+      .toMatchObject({
+        severity: "advisory",
+        code: "DUPLICATE_PLOT_LAYER",
+        kind: "facet",
+      });
+  });
+
+  it("fires DUPLICATE_PLOT_LAYER for two theme children", async () => {
+    const { diagnostics, ondiagnostic } = collect();
+    render(CoordFacetChildrenPlot, {
+      useThemeDark: true,
+      useThemeLight: true,
+      ondiagnostic,
+    });
+    await expect
+      .poll(() => diagnostics.find((d) => d.code === "DUPLICATE_PLOT_LAYER"))
+      .toMatchObject({
+        severity: "advisory",
+        code: "DUPLICATE_PLOT_LAYER",
+        kind: "theme",
+      });
+  });
+
+  it("delivers distinct compositionAdvisoryDedupKey entries for coord + facet dups", async () => {
+    // Without compositionAdvisoryDedupKey the default `${code}:${prop}` collapses
+    // both REPLACE advisories to one key (`DUPLICATE_PLOT_LAYER:undefined`).
+    const { diagnostics, ondiagnostic } = collect();
+    render(CoordFacetChildrenPlot, {
+      useCoordFlip: true,
+      useCoordFixed: true,
+      fixedRatio: 2,
+      useFacetWrap: true,
+      useFacetGrid: true,
+      facetField: "g",
+      facetRows: "a",
+      facetCols: "b",
+      ondiagnostic,
+    });
+    await expect
+      .poll(() => diagnostics.filter((d) => d.code === "DUPLICATE_PLOT_LAYER").length)
+      .toBe(2);
+    const plotLayerAdvisories = diagnostics.filter(
+      (diagnostic) => diagnostic.code === "DUPLICATE_PLOT_LAYER",
+    );
+    const kinds = plotLayerAdvisories.map((diagnostic) =>
+      "kind" in diagnostic ? diagnostic.kind : null,
+    );
+    expect(new Set(kinds)).toEqual(new Set(["coord", "facet"]));
+    for (const advisory of plotLayerAdvisories) {
+      expect(advisory.severity).toBe("advisory");
+    }
+  });
+
+  it("stays silent for a clean scale composition (distinct channels)", async () => {
+    const { diagnostics, ondiagnostic } = collect();
+    const { container } = render(ScaleChildrenPlot, {
+      useScaleColorDiscrete: true,
+      colorScheme: "colorblind",
+      useScaleFillContinuous: true,
+      ondiagnostic,
+    });
+    await settled(container);
+    for (const code of COMPOSITION_CODES) {
+      expect(diagnostics.map((d) => d.code)).not.toContain(code);
+    }
+  });
+
+  it("stays silent for a clean merge-key composition (distinct keys)", async () => {
+    const { diagnostics, ondiagnostic } = collect();
+    const { container } = render(LabsGuidesLegendPlot, {
+      useLabs: true,
+      labsTitle: "First",
+      useSecondLabs: true,
+      secondLabsY: "Y",
+      useGuideLegend: true,
+      guideChannel: "color",
+      useSecondGuideNone: true,
+      secondGuideChannel: "size",
+      ondiagnostic,
+    });
+    await settled(container);
+    for (const code of COMPOSITION_CODES) {
+      expect(diagnostics.map((d) => d.code)).not.toContain(code);
+    }
+  });
+
+  it("stays silent for a single REPLACE child of each kind", async () => {
+    const { diagnostics, ondiagnostic } = collect();
+    const { container } = render(CoordFacetChildrenPlot, {
+      useCoordFlip: true,
+      useFacetWrap: true,
+      facetField: "g",
+      useThemeDark: true,
+      ondiagnostic,
+    });
+    await settled(container);
+    for (const code of COMPOSITION_CODES) {
+      expect(diagnostics.map((d) => d.code)).not.toContain(code);
+    }
+  });
+
+  it("delivers once per plot instance, not once per reactive update", async () => {
+    const { diagnostics, ondiagnostic } = collect();
+    const view = render(ScaleChildrenPlot, {
+      useScaleColorDiscrete: true,
+      colorScheme: "colorblind",
+      useScaleColourContinuous: true,
+      ondiagnostic,
+    });
+    await expect
+      .poll(() => diagnostics.filter((d) => d.code === "DUPLICATE_SCALE_CHANNEL").length)
+      .toBe(1);
+
+    for (const next of ["observable10", "ipsum", "flexoki"] as const) {
+      await view.rerender({
+        useScaleColorDiscrete: true,
+        colorScheme: next,
+        useScaleColourContinuous: true,
+        ondiagnostic,
+      });
+      flushSync();
+      await new Promise((resolve) => {
+        setTimeout(resolve, 0);
+      });
+    }
+    expect(diagnostics.filter((d) => d.code === "DUPLICATE_SCALE_CHANNEL")).toHaveLength(1);
+  });
+});

--- a/packages/svelte/tests/diagnostics/composition-diagnostics.test.ts
+++ b/packages/svelte/tests/diagnostics/composition-diagnostics.test.ts
@@ -22,7 +22,7 @@ import CoordFacetChildrenPlot from "../fixtures/CoordFacetChildrenPlot.svelte";
 import LabsGuidesLegendPlot from "../fixtures/LabsGuidesLegendPlot.svelte";
 import ScaleChildrenPlot from "../fixtures/ScaleChildrenPlot.svelte";
 import { render } from "../helpers/render.js";
-import { collect, settled } from "../interaction/diagnostic-harness.js";
+import { collect, settled } from "../helpers/diagnostic-harness.js";
 
 const COMPOSITION_CODES = [
   "DUPLICATE_SCALE_CHANNEL",

--- a/packages/svelte/tests/fixtures/LabsGuidesLegendPlot.svelte
+++ b/packages/svelte/tests/fixtures/LabsGuidesLegendPlot.svelte
@@ -52,7 +52,9 @@
     scaleLocalGuideTitle,
     useLegend = false,
     useBareLegend = false,
+    useSecondLegend = false,
     legendOrder = "sorted",
+    secondLegendOrder = "stable-domain",
     guideOrder,
     useSpec = false,
     captureRegistry,
@@ -83,7 +85,10 @@
     scaleLocalGuideTitle?: string;
     useLegend?: boolean;
     useBareLegend?: boolean;
+    /** Second <Legend> for DUPLICATE_MERGE_KEY delivery pins (#1408). */
+    useSecondLegend?: boolean;
     legendOrder?: LegendSpec["order"];
+    secondLegendOrder?: LegendSpec["order"];
     guideOrder?: number;
     useSpec?: boolean;
     captureRegistry?: (registry: LayerRegistry) => void;
@@ -148,6 +153,9 @@
     {/if}
     {#if useLegend}
       <Legend order={legendOrder} />
+    {/if}
+    {#if useSecondLegend}
+      <Legend order={secondLegendOrder} />
     {/if}
     {#if useBareLegend}
       <Legend order={undefined} />

--- a/packages/svelte/tests/helpers/diagnostic-harness.ts
+++ b/packages/svelte/tests/helpers/diagnostic-harness.ts
@@ -1,10 +1,13 @@
 /**
- * Shared harness for browser-lane GGPlot-mount diagnostic tests.
+ * Shared harness for browser-lane GGPlot-mount diagnostic tests
+ * (interaction + composition suites). Lives in tests/helpers/ so multiple
+ * feature folders can import it without crossing feature-to-feature paths.
  *
  * Why browser lane only: every advisory delivery path in plot-engine.svelte.ts
  * (deliverAdvisoriesOnce, the config-diagnostics effect) runs inside $effect,
  * which svelte/server render() never executes. Assertions on ondiagnostic
- * payloads placed in *.ssr.test.ts would be vacuous passes — keep them here.
+ * payloads placed in *.ssr.test.ts would be vacuous passes — keep them in
+ * browser-lane suites that import this helper.
  */
 import { expect } from "vitest";
 

--- a/packages/svelte/tests/interaction/inspect-geom-diagnostics.test.ts
+++ b/packages/svelte/tests/interaction/inspect-geom-diagnostics.test.ts
@@ -15,7 +15,7 @@ import GGPlot from "../../src/lib/GGPlot.svelte";
 import InspectGeomAdvisoriesFixture from "../fixtures/InspectGeomAdvisoriesFixture.svelte";
 import { withGrammarAsSpec } from "../helpers/ggplot-input.js";
 import { render } from "../helpers/render.js";
-import { collect, settled } from "./diagnostic-harness.js";
+import { collect, settled } from "../helpers/diagnostic-harness.js";
 
 const rows = [
   { id: "a", x: 1, y: 10, label: "10" },

--- a/packages/svelte/tests/interaction/wiring-diagnostics.test.ts
+++ b/packages/svelte/tests/interaction/wiring-diagnostics.test.ts
@@ -10,7 +10,7 @@ import GGPlot from "../../src/lib/GGPlot.svelte";
 import { createPlotInteraction } from "../../src/lib/interaction/controller.svelte.js";
 import type { InteractionDiagnostic } from "../../src/lib/interaction/interaction.js";
 import { render } from "../helpers/render.js";
-import { collect, settled } from "./diagnostic-harness.js";
+import { collect, settled } from "../helpers/diagnostic-harness.js";
 
 const rows = [
   { id: "a", x: 1, y: 10 },


### PR DESCRIPTION
## Summary

Pins composition advisory delivery through a mounted `<GGPlot>` in the browser lane (the same gap shape as #1206 for inspect advisories).

- Pure collectors stay in `composition-collect.test.ts`
- Family suites still assert last-wins assembly for their own children
- This file is the dedicated wire-up pin: `registry.layers` → `collectCompositionDiagnostics` → `deliverAdvisoriesOnce(compositionAdvisoryDedupKey)` → `ondiagnostic`

### Coverage

| Case | Assertion |
|------|-----------|
| Scale color/colour collision | `DUPLICATE_SCALE_CHANNEL` severity advisory |
| Labs title collision | `DUPLICATE_MERGE_KEY` kind labs |
| Guides channel collision | `DUPLICATE_MERGE_KEY` kind guides |
| Legend order collision | `DUPLICATE_MERGE_KEY` kind legend (fixture gained second Legend) |
| Coord / facet / theme dups | `DUPLICATE_PLOT_LAYER` per kind |
| Coord + facet together | two advisories (proves custom dedup key is wired) |
| Clean compositions | silence across all three codes |
| Reactive scheme updates | once per instance |

Reuses `tests/interaction/diagnostic-harness.ts` (`collect` / `settled`).

## Investigation notes

Family suites already mount and assert some of these codes, but they use private `collect()` helpers and mix delivery with assembly checks. Issue #1408 asked for a #1206-style dedicated browser-lane pin after the harness landed.

## Test plan

- [x] `bunx vitest run tests/diagnostics/composition-diagnostics.test.ts --project chromium` — 12 passed
- [ ] CI svelte browser job on PR

Closes #1408

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1543" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->