### PR TITLE
fix(core): fill-position tooltips show shares, not 87300%

### DIFF
--- a/.changeset/fill-tooltip-percent-y.md
+++ b/.changeset/fill-tooltip-percent-y.md
@@ -1,0 +1,9 @@
+---
+"@ggsvelte/core": patch
+"@ggsvelte/cli": patch
+"@ggsvelte/svelte": patch
+"@ggsvelte/spec": patch
+"@ggsvelte/skill": patch
+---
+
+Fix position-fill tooltips that printed absurd percentages (e.g. "87300%") by publishing post-position proportions as candidate y values, and emit a `percent-labels-out-of-range` advisory when scale labels are percent formats on non-proportion domains.

--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -12353,6 +12353,11 @@ export const DOCS_ROUTES = [
         title: "band-labels-rotated",
         level: 3,
       },
+      {
+        id: "percent-labels-out-of-range",
+        title: "percent-labels-out-of-range",
+        level: 3,
+      },
     ],
   },
   {

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -20415,6 +20415,16 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["band-labels-rotated"],
   },
   {
+    id: "heading:guide-advisories:percent-labels-out-of-range",
+    kind: "heading",
+    title: "percent-labels-out-of-range",
+    summary:
+      "percent-labels-out-of-range in Advisories. Spec-lint advisories and the pipeline's disclosed heuristics.",
+    href: "/guide/advisories#percent-labels-out-of-range",
+    keywords: ["Advisories", "Reference"],
+    exact: ["percent-labels-out-of-range"],
+  },
+  {
     id: "page:guide-lifecycle",
     kind: "page",
     title: "Lifecycle & editions",

--- a/packages/cli/tests/cli-surface.test.ts
+++ b/packages/cli/tests/cli-surface.test.ts
@@ -59,4 +59,32 @@ describe("@ggsvelte/cli surface (src/index.ts)", () => {
     expect(out).toEqual(["0.0.0-test\n"]);
     expect(err).toEqual([]);
   });
+
+  it("emits percent-labels-out-of-range when labels are % on count-scale data", async () => {
+    // Counts (40, 80) with ".0%" would print 4000%/8000% — CLI must disclose.
+    const percentSpec = {
+      data: {
+        values: [
+          { x: "a", y: 40 },
+          { x: "b", y: 80 },
+        ],
+      },
+      aes: { x: { field: "x" }, y: { field: "y" } },
+      layers: [{ geom: "col" }],
+      scales: { y: { labels: ".0%" } },
+    };
+    const { io, err } = makeIO(JSON.stringify(percentSpec));
+    const code = await runCLI([], io);
+    expect(code).toBe(0);
+    const advisories = err
+      .map((line) => {
+        try {
+          return JSON.parse(line) as { kind?: string; code?: string };
+        } catch {
+          return null;
+        }
+      })
+      .filter((row) => row !== null && row.kind === "advisory");
+    expect(advisories.some((row) => row!.code === "percent-labels-out-of-range")).toBe(true);
+  });
 });

--- a/packages/core/src/diagnostics-emission-registry.ts
+++ b/packages/core/src/diagnostics-emission-registry.ts
@@ -121,6 +121,7 @@ export const ADVISORY_EMISSION_REGISTRY = {
   "temporal-inference-invalid": { channel: "advisory" },
   "band-labels-wrapped": { channel: "advisory" },
   "band-labels-rotated": { channel: "advisory" },
+  "percent-labels-out-of-range": { channel: "advisory" },
 } as const satisfies Record<AdvisoryCode, EmissionRegistryEntry>;
 
 /**

--- a/packages/core/src/diagnostics.ts
+++ b/packages/core/src/diagnostics.ts
@@ -95,6 +95,10 @@ export const ADVISORY_CATALOG = {
     summary:
       "Long categorical x labels were rotated to avoid collisions; pin with scales.x.guide.mode/angle, or coordFlip() for horizontal rows.",
   },
+  "percent-labels-out-of-range": {
+    summary:
+      "A continuous scale uses a percent labels format (…%) but its domain is far outside proportion space — ticks/tooltips would print values like 87300%.",
+  },
 } as const satisfies Record<string, { summary: string }>;
 
 export type AdvisoryCode = keyof typeof ADVISORY_CATALOG;

--- a/packages/core/src/pipeline/candidate-construction/datum-values.ts
+++ b/packages/core/src/pipeline/candidate-construction/datum-values.ts
@@ -120,6 +120,9 @@ function stackOrFillSegmentHeight(
   // Partial frames (unit fixtures) may omit binding — treat as non-stack.
   const geom = frame.binding?.layer?.geom;
   if (geom === undefined || !isBarLike(geom)) return undefined;
+  // Transformed measure axes stack in transform space; a height is not
+  // invertible to a data value (log: 10^(a−b) = ratio). Keep prior path.
+  if (frame.binding?.yTransform !== undefined) return undefined;
   const position = frame.binding?.layer?.position ?? "identity";
   if (position !== "stack" && position !== "fill") return undefined;
   const lo = frame.ymin[frameRow];

--- a/packages/core/src/pipeline/candidate-construction/datum-values.ts
+++ b/packages/core/src/pipeline/candidate-construction/datum-values.ts
@@ -82,18 +82,44 @@ export function resolveCandidateLogicalValues(input: {
         : sourceValue(xField)
       : (frame?.box?.outlierX[primitiveIndex] ?? null);
 
+  // Stack/fill rewrite ymin/ymax (and yNumeric after position-bar). Prefer the
+  // post-position segment height so identity cols and stat bars both report the
+  // drawn share/contribution — not the pre-position source column.
+  const stackHeight = stackOrFillSegmentHeight(frame, frameRow);
+
   const yValue = annotationRule
     ? annotationY
     : outlierSourceRow === null
-      ? sourceRow === null
-        ? (frame?.yValues?.[frameRow] ??
-          semanticFrameNumber(
-            frame,
-            "y",
-            frame?.yNumeric?.[frameRow] ?? frame?.box?.middle[frameRow],
-          ))
-        : sourceValue(yField)
+      ? stackHeight !== undefined
+        ? semanticFrameNumber(frame, "y", stackHeight)
+        : sourceRow === null
+          ? (frame?.yValues?.[frameRow] ??
+            semanticFrameNumber(
+              frame,
+              "y",
+              frame?.yNumeric?.[frameRow] ?? frame?.box?.middle[frameRow],
+            ))
+          : sourceValue(yField)
       : semanticFrameNumber(frame, "y", frame?.box?.outlierY[primitiveIndex]);
 
   return { xValue, yValue };
+}
+
+/**
+ * Post-position segment height for stack/fill (ymax − ymin), or undefined when
+ * the layer is not stack/fill or edges are missing/non-finite.
+ */
+function stackOrFillSegmentHeight(
+  frame: LayerFrame | undefined,
+  frameRow: number,
+): number | undefined {
+  if (frame === undefined || frame.ymin === null || frame.ymax === null) return undefined;
+  const position = frame.binding.layer.position ?? "identity";
+  if (position !== "stack" && position !== "fill") return undefined;
+  const lo = frame.ymin[frameRow];
+  const hi = frame.ymax[frameRow];
+  if (lo === undefined || hi === undefined || !Number.isFinite(lo) || !Number.isFinite(hi)) {
+    return undefined;
+  }
+  return hi - lo;
 }

--- a/packages/core/src/pipeline/candidate-construction/datum-values.ts
+++ b/packages/core/src/pipeline/candidate-construction/datum-values.ts
@@ -1,4 +1,6 @@
 import type { CellValue } from "../../table.js";
+import { signedStackSegmentHeight } from "../position-bar.js";
+import { isBarLike } from "../scale-axis-train.js";
 import type { LayerFrame, ResolvedColorScale } from "../types.js";
 
 /**
@@ -106,8 +108,9 @@ export function resolveCandidateLogicalValues(input: {
 }
 
 /**
- * Post-position segment height for stack/fill (ymax − ymin), or undefined when
- * the layer is not stack/fill or edges are missing/non-finite.
+ * Post-position segment height for bar-like stack/fill, or undefined when the
+ * layer is not a bar/col/area under stack/fill (so smooth/errorbar ymin/ymax
+ * bands are never mistaken for stack heights).
  */
 function stackOrFillSegmentHeight(
   frame: LayerFrame | undefined,
@@ -115,12 +118,13 @@ function stackOrFillSegmentHeight(
 ): number | undefined {
   if (frame === undefined || frame.ymin === null || frame.ymax === null) return undefined;
   // Partial frames (unit fixtures) may omit binding — treat as non-stack.
+  const geom = frame.binding?.layer?.geom;
+  if (geom === undefined || !isBarLike(geom)) return undefined;
   const position = frame.binding?.layer?.position ?? "identity";
   if (position !== "stack" && position !== "fill") return undefined;
   const lo = frame.ymin[frameRow];
   const hi = frame.ymax[frameRow];
-  if (lo === undefined || hi === undefined || !Number.isFinite(lo) || !Number.isFinite(hi)) {
-    return undefined;
-  }
-  return hi - lo;
+  if (lo === undefined || hi === undefined) return undefined;
+  const signed = signedStackSegmentHeight(lo, hi);
+  return Number.isFinite(signed) ? signed : undefined;
 }

--- a/packages/core/src/pipeline/candidate-construction/datum-values.ts
+++ b/packages/core/src/pipeline/candidate-construction/datum-values.ts
@@ -90,9 +90,8 @@ export function resolveCandidateLogicalValues(input: {
   const yValue = annotationRule
     ? annotationY
     : outlierSourceRow === null
-      ? stackHeight !== undefined
-        ? semanticFrameNumber(frame, "y", stackHeight)
-        : sourceRow === null
+      ? stackHeight === undefined
+        ? sourceRow === null
           ? (frame?.yValues?.[frameRow] ??
             semanticFrameNumber(
               frame,
@@ -100,6 +99,7 @@ export function resolveCandidateLogicalValues(input: {
               frame?.yNumeric?.[frameRow] ?? frame?.box?.middle[frameRow],
             ))
           : sourceValue(yField)
+        : semanticFrameNumber(frame, "y", stackHeight)
       : semanticFrameNumber(frame, "y", frame?.box?.outlierY[primitiveIndex]);
 
   return { xValue, yValue };
@@ -114,7 +114,8 @@ function stackOrFillSegmentHeight(
   frameRow: number,
 ): number | undefined {
   if (frame === undefined || frame.ymin === null || frame.ymax === null) return undefined;
-  const position = frame.binding.layer.position ?? "identity";
+  // Partial frames (unit fixtures) may omit binding — treat as non-stack.
+  const position = frame.binding?.layer?.position ?? "identity";
   if (position !== "stack" && position !== "fill") return undefined;
   const lo = frame.ymin[frameRow];
   const hi = frame.ymax[frameRow];

--- a/packages/core/src/pipeline/position-bar.ts
+++ b/packages/core/src/pipeline/position-bar.ts
@@ -59,7 +59,11 @@ export function applyBarLikePosition(frame: LayerFrame): boolean {
     if (frame.binding.yTransform === undefined) {
       const heights = new Float64Array(frame.n);
       for (let i = 0; i < frame.n; i++) {
-        heights[i] = signedStackSegmentHeight(ymin[i]!, ymax[i]!);
+        // positionStack coerces non-finite y to zero-height; keep NaN so
+        // tooltips do not present missing measures as hard zeros.
+        heights[i] = Number.isFinite(y[i]!)
+          ? signedStackSegmentHeight(ymin[i]!, ymax[i]!)
+          : Number.NaN;
       }
       frame.yNumeric = heights;
     }

--- a/packages/core/src/pipeline/position-bar.ts
+++ b/packages/core/src/pipeline/position-bar.ts
@@ -54,13 +54,15 @@ export function applyBarLikePosition(frame: LayerFrame): boolean {
     frame.ymax = ymax;
     // Fresh array — yNumeric may alias a table-cached column (identity) or a
     // stat series (forwardMeasureOnce with no transform); never mutate in place.
-    // Segment height matches axis space: share for fill, contribution for stack.
-    // Negative runs stack below 0 (ymax ≤ 0, ymin more negative), so re-sign.
-    const heights = new Float64Array(frame.n);
-    for (let i = 0; i < frame.n; i++) {
-      heights[i] = signedStackSegmentHeight(ymin[i]!, ymax[i]!);
+    // Only rewrite under identity measure transforms: with log/sqrt, ymin/ymax
+    // live in transformed space and heights are not invertible to data values.
+    if (frame.binding.yTransform === undefined) {
+      const heights = new Float64Array(frame.n);
+      for (let i = 0; i < frame.n; i++) {
+        heights[i] = signedStackSegmentHeight(ymin[i]!, ymax[i]!);
+      }
+      frame.yNumeric = heights;
     }
-    frame.yNumeric = heights;
     return true;
   }
   // identity / dodge: bars grow from the shared transformed-origin baseline.

--- a/packages/core/src/pipeline/position-bar.ts
+++ b/packages/core/src/pipeline/position-bar.ts
@@ -8,6 +8,19 @@ import { TRANSFORMED_ZERO_BASELINE } from "./position-baseline.js";
 import { isBarLike } from "./scale-axis-train.js";
 import type { LayerFrame } from "./types.js";
 
+/**
+ * Signed segment height from stack/fill ymin/ymax.
+ * Positive runs: ymax − ymin. Negative runs stack below 0 with ymin more
+ * negative than ymax, so the unsigned gap must be re-signed.
+ */
+export function signedStackSegmentHeight(ymin: number, ymax: number): number {
+  if (!Number.isFinite(ymin) || !Number.isFinite(ymax)) return Number.NaN;
+  const height = ymax - ymin;
+  // Negative run: both edges ≤ 0 (ymax at the prior total, ymin further down).
+  if (ymax <= 0 && ymin < 0) return -height;
+  return height;
+}
+
 /** Per-row slot keys: band categories, or bin centers for binned bars.
  * `encodeKey` matches the band scale's typed identity, so categories with
  * colliding labels (`1` vs `"1"`) occupy distinct slots. */
@@ -39,15 +52,15 @@ export function applyBarLikePosition(frame: LayerFrame): boolean {
     const { ymin, ymax } = positionStack({ slots, groups: frame.groups, y, mode: position });
     frame.ymin = ymin;
     frame.ymax = ymax;
-    // Keep yNumeric in post-position data space so inspect/tooltips match the
-    // axis. Stack: ymax−ymin equals the original contribution. Fill: it is the
-    // share of the band (proportions in [0,1]). Without this, percent labels
-    // (".0%") format raw counts as absurd percentages (873 → "87300%").
+    // Fresh array — yNumeric may alias a table-cached column (identity) or a
+    // stat series (forwardMeasureOnce with no transform); never mutate in place.
+    // Segment height matches axis space: share for fill, contribution for stack.
+    // Negative runs stack below 0 (ymax ≤ 0, ymin more negative), so re-sign.
+    const heights = new Float64Array(frame.n);
     for (let i = 0; i < frame.n; i++) {
-      const lo = ymin[i]!;
-      const hi = ymax[i]!;
-      y[i] = Number.isFinite(lo) && Number.isFinite(hi) ? hi - lo : 0;
+      heights[i] = signedStackSegmentHeight(ymin[i]!, ymax[i]!);
     }
+    frame.yNumeric = heights;
     return true;
   }
   // identity / dodge: bars grow from the shared transformed-origin baseline.

--- a/packages/core/src/pipeline/position-bar.ts
+++ b/packages/core/src/pipeline/position-bar.ts
@@ -39,6 +39,15 @@ export function applyBarLikePosition(frame: LayerFrame): boolean {
     const { ymin, ymax } = positionStack({ slots, groups: frame.groups, y, mode: position });
     frame.ymin = ymin;
     frame.ymax = ymax;
+    // Keep yNumeric in post-position data space so inspect/tooltips match the
+    // axis. Stack: ymax−ymin equals the original contribution. Fill: it is the
+    // share of the band (proportions in [0,1]). Without this, percent labels
+    // (".0%") format raw counts as absurd percentages (873 → "87300%").
+    for (let i = 0; i < frame.n; i++) {
+      const lo = ymin[i]!;
+      const hi = ymax[i]!;
+      y[i] = Number.isFinite(lo) && Number.isFinite(hi) ? hi - lo : 0;
+    }
     return true;
   }
   // identity / dodge: bars grow from the shared transformed-origin baseline.

--- a/packages/core/src/pipeline/scale-axis-train-continuous.ts
+++ b/packages/core/src/pipeline/scale-axis-train-continuous.ts
@@ -18,9 +18,9 @@ import { pushContinuousTrainingWarnings } from "./scale-axis-train-continuous-wa
 
 /**
  * Documented numeric percent formats from `numberFormatter` (not strftime
- * tokens like `%Y`). Matches `%`, `.0%`, `.1%`, `,.0%`.
+ * tokens like `%Y`). Matches `%`, `.0%`, `.1%`, `,.0%`, `~%`, `.1~%`.
  */
-const NUMERIC_PERCENT_LABELS = /^(?:,)?(?:\.\d+)?%$/;
+const NUMERIC_PERCENT_LABELS = /^(?:,)?(?:\.\d+)?~?%$/;
 
 /**
  * Percent formats (`".0%"`, `"%"`) multiply by 100. Domains far outside

--- a/packages/core/src/pipeline/scale-axis-train-continuous.ts
+++ b/packages/core/src/pipeline/scale-axis-train-continuous.ts
@@ -16,6 +16,37 @@ import type { ScaleDiagnostic } from "./types-scale-diagnostics.js";
 import { maybeForceZeroForBars } from "./scale-axis-train-continuous-zero.js";
 import { pushContinuousTrainingWarnings } from "./scale-axis-train-continuous-warn.js";
 
+/**
+ * Documented numeric percent formats from `numberFormatter` (not strftime
+ * tokens like `%Y`). Matches `%`, `.0%`, `.1%`, `,.0%`.
+ */
+const NUMERIC_PERCENT_LABELS = /^(?:,)?(?:\.\d+)?%$/;
+
+/**
+ * Percent formats (`".0%"`, `"%"`) multiply by 100. Domains far outside
+ * proportion space ([0,1] / roughly [-1,1]) print absurd labels like "87300%".
+ * Expansion pads ~5%, so a true [0,1] domain stays near 1.05 — threshold 2
+ * allows modest overshoot (e.g. 150%) without flagging position:"fill".
+ */
+function maybePercentLabelsAdvisory(
+  axis: "x" | "y",
+  config: PositionScaleSpec | undefined,
+  domain: readonly [number, number],
+  advisories: Advisory[],
+): void {
+  const labels = config?.labels;
+  if (labels === undefined || !NUMERIC_PERCENT_LABELS.test(labels)) return;
+  const [lo, hi] = domain;
+  const extreme = Math.max(Math.abs(lo), Math.abs(hi));
+  if (!Number.isFinite(extreme) || extreme <= 2) return;
+  advisories.push({
+    code: "percent-labels-out-of-range",
+    path: `scales.${axis}`,
+    chosen: `labels "${labels}" on domain [${lo}, ${hi}] (extreme |v|=${extreme})`,
+    howToOverride: `Percent label formats multiply values by 100. Use proportions in [0, 1] (position: "fill" for parts-of-a-whole), or drop labels / use a non-percent format (".0f", ",d") when the data is already in percent points or counts.`,
+  });
+}
+
 export function trainContinuousAxis(
   axis: "x" | "y",
   inputs: AxisInputs,
@@ -49,6 +80,7 @@ export function trainContinuousAxis(
     throw error;
   }
   pushContinuousTrainingWarnings(axis, training, warnings);
+  maybePercentLabelsAdvisory(axis, config, training.scale.domain, advisories);
   // Explicit continuous breaks outside the trained (expanded, ggplot2-correct)
   // display domain are dropped by the layout tick filter. Structured facts
   // project lean + rich channels once (#628) — no post-hoc message parsing.

--- a/packages/core/tests/pipeline-position-fill-candidates.test.ts
+++ b/packages/core/tests/pipeline-position-fill-candidates.test.ts
@@ -1,0 +1,102 @@
+/**
+ * position: "fill" must publish post-position proportions as candidate y
+ * values so scale labels like ".0%" format shares (65%), not raw counts
+ * (87300%). Repro: examples/bar/proportions — Naples Soldiers men=873.
+ */
+import { describe, expect, it } from "bun:test";
+
+import { aes, gg } from "@ggsvelte/spec";
+
+import { registerAll } from "../src/index.ts";
+import { runPipeline } from "../src/pipeline.ts";
+
+registerAll();
+
+const size = { width: 640, height: 400 };
+
+/** Armada Naples subset from examples/bar/proportions/data.ts. */
+const naples = [
+  { squadron: "Naples", role: "Soldiers", men: 873 },
+  { squadron: "Naples", role: "Sailors", men: 468 },
+] as const;
+
+describe("position fill — candidate y matches axis space", () => {
+  it("publishes proportions (not raw weights) so percent labels format shares", () => {
+    const model = runPipeline(
+      gg([...naples], aes({ x: "squadron", fill: "role", weight: "men" }))
+        .geomBar({ position: "fill" })
+        .scales({ y: { labels: ".0%" } })
+        .spec(),
+      size,
+    );
+
+    const candidates = Array.from({ length: model.candidates.size }, (_, id) =>
+      model.candidates.candidate(id),
+    ).filter((c) => c !== null);
+
+    expect(candidates.length).toBe(2);
+
+    // Soldiers 873 / (873+468) ≈ 0.650; Sailors ≈ 0.350.
+    const byRole = new Map(
+      candidates.map((c) => {
+        // seriesId follows first-seen fill order: Soldiers=0, Sailors=1.
+        return [c.seriesId, c] as const;
+      }),
+    );
+    const soldiers = byRole.get(0)!;
+    const sailors = byRole.get(1)!;
+
+    expect(soldiers.yValue).toBeCloseTo(873 / (873 + 468), 8);
+    expect(sailors.yValue).toBeCloseTo(468 / (873 + 468), 8);
+
+    // Axis formatter multiplies by 100 — pre-fix this printed "87300%".
+    expect(model.axisFormatters.y(soldiers.yValue)).toBe("65%");
+    expect(model.axisFormatters.y(sailors.yValue)).toBe("35%");
+    expect(model.axisFormatters.y(soldiers.yValue)).not.toContain("873");
+  });
+
+  it("keeps stack candidate y as the segment height (raw contribution)", () => {
+    const model = runPipeline(
+      gg([...naples], aes({ x: "squadron", fill: "role", weight: "men" }))
+        .geomBar({ position: "stack" })
+        .spec(),
+      size,
+    );
+    const candidates = Array.from({ length: model.candidates.size }, (_, id) =>
+      model.candidates.candidate(id),
+    ).filter((c) => c !== null);
+    const yValues = candidates.map((c) => c.yValue as number).toSorted((a, b) => a - b);
+    expect(yValues[0]).toBeCloseTo(468, 8);
+    expect(yValues[1]).toBeCloseTo(873, 8);
+  });
+});
+
+describe("percent labels out-of-range advisory", () => {
+  it("fires when labels are percent and the domain is not proportion-scale", () => {
+    const model = runPipeline(
+      gg(
+        [
+          { x: "a", y: 40 },
+          { x: "b", y: 80 },
+        ],
+        aes({ x: "x", y: "y" }),
+      )
+        .geomCol()
+        .scales({ y: { labels: ".0%" } })
+        .spec(),
+      size,
+    );
+    expect(model.advisories.some((a) => a.code === "percent-labels-out-of-range")).toBe(true);
+  });
+
+  it("stays quiet for position fill with percent labels (domain ≈ [0,1])", () => {
+    const model = runPipeline(
+      gg([...naples], aes({ x: "squadron", fill: "role", weight: "men" }))
+        .geomBar({ position: "fill" })
+        .scales({ y: { labels: ".0%" } })
+        .spec(),
+      size,
+    );
+    expect(model.advisories.some((a) => a.code === "percent-labels-out-of-range")).toBe(false);
+  });
+});

--- a/packages/core/tests/pipeline-position-fill-candidates.test.ts
+++ b/packages/core/tests/pipeline-position-fill-candidates.test.ts
@@ -69,6 +69,46 @@ describe("position fill — candidate y matches axis space", () => {
     expect(yValues[0]).toBeCloseTo(468, 8);
     expect(yValues[1]).toBeCloseTo(873, 8);
   });
+
+  it("preserves sign for negative stacked contributions", () => {
+    const model = runPipeline(
+      gg(
+        [
+          { g: "a", cls: "pos", y: 3 },
+          { g: "a", cls: "neg", y: -2 },
+        ],
+        aes({ x: "g", y: "y", fill: "cls" }),
+      )
+        .geomCol({ position: "stack" })
+        .spec(),
+      size,
+    );
+    const yValues = Array.from({ length: model.candidates.size }, (_, id) =>
+      model.candidates.candidate(id),
+    )
+      .filter((c) => c !== null)
+      .map((c) => c.yValue as number)
+      .toSorted((a, b) => a - b);
+    expect(yValues[0]).toBeCloseTo(-2, 8);
+    expect(yValues[1]).toBeCloseTo(3, 8);
+  });
+
+  it("does not mutate the shared source y column under identity stack", () => {
+    const rows = [
+      { g: "a", cls: "x", y: 10 },
+      { g: "a", cls: "y", y: 20 },
+    ];
+    runPipeline(
+      gg(rows, aes({ x: "g", y: "y", fill: "cls" }))
+        .geomCol({ position: "fill" })
+        .spec(),
+      size,
+    );
+    // Source rows must still hold the authored values after fill rewrites
+    // frame.yNumeric (no in-place alias mutation of the table cache).
+    expect(rows[0]!.y).toBe(10);
+    expect(rows[1]!.y).toBe(20);
+  });
 });
 
 describe("percent labels out-of-range advisory", () => {

--- a/packages/core/tests/pipeline-position-fill-candidates.test.ts
+++ b/packages/core/tests/pipeline-position-fill-candidates.test.ts
@@ -129,6 +129,23 @@ describe("percent labels out-of-range advisory", () => {
     expect(model.advisories.some((a) => a.code === "percent-labels-out-of-range")).toBe(true);
   });
 
+  it("also fires for trimmed percent formats (~%) that numberFormatter accepts", () => {
+    const model = runPipeline(
+      gg(
+        [
+          { x: "a", y: 40 },
+          { x: "b", y: 80 },
+        ],
+        aes({ x: "x", y: "y" }),
+      )
+        .geomCol()
+        .scales({ y: { labels: ".1~%" } })
+        .spec(),
+      size,
+    );
+    expect(model.advisories.some((a) => a.code === "percent-labels-out-of-range")).toBe(true);
+  });
+
   it("stays quiet for position fill with percent labels (domain ≈ [0,1])", () => {
     const model = runPipeline(
       gg([...naples], aes({ x: "squadron", fill: "role", weight: "men" }))

--- a/packages/core/tests/pipeline-position.test.ts
+++ b/packages/core/tests/pipeline-position.test.ts
@@ -69,6 +69,30 @@ describe("applyPosition — stack/fill/dodge on bars", () => {
     }
   });
 
+  it("preserves non-finite pre-position y as NaN after stack rewrite (not 0)", () => {
+    const table = ColumnTable.fromRows([
+      { g: "a", cls: "x", y: 5 },
+      { g: "a", cls: "y", y: Number.NaN },
+    ]);
+    const binding = bindLayer(
+      {
+        geom: "col",
+        aes: { x: { field: "g" }, y: { field: "y" }, fill: { field: "cls" } },
+        position: "stack",
+      },
+      0,
+      table,
+      [],
+    );
+    const frame = buildFrame(binding, table, [], []);
+    // Force a non-finite measure so positionStack zero-heights it; rewrite
+    // must not publish a hard 0 for tooltips.
+    frame.yNumeric![1] = Number.NaN;
+    applyPosition(frame, [], table);
+    expect(Number.isNaN(frame.yNumeric![1]!)).toBe(true);
+    expect(frame.yNumeric![0]).toBeCloseTo(5, 8);
+  });
+
   it("dodges boxplots into per-slot indices", () => {
     const table = ColumnTable.fromRows([
       { g: "a", cls: "x", y: 1 },

--- a/packages/core/tests/pipeline-position.test.ts
+++ b/packages/core/tests/pipeline-position.test.ts
@@ -89,7 +89,7 @@ describe("applyPosition — stack/fill/dodge on bars", () => {
     // must not publish a hard 0 for tooltips.
     frame.yNumeric![1] = Number.NaN;
     applyPosition(frame, [], table);
-    expect(Number.isNaN(frame.yNumeric![1]!)).toBe(true);
+    expect(Number.isNaN(frame.yNumeric![1])).toBe(true);
     expect(frame.yNumeric![0]).toBeCloseTo(5, 8);
   });
 


### PR DESCRIPTION
## Summary

- **Bug:** `position: "fill"` stacked bars (e.g. gallery bar/proportions) showed tooltips like `y: 87300%` when the y scale used percent labels (`.0%`). Root cause: fill rewrote `ymin`/`ymax` to proportions in [0,1] but left `yNumeric` as raw counts/weights; inspect/tooltips read `yNumeric`, so the percent formatter multiplied counts by 100 (Naples Soldiers `men: 873` → `"87300%"`). Axis ticks were fine because domain training used `ymin`/`ymax`.
- **Fix:** After stack/fill, set `yNumeric[i] = ymax[i] - ymin[i]` (segment height = contribution for stack, share for fill). Candidate resolution prefers that post-position height so identity cols and stat bars agree with the axis.
- **Advisory:** New pipeline code `percent-labels-out-of-range` when a continuous scale uses a numeric percent labels format and the trained domain extreme is > 2 (counts or 0–100 percent-points). Quiet for real position-fill charts (domain ≈ [0,1]). Surfaces on `ggsvelte-render` stderr as `{"kind":"advisory","code":"percent-labels-out-of-range",…}`.

## Test plan

- [x] RED/GREEN: `packages/core/tests/pipeline-position-fill-candidates.test.ts` — Naples armada subset formats to `65%` / `35%`, not `87300%`
- [x] Advisory fires on counts+`.0%`; silent on fill+`.0%`
- [x] CLI surface test: `ggsvelte-render` stderr includes the advisory
- [x] Existing stack/fill/geom parity suites pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1569" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->