### PR TITLE
fix(inspect): clarify x-guide advisories under coord_flip (#1409)

### DIFF
--- a/.changeset/inspect-coord-flip-advisories.md
+++ b/.changeset/inspect-coord-flip-advisories.md
@@ -1,0 +1,14 @@
+---
+"@ggsvelte/core": patch
+"@ggsvelte/svelte": patch
+---
+
+# Inspect x-guide advisories under coord_flip (#1409)
+
+Product decision: mode `x`/`xy` bar/col advisories still fire under
+`coord_flip`. The crosshair tracks the data-x band even when the guide is
+horizontal on screen, so it still cuts the filled mark.
+
+Catalog messages no longer claim the guide is always "vertical"; they name
+`coord_flip` so agents do not treat flip as a free pass to keep x/xy inspect
+on bar/col.

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -44626,7 +44626,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "diagnostic",
     title: "INTERACTION_INSPECT_X_ON_COL · interaction",
     summary:
-      "inspect.mode draws a vertical guide through column marks; columns already encode x as a filled band, so the guide cuts the bar body and rarely adds information.",
+      "inspect.mode x/xy draws a crosshair on the x (band) axis through column marks; columns already encode x as a filled band, so the guide cuts the bar body and rarely adds information. Under coord_flip the guide is horizontal but still tracks the band.",
     href: "/guide/errors#interaction-inspect-x-on-col",
     keywords: [
       "interaction",
@@ -44640,7 +44640,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "diagnostic",
     title: "INTERACTION_INSPECT_X_ON_BAR · interaction",
     summary:
-      "inspect.mode draws a vertical guide through bar marks; bars already encode the band axis as a filled region, so the guide cuts the bar body and rarely adds information.",
+      "inspect.mode x/xy draws a crosshair through bar marks; bars are filled regions on the band axis, so the guide cuts the bar body and rarely adds information. Under coord_flip the guide orientation swaps with the axes but still fights the marks.",
     href: "/guide/errors#interaction-inspect-x-on-bar",
     keywords: [
       "interaction",
@@ -44654,7 +44654,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "diagnostic",
     title: "INTERACTION_INSPECT_X_BISECTS_COL_LABELS · interaction",
     summary:
-      "inspect.mode draws a vertical guide through GeomCol marks that also carry GeomText/GeomLabel values; the guide bisects the on-bar totals and makes them hard to read.",
+      "inspect.mode x/xy draws a crosshair through GeomCol marks that also carry GeomText/GeomLabel values; the guide bisects the on-bar totals and makes them hard to read (including under coord_flip, when the guide is horizontal).",
     href: "/guide/errors#interaction-inspect-x-bisects-col-labels",
     keywords: [
       "interaction",
@@ -44671,7 +44671,7 @@ export const DOCS_SEARCH_INDEX = [
     kind: "diagnostic",
     title: "INTERACTION_INSPECT_X_BISECTS_BAR_LABELS · interaction",
     summary:
-      "inspect.mode draws a vertical guide through GeomBar marks that also carry GeomText/GeomLabel values; the guide bisects the on-bar totals and makes them hard to read.",
+      "inspect.mode x/xy draws a crosshair through GeomBar marks that also carry GeomText/GeomLabel values; the guide bisects the on-bar totals and makes them hard to read (including under coord_flip).",
     href: "/guide/errors#interaction-inspect-x-bisects-bar-labels",
     keywords: [
       "interaction",

--- a/packages/core/src/inspect-geom-advisories.ts
+++ b/packages/core/src/inspect-geom-advisories.ts
@@ -45,7 +45,7 @@ export const INSPECT_GEOM_DIAGNOSTIC_CATALOG: Readonly<
     severity: "advisory",
     code: "INTERACTION_INSPECT_X_ON_COL",
     message:
-      "inspect.mode draws a vertical guide through column marks; columns already encode x as a filled band, so the guide cuts the bar body and rarely adds information.",
+      "inspect.mode x/xy draws a crosshair on the x (band) axis through column marks; columns already encode x as a filled band, so the guide cuts the bar body and rarely adds information. Under coord_flip the guide is horizontal but still tracks the band.",
     prop: "inspect.mode",
     suggestions: [
       'Use inspect={{ mode: "exact" }} (or leave mode as "auto") for GeomCol',
@@ -57,7 +57,7 @@ export const INSPECT_GEOM_DIAGNOSTIC_CATALOG: Readonly<
     severity: "advisory",
     code: "INTERACTION_INSPECT_X_ON_BAR",
     message:
-      "inspect.mode draws a vertical guide through bar marks; bars already encode the band axis as a filled region, so the guide cuts the bar body and rarely adds information.",
+      "inspect.mode x/xy draws a crosshair through bar marks; bars are filled regions on the band axis, so the guide cuts the bar body and rarely adds information. Under coord_flip the guide orientation swaps with the axes but still fights the marks.",
     prop: "inspect.mode",
     suggestions: [
       'Use inspect={{ mode: "exact" }} (or leave mode as "auto") for GeomBar',
@@ -69,7 +69,7 @@ export const INSPECT_GEOM_DIAGNOSTIC_CATALOG: Readonly<
     severity: "warning",
     code: "INTERACTION_INSPECT_X_BISECTS_COL_LABELS",
     message:
-      "inspect.mode draws a vertical guide through GeomCol marks that also carry GeomText/GeomLabel values; the guide bisects the on-bar totals and makes them hard to read.",
+      "inspect.mode x/xy draws a crosshair through GeomCol marks that also carry GeomText/GeomLabel values; the guide bisects the on-bar totals and makes them hard to read (including under coord_flip, when the guide is horizontal).",
     prop: "inspect.mode",
     suggestions: [
       'Use inspect={{ mode: "exact" }} (or leave mode as "auto") when columns have value labels',
@@ -82,7 +82,7 @@ export const INSPECT_GEOM_DIAGNOSTIC_CATALOG: Readonly<
     severity: "warning",
     code: "INTERACTION_INSPECT_X_BISECTS_BAR_LABELS",
     message:
-      "inspect.mode draws a vertical guide through GeomBar marks that also carry GeomText/GeomLabel values; the guide bisects the on-bar totals and makes them hard to read.",
+      "inspect.mode x/xy draws a crosshair through GeomBar marks that also carry GeomText/GeomLabel values; the guide bisects the on-bar totals and makes them hard to read (including under coord_flip).",
     prop: "inspect.mode",
     suggestions: [
       'Use inspect={{ mode: "exact" }} (or leave mode as "auto") when bars have value labels',
@@ -113,8 +113,13 @@ export const INSPECT_GEOM_DIAGNOSTIC_CATALOG: Readonly<
  */
 export const HIGH_CARDINALITY_DISCRETE_THRESHOLD = 16;
 
-/** Modes that draw a vertical (x) crosshair guide in non-flipped coords. */
-const X_GUIDE_MODES = new Set(["x", "xy"]);
+/**
+ * Inspect modes that draw a crosshair on the data-x (band) axis for bar/col.
+ * Screen orientation swaps under coord_flip (InteractionOverlay remaps x/y to
+ * horizontal/vertical), but the guide still tracks the filled band — so these
+ * advisories fire for x/xy regardless of flip (#1409 product decision).
+ */
+const X_BAND_GUIDE_MODES = new Set(["x", "xy"]);
 
 const VALUE_LABEL_GEOMS = new Set(["text", "label", "sf_text", "sf_label"]);
 
@@ -127,14 +132,18 @@ export function isInspectIntentMode(value: string): value is InspectIntentMode {
 }
 
 /**
- * Advisories when inspect.mode draws an x-axis guide through bar/col marks.
- * Labels present → stronger bisect warning replaces the plain-geom advisory.
+ * Advisories when inspect.mode x/xy draws a band-axis crosshair through bar/col
+ * marks. Labels present → stronger bisect warning replaces the plain-geom advisory.
+ *
+ * #1409: coord_flip does **not** suppress these. Mode x still tracks data-x
+ * (the col band); under flip the guide is horizontal and still bisects the
+ * filled mark. Mode y alone never fires here (value-axis guide, not band).
  */
 export function inspectAxisOnBarColDiagnostics(
   inspectMode: string | null | undefined,
   geoms: readonly string[],
 ): InspectGeomAdvisory[] {
-  if (inspectMode === null || inspectMode === undefined || !X_GUIDE_MODES.has(inspectMode)) {
+  if (inspectMode === null || inspectMode === undefined || !X_BAND_GUIDE_MODES.has(inspectMode)) {
     return [];
   }
 

--- a/packages/core/tests/cli.test.ts
+++ b/packages/core/tests/cli.test.ts
@@ -297,6 +297,29 @@ describe("runCLI", () => {
     expect(lines.some((l) => l["code"] === "INTERACTION_INSPECT_X_ON_COL")).toBe(false);
   });
 
+  it("still emits X_ON_COL for --inspect x under coord flip (#1409 band guide remains)", async () => {
+    // PortableSpec coord is the object form; bare "flip" is a host-prop shorthand.
+    const flippedCol = {
+      data: {
+        values: [
+          { category: "a", amount: 3 },
+          { category: "b", amount: 5 },
+        ],
+      },
+      aes: { x: { field: "category" }, y: { field: "amount" } },
+      layers: [{ geom: "col" }],
+      coord: { type: "flip" },
+    };
+    const { io, err } = makeIO(JSON.stringify(flippedCol));
+    expect(await runCLI(["--inspect", "x"], io)).toBe(0);
+    const lines = err.map((l) => JSON.parse(l) as Record<string, unknown>);
+    expect(
+      lines.some(
+        (l) => l["source"] === "interaction" && l["code"] === "INTERACTION_INSPECT_X_ON_COL",
+      ),
+    ).toBe(true);
+  });
+
   it("exit 2 for an unknown --inspect mode", async () => {
     const { io, err } = makeIO(JSON.stringify(SPEC));
     expect(await runCLI(["--inspect", "nearest"], io)).toBe(2);

--- a/packages/core/tests/inspect-geom-advisories.test.ts
+++ b/packages/core/tests/inspect-geom-advisories.test.ts
@@ -81,6 +81,34 @@ describe("inspectAxisOnBarColDiagnostics", () => {
       "INTERACTION_INSPECT_X_BISECTS_BAR_LABELS",
     ]);
   });
+
+  // #1409 — product decision: x/xy still fire under coord_flip (band guide
+  // remains; only screen orientation swaps). Mode y alone never fires.
+  describe("coord_flip (#1409)", () => {
+    it("still fires for mode x and xy (band-axis guide still fights the mark)", () => {
+      expect(inspectAxisOnBarColDiagnostics("x", ["col"]).map((d) => d.code)).toEqual([
+        "INTERACTION_INSPECT_X_ON_COL",
+      ]);
+      expect(inspectAxisOnBarColDiagnostics("xy", ["bar", "text"]).map((d) => d.code)).toEqual([
+        "INTERACTION_INSPECT_X_BISECTS_BAR_LABELS",
+      ]);
+    });
+
+    it("stays silent for mode y (value-axis guide, not the x band)", () => {
+      expect(inspectAxisOnBarColDiagnostics("y", ["col", "bar", "text"])).toEqual([]);
+    });
+
+    it("catalog messages mention coord_flip so agents do not treat orientation as a free pass", () => {
+      for (const code of [
+        "INTERACTION_INSPECT_X_ON_COL",
+        "INTERACTION_INSPECT_X_ON_BAR",
+        "INTERACTION_INSPECT_X_BISECTS_COL_LABELS",
+        "INTERACTION_INSPECT_X_BISECTS_BAR_LABELS",
+      ] as const) {
+        expect(INSPECT_GEOM_DIAGNOSTIC_CATALOG[code].message.toLowerCase()).toContain("coord_flip");
+      }
+    });
+  });
 });
 
 describe("layerGeomsFromSpecLayers", () => {

--- a/packages/svelte/src/lib/plot-engine.svelte.ts
+++ b/packages/svelte/src/lib/plot-engine.svelte.ts
@@ -473,6 +473,7 @@ export function createPlotEngine(host: PlotEngineHost): PlotEngine {
 
   // Inspect axis guides that fight bar/col geometry (or bisect on-bar labels).
   // Needs assembled layers + resolved inspect.mode; once-per-code:prop like wiring.
+  // Mode x/xy still fire under coord_flip (#1409): the band-axis guide remains.
   const inspectGeomDiagnostics = $derived.by((): InteractionDiagnostic[] => {
     const mode = interactionConfig().inspect?.mode;
     if (mode === undefined) return [];

--- a/packages/svelte/tests/interaction/inspect-geom-advisories.test.ts
+++ b/packages/svelte/tests/interaction/inspect-geom-advisories.test.ts
@@ -98,6 +98,33 @@ describe("inspectAxisOnBarColDiagnostics", () => {
       expect(INTERACTION_DIAGNOSTIC_CATALOG[code].code).toBe(code);
     }
   });
+
+  // #1409 — x/xy still fire under coord_flip (band guide remains); y stays silent.
+  describe("coord_flip (#1409)", () => {
+    it("still advises for mode x/xy (band-axis guide still fights the mark)", () => {
+      expect(inspectAxisOnBarColDiagnostics("x", ["col"]).map((d) => d.code)).toEqual([
+        "INTERACTION_INSPECT_X_ON_COL",
+      ]);
+      expect(inspectAxisOnBarColDiagnostics("xy", ["bar"]).map((d) => d.code)).toEqual([
+        "INTERACTION_INSPECT_X_ON_BAR",
+      ]);
+    });
+
+    it("stays silent for mode y", () => {
+      expect(inspectAxisOnBarColDiagnostics("y", ["col", "bar"])).toEqual([]);
+    });
+
+    it("catalog messages mention coord_flip", () => {
+      for (const code of [
+        "INTERACTION_INSPECT_X_ON_COL",
+        "INTERACTION_INSPECT_X_ON_BAR",
+        "INTERACTION_INSPECT_X_BISECTS_COL_LABELS",
+        "INTERACTION_INSPECT_X_BISECTS_BAR_LABELS",
+      ] as const) {
+        expect(INTERACTION_DIAGNOSTIC_CATALOG[code].message.toLowerCase()).toContain("coord_flip");
+      }
+    });
+  });
 });
 
 describe("inspectHighCardinalityDiagnostics (#1274)", () => {

--- a/packages/svelte/tests/interaction/inspect-geom-diagnostics.test.ts
+++ b/packages/svelte/tests/interaction/inspect-geom-diagnostics.test.ts
@@ -152,6 +152,45 @@ describe("inspect x-guide advisories on bar/col (#1206)", () => {
     for (const code of X_GUIDE_CODES) expect(diagnostics.map((d) => d.code)).not.toContain(code);
   });
 
+  // #1409 — band-axis advisories still fire under coord_flip (not a false positive).
+  // coord is children-only on GGPlot (#704); fold via withGrammarAsSpec.
+  it("fires X_ON_COL for mode x under coord=flip (band guide remains)", async () => {
+    const { diagnostics, ondiagnostic } = collect();
+    render(
+      GGPlot,
+      withGrammarAsSpec({
+        data: rows,
+        aes,
+        layers: [{ geom: "col" as const }],
+        coord: "flip" as const,
+        inspect: { mode: "x" as const },
+        ondiagnostic,
+        ...size,
+      }),
+    );
+    await expect
+      .poll(() => diagnostics.find((d) => d.code === "INTERACTION_INSPECT_X_ON_COL"))
+      .toMatchObject({ severity: "advisory", actual: "x" });
+  });
+
+  it("stays silent for mode y under coord=flip (value axis, not the x band)", async () => {
+    const { diagnostics, ondiagnostic } = collect();
+    const { container } = render(
+      GGPlot,
+      withGrammarAsSpec({
+        data: rows,
+        aes,
+        layers: [{ geom: "col" as const }],
+        coord: "flip" as const,
+        inspect: { mode: "y" as const },
+        ondiagnostic,
+        ...size,
+      }),
+    );
+    await settled(container);
+    for (const code of X_GUIDE_CODES) expect(diagnostics.map((d) => d.code)).not.toContain(code);
+  });
+
   it("delivers once per plot instance, not once per reactive update", async () => {
     const { diagnostics, ondiagnostic } = collect();
     const view = render(GGPlot, {


### PR DESCRIPTION
## Summary

Closes #1409 after investigating against actual guide rendering in `InteractionOverlay`.

**Product decision:** mode `x`/`xy` bar/col advisories are **not** false positives under `coord_flip`. The crosshair still tracks the data-x band; only screen orientation swaps (horizontal under flip). The guide still cuts the filled mark (and bisects on-bar labels).

**What changed**
- Catalog messages no longer say the guide is always “vertical”; they name `coord_flip` so agents do not treat flip as a free pass
- Pure, CLI, and host tests pin: `x`/`xy` still fire under flip; mode `y` stays silent
- Docs search index regenerated from the catalog

**Rejected approach (subagent review):** gating on “vertical screen guide only” (suppress `x` under flip, fire for `y`) inverted band-axis semantics and invented `actual: "y"` false positives.

## Test plan

- [x] `bun test packages/core/tests/inspect-geom-advisories.test.ts packages/core/tests/cli.test.ts`
- [x] `vitest run` inspect-geom advisories + diagnostics (chromium)
- [ ] CI green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1544" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->