### PR TITLE
fix(examples): keep Minard fullWidth charts at shell size on hover

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -388,12 +388,17 @@ Authoring a new example:
      the canonical `PortableSpec`; it is validated at tier 2 on import, and
      its JSON is the docs "Spec" tab.
    - **`Example.svelte`** — idiomatic component usage (`<GGPlot ...>` with
-     `<GeomX>` children), importing data from `./data.js`. Give the corpus
-     file an explicit `width={640} height={400}` (or `height={vrHeight}` if
-     you set one) so VR captures at a fixed size. These props are VR
-     plumbing, not the recommended authoring style: package README and
-     docs snippets omit them, and user code should too — omitted width is
-     container-responsive, omitted height is 400.
+     `<GeomX>` children), importing data from `./data.js`. Default: pin
+     `width={640} height={400}` (or `height={vrHeight}` if you set one) so
+     VR captures at a fixed size. **Exception — `journey.fullWidth`:** the
+     docs frame drops max-width and the gallery PNG fills the content
+     column, so live plots must use `width="container"` (or omit width)
+     rather than a fixed pixel width — otherwise first hover snaps the
+     chart from a stretched static preview down to that fixed size. VR
+     still pins the outer frame to `vrWidth`×`vrHeight` from `meta.json`,
+     so container mode measures that size under `?vr`. Package README and
+     docs snippets omit width/height; user code should too — omitted width
+     is container-responsive, omitted height is 400.
    - **`meta.json`** — `{ title, description, tags, docsSection, vrHeight? }`
      (validated by the generator; `docsSection` groups the gallery).
    - **`data.ts`** (optional) — static rows or `mulberry32`-seeded

--- a/apps/docs/static/previews/provenance.json
+++ b/apps/docs/static/previews/provenance.json
@@ -263,7 +263,7 @@
     },
     "path/trajectory": {
       "filename": "path-trajectory-light.png",
-      "sourceSha256": "6df24bd26acc66f46ceb48b2fd24283bd7c87dcfb4ab16649abc62e354007305",
+      "sourceSha256": "72680441168fbf37ce3134372408fc1844a452772d327a084232f8ec1845220b",
       "pngSha256": "c829528a4a14f19b729318254a968aca54f679b1432971281f2f8a457178bcad"
     },
     "point/abline-identity": {

--- a/examples/path/trajectory/Example.svelte
+++ b/examples/path/trajectory/Example.svelte
@@ -66,7 +66,7 @@
 {/snippet}
 
 <div class="minard">
-  <GGPlot width={960} height={520}>
+  <GGPlot width="container" height={520}>
     <GeomPath
       data={campaignRivers}
       aes={{ x: "long", y: "lat", group: "river", color: { value: "#8fa8c0" } }}
@@ -122,7 +122,7 @@
     <Inspect mode="xy" pin maxDistance={24} content={mapTooltip} />
   </GGPlot>
 
-  <GGPlot data={minardCold} width={960} height={190}>
+  <GGPlot data={minardCold} width="container" height={190}>
     <GeomPath
       aes={{ x: "long", y: "temp", color: { value: "#6b7280" } }}
       linewidth={1.5}
@@ -154,6 +154,10 @@
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
+    /* fullWidth frame + container-width plots: fill the shell so live
+       matches the stretched gallery PNG instead of snapping to a fixed px. */
+    width: 100%;
+    min-width: 0;
   }
 
   .minard-tip {

--- a/scripts/docs-example-fullwidth-container.test.ts
+++ b/scripts/docs-example-fullwidth-container.test.ts
@@ -1,0 +1,57 @@
+/**
+ * fullWidth example frames drop max-width so the gallery PNG can fill the
+ * content column. Live GGPlot children must use container (or omit width)
+ * so the interactive upgrade does not snap from a stretched PNG down to a
+ * fixed pixel width — the path/trajectory Minard page did that with
+ * width={960} under journey.fullWidth.
+ */
+import { describe, expect, it } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+const root = path.join(import.meta.dirname, "..");
+const examplesRoot = path.join(root, "examples");
+
+/** GGPlot width={960} / width={ 640 } — fixed px, not container. */
+const FIXED_PLOT_WIDTH = /\bwidth\s*=\s*\{\s*\d+\s*\}/;
+
+function fullWidthExampleIds(): string[] {
+  const ids: string[] = [];
+  for (const category of readdirSync(examplesRoot, { withFileTypes: true })) {
+    if (!category.isDirectory() || category.name.startsWith(".")) continue;
+    const catDir = path.join(examplesRoot, category.name);
+    for (const name of readdirSync(catDir, { withFileTypes: true })) {
+      if (!name.isDirectory()) continue;
+      const metaPath = path.join(catDir, name.name, "meta.json");
+      let meta: { journey?: { fullWidth?: boolean } };
+      try {
+        meta = JSON.parse(readFileSync(metaPath, "utf8")) as typeof meta;
+      } catch {
+        continue;
+      }
+      if (meta.journey?.fullWidth === true) {
+        ids.push(`${category.name}/${name.name}`);
+      }
+    }
+  }
+  return ids.toSorted();
+}
+
+describe("fullWidth examples keep container plot width", () => {
+  const ids = fullWidthExampleIds();
+
+  it("finds at least one fullWidth journey (corpus not empty)", () => {
+    expect(ids.length).toBeGreaterThan(0);
+  });
+
+  it("does not pin a fixed pixel width on GGPlot under fullWidth frames", () => {
+    // Fixed width + fullWidth shell: static PNG stretches, live chart stays
+    // narrow — jarring shrink on first hover/intent upgrade.
+    const offenders: string[] = [];
+    for (const id of ids) {
+      const src = readFileSync(path.join(examplesRoot, id, "Example.svelte"), "utf8");
+      if (FIXED_PLOT_WIDTH.test(src)) offenders.push(id);
+    }
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- **Symptom:** On `/examples/path/trajectory`, the static gallery PNG looks large and sharp. On first hover/intent the live chart loads and both plots snap much smaller — jarring on a normal-width screen.
- **Root cause:** `journey.fullWidth: true` drops `ExampleLiveFrame` max-width so the PNG fills the content column (up to `--content-max`). Live plots still used `width={960}`, so upgrade went wide → fixed 960px. Every other fullWidth example already uses `width="container"`.
- **Fix:** Both Minard `GGPlot`s use `width="container"`; shell `.minard` fills the frame. Contract test: no fullWidth example may pin a numeric plot width.

No package surface change — no changeset.

## Test plan

- [x] RED then GREEN: `bun test scripts/docs-example-fullwidth-container.test.ts`
- [x] Related docs contracts: `docs-example-png-first`, `docs-chart-intent-load`
- [ ] CI green on this PR
- [ ] Visual: open `/examples/path/trajectory` at a normal desktop width; hover either plot — size must not jump down
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1560" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->