### PR TITLE
docs: fix residual polish-first order in getting-started fragments

### DIFF
--- a/scripts/diagnostic-docs.ts
+++ b/scripts/diagnostic-docs.ts
@@ -80,8 +80,8 @@ const recipes = new Map<string, DiagnosticDocEntry["recipe"]>([
     {
       language: "svelte",
       code: `<GGPlot data={rows} aes={{ x: "group", y: "amount" }}>
-  <Inspect mode="exact" />
   <GeomCol />
+  <Inspect mode="exact" />
 </GGPlot>`,
     },
   ],
@@ -90,8 +90,8 @@ const recipes = new Map<string, DiagnosticDocEntry["recipe"]>([
     {
       language: "svelte",
       code: `<GGPlot data={rows} aes={{ x: "run", y: "value" }}>
-  <Inspect mode="exact" />
   <GeomViolin />
+  <Inspect mode="exact" />
 </GGPlot>`,
     },
   ],
@@ -100,9 +100,9 @@ const recipes = new Map<string, DiagnosticDocEntry["recipe"]>([
     {
       language: "svelte",
       code: `<GGPlot data={rows} aes={{ x: "group", y: "amount" }}>
-  <Inspect mode="exact" />
   <GeomCol />
   <GeomText aes={{ label: "label" }} dy={-8} />
+  <Inspect mode="exact" />
 </GGPlot>`,
     },
   ],
@@ -111,8 +111,8 @@ const recipes = new Map<string, DiagnosticDocEntry["recipe"]>([
     {
       language: "svelte",
       code: `<GGPlot data={rows} aes={{ x: "x", y: "y" }}>
-  <Inspect mode="xy" />
   <GeomPoint />
+  <Inspect mode="xy" />
 </GGPlot>`,
     },
   ],

--- a/scripts/quickstart/steps.ts
+++ b/scripts/quickstart/steps.ts
@@ -250,14 +250,9 @@ export const SAKURA_STEPS: readonly SakuraStep[] = [
     // labels, and a domain strip for later epoch names — not a second reverse.
     // Dotted chartlines hang off the two outer breaks so each labeled date has
     // a line a reader can use, matching the reference chart.
-    fragment: `<ThemeTufte />
-<ScaleYMonthDay
-  reverse
-  breaks={[${SAKURA_Y_BREAKS.map((d) => `"${d}"`).join(", ")}]}
-  dateLabels="%b %e"
-  domain={["${DOMAIN_BOTTOM}", "${DOMAIN_TOP}"]}
-/>
-<GeomRule yintercept="${SAKURA_Y_BREAKS[0]}" linewidth={0.75}
+    // Fragment order matches ggplot2 thinking order (marks → scales → theme),
+    // same as foldSakura grammar emission — not the polish-first reading order.
+    fragment: `<GeomRule yintercept="${SAKURA_Y_BREAKS[0]}" linewidth={0.75}
   aes={{ color: { value: "#b7c1cd" }, linetype: { value: "dotted" } }}
   inspect={false} />
 <GeomRule yintercept="${SAKURA_Y_BREAKS[2]}" linewidth={0.75}
@@ -267,7 +262,14 @@ export const SAKURA_STEPS: readonly SakuraStep[] = [
   aes={{ color: { value: "#4a5568" } }} />
 <GeomLine stat="summary_rolling" fun="median" window={${SAKURA_TREND_WINDOW}}
   curve="linear" linewidth={1.8}
-  aes={{ color: { value: "#262626" } }} />`,
+  aes={{ color: { value: "#262626" } }} />
+<ScaleYMonthDay
+  reverse
+  breaks={[${SAKURA_Y_BREAKS.map((d) => `"${d}"`).join(", ")}]}
+  dateLabels="%b %e"
+  domain={["${DOMAIN_BOTTOM}", "${DOMAIN_TOP}"]}
+/>
+<ThemeTufte />`,
     spec: {
       theme: "tufte",
       scales: {

--- a/scripts/sakura-lesson.test.ts
+++ b/scripts/sakura-lesson.test.ts
@@ -58,6 +58,15 @@ function countHitsInBox(
   return { points, trend };
 }
 
+/** ggplot2 thinking-order rank for a GGPlot child tag name (lower = earlier). */
+function thinkingOrderRank(tag: string): number {
+  if (tag.startsWith("Geom")) return 0;
+  if (/^(Scale|Coord|Facet)/.test(tag)) return 1;
+  if (/^(Theme|Guide|Labs)/.test(tag)) return 2;
+  if (tag === "Inspect") return 3;
+  return 1;
+}
+
 /** Tick labels of one axis, top-to-bottom in screen order. */
 function yTicks(spec: unknown): { label: string; pos: number }[] {
   const model = runPipeline(spec as never, { width: 900, height: 480 });
@@ -338,6 +347,23 @@ describe("the sakura lesson folds to renderable specs", () => {
     }
     // key/inspect are runtime props, not spec fields — assert them there.
     expect(finished.key).toBe("year");
+  });
+
+  it("authors step fragments in ggplot2 thinking order", () => {
+    // GettingStartedGuide prints step.fragment verbatim — foldSakura only
+    // reorders the finished file. Theme/scale-before-mark fragments are a
+    // silent docs regression (caught on #1555 leftovers).
+    const tagRe = /<(Theme\w+|Inspect|Geom\w+|Scale\w+|Coord\w+|Facet\w+|Guide\w+|Labs)\b/g;
+    for (const step of SAKURA_STEPS) {
+      const tags = [...step.fragment.matchAll(tagRe)].map((m) => m[1]!);
+      if (tags.length < 2) continue;
+      for (let i = 1; i < tags.length; i += 1) {
+        expect(
+          thinkingOrderRank(tags[i]!) >= thinkingOrderRank(tags[i - 1]!),
+          `${step.id}: fragment out of thinking order: ${tags.join(" → ")}`,
+        ).toBe(true);
+      }
+    }
   });
 
   it("uses only attributes the geom components actually accept", () => {


### PR DESCRIPTION
## Summary

- **Root cause:** #1555 fixed `foldSakura` emission order and gallery examples, but `GettingStartedGuide` prints hand-authored `step.fragment` strings from `scripts/quickstart/steps.ts`. The first lesson step still led with `<ThemeTufte />` (user report).
- **Fix:** Reorder that fragment to marks → scales → theme; put `<Inspect>` last in diagnostic error recipes; add a regression test that step fragments stay in ggplot2 thinking order.
- No runtime/engine change — authoring surfaces only.

## Residual audit (investigate)

| Surface | Status |
|---------|--------|
| `steps.ts` step 0 `fragment` | **Was wrong — fixed** |
| Other step fragments | Already marks-first |
| `foldSakura` finished file | Already correct after #1555 |
| skill / recipes / examples | Clean on per-fence scan |
| diagnostic-docs recipes | Inspect-before-mark — **fixed** |
| test fixtures / CHANGELOG | Left alone (not teaching surfaces) |

## Test plan

- [x] `bun test scripts/sakura-lesson.test.ts` (35 pass, including new order test)
- [x] `bun test scripts/gen-llms.test.ts scripts/progressive-docs.test.ts`
- [ ] CI green on this PR
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1557" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->