### PR TITLE
feat(examples): link Minard cold strip stations to the march map

### DIFF
--- a/apps/docs/static/previews/provenance.json
+++ b/apps/docs/static/previews/provenance.json
@@ -258,7 +258,7 @@
     },
     "path/trajectory": {
       "filename": "path-trajectory-light.png",
-      "sourceSha256": "43dc2ff3332c6c78c6d74c8b53d62f5fdae579ed05b0bb59b8ae4df85c3e09fe",
+      "sourceSha256": "9a24ad30c99bacf748e77bf0448f34a91d8502eddd05f82b5872d45c1fcde070",
       "pngSha256": "842aca1ae410868acfa0e51ce0515191e01ac9b78907870fbea1d6a8cde28a6a"
     },
     "point/abline-identity": {

--- a/apps/docs/static/previews/provenance.json
+++ b/apps/docs/static/previews/provenance.json
@@ -258,7 +258,7 @@
     },
     "path/trajectory": {
       "filename": "path-trajectory-light.png",
-      "sourceSha256": "9a24ad30c99bacf748e77bf0448f34a91d8502eddd05f82b5872d45c1fcde070",
+      "sourceSha256": "e17905bd21a2cf2dce3f0152913600612f4ecd63b932a23949ec35c5d5876abf",
       "pngSha256": "842aca1ae410868acfa0e51ce0515191e01ac9b78907870fbea1d6a8cde28a6a"
     },
     "point/abline-identity": {

--- a/apps/docs/static/previews/provenance.json
+++ b/apps/docs/static/previews/provenance.json
@@ -258,7 +258,7 @@
     },
     "path/trajectory": {
       "filename": "path-trajectory-light.png",
-      "sourceSha256": "40e4a38882d14be06a6324e7a41d09391acceb71e4d97d763a071fabb7f79732",
+      "sourceSha256": "43dc2ff3332c6c78c6d74c8b53d62f5fdae579ed05b0bb59b8ae4df85c3e09fe",
       "pngSha256": "842aca1ae410868acfa0e51ce0515191e01ac9b78907870fbea1d6a8cde28a6a"
     },
     "point/abline-identity": {

--- a/examples/path/trajectory/Example.svelte
+++ b/examples/path/trajectory/Example.svelte
@@ -19,11 +19,13 @@
     minardCityLabels,
     minardColdStations,
     minardStrengthLabels,
-    minardTroopsWithCold,
+    minardTroops,
   } from "./data.js";
 
   // Shared keys: cold strip and map station points both use stationKey so a
   // click on Nov 09 selects the same retreat station on the march map.
+  // Only one inspectable layer per plot may own those keys (engine: unique
+  // PropertyKey per plot). Path uses plain troops without stationKey.
   const interaction = createPlotInteraction<string>();
   const scope = { keys: "minard-cold-station" } as const;
 </script>
@@ -66,10 +68,9 @@
       alpha={0.7}
       inspect={false}
     />
-    <!-- Troops keep stationKey for linking; date is on cold-station points only so
-         path pins do not show an empty date row on Advance / non-station vertices. -->
+    <!-- Plain troops: no stationKey so path inspect stays free of key collisions -->
     <GeomPath
-      data={minardTroopsWithCold}
+      data={minardTroops}
       aes={{
         x: "long",
         y: "lat",
@@ -78,7 +79,7 @@
         linewidth: "survivors",
       }}
     />
-    <!-- Cold stations: pin targets with date + shared selection keys -->
+    <!-- Sole map owner of stationKey: pin targets with date + linked selection -->
     <GeomPoint
       data={minardColdStations}
       aes={{
@@ -104,7 +105,9 @@
     />
   </GGPlot>
 
+  <!-- Plot-level data so path + point share one row namespace for stationKey -->
   <GGPlot
+    data={minardColdStations}
     width={960}
     height={190}
     select={{ type: "point" }}
@@ -116,17 +119,14 @@
     <ScaleXContinuous limits={[23.5, 38.2]} />
     <Labs title="The cold on the road back" x="Longitude east" y="°Réaumur" />
     <GeomPath
-      data={minardColdStations}
       aes={{ x: "long", y: "temp", color: { value: "#6b7280" } }}
       linewidth={1.5}
     />
     <GeomPoint
-      data={minardColdStations}
       aes={{ x: "long", y: "temp", color: { value: "#374151" }, label: "date" }}
       size={2.5}
     />
     <GeomText
-      data={minardColdStations}
       aes={{ x: "long", y: "temp", label: "date", color: { value: "#374151" } }}
       size={10}
       dy={-11}

--- a/examples/path/trajectory/Example.svelte
+++ b/examples/path/trajectory/Example.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import {
     CoordFixed,
+    createPlotInteraction,
     GeomPath,
     GeomPoint,
     GeomText,
@@ -16,16 +17,26 @@
   import {
     campaignRivers,
     minardCityLabels,
-    minardCold,
     minardColdStations,
     minardStrengthLabels,
     minardTroopsWithCold,
   } from "./data.js";
+
+  // Shared keys: cold strip and map station points both use stationKey so a
+  // click on Nov 09 selects the same retreat station on the march map.
+  const interaction = createPlotInteraction<string>();
+  const scope = { keys: "minard-cold-station" } as const;
 </script>
 
 <div class="minard">
-  <GGPlot width={960} height={520}>
-    <Inspect mode="xy" pin maxDistance={24} />
+  <GGPlot
+    width={960}
+    height={520}
+    select={{ type: "point" }}
+    {interaction}
+    interactionScope={scope}
+  >
+    <Inspect mode="xy" pin maxDistance={24} identity="stationKey" />
     <ThemeClassic />
     <!-- lon/lat degrees are not the same length on the ground at 55°N -->
     <CoordFixed ratio={1.6} />
@@ -67,7 +78,7 @@
         linewidth: "survivors",
       }}
     />
-    <!-- Cold stations: pin targets with date in the default tooltip (label is tooltip-only on point) -->
+    <!-- Cold stations: pin targets with date + shared selection keys -->
     <GeomPoint
       data={minardColdStations}
       aes={{
@@ -93,23 +104,29 @@
     />
   </GGPlot>
 
-  <GGPlot width={960} height={190}>
-    <Inspect mode="xy" pin maxDistance={24} />
+  <GGPlot
+    width={960}
+    height={190}
+    select={{ type: "point" }}
+    {interaction}
+    interactionScope={scope}
+  >
+    <Inspect mode="xy" pin maxDistance={24} identity="stationKey" />
     <ThemeClassic />
     <ScaleXContinuous limits={[23.5, 38.2]} />
     <Labs title="The cold on the road back" x="Longitude east" y="°Réaumur" />
     <GeomPath
-      data={minardCold}
+      data={minardColdStations}
       aes={{ x: "long", y: "temp", color: { value: "#6b7280" } }}
       linewidth={1.5}
     />
     <GeomPoint
-      data={minardCold}
-      aes={{ x: "long", y: "temp", color: { value: "#374151" } }}
+      data={minardColdStations}
+      aes={{ x: "long", y: "temp", color: { value: "#374151" }, label: "date" }}
       size={2.5}
     />
     <GeomText
-      data={minardCold}
+      data={minardColdStations}
       aes={{ x: "long", y: "temp", label: "date", color: { value: "#374151" } }}
       size={10}
       dy={-11}

--- a/scripts/example-interaction-api.test.ts
+++ b/scripts/example-interaction-api.test.ts
@@ -100,7 +100,12 @@ describe("example interaction API (v0.20)", () => {
    * `interaction/` must stay free of that boilerplate (default index/`id`
    * identity is enough for GuideLegend focus). README snippets are also gated
    * by scripts/readme-showcase.test.ts; this covers the corpus itself.
+   *
+   * Allowlist: path/trajectory is a dual-panel Minard teaching surface — the
+   * cold strip exists to date the retreat, so linked station keys belong there.
    */
+  const LINKED_VIEW_ALLOWLIST = new Set(["path/trajectory"]);
+
   it("keeps createPlotInteraction out of non-interaction gallery examples", () => {
     const offenders = files
       .map((path) => ({
@@ -108,6 +113,7 @@ describe("example interaction API (v0.20)", () => {
         source: readFileSync(path, "utf8"),
       }))
       .filter(({ id }) => !id.startsWith("interaction/"))
+      .filter(({ id }) => !LINKED_VIEW_ALLOWLIST.has(id))
       .filter(
         ({ source }) =>
           source.includes("createPlotInteraction") ||
@@ -117,6 +123,10 @@ describe("example interaction API (v0.20)", () => {
       .map(({ id }) => id);
 
     expect(offenders).toEqual([]);
+  });
+
+  it("path/trajectory is the only non-interaction linked-view allowlist entry", () => {
+    expect([...LINKED_VIEW_ALLOWLIST]).toEqual(["path/trajectory"]);
   });
 
   /**

--- a/scripts/minard-linked-stations.test.ts
+++ b/scripts/minard-linked-stations.test.ts
@@ -34,12 +34,20 @@ describe("path/trajectory linked cold stations", () => {
     }
   });
 
-  it("uses minardColdStations for cold-strip points (shared keys with the map)", () => {
-    // Cold chart point layer must use stations so keys match the map points.
-    expect(source).toMatch(/data=\{minardColdStations\}/);
+  it("uses plot-level minardColdStations on the cold strip (shared rows for path+point)", () => {
     const coldPlot = (source.match(/<GGPlot[\s\S]*?<\/GGPlot>/g) ?? [])[1] ?? "";
-    expect(coldPlot).toContain("data={minardColdStations}");
-    expect(coldPlot).toMatch(/identity=["']stationKey["']/);
+    expect(coldPlot).toMatch(/data=\{minardColdStations\}/);
+    // Layers inherit plot data — no second layer-local copy of stations.
+    expect(coldPlot).not.toMatch(/<GeomPath[\s\S]*data=\{minardColdStations\}/);
+    expect(coldPlot).not.toMatch(/<GeomPoint[\s\S]*data=\{minardColdStations\}/);
+  });
+
+  it("keeps map stationKey only on cold-station points (not the troop path)", () => {
+    const mapPlot = (source.match(/<GGPlot[\s\S]*?<\/GGPlot>/g) ?? [])[0] ?? "";
+    expect(mapPlot).toMatch(/data=\{minardTroops\}/);
+    expect(mapPlot).toMatch(/data=\{minardColdStations\}/);
+    // Path must not use the date-stamped table (would collide keys with points).
+    expect(mapPlot).not.toContain("minardTroopsWithCold");
   });
 });
 

--- a/scripts/minard-linked-stations.test.ts
+++ b/scripts/minard-linked-stations.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Slice C: dual Minard charts share createPlotInteraction so clicking a cold
+ * reading selects the same station on the march map (and vice versa).
+ */
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = join(import.meta.dir, "..");
+const EXAMPLE = join(ROOT, "examples/path/trajectory/Example.svelte");
+const INTERACTION_API = join(ROOT, "scripts/example-interaction-api.test.ts");
+
+describe("path/trajectory linked cold stations", () => {
+  const source = readFileSync(EXAMPLE, "utf8");
+
+  it("shares one createPlotInteraction controller across both plots", () => {
+    expect(source).toContain("createPlotInteraction");
+    expect(source).toMatch(/interactionScope=\{scope\}/g);
+    // Both GGPlots get the controller
+    const plots = source.match(/<GGPlot[\s\S]*?<\/GGPlot>/g) ?? [];
+    expect(plots.length).toBe(2);
+    for (const plot of plots) {
+      expect(plot).toContain("{interaction}");
+      expect(plot).toContain("interactionScope={scope}");
+      expect(plot).toMatch(/select=\{\{\s*type:\s*["']point["']/);
+    }
+  });
+
+  it("uses stationKey identity on both Inspect children", () => {
+    const inspects = source.match(/<Inspect\b[^/]*\/>/g) ?? [];
+    expect(inspects.length).toBeGreaterThanOrEqual(2);
+    for (const inspect of inspects) {
+      expect(inspect).toMatch(/identity=["']stationKey["']/);
+    }
+  });
+
+  it("uses minardColdStations for cold-strip points (shared keys with the map)", () => {
+    // Cold chart point layer must use stations so keys match the map points.
+    expect(source).toMatch(/data=\{minardColdStations\}/);
+    const coldPlot = (source.match(/<GGPlot[\s\S]*?<\/GGPlot>/g) ?? [])[1] ?? "";
+    expect(coldPlot).toContain("data={minardColdStations}");
+    expect(coldPlot).toMatch(/identity=["']stationKey["']/);
+  });
+});
+
+describe("example-interaction-api allowlist for Minard dual-chart linking", () => {
+  it("allows path/trajectory via LINKED_VIEW_ALLOWLIST", () => {
+    const gate = readFileSync(INTERACTION_API, "utf8");
+    expect(gate).toContain('LINKED_VIEW_ALLOWLIST = new Set(["path/trajectory"])');
+  });
+});

--- a/scripts/minard-map-date.test.ts
+++ b/scripts/minard-map-date.test.ts
@@ -1,7 +1,7 @@
 /**
- * Slice B: map-panel tooltips must carry Minard's cold date.
- * attachColdDatesToTroops stamps the nearest Column-1 retreat vertex;
- * the live Example maps label:"date" on that path so default Inspect shows it.
+ * Slice B/C: map-panel tooltips carry Minard's cold date on station points.
+ * attachColdDatesToTroops remains available for stamped troop tables; the live
+ * Example maps label:"date" on minardColdStations points only (unique keys).
  */
 import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
@@ -49,21 +49,6 @@ describe("attachColdDatesToTroops", () => {
 describe("path/trajectory Example map date tooltip wiring", () => {
   const source = readFileSync(EXAMPLE, "utf8");
 
-  it("uses the date-stamped troop table on the march path", () => {
-    expect(source).toContain("minardTroopsWithCold");
-    expect(source).toMatch(/data=\{minardTroopsWithCold\}/);
-  });
-
-  it("does not map date on the troop path (avoids empty date rows on Advance pins)", () => {
-    const dataAt = source.indexOf("data={minardTroopsWithCold}");
-    expect(dataAt).toBeGreaterThan(-1);
-    const openAt = source.lastIndexOf("<GeomPath", dataAt);
-    const closeAt = source.indexOf("/>", dataAt);
-    const troopPath = source.slice(openAt, closeAt + 2);
-    expect(troopPath).not.toMatch(/label:\s*["']date["']/);
-    expect(troopPath).not.toContain("inspect={false}");
-  });
-
   it("maps label to date on cold-station points so map pin shows the date", () => {
     expect(source).toContain("minardColdStations");
     const stationPoint = source.match(
@@ -72,5 +57,11 @@ describe("path/trajectory Example map date tooltip wiring", () => {
     expect(stationPoint).toBeDefined();
     expect(stationPoint!).toMatch(/label:\s*["']date["']/);
     expect(stationPoint!).not.toContain("inspect={false}");
+  });
+
+  it("keeps the march path free of stationKey collisions (plain minardTroops)", () => {
+    const mapPlot = (source.match(/<GGPlot[\s\S]*?<\/GGPlot>/g) ?? [])[0] ?? "";
+    expect(mapPlot).toMatch(/data=\{minardTroops\}/);
+    expect(mapPlot).not.toContain("minardTroopsWithCold");
   });
 });


### PR DESCRIPTION
## Summary

Slice C of the Minard dual-chart series (after #1545, #1547):

- Shared `createPlotInteraction` + `interactionScope.keys` across both panels
- Point select + `identity="stationKey"` on both Inspect children
- Cold strip path/points/text use `minardColdStations` so keys match the map
- Gallery allowlist: only `path/trajectory` may use controllers outside `interaction/`

## Test plan

- [x] bun test scripts/minard-linked-stations.test.ts
- [x] bun test scripts/example-interaction-api.test.ts
- [x] bun run check:examples
- [ ] CI green

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1549" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->