### PR TITLE
fix(inspect): stop qq_line mid-stroke flip and empty tooltip values

### DIFF
--- a/.changeset/qq-line-inspect.md
+++ b/.changeset/qq-line-inspect.md
@@ -1,0 +1,8 @@
+---
+"@ggsvelte/core": patch
+"@ggsvelte/svelte": patch
+---
+
+Fix geom_qq_line Inspect: mid-stroke hover no longer teleports between line ends, and tooltips show theoretical/sample quantiles instead of a blank value row.
+
+Migration: none — bugfix.

--- a/packages/core/src/pipeline/layer-fields.ts
+++ b/packages/core/src/pipeline/layer-fields.ts
@@ -37,6 +37,12 @@ export function resolveLayerFields(
     if (identityLike) {
       push("x", binding.xField);
       push("y", binding.yField);
+    } else if (stat === "qq" || stat === "qq_line") {
+      // aes.sample only — x/y are after_stat theoretical/sample quantiles.
+      // Do not advertise the input sample column: synthesized rows have NO_ROW
+      // and paint "value: –" on tooltips (qq_line inspect regression).
+      push("x", "theoretical", "stat");
+      push("y", "sample", "stat");
     } else {
       // Synthesized stat rows have no source row. Advertise only semantic
       // generated channels that CandidateFacts can resolve truthfully.
@@ -75,9 +81,7 @@ export function resolveLayerFields(
         stat === "contour" ||
         stat === "density_2d" ||
         stat === "density_2d_filled" ||
-        stat === "bin_hex" ||
-        stat === "qq" ||
-        stat === "qq_line"
+        stat === "bin_hex"
       ) {
         push("y", "y", "stat");
       }
@@ -108,7 +112,8 @@ export function resolveLayerFields(
     }
     push("label", binding.labelField);
     push("weight", binding.weightField);
-    push("sample", binding.sampleField);
+    // qq / qq_line: sample is after_stat y (handled above), not the input column.
+    if (stat !== "qq" && stat !== "qq_line") push("sample", binding.sampleField);
     return fields;
   });
 }

--- a/packages/core/tests/pipeline-layer-contracts.test.ts
+++ b/packages/core/tests/pipeline-layer-contracts.test.ts
@@ -141,6 +141,28 @@ describe("resolveLayerFields", () => {
     expect(fields[0]).toEqual([]);
     expect(fields[1]).toEqual([]);
   });
+
+  it("qq / qq_line advertise theoretical + sample quantiles as stat x/y, not the input sample column", () => {
+    // Regression: qq_line tooltips painted sample→source "value" as null (NO_ROW
+    // synthesized rows) and omitted theoretical because aes.x is unset.
+    const sampleTable = ColumnTable.fromRows([{ value: 1.1 }, { value: 2 }, { value: 3.4 }]);
+    for (const geom of ["qq", "qq_line"] as const) {
+      const binding = bindLayer(
+        { geom, aes: { sample: { field: "value" } }, stat: geom },
+        0,
+        sampleTable,
+        [],
+      );
+      const fields = resolveLayerFields(1, [binding])[0]!;
+      const x = fields.find((f) => f.channel === "x");
+      const y = fields.find((f) => f.channel === "y");
+      expect(x).toEqual({ channel: "x", field: "theoretical", source: "stat" });
+      expect(y).toEqual({ channel: "y", field: "sample", source: "stat" });
+      // Input sample column is not a tooltip reading for after_stat marks.
+      expect(fields.some((f) => f.channel === "sample" && f.source !== "stat")).toBe(false);
+      expect(fields.some((f) => f.field === "value")).toBe(false);
+    }
+  });
 });
 
 describe("resolveLayerScaledConstants", () => {

--- a/packages/svelte/src/lib/inspection/pointer-inspect.ts
+++ b/packages/svelte/src/lib/inspection/pointer-inspect.ts
@@ -37,28 +37,29 @@ export type SchedulePointerInspectInput = {
 /**
  * hitTest resurrection when nearest misses.
  *
- * Axis modes (`x` / `y` / `xy`) already applied maxDistance in nearest —
- * including under coord_flip (dominant axis is screen y when flipped).
- * hitTest ignores that policy and returns any mark under the pointer; on a
- * two-vertex path (geom_qq_line) that teleports between endpoints mid-stroke.
+ * nearest under axis modes measures distance to the **anchor**, not painted
+ * geometry. hitTest finds whatever mark is under the pointer:
+ * - **rects** (bars/tiles): containment of the bar body — keep rescuing so
+ *   wide columns under mode x still tooltips when the pointer is on the fill
+ *   but farther than maxDistance from the centre anchor.
+ * - **paths/segments** (lines, areas, qq_line): stroke/fill can hit far from
+ *   vertex anchors; on a two-vertex path that teleports between ends
+ *   mid-stroke. Drop those under axis modes (and auto→axis autoMode).
  *
- * Exact keeps geometric stroke/fill hits. Auto only resurrects marks whose
- * own autoMode is exact (points); line/area autoMode x/y stay quiet after a
- * nearest miss — same contract as explicit axis modes, flip-safe without
- * re-implementing nearest's distance formula here.
+ * Exact always keeps geometric hits. Auto→exact marks (points, default bars)
+ * keep full hitTest. Flip-safe: no re-implementation of nearest's axis swap.
  */
 function hitTestFallback(
   model: RenderModel,
   input: SchedulePointerInspectInput,
 ): CandidateFacts | null {
-  if (input.mode === "x" || input.mode === "y" || input.mode === "xy") return null;
   const hit = model.candidates.hitTest(input.point.x, input.point.y);
   if (hit === null) return null;
-  if (input.mode === "auto") {
-    const resolved = hit.autoMode ?? "exact";
-    if (resolved !== "exact") return null;
-  }
-  return hit;
+  if (input.mode === "exact") return hit;
+  const resolved = input.mode === "auto" ? (hit.autoMode ?? "exact") : input.mode;
+  if (resolved === "exact") return hit;
+  // Axis mode (explicit or auto→x/y): rect containment only.
+  return hit.kind === "rects" ? hit : null;
 }
 
 /** Cancel policy for pending pointer-inspect work. */

--- a/packages/svelte/src/lib/inspection/pointer-inspect.ts
+++ b/packages/svelte/src/lib/inspection/pointer-inspect.ts
@@ -34,6 +34,33 @@ export type SchedulePointerInspectInput = {
   readonly maxDistance: number;
 };
 
+/**
+ * hitTest resurrection when nearest misses.
+ *
+ * Axis modes (`x` / `y` / `xy`) already applied maxDistance in nearest —
+ * including under coord_flip (dominant axis is screen y when flipped).
+ * hitTest ignores that policy and returns any mark under the pointer; on a
+ * two-vertex path (geom_qq_line) that teleports between endpoints mid-stroke.
+ *
+ * Exact keeps geometric stroke/fill hits. Auto only resurrects marks whose
+ * own autoMode is exact (points); line/area autoMode x/y stay quiet after a
+ * nearest miss — same contract as explicit axis modes, flip-safe without
+ * re-implementing nearest's distance formula here.
+ */
+function hitTestFallback(
+  model: RenderModel,
+  input: SchedulePointerInspectInput,
+): CandidateFacts | null {
+  if (input.mode === "x" || input.mode === "y" || input.mode === "xy") return null;
+  const hit = model.candidates.hitTest(input.point.x, input.point.y);
+  if (hit === null) return null;
+  if (input.mode === "auto") {
+    const resolved = hit.autoMode ?? "exact";
+    if (resolved !== "exact") return null;
+  }
+  return hit;
+}
+
 /** Cancel policy for pending pointer-inspect work. */
 export type CancelPointerInspectPolicy = {
   /** Leave/clear: discard stash. Cancel/down/blur tool paths: preserve. */
@@ -106,7 +133,7 @@ export function createPointerInspectQueue(deps: PointerInspectQueueDeps): Pointe
       match,
       source: input.source,
       epoch: model?.runId ?? 0,
-      fallbackCandidate: () => model?.candidates.hitTest(input.point.x, input.point.y) ?? null,
+      fallbackCandidate: () => (model === null ? null : hitTestFallback(model, input)),
     });
     const reducer = deps.reducer();
     queuedPointerInspection = frame.queued;

--- a/packages/svelte/tests/inspection/pointer-inspect-queue.test.ts
+++ b/packages/svelte/tests/inspection/pointer-inspect-queue.test.ts
@@ -270,6 +270,55 @@ describe("createPointerInspectQueue", () => {
     hitTest.mockRestore();
   });
 
+  it("still rescues wide bar bodies under mode x via rect hitTest", () => {
+    // Devin review on #1577: bars anchor at centre/top; mode x nearest can
+    // miss the fill body while hitTest containment still sees the rect.
+    const barModel = runPipeline(
+      gg(
+        [
+          { g: "a", n: 40 },
+          { g: "b", n: 80 },
+        ],
+        aes({ x: "g", y: "n" }),
+      )
+        .geomCol()
+        .spec(),
+      { width: 640, height: 400 },
+    );
+    const bar = barModel.candidates.candidate(0)!;
+    expect(bar.kind).toBe("rects");
+    // Force nearest miss + rect hit so the fallback path is the only hit.
+    // panel.nearest is used by resolveTarget — stub the store nearest too so
+    // any path that reaches candidates.nearest also misses.
+    const nearestSpy = vi.spyOn(barModel.candidates, "nearest").mockReturnValue(null);
+    const hitTestSpy = vi.spyOn(barModel.candidates, "hitTest").mockReturnValue(bar);
+    const queued: QueuedInspect[] = [];
+    const queue = createPointerInspectQueue({
+      model: () => barModel,
+      reducer: () =>
+        makeReducer({
+          frameToken: () => token(8),
+          queuePointer: (action) => {
+            if (action.type === "inspect") queued.push(action);
+          },
+        }),
+      inspectionState: () => "none",
+      setInspection: noopCancel,
+    });
+    queue.schedule({
+      point: { x: bar.x + 80, y: bar.y + 40 },
+      source: "pointer",
+      mode: "x",
+      maxDistance: 12,
+    });
+    expect(hitTestSpy).toHaveBeenCalled();
+    // Reducer candidate ref carries the rescued bar id.
+    expect(queued[0]?.candidate?.id).toBe(bar.id);
+    nearestSpy.mockRestore();
+    hitTestSpy.mockRestore();
+    barModel.dispose();
+  });
+
   it("does not teleport between qq_line endpoints mid-stroke under mode x or auto", () => {
     // Regression: nearest(mode=x) misses mid-line (anchor maxDistance), then
     // hitTest returned the path stroke and flipped left/right endpoints.

--- a/packages/svelte/tests/inspection/pointer-inspect-queue.test.ts
+++ b/packages/svelte/tests/inspection/pointer-inspect-queue.test.ts
@@ -269,4 +269,94 @@ describe("createPointerInspectQueue", () => {
     expect(queued[0]?.candidate?.id).toBe(seed.id);
     hitTest.mockRestore();
   });
+
+  it("does not teleport between qq_line endpoints mid-stroke under mode x or auto", () => {
+    // Regression: nearest(mode=x) misses mid-line (anchor maxDistance), then
+    // hitTest returned the path stroke and flipped left/right endpoints.
+    const qqModel = runPipeline(
+      gg(
+        [
+          { value: 1.1 },
+          { value: 2.0 },
+          { value: 2.6 },
+          { value: 3.1 },
+          { value: 3.4 },
+          { value: 3.9 },
+          { value: 4.2 },
+          { value: 4.8 },
+          { value: 5.3 },
+          { value: 5.9 },
+          { value: 6.7 },
+          { value: 8.1 },
+        ],
+        aes({ sample: "value" }),
+      )
+        .geomQqLine({ linewidth: 3.2 })
+        .spec(),
+      { width: 640, height: 400 },
+    );
+    expect(qqModel.candidates.size).toBe(2);
+    const left = qqModel.candidates.candidate(0)!;
+    const right = qqModel.candidates.candidate(1)!;
+    const midX = (left.x + right.x) / 2;
+    const midY = (left.y + right.y) / 2;
+
+    for (const mode of ["x", "auto"] as const) {
+      const ids: Array<number | null> = [];
+      for (const point of [
+        { x: midX - 1, y: midY },
+        { x: midX + 1, y: midY },
+        { x: midX, y: midY },
+      ]) {
+        const queued: QueuedInspect[] = [];
+        const queue = createPointerInspectQueue({
+          model: () => qqModel,
+          reducer: () =>
+            makeReducer({
+              frameToken: () => token(20),
+              queuePointer: (action) => {
+                if (action.type === "inspect") queued.push(action);
+              },
+            }),
+          inspectionState: () => "none",
+          setInspection: noopCancel,
+        });
+        queue.schedule({
+          point,
+          source: "pointer",
+          mode,
+          maxDistance: 24,
+        });
+        ids.push(queued[0]?.candidate?.id ?? null);
+      }
+      // Mid-stroke must not hop between the two ends (prefer quiet null).
+      expect(new Set(ids.filter((id) => id !== null)).size).toBeLessThanOrEqual(1);
+      expect(ids.every((id) => id === null)).toBe(true);
+    }
+
+    // Ends still resolve under mode x.
+    for (const seed of [left, right]) {
+      const queued: QueuedInspect[] = [];
+      const queue = createPointerInspectQueue({
+        model: () => qqModel,
+        reducer: () =>
+          makeReducer({
+            frameToken: () => token(21),
+            queuePointer: (action) => {
+              if (action.type === "inspect") queued.push(action);
+            },
+          }),
+        inspectionState: () => "none",
+        setInspection: noopCancel,
+      });
+      queue.schedule({
+        point: { x: seed.x, y: seed.y },
+        source: "pointer",
+        mode: "x",
+        maxDistance: 24,
+      });
+      expect(queued[0]?.candidate?.id).toBe(seed.id);
+    }
+    qqModel.dispose();
+  });
 });

--- a/packages/svelte/tests/inspection/resolve-snapshot.test.ts
+++ b/packages/svelte/tests/inspection/resolve-snapshot.test.ts
@@ -18,6 +18,57 @@ import {
 } from "../../src/lib/inspection/resolver.js";
 
 describe("inspection snapshot resolve", () => {
+  it("qq_line tooltips expose theoretical + sample quantiles without a null value row", () => {
+    // Regression: only the two reference-line ends are candidates; their
+    // tooltips must not paint the raw sample input column as "–".
+    const data = [
+      { value: 1.1 },
+      { value: 2.0 },
+      { value: 2.6 },
+      { value: 3.1 },
+      { value: 3.4 },
+      { value: 3.9 },
+      { value: 4.2 },
+      { value: 4.8 },
+      { value: 5.3 },
+      { value: 5.9 },
+      { value: 6.7 },
+      { value: 8.1 },
+    ];
+    const model = runPipeline(
+      gg(data, aes({ sample: "value" }))
+        .geomQqLine()
+        .labs({ x: "Theoretical quantile", y: "Sample quantile" })
+        .spec(),
+      { width: 640, height: 400 },
+    );
+    expect(model.candidates.size).toBe(2);
+    for (let id = 0; id < model.candidates.size; id++) {
+      const seed = model.candidates.candidate(id)!;
+      const inspection = resolveInspection({
+        model,
+        seed,
+        mode: "x",
+        state: "transient",
+        source: "pointer",
+        keyOf: () => null,
+      });
+      expect(typeof inspection.axisValue).toBe("number");
+      expect(Number.isFinite(inspection.axisValue as number)).toBe(true);
+      const xField = inspection.focus.fields.find((f) => f.channel === "x");
+      const yField = inspection.focus.fields.find((f) => f.channel === "y");
+      expect(xField?.field).toBe("theoretical");
+      expect(typeof xField?.value).toBe("number");
+      expect(Number.isFinite(xField?.value as number)).toBe(true);
+      expect(yField?.field).toBe("sample");
+      expect(typeof yField?.value).toBe("number");
+      expect(Number.isFinite(yField?.value as number)).toBe(true);
+      // No dead source-column "value: –" row.
+      expect(inspection.focus.fields.some((f) => f.field === "value")).toBe(false);
+    }
+    model.dispose();
+  });
+
   it("uses one core grouped target for focus, legend order, fields, and lineage", () => {
     const data = [
       { id: "a1", x: 1, y: 3, series: "a" },


### PR DESCRIPTION
## Summary

- **Mid-stroke teleport:** `geom_qq_line` has two path vertices. Under mode `x` (or auto→`x`), `nearest` misses mid-line, then `hitTest` resurrected the stroke and flipped the tooltip between the ends. Axis-mode / auto→non-exact hover no longer falls back to `hitTest` (exact path hits still do).
- **Empty tooltip row:** QQ field maps advertised the input `sample` column (`value`) on synthesized `NO_ROW` rows (`value: –`) and omitted theoretical. They now expose after_stat `theoretical` / `sample` on x/y.

## Root cause

1. Two candidates only (quartile-line endpoints) + axis nearest + unconstrained `hitTest` fallback.
2. `layerFields` treated QQ like a generic stat with raw `sample` source field.

## Test plan

- [x] RED→GREEN: `resolveLayerFields` qq/qq_line theoretical+sample, no input `value`
- [x] RED→GREEN: `resolveInspection` on qq_line ends has finite theoretical/sample, no `value` field
- [x] RED→GREEN: mid-stroke under mode `x` and `auto` stays quiet; ends still hit
- [x] Exact-mode `hitTest` fallback still works (existing test)
- [x] Full `packages/svelte` inspection suite (519 tests)

## Notes

- Mid-line under mode `x` is intentionally quiet: there is no mid-line datum on a 2-vertex reference line. Quiet beats teleport.
- Dense multi-vertex lines still use `nearest` as before.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1577" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->