### PR TITLE
fix(examples): register tile geom for bare-spec heatmap

### DIFF
--- a/apps/docs/static/previews/provenance.json
+++ b/apps/docs/static/previews/provenance.json
@@ -458,7 +458,7 @@
     },
     "tile/heatmap": {
       "filename": "tile-heatmap-light.png",
-      "sourceSha256": "fdb6f9850842963e13a9c084c3896030a8d7ce63399bbd6b2eac414e4c452b85",
+      "sourceSha256": "292f44efa46d0ccd602f8d05fec8d1eb6076fb3cc01cfca1bd51962ce51e5561",
       "pngSha256": "19bc71b1103f298ecdbbc69b1dd1f4bdd791c6e27df82ae6a30d34ba3b26c857"
     },
     "vline/cutoff": {

--- a/apps/docs/static/previews/provenance.json
+++ b/apps/docs/static/previews/provenance.json
@@ -373,7 +373,7 @@
     },
     "ribbon/paint": {
       "filename": "ribbon-paint-light.png",
-      "sourceSha256": "159b66375811316387fbc0770e865a81b07e97b0478dd6e47c5b02f80e91375f",
+      "sourceSha256": "af25de2c8d0dc943c5301c3b3602548e0b2f62798ce0f28894f0a95aa99a74bd",
       "pngSha256": "f5039b1f13b2360d1dd0a404ded7c98ab47090e7059b1584b954860830e2f0fe"
     },
     "rug/ticks": {
@@ -458,7 +458,7 @@
     },
     "tile/heatmap": {
       "filename": "tile-heatmap-light.png",
-      "sourceSha256": "292f44efa46d0ccd602f8d05fec8d1eb6076fb3cc01cfca1bd51962ce51e5561",
+      "sourceSha256": "ee5d628a0644dca783a323f28342ce4002d63c42aca1c2f2524e15f40b67a164",
       "pngSha256": "19bc71b1103f298ecdbbc69b1dd1f4bdd791c6e27df82ae6a30d34ba3b26c857"
     },
     "vline/cutoff": {

--- a/examples/ribbon/paint/Example.svelte
+++ b/examples/ribbon/paint/Example.svelte
@@ -1,8 +1,59 @@
 <script lang="ts">
-  import { GGPlot, Inspect } from "@ggsvelte/svelte";
-  import spec from "./spec.js";
+  import { fillPaintLinear, glow, strokePaintLinear } from "@ggsvelte/spec";
+  import {
+    GeomLine,
+    GeomRibbon,
+    GGPlot,
+    Inspect,
+    Labs,
+  } from "@ggsvelte/svelte";
+
+  import { series } from "./data.js";
 </script>
 
-<GGPlot {spec} width={640} height={360}>
+<GGPlot
+  data={series}
+  aes={{ x: "x", ymin: "lo", ymax: "hi" }}
+  width={640}
+  height={360}
+>
   <Inspect mode="x" pin />
+  <Labs
+    title="What a ribbon can be painted with"
+    subtitle="One interval band carrying a gradient fill, a gradient stroke and a glow"
+    x="x"
+    y="value"
+    caption="Within-mark paint (not a data scale); solid fallbacks remain for a11y."
+  />
+  <GeomRibbon
+    alpha={0.85}
+    outline="both"
+    fillPaint={fillPaintLinear({
+      x1: 0,
+      y1: 0,
+      x2: 0,
+      y2: 1,
+      space: "mark",
+      stops: [
+        { offset: 0, color: "#4c78a8", opacity: 0.9 },
+        { offset: 1, color: "#f58518", opacity: 0.75 },
+      ],
+      fallback: "#4c78a8",
+    })}
+    strokePaint={strokePaintLinear({
+      x1: 0,
+      y1: 0,
+      x2: 1,
+      y2: 0,
+      space: "panel",
+      stops: [
+        { offset: 0, color: "#1a1a1a" },
+        { offset: 1, color: "#666666" },
+      ],
+      fallback: "#1a1a1a",
+    })}
+    glow={glow({ color: "#4c78a8", radius: 5, opacity: 0.35 })}
+    linewidth={1.25}
+  />
+  <GeomLine aes={{ x: "x", y: "mid" }} linewidth={1.5} />
 </GGPlot>

--- a/examples/tile/heatmap/Example.svelte
+++ b/examples/tile/heatmap/Example.svelte
@@ -1,21 +1,49 @@
 <script lang="ts">
-  /**
-   * Object-form theme (light + no grid) lives in spec.ts only — theme-parity
-   * requires hand-written plots to stay on string themes or use {spec}.
-   * Spec-driven charts skip the GeomTile shell, so register the tile batch here (#1420).
-   */
-  import { GGPlot, Inspect, registerTile } from "@ggsvelte/svelte";
+  import {
+    CoordFixed,
+    GeomTile,
+    GGPlot,
+    GuideColorbar,
+    Inspect,
+    Labs,
+    ScaleFillContinuous,
+    ScaleXDiscrete,
+    ScaleYDiscrete,
+    ThemeLight,
+  } from "@ggsvelte/svelte";
 
-  registerTile();
-
-  import spec from "./spec.js";
+  import { cholera1849 } from "./data.js";
 </script>
 
 <!--
   1200×380 (not the default 640×400): a 53-week × 7-day calendar needs a wide,
   short frame so CoordFixed can keep each band cell square and large enough
-  to read. Spec turns grid off so incomplete weeks are real holes.
+  to read. Theme turns grid off so incomplete weeks are real holes.
 -->
-<GGPlot {spec} width={1200} height={380}>
+<GGPlot
+  data={cholera1849}
+  aes={{ x: "week", y: "weekday", fill: "deaths" }}
+  width={1200}
+  height={380}
+>
   <Inspect mode="exact" pin />
+  <ThemeLight grid="none" gridX={false} gridY={false} />
+  <CoordFixed />
+  <ScaleFillContinuous scheme="viridis" />
+  <!-- Weeks are numeric but read as a band — one column per week. -->
+  <ScaleXDiscrete />
+  <!-- Weekday domain reversed so Sunday sits at the top of a calendar. -->
+  <ScaleYDiscrete
+    domain={["Sat", "Fri", "Thu", "Wed", "Tue", "Mon", "Sun"]}
+    breaks={["Mon", "Wed", "Fri"]}
+  />
+  <GuideColorbar channel="fill" position="bottom" direction="horizontal" />
+  <Labs
+    title="Cholera in England and Wales, 1849"
+    subtitle="Registered deaths every day of the year; 53,293 in all, peaking at 1,121 on 6 September"
+    x="Week of 1849"
+    y=""
+    fill="Deaths"
+  />
+  <GeomTile />
 </GGPlot>

--- a/examples/tile/heatmap/Example.svelte
+++ b/examples/tile/heatmap/Example.svelte
@@ -2,8 +2,11 @@
   /**
    * Object-form theme (light + no grid) lives in spec.ts only — theme-parity
    * requires hand-written plots to stay on string themes or use {spec}.
+   * Spec-driven charts skip the GeomTile shell, so register the tile batch here (#1420).
    */
-  import { GGPlot, Inspect } from "@ggsvelte/svelte";
+  import { GGPlot, Inspect, registerTile } from "@ggsvelte/svelte";
+
+  registerTile();
 
   import spec from "./spec.js";
 </script>

--- a/scripts/example-theme-parity.test.ts
+++ b/scripts/example-theme-parity.test.ts
@@ -122,9 +122,20 @@ describe("example theme parity (spec.ts vs Example.svelte)", () => {
       const handWritten = plots - passthrough;
 
       if (typeof theme !== "string") {
-        // Object-form theme overrides are too fiddly to mirror by hand; such an
-        // example must render through {spec} so there is only one source.
-        expect(handWritten).toBe(0);
+        // Object-form theme (name + role overrides). Either pure {spec}
+        // passthrough, or hand-written plots that declare the matching Theme
+        // shell and every role key as a prop — so the Svelte tab still shows
+        // the full chart instead of a thin {spec} shell.
+        if (handWritten === 0) {
+          expect(passthrough).toBeGreaterThan(0);
+          return;
+        }
+        const name = typeof theme.name === "string" ? theme.name : "default";
+        expect(themeDeclarations(source, name)).toBe(handWritten);
+        for (const key of Object.keys(theme)) {
+          if (key === "name") continue;
+          expect(source).toMatch(new RegExp(`\\b${key}=`));
+        }
         return;
       }
 

--- a/scripts/examples-registration.test.ts
+++ b/scripts/examples-registration.test.ts
@@ -88,17 +88,17 @@ function basicGeoms(): Set<string> {
 /** `.geomTile()` / `.geomDensity2dFilled()` → `tile` / `density_2d_filled`. */
 function geomMethodToName(method: string): string {
   return method
-    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
-    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1_$2")
+    .replaceAll(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replaceAll(/([A-Z]+)([A-Z][a-z])/g, "$1_$2")
     .toLowerCase();
 }
 
 /** Drop JS/HTML comments so comment prose cannot fake a Geom child. */
 function stripComments(source: string): string {
   return source
-    .replace(/\/\*[\s\S]*?\*\//g, "")
-    .replace(/(^|[^:])\/\/.*$/gm, "$1")
-    .replace(/<!--[\s\S]*?-->/g, "");
+    .replaceAll(/\/\*[\s\S]*?\*\//g, "")
+    .replaceAll(/(^|[^:])\/\/.*$/gm, "$1")
+    .replaceAll(/<!--[\s\S]*?-->/g, "");
 }
 
 /** True when Example.svelte mounts a portable spec without a Geom* child. */

--- a/scripts/examples-registration.test.ts
+++ b/scripts/examples-registration.test.ts
@@ -88,6 +88,7 @@ function basicGeoms(): Set<string> {
 /** `.geomTile()` / `.geomDensity2dFilled()` → `tile` / `density_2d_filled`. */
 function geomMethodToName(method: string): string {
   return method
+    .replaceAll(/([a-z])([0-9])/g, "$1_$2")
     .replaceAll(/([a-z0-9])([A-Z])/g, "$1_$2")
     .replaceAll(/([A-Z]+)([A-Z][a-z])/g, "$1_$2")
     .toLowerCase();

--- a/scripts/examples-registration.test.ts
+++ b/scripts/examples-registration.test.ts
@@ -1,15 +1,21 @@
 /**
- * Guard (#1420): stat overrides in shipped examples must register their family.
+ * Guard (#1420): shipped examples must register every non-basic stat/geom they
+ * use outside a self-registering <Geom*> shell.
  *
- * GGPlot registers the basic tier (identity + count/sum) at runtime and each
- * generated <Geom*> shell registers only its own geom batch + default stat.
- * An example that passes `stat="<name>"` for a non-basic stat must call the
- * matching register<Family>() function itself, or the chart throws
- * "Stat <name> is not registered in this build" when the live example mounts.
+ * GGPlot registers the basic tier (identity + count/sum, scatter/line/bar/…)
+ * at runtime and each generated <Geom*> shell registers only its own geom
+ * batch + default stat. Two failure modes when that is not enough:
+ *
+ * 1. An example that passes `stat="<name>"` for a non-basic stat must call the
+ *    matching register<Family>() function itself, or the chart throws
+ *    "Stat <name> is not registered in this build" when the live example mounts.
+ * 2. An example that mounts via `{spec}` without a matching <Geom*> child must
+ *    call the matching register for every non-basic geom in sibling `spec.ts`,
+ *    or the chart throws "Geom <name> is not registered in this build".
  *
  * This static lint parses the granular register modules for their
- * stat-name → function-name mapping, scans every examples/* Example.svelte
- * for stat overrides, and requires the matching call in the file source.
+ * name → function-name mapping, scans every examples/* Example.svelte, and
+ * requires the matching call in the file source.
  */
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -23,9 +29,13 @@ const ROOT = join(import.meta.dir, "..");
 const EXAMPLES = join(ROOT, "examples");
 const REGISTER_DIR = join(ROOT, "packages/core/src/pipeline");
 
-/** stat name -> register function, parsed from the granular register modules. */
-function statRegisterMap(): Map<string, string> {
-  const map = new Map<string, string>();
+/** Parse every register-*.ts module once: name → registerFn for stats and geoms. */
+function registerMaps(): {
+  stats: Map<string, string>;
+  geoms: Map<string, string>;
+} {
+  const stats = new Map<string, string>();
+  const geoms = new Map<string, string>();
   for (const entry of readdirSync(REGISTER_DIR)) {
     if (!/^register-.+\.ts$/.test(entry)) continue;
     const source = readFileSync(join(REGISTER_DIR, entry), "utf8");
@@ -33,10 +43,24 @@ function statRegisterMap(): Map<string, string> {
     if (fn === undefined) continue;
     for (const match of source.matchAll(/registerStatFrame\("([a-z0-9_]+)"/g)) {
       const statName = match[1];
-      if (statName !== undefined) map.set(statName, fn);
+      if (statName !== undefined) stats.set(statName, fn);
+    }
+    for (const match of source.matchAll(/registerGeomBatch\("([a-z0-9_]+)"/g)) {
+      const geomName = match[1];
+      if (geomName !== undefined) geoms.set(geomName, fn);
     }
   }
-  return map;
+  return { stats, geoms };
+}
+
+/** stat name -> register function, parsed from the granular register modules. */
+function statRegisterMap(): Map<string, string> {
+  return registerMaps().stats;
+}
+
+/** geom name -> register function for specialty geoms outside registerBasic(). */
+function geomRegisterMap(): Map<string, string> {
+  return registerMaps().geoms;
 }
 
 /** Stats every GGPlot app already has: the registerBasic() tier + identity. */
@@ -48,6 +72,41 @@ function basicStats(): Set<string> {
     if (statName !== undefined) stats.add(statName);
   }
   return stats;
+}
+
+/** Geoms every GGPlot app already has via registerBasic(). */
+function basicGeoms(): Set<string> {
+  const source = readFileSync(join(REGISTER_DIR, "geometry-register-basic.ts"), "utf8");
+  const geoms = new Set<string>();
+  for (const match of source.matchAll(/registerGeomBatch\("([a-z0-9_]+)"/g)) {
+    const geomName = match[1];
+    if (geomName !== undefined) geoms.add(geomName);
+  }
+  return geoms;
+}
+
+/** `.geomTile()` / `.geomDensity2dFilled()` → `tile` / `density_2d_filled`. */
+function geomMethodToName(method: string): string {
+  return method
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1_$2")
+    .toLowerCase();
+}
+
+/** Drop JS/HTML comments so comment prose cannot fake a Geom child. */
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/.*$/gm, "$1")
+    .replace(/<!--[\s\S]*?-->/g, "");
+}
+
+/** True when Example.svelte mounts a portable spec without a Geom* child. */
+function isBareSpecExample(source: string): boolean {
+  const code = stripComments(source);
+  const usesSpec = /\{spec\}|\bspec=\{/.test(code);
+  const hasGeomChild = /<Geom[A-Z][A-Za-z0-9]*[\s/>]/.test(code);
+  return usesSpec && !hasGeomChild;
 }
 
 function exampleFiles(): string[] {
@@ -131,5 +190,52 @@ describe("example stat overrides register their family (#1420)", () => {
       }
     }
     expect(violations).toEqual([]);
+  });
+});
+
+describe("bare-spec examples register non-basic geoms (#1420)", () => {
+  it("every non-basic geom in a bare-{spec} Example.svelte has its register call in-file", () => {
+    const registers = geomRegisterMap();
+    const basic = basicGeoms();
+    const violations: string[] = [];
+    for (const file of exampleFiles()) {
+      const source = readFileSync(file, "utf8");
+      if (!isBareSpecExample(source)) continue;
+      const specPath = join(file, "..", "spec.ts");
+      let specSource: string;
+      try {
+        specSource = readFileSync(specPath, "utf8");
+      } catch {
+        violations.push(`${file}: bare {spec} mount but sibling spec.ts is missing`);
+        continue;
+      }
+      const geoms = new Set<string>();
+      for (const match of specSource.matchAll(/\.geom([A-Z][A-Za-z0-9]*)\s*\(/g)) {
+        const method = match[1];
+        if (method === undefined) continue;
+        geoms.add(geomMethodToName(method));
+      }
+      for (const geom of geoms) {
+        if (basic.has(geom)) continue;
+        const fn = registers.get(geom);
+        if (fn === undefined) {
+          violations.push(`${file}: geom "${geom}" has no granular register module`);
+          continue;
+        }
+        if (!source.includes(`${fn}()`) && !source.includes("registerAll()")) {
+          violations.push(
+            `${file}: bare {spec} geom "${geom}" needs ${fn}() — no <Geom*> child self-registers it`,
+          );
+        }
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+
+  it("the geom register map covers specialty families bare-spec examples use", () => {
+    const registers = geomRegisterMap();
+    expect(registers.get("tile")).toBe("registerTile");
+    expect(registers.get("hex")).toBe("registerHex");
+    expect(registers.get("raster")).toBe("registerRaster");
   });
 });


### PR DESCRIPTION
## Summary

- Live gallery page for `tile/heatmap` threw `PipelineError: Geom "tile" is not registered` when Inspect loaded: the example mounted via `{spec}` and never pulled in the self-registering `GeomTile` shell.
- **Rewrite both bare-`{spec}` gallery stubs into full Svelte charts** so the Svelte code tab shows the real layers (not a thin shell):
  - `tile/heatmap` — `GeomTile`, band scales, colorbar, `ThemeLight` with `grid="none"`, `CoordFixed`
  - `ribbon/paint` — `GeomRibbon` + paint helpers + `GeomLine`
- Audit of all 93 gallery examples: **only these two** were bare-`{spec}` stubs without geom children.
- Theme parity: object-form themes may use hand-written plots when they declare the matching Theme shell and every role prop (no longer force `{spec}` only).
- Guard: `scripts/examples-registration.test.ts` still covers bare-`{spec}` non-basic geoms if any return later.

## Root cause

GGPlot only installs the basic geom tier. Component children register their own batch; pure `GGPlot {spec}` does not. The heatmap stayed on `{spec}` for object-form theme parity (grid off). The durable fix is full Svelte children (`GeomTile` self-registers) plus parity that allows object themes on hand-written plots.

## Test plan

- [x] `bun test scripts/examples-registration.test.ts scripts/example-theme-parity.test.ts`
- [x] `bun run gallery:previews:check` after provenance refresh
- [x] oxlint type-aware clean on changed scripts
- [ ] Confirm live docs `/examples/tile/heatmap` mounts Inspect and Svelte tab shows full chart after deploy