### PR TITLE
fix(inspect): show per-dot x/y on geom_dotplot tooltips

### DIFF
--- a/.changeset/bindot-inspect-tooltip-values.md
+++ b/.changeset/bindot-inspect-tooltip-values.md
@@ -1,0 +1,6 @@
+---
+"@ggsvelte/core": patch
+"@ggsvelte/svelte": patch
+---
+
+Fix geom_dotplot Inspect tooltips: hybrid identity+after_stat candidates now expose per-dot x (bin center) and stackpos instead of printing "–" for every mark.

--- a/packages/core/src/pipeline/candidate-construction/datum-values.ts
+++ b/packages/core/src/pipeline/candidate-construction/datum-values.ts
@@ -48,6 +48,17 @@ function semanticFrameNumber(
   return transform === undefined ? value : transform.inverse(value);
 }
 
+function frameLogicalX(frame: LayerFrame | undefined, frameRow: number): CellValue {
+  return frame?.xValues?.[frameRow] ?? semanticFrameNumber(frame, "x", frame?.xNumeric?.[frameRow]);
+}
+
+function frameLogicalY(frame: LayerFrame | undefined, frameRow: number): CellValue {
+  return (
+    frame?.yValues?.[frameRow] ??
+    semanticFrameNumber(frame, "y", frame?.yNumeric?.[frameRow] ?? frame?.box?.middle[frameRow])
+  );
+}
+
 export function resolveCandidateLogicalValues(input: {
   annotationRule: boolean;
   annotationX: CellValue;
@@ -75,12 +86,15 @@ export function resolveCandidateLogicalValues(input: {
     yField,
   } = input;
 
+  // Identity rows read mapped source columns. When a channel is after_stat only
+  // (bindot: x/stackpos while sourceRow stays set for color/lineage — #803),
+  // `xField`/`yField` are undefined and the frame holds the generated values.
+  // Fall through to frame numerics rather than sourceValue(undefined) → null.
   const xValue = annotationRule
     ? annotationX
     : outlierSourceRow === null
-      ? sourceRow === null
-        ? (frame?.xValues?.[frameRow] ??
-          semanticFrameNumber(frame, "x", frame?.xNumeric?.[frameRow]))
+      ? sourceRow === null || xField === undefined
+        ? frameLogicalX(frame, frameRow)
         : sourceValue(xField)
       : (frame?.box?.outlierX[primitiveIndex] ?? null);
 
@@ -93,13 +107,8 @@ export function resolveCandidateLogicalValues(input: {
     ? annotationY
     : outlierSourceRow === null
       ? stackHeight === undefined
-        ? sourceRow === null
-          ? (frame?.yValues?.[frameRow] ??
-            semanticFrameNumber(
-              frame,
-              "y",
-              frame?.yNumeric?.[frameRow] ?? frame?.box?.middle[frameRow],
-            ))
+        ? sourceRow === null || yField === undefined
+          ? frameLogicalY(frame, frameRow)
           : sourceValue(yField)
         : semanticFrameNumber(frame, "y", stackHeight)
       : semanticFrameNumber(frame, "y", frame?.box?.outlierY[primitiveIndex]);

--- a/packages/core/tests/candidate-construction/logical-values.test.ts
+++ b/packages/core/tests/candidate-construction/logical-values.test.ts
@@ -127,4 +127,59 @@ describe("resolveCandidateLogicalValues", () => {
       }),
     ).toEqual({ xValue: 1.5, yValue: 99 });
   });
+
+  it("uses frame positions when sourceRow is set but x/y are after_stat only (bindot)", () => {
+    // Hybrid identity+stat: bindot keeps a real source row for color/lineage
+    // while x/y are generated (bin center + stackpos). Source field names are
+    // undefined after resolveCandidateFieldChannels skips source:"stat".
+    const frame = fromAny({
+      xValues: null,
+      yValues: null,
+      xNumeric: new Float64Array([5.275, 5.325]),
+      yNumeric: new Float64Array([1, 2]),
+      box: null,
+      binding: {},
+    });
+    expect(
+      resolveCandidateLogicalValues({
+        annotationRule: false,
+        annotationX: null,
+        annotationY: null,
+        outlierSourceRow: null,
+        sourceRow: 4,
+        frame,
+        frameRow: 1,
+        primitiveIndex: 0,
+        sourceValue: () => "must-not-read",
+        xField: undefined,
+        yField: undefined,
+      }),
+    ).toEqual({ xValue: 5.325, yValue: 2 });
+  });
+
+  it("uses frame y when only y is after_stat while x stays a source field", () => {
+    const frame = fromAny({
+      xValues: null,
+      yValues: null,
+      xNumeric: new Float64Array([0]),
+      yNumeric: new Float64Array([3]),
+      box: null,
+      binding: {},
+    });
+    expect(
+      resolveCandidateLogicalValues({
+        annotationRule: false,
+        annotationX: null,
+        annotationY: null,
+        outlierSourceRow: null,
+        sourceRow: 0,
+        frame,
+        frameRow: 0,
+        primitiveIndex: 0,
+        sourceValue: (field) => (field === "density" ? 5.5 : "wrong"),
+        xField: "density",
+        yField: undefined,
+      }),
+    ).toEqual({ xValue: 5.5, yValue: 3 });
+  });
 });

--- a/packages/core/tests/pipeline-m2/dotplot.test.ts
+++ b/packages/core/tests/pipeline-m2/dotplot.test.ts
@@ -119,4 +119,41 @@ describe("dotplot geom (histodot bindot)", () => {
     // fill has 2 levels; color is constant — paint must follow fill.
     expect(new Set(batch.colors).size).toBe(2);
   });
+
+  it("exposes per-dot xValue/yValue for inspect tooltips (hybrid source row + after_stat)", () => {
+    // One observation alone at x=1 → stackpos 1; three at x=2 → stackpos 1,2,3.
+    // Candidates keep real source rowIndex for aesthetics, but x/y are after_stat.
+    const model = runPipeline(
+      gg({ x: [1, 2, 2, 2] }, aes({ x: "x" }))
+        .geomDotplot({ binwidth: 1, boundary: 0.5, stackdir: "up" })
+        .spec(),
+      size,
+    );
+    expect(model.layerFields[0]).toEqual([
+      { channel: "x", field: "x", source: "stat" },
+      { channel: "y", field: "stackpos", source: "stat" },
+    ]);
+
+    const values: { xValue: unknown; yValue: unknown; rowIndex: number | null }[] = [];
+    for (let id = 0; model.candidates.candidate(id) !== null; id++) {
+      const candidate = model.candidates.candidate(id)!;
+      values.push({
+        xValue: candidate.xValue,
+        yValue: candidate.yValue,
+        rowIndex: candidate.rowIndex,
+      });
+    }
+    expect(values).toHaveLength(4);
+    // Every dot carries a real source row and non-null position semantics.
+    for (const value of values) {
+      expect(value.rowIndex).not.toBeNull();
+      expect(value.xValue).not.toBeNull();
+      expect(value.yValue).not.toBeNull();
+    }
+    // Stack ranks differ inside the denser bin; x values differ across bins.
+    expect(new Set(values.map((v) => v.xValue)).size).toBeGreaterThan(1);
+    expect(new Set(values.map((v) => v.yValue)).size).toBeGreaterThan(1);
+    // Tallest stack at the denser bin reaches 3 under stackdir=up.
+    expect(values.some((v) => v.yValue === 3)).toBe(true);
+  });
 });

--- a/packages/svelte/src/lib/inspection/resolver.ts
+++ b/packages/svelte/src/lib/inspection/resolver.ts
@@ -306,14 +306,20 @@ function datum<Row extends Record<string, CellValue>, Key extends PropertyKey>(
     return firstLineageRow[fieldName] ?? null;
   };
   const fields = (model.layerFields[candidate.layerIndex] ?? []).map((field) => {
+    // after_stat channels never live on the source table under their generated
+    // names (bindot keeps real source rowIndex for color/lineage while x/y are
+    // bin center + stackpos — #803). Prefer CandidateFacts position values;
+    // do not look up "x"/"stackpos" on the observation row.
+    if (field.source === "stat") {
+      const fromCandidate = candidateValue(field.channel);
+      if (fromCandidate !== undefined) return { ...field, value: fromCandidate };
+      return { ...field, value: null };
+    }
     if (row !== null) {
       return { ...field, value: row[field.field] ?? null };
     }
     const fromCandidate = candidateValue(field.channel);
     if (fromCandidate !== undefined) return { ...field, value: fromCandidate };
-    // Stat outputs are not source-table columns; a same-named source column
-    // would print an unrelated value.
-    if (field.source === "stat") return { ...field, value: null };
     return { ...field, value: lineageFieldValue(field.channel, field.field) };
   });
   return Object.freeze({

--- a/packages/svelte/tests/inspection/resolve-snapshot.test.ts
+++ b/packages/svelte/tests/inspection/resolve-snapshot.test.ts
@@ -473,6 +473,49 @@ describe("inspection snapshot resolve", () => {
     });
     model.dispose();
   });
+
+  it("resolves bindot after_stat x/y when candidates keep a source rowIndex", () => {
+    // geom_dotplot is hybrid: real source rows for color/lineage, after_stat
+    // x (bin center) + stackpos for positions. Tooltip fields must not look
+    // up generated names on the source table (would print "–" for every dot).
+    const model = runPipeline(
+      gg({ density: [1, 2, 2, 2] }, aes({ x: "density" }))
+        .geomDotplot({ binwidth: 1, boundary: 0.5, stackdir: "up" })
+        .spec(),
+      { width: 480, height: 320 },
+    );
+    expect(model.candidates.size).toBe(4);
+
+    const byKey = new Map<string, number>();
+    for (let id = 0; id < model.candidates.size; id++) {
+      const seed = model.candidates.candidate(id)!;
+      expect(seed.rowIndex).not.toBeNull();
+      expect(seed.xValue).not.toBeNull();
+      expect(seed.yValue).not.toBeNull();
+
+      const inspection = resolveInspection({
+        model,
+        seed,
+        mode: "exact",
+        state: "transient",
+        source: "pointer",
+        keyOf: () => null,
+      });
+      // Source row is present, but focus.fields still carry after_stat values.
+      expect(inspection.focus.row).not.toBeNull();
+      const byChannel = Object.fromEntries(
+        inspection.focus.fields.map((field) => [field.channel, field.value]),
+      );
+      expect(byChannel.x).toBe(seed.xValue);
+      expect(byChannel.y).toBe(seed.yValue);
+      expect(byChannel.x).not.toBeNull();
+      expect(byChannel.y).not.toBeNull();
+      byKey.set(`${String(byChannel.x)}:${String(byChannel.y)}`, id);
+    }
+    // Different dots must not all collapse to one tooltip payload.
+    expect(byKey.size).toBeGreaterThan(1);
+    model.dispose();
+  });
 });
 
 describe("selectTransientMembers top-k by value (#1274)", () => {


### PR DESCRIPTION
## Summary

- **Bug:** On `examples/dotplot/histodot`, every Inspect tooltip printed `Density… –` and `Runs –` no matter which dot you clicked. Values did not vary with x or stack position.
- **Root cause:** `geom_dotplot` / `stat_bindot` is hybrid identity+after_stat: each candidate keeps a real source `rowIndex` (for color/lineage) while x and y are generated (`x` bin center, `stackpos`). Two layers both produced nulls:
  1. `resolveCandidateLogicalValues` took the source-row branch and called `sourceValue(undefined)` after #803 skipped after_stat field names → `xValue`/`yValue` always null.
  2. `resolveInspection` preferred the source row and looked up generated names (`"x"`, `"stackpos"`) that do not exist on the observation → tooltip values `"–"`.
- **Fix:** Fall back to frame positions when a position channel has no source field; resolve `source: "stat"` tooltip fields from `CandidateFacts` instead of the source row.

## Test plan

- [x] Unit: `resolveCandidateLogicalValues` hybrid after_stat + sourceRow cases
- [x] Pipeline: bindot candidates expose non-null, varying `xValue`/`yValue`
- [x] Inspection: exact-mode snapshot fields match candidate x/y and differ across dots
- [ ] Gallery histodot: click different dots → tooltips show density bin center and stack rank
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1574" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->