### PR TITLE
fix(inspect): omit weight from default tooltip body

### DIFF
--- a/.changeset/tooltip-drop-weight-echo.md
+++ b/.changeset/tooltip-drop-weight-echo.md
@@ -1,0 +1,5 @@
+---
+"@ggsvelte/svelte": patch
+---
+
+Omit aes.weight from the default tooltip body — y already carries the weighted measure for count/sum bars, so printing the source weight column was pure redundancy.

--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -12754,8 +12754,7 @@ export const DOCS_ROUTES = [
   {
     path: "/examples/bar/dodged",
     title: "US beer production by package type — ggsvelte gallery",
-    description:
-      "Dodged bars of national production by year and package. Copy this when categories share an x-axis and need side-by-side comparison.",
+    description: "Dodged bars of national production by year and package.",
     canonicalPath: "/examples/bar/dodged",
     kind: "page",
     index: true,

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -21152,8 +21152,7 @@ export const DOCS_SEARCH_INDEX = [
     id: "example:bar:dodged",
     kind: "example",
     title: "US beer production by package type",
-    summary:
-      "Dodged bars of national production by year and package. Copy this when categories share an x-axis and need side-by-side comparison.",
+    summary: "Dodged bars of national production by year and package.",
     href: "/examples/bar/dodged",
     keywords: [
       "US beer production by package type",

--- a/apps/docs/static/previews/provenance.json
+++ b/apps/docs/static/previews/provenance.json
@@ -13,7 +13,7 @@
     },
     "bar/dodged": {
       "filename": "bar-dodged-light.png",
-      "sourceSha256": "5b971a554c8881045d4aa52ecac4cad1ddda50e1d5564fd631f621c97e65225b",
+      "sourceSha256": "eea92f32e4982c90f061de7b918c315476c368ecbc78f92786db91a78eac8ae9",
       "pngSha256": "3a3a4284ab80901182bcc578d3778933272ae784bd05ed10078c333e2910f00d"
     },
     "bar/horizontal": {

--- a/examples/bar/dodged/meta.json
+++ b/examples/bar/dodged/meta.json
@@ -1,6 +1,6 @@
 {
   "title": "US beer production by package type",
-  "description": "Dodged bars of national production by year and package. Copy this when categories share an x-axis and need side-by-side comparison.",
+  "description": "Dodged bars of national production by year and package.",
   "tags": ["bar", "count", "dodge", "fill", "legend", "weight", "theme", "palette"],
   "docsSection": "Bars & columns"
 }

--- a/examples/manifest.ts
+++ b/examples/manifest.ts
@@ -65,7 +65,7 @@ export const EXAMPLES: readonly ExampleManifestEntry[] = [
     category: "bar",
     name: "dodged",
     title: "US beer production by package type",
-    description: "Dodged bars of national production by year and package. Copy this when categories share an x-axis and need side-by-side comparison.",
+    description: "Dodged bars of national production by year and package.",
     tags: ["bar", "count", "dodge", "fill", "legend", "weight", "theme", "palette"],
     docsSection: "Bars & columns",
     hasData: true,

--- a/packages/svelte/src/lib/inspection/display-members.ts
+++ b/packages/svelte/src/lib/inspection/display-members.ts
@@ -130,6 +130,12 @@ export function tooltipFieldLabel(
  * on categorical bars keeps the x row (labs-titled) and drops the fill echo.
  * A11y live-text already dedupes by field name in `labels.ts`; default
  * tooltips match that contract so paint-only remaps never invent a third row.
+ *
+ * Weight is a statistical input (feeds count/sum into y), not a display
+ * aesthetic. When y already carries the aggregated reading, painting weight
+ * as a second numeric row is pure redundancy (#1526 preferred this; #1532
+ * recovered weight on the public snapshot for custom content, but default
+ * presentation must still omit it).
  */
 export function fieldsForDefaultTooltip(
   fields: readonly TooltipField[],
@@ -147,6 +153,8 @@ export function fieldsForDefaultTooltip(
     }
   }
   return withoutAxis.filter((field) => {
+    // Stat input, not a visual channel — y (or x on flipped) is the reading.
+    if (field.channel === "weight") return false;
     if (seenColumns.has(field.field)) return false;
     seenColumns.add(field.field);
     return true;

--- a/packages/svelte/tests/inspection/display-members.test.ts
+++ b/packages/svelte/tests/inspection/display-members.test.ts
@@ -165,6 +165,23 @@ describe("fieldsForDefaultTooltip (#754)", () => {
       "species",
     ]);
   });
+
+  it("omits weight when y already carries the aggregated reading (#1526)", () => {
+    // geom_bar + weight: layerFields advertise weight for custom content, but
+    // the default tooltip must not re-print barrelsMillions next to y.
+    const weightedBar = [
+      field("x", "year", 2014),
+      field("y", "count", 158.54),
+      field("fill", "package", "Bottles and cans"),
+      field("weight", "barrelsMillions", 158.54),
+    ];
+    expect(fieldsForDefaultTooltip(weightedBar, "exact").map((f) => f.channel)).toEqual([
+      "x",
+      "y",
+      "fill",
+    ]);
+    expect(fieldsForDefaultTooltip(weightedBar, "x").map((f) => f.channel)).toEqual(["y", "fill"]);
+  });
 });
 
 describe("defaultTooltipRows (series-centric axis groups)", () => {
@@ -240,6 +257,7 @@ describe("defaultTooltipRows (series-centric axis groups)", () => {
     // Stat aggregates can advertise fill/weight fields with null values
     // (no source row + CandidateFacts has no fillValue). Do not invent a
     // "– → measure" row; keep readable field labels so y at least shows.
+    // Weight is a stat input — omit even when blank (y is the reading).
     const blankSeries = [
       field("x", "x", "1876"),
       field("y", "count", 175),
@@ -249,8 +267,53 @@ describe("defaultTooltipRows (series-centric axis groups)", () => {
     const rows = defaultTooltipRows(blankSeries, "x", {
       labs: { x: "Year", y: "Deaths per million", fill: "County" },
     });
-    expect(rows.map((r) => r.label)).toEqual(["Deaths per million", "County", "deaths"]);
-    expect(rows.map((r) => r.value)).toEqual([175, null, null]);
+    expect(rows.map((r) => r.label)).toEqual(["Deaths per million", "County"]);
+    expect(rows.map((r) => r.value)).toEqual([175, null]);
+  });
+
+  it("does not re-print weight next to the measure for exact weighted bars", () => {
+    // Gallery beer dodged bars: aes(x=year, fill=package, weight=barrelsMillions).
+    // Exact mode used to dump Year / Millions of barrels / Package / barrels millions.
+    const beer = [
+      field("x", "year", 2014),
+      field("y", "count", 158.54),
+      field("fill", "package", "Bottles and cans"),
+      field("weight", "barrelsMillions", 158.54),
+    ];
+    const rows = defaultTooltipRows(beer, "exact", {
+      labs: {
+        x: "Year",
+        y: "Millions of barrels",
+        fill: "Package",
+      },
+    });
+    expect(rows.map((r) => r.label)).toEqual(["Year", "Millions of barrels", "Package"]);
+    expect(rows.map((r) => r.value)).toEqual([2014, 158.54, "Bottles and cans"]);
+  });
+
+  it("series-centric axis groups also drop the weight echo", () => {
+    const beer = [
+      field("x", "year", 2016),
+      field("y", "count", 17),
+      field("fill", "package", "Kegs and barrels"),
+      field("weight", "barrelsMillions", 17),
+    ];
+    const rows = defaultTooltipRows(beer, "x", {
+      labs: {
+        x: "Year",
+        y: "Millions of barrels",
+        fill: "Package",
+      },
+    });
+    expect(rows).toEqual([
+      {
+        key: "fill:package:count",
+        label: "Kegs and barrels",
+        value: 17,
+        valueChannel: "y",
+        valueField: "count",
+      },
+    ]);
   });
 
   it("falls back when there is no series aesthetic (single-series line)", () => {


### PR DESCRIPTION
## Summary

- Default tooltips for `geom_bar` + `aes.weight` no longer re-print the weight column next to `y` (the weighted measure). Weight stays on the public inspection snapshot for custom content; only presentation drops it.
- Trims the dodged beer gallery description instructional "Copy this when categories share an x-axis…" line.

## Context

After #1532 recovered fill/weight on stat-aggregate bar tooltips, exact-mode hover on the beer dodged chart showed:

```
Year · Millions of barrels · Package · barrels millions
```

with the last two numbers essentially the same measure twice. Issue #1526 already preferred not inventing a second numeric row for weight when `y` carries the aggregate.

## Test plan

- [x] `vitest run tests/inspection/display-members.test.ts --project chromium` (35 pass)
- [ ] CI green
- [ ] Hover exact tooltip on `examples/bar/dodged` shows Year / Millions of barrels / Package only
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1565" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->