### PR TITLE
feat(examples): join Minard cold readings to retreat vertices

### DIFF
--- a/apps/docs/static/previews/provenance.json
+++ b/apps/docs/static/previews/provenance.json
@@ -258,7 +258,7 @@
     },
     "path/trajectory": {
       "filename": "path-trajectory-light.png",
-      "sourceSha256": "fae61f571f3751cad5d0b1383126a072d5441e91fac0cf052d9494bbebefb7c1",
+      "sourceSha256": "0c67543f79d05a0c389f8bb855cac3362340efef731ec3b0e9f94595df97e454",
       "pngSha256": "2949dc19048c52de04fced10fa7a563726b70d02b5f091f35f84c7d8a7b7f157"
     },
     "point/abline-identity": {

--- a/apps/docs/static/previews/provenance.json
+++ b/apps/docs/static/previews/provenance.json
@@ -258,7 +258,7 @@
     },
     "path/trajectory": {
       "filename": "path-trajectory-light.png",
-      "sourceSha256": "0c67543f79d05a0c389f8bb855cac3362340efef731ec3b0e9f94595df97e454",
+      "sourceSha256": "1a5701568a6a8b1af6b9dcd6a8086aeb666ba02f5533f69d27416156873b18af",
       "pngSha256": "2949dc19048c52de04fced10fa7a563726b70d02b5f091f35f84c7d8a7b7f157"
     },
     "point/abline-identity": {

--- a/examples/path/trajectory/data.ts
+++ b/examples/path/trajectory/data.ts
@@ -144,14 +144,10 @@ type TroopVertex = {
   leg: string;
 };
 
-/** Durable identity for a cold station — cold longitude, not the troop long. */
-export function coldStationKey(long: number): string {
-  return String(long);
-}
-
 /**
  * Join each cold reading to the nearest Column-1 retreat vertex by longitude.
  * Advance and side columns are ignored: the temperature series is retreat-only.
+ * stationKey is String(cold.long) so map and strip share durable identity.
  */
 export function buildColdStations(
   cold: readonly ColdReading[],
@@ -173,7 +169,8 @@ export function buildColdStations(
       }
     }
     return {
-      stationKey: coldStationKey(reading.long),
+      // Cold longitude, not the troop long — identity for linked selection.
+      stationKey: String(reading.long),
       long: reading.long,
       lat: nearest.lat,
       temp: reading.temp,

--- a/examples/path/trajectory/data.ts
+++ b/examples/path/trajectory/data.ts
@@ -15,6 +15,10 @@
  * in degrees Reaumur (-30 Reaumur is about -37.5 Celsius). `date` is the day
  * Minard recorded; the fifth reading has none in the source and is blank.
  *
+ * Cold stations: `buildColdStations` joins each temperature reading to the
+ * nearest Column-1 retreat vertex by longitude, producing `minardColdStations`
+ * with a shared `stationKey` for linked map/strip selection.
+ *
  * Rivers: the Niemen, Vilija, Berezina, Western Dvina, Dnieper and Moskva,
  * simplified to ~55 points each from OpenStreetMap relations (Niemen,
  * Berezina; (c) OpenStreetMap contributors, ODbL) and Natural Earth 10m
@@ -114,6 +118,73 @@ export const minardCold: { long: number; temp: number; date: string }[] = [
   { long: 26.7, temp: -30, date: "Dec 06" },
   { long: 25.3, temp: -26, date: "Dec 07" },
 ];
+
+/**
+ * One cold reading joined to the nearest Column-1 retreat vertex so the map
+ * and temperature strip share a durable `stationKey` for linked selection.
+ * Minard aligned the cold strip under the retreat by longitude; troop longs
+ * do not always match exactly (e.g. Nov 09 at 33.2° sits nearest 33.3°).
+ */
+export type MinardColdStation = {
+  stationKey: string;
+  long: number;
+  lat: number;
+  temp: number;
+  date: string;
+  survivors: number;
+  direction: string;
+};
+
+type ColdReading = { long: number; temp: number; date: string };
+type TroopVertex = {
+  long: number;
+  lat: number;
+  survivors: number;
+  direction: string;
+  leg: string;
+};
+
+/** Durable identity for a cold station — cold longitude, not the troop long. */
+export function coldStationKey(long: number): string {
+  return String(long);
+}
+
+/**
+ * Join each cold reading to the nearest Column-1 retreat vertex by longitude.
+ * Advance and side columns are ignored: the temperature series is retreat-only.
+ */
+export function buildColdStations(
+  cold: readonly ColdReading[],
+  troops: readonly TroopVertex[],
+): MinardColdStation[] {
+  const retreat = troops.filter((t) => t.leg === "Column 1 Retreat");
+  return cold.map((reading) => {
+    let nearest = retreat[0];
+    if (nearest === undefined) {
+      throw new Error("buildColdStations requires at least one Column 1 Retreat vertex");
+    }
+    let best = Math.abs(nearest.long - reading.long);
+    for (let i = 1; i < retreat.length; i++) {
+      const candidate = retreat[i]!;
+      const dist = Math.abs(candidate.long - reading.long);
+      if (dist < best) {
+        best = dist;
+        nearest = candidate;
+      }
+    }
+    return {
+      stationKey: coldStationKey(reading.long),
+      long: reading.long,
+      lat: nearest.lat,
+      temp: reading.temp,
+      date: reading.date,
+      survivors: nearest.survivors,
+      direction: nearest.direction,
+    };
+  });
+}
+
+export const minardColdStations: MinardColdStation[] = buildColdStations(minardCold, minardTroops);
 
 // Town-name nudges in degrees, so labels clear the bands the way Minard
 // placed them: Kowno left of the crossing, the Vilna-loop names off the ink.

--- a/scripts/minard-cold-stations.test.ts
+++ b/scripts/minard-cold-stations.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Minard cold-strip stations join Column-1 retreat vertices by nearest
+ * longitude so the two charts share a durable stationKey for linking.
+ *
+ * Worked values are from HistData::Minard.temp + Minard.troops (see
+ * examples/path/trajectory/data.ts), not recomputed from the implementation.
+ */
+import { describe, expect, it } from "bun:test";
+
+import {
+  buildColdStations,
+  minardCold,
+  minardColdStations,
+  minardTroops,
+} from "../examples/path/trajectory/data.ts";
+
+describe("buildColdStations", () => {
+  it("returns one station per cold reading (9 in the HistData table)", () => {
+    const stations = buildColdStations(minardCold, minardTroops);
+    expect(stations).toHaveLength(9);
+  });
+
+  it("joins Nov 09 (long 33.2) to the nearest Column-1 retreat vertex", () => {
+    const nov09 = buildColdStations(minardCold, minardTroops).find((s) => s.date === "Nov 09");
+    expect(nov09).toEqual({
+      stationKey: "33.2",
+      long: 33.2,
+      lat: 54.8,
+      temp: -9,
+      date: "Nov 09",
+      survivors: 37000,
+      direction: "Retreat",
+    });
+  });
+
+  it("keeps an empty date when Minard left the reading blank", () => {
+    const blank = buildColdStations(minardCold, minardTroops).find((s) => s.long === 29.2);
+    expect(blank?.date).toBe("");
+    expect(blank?.stationKey).toBe("29.2");
+    expect(blank?.survivors).toBe(20000);
+    // Column 1 Retreat vertex at long 29.2 (exact match)
+    expect(blank?.lat).toBe(54.3);
+  });
+
+  it("never attaches Advance vertices (cold is retreat-only)", () => {
+    for (const station of buildColdStations(minardCold, minardTroops)) {
+      expect(station.direction).toBe("Retreat");
+    }
+  });
+
+  it("uses unique stationKey values so linked identity is 1:1", () => {
+    const keys = buildColdStations(minardCold, minardTroops).map((s) => s.stationKey);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it("exports the prebuilt table used by the example", () => {
+    expect(minardColdStations).toEqual(buildColdStations(minardCold, minardTroops));
+  });
+});


### PR DESCRIPTION
## Summary

- Add `buildColdStations` / `minardColdStations` so each HistData temperature reading joins the nearest Column-1 retreat vertex by longitude.
- Durable `stationKey` is the cold longitude string (shared identity for a later linked map + cold-strip chart).
- Unit tests with known-good Nov 09 / blank-date / retreat-only cases.

Slice A of a planned series: date-on-map tooltip → linked select → polish. No UI change in this PR (examples data + tests only; no changeset).

## Test plan

- [x] `bun test scripts/minard-cold-stations.test.ts` (6 pass)
- [x] `bun run check:examples`
- [ ] CI green
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1545" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->