### PR TITLE
fix(docs): order comparison peers SveltePlot, Unovis, LayerCake

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,18 +55,18 @@ and Windows.
 
 ## Why ggsvelte?
 
-| Capability                                 | ggsvelte   | LayerCake            | Unovis                 | SveltePlot           |
+| Capability                                 | ggsvelte   | SveltePlot           | Unovis                 | LayerCake            |
 | ------------------------------------------ | ---------- | -------------------- | ---------------------- | -------------------- |
-| **Bundle size** (min+gzip, 1k scatter app) | ⚠️ 141 KB  | ✅ 41 KB             | ✅ 80 KB               | ✅ 109 KB            |
-| **API stability**                          | ⚠️ v0.34.4 | ✅ v10               | ✅ v1.6                | ⚠️ v0.14             |
-| **Headless server-side SVG** (no DOM)      | ✅         | ⚠️ opt-in `ssr` flag | ❌ client `onMount`    | ❌ empty shell       |
+| **Bundle size** (min+gzip, 1k scatter app) | ⚠️ 141 KB  | ✅ 109 KB            | ✅ 80 KB               | ✅ 41 KB             |
+| **API stability**                          | ⚠️ v0.34.4 | ⚠️ v0.14             | ✅ v1.6                | ✅ v10               |
+| **Headless server-side SVG** (no DOM)      | ✅         | ❌ empty shell       | ❌ client `onMount`    | ⚠️ opt-in `ssr` flag |
 | **Portable JSON spec + schema**            | ✅         | ❌                   | ❌                     | ❌                   |
 | **CLI validator + renderer**               | ✅         | ❌                   | ❌                     | ❌                   |
 | **Agent skill**                            | ✅         | ❌                   | ❌                     | ❌                   |
-| **Automatic temporal detection**           | ✅         | ❌                   | ❌                     | ⚠️ Date objects only |
-| **Built-in interactions**                  | ✅         | ❌                   | ⚠️ tooltip + crosshair | ⚠️ tooltip + brush   |
+| **Automatic temporal detection**           | ✅         | ⚠️ Date objects only | ❌                     | ❌                   |
+| **Built-in interactions**                  | ✅         | ⚠️ tooltip + brush   | ⚠️ tooltip + crosshair | ❌                   |
 | **ggplot2 API**                            | ✅         | ❌                   | ❌                     | ❌                   |
-| **Scale, axis & coord control**            | ✅         | ⚠️ d3 scales         | ✅                     | ✅                   |
+| **Scale, axis & coord control**            | ✅         | ✅                   | ✅                     | ⚠️ d3 scales         |
 
 ## Reference
 

--- a/apps/docs/src/lib/components/Benchmarks.svelte
+++ b/apps/docs/src/lib/components/Benchmarks.svelte
@@ -33,10 +33,10 @@
   const kb = (value: number): string => `${String(Math.round(value))} KB`;
 
   /*
-   * Column order matches cold-mount chart rank (ggsvelte → LayerCake →
-   * Unovis → SveltePlot). Bun's homepage table leads with its flaw before
-   * the wins; same here: bundle size and pre-1.0 up top. Claims verified
-   * against layercake@10 / @unovis/svelte@1.6 / svelteplot@0.14 sources.
+   * Column order: ggsvelte → SveltePlot → Unovis → LayerCake. Bun's
+   * homepage table leads with its flaw before the wins; same here: bundle
+   * size and pre-1.0 up top. Claims verified against svelteplot@0.14 /
+   * @unovis/svelte@1.6 / layercake@10 sources.
    */
   const rows: readonly Row[] = [
     {
@@ -131,9 +131,9 @@
         <tr>
           <th scope="col">Capability</th>
           <th scope="col">ggsvelte</th>
-          <th scope="col">LayerCake</th>
-          <th scope="col">Unovis</th>
           <th scope="col">SveltePlot</th>
+          <th scope="col">Unovis</th>
+          <th scope="col">LayerCake</th>
         </tr>
       </thead>
       <tbody>
@@ -143,7 +143,7 @@
               {row.feature}
               {#if row.desc !== undefined}<small>{row.desc}</small>{/if}
             </th>
-            {#each [row.gg, row.lc, row.uv, row.sp] as cell, i (i)}
+            {#each [row.gg, row.sp, row.uv, row.lc] as cell, i (i)}
               <td>
                 <span class={`mark mark--${cell.mark}`} aria-hidden="true"
                   >{GLYPH[cell.mark]}</span


### PR DESCRIPTION
## Summary

- Reorder the Why ggsvelte? comparison columns to **ggsvelte | SveltePlot | Unovis | LayerCake** in README and the docs homepage table (`Benchmarks.svelte`, used by `+page.svelte`).
- Peer cell values move with their headers; content is unchanged.

## Test plan

- [ ] README comparison table headers and cells match the new column order
- [ ] Docs homepage Why ggsvelte? table matches the same order
- [ ] `bun run comparison:versions:check` still passes (ggsvelte API-stability cell unchanged)