### PR TITLE
perf(bench): exclude builder sugar from headless bundles

### DIFF
--- a/benchmarks/competitive/README.md
+++ b/benchmarks/competitive/README.md
@@ -61,7 +61,7 @@ bun scripts/gen-benchmark-charts.ts --check # docs CI freshness gate
 
 1. **Apples and oranges by design.** uPlot is a lean canvas time-series painter with almost no grammar. ggsvelte runs a ggplot-like pipeline (scales, stats hooks, guides, candidates). Beating uPlot on raw line paint is a long game; the matrix shows the gap honestly.
 2. **ggsvelte-canvas harness draws mark strata only** (no axis/legend SVG chrome). That isolates mark cost; production `GGPlot` still composites SVG chrome.
-3. **ggsvelte-svg** is `renderToSVGString` innerHTML — full chart including axes.
+3. **ggsvelte-svg** is `renderToSVGString` innerHTML — full chart including axes. The adapter uses direct `SpecInput` objects rather than fluent builder sugar so bundle cells measure the renderer graph, not an optional authoring API; output-equivalence tests lock the same normalized chart.
 4. **`replace` is a full remount**, not in-place `setData`. The browser harness therefore **does not re-sample** replace (it mirrors mount stats) until a real in-place update metric lands (LightningChart's streaming score).
 5. **`area-multiseries` is overlaid (identity), not stacked.** ggsvelte `geomArea` defaults to `stack`; adapters pass `position: "identity"` so ggsvelte matches D3/Chart.js/ECharts/uPlot overlays. `bars-stacked` remains the stack fairness cell.
 6. **No interaction (mousemove) or max-capacity sweep yet.** uPlot's table and LC's capacity/stream metrics are the next expansion targets.

--- a/benchmarks/competitive/adapters/ggsvelte-canvas.ts
+++ b/benchmarks/competitive/adapters/ggsvelte-canvas.ts
@@ -9,7 +9,7 @@
  */
 import { cssColorResolver, drawStratum, sizeCanvasForDpr } from "@ggsvelte/core/dom";
 import { planStrata, runPipeline } from "@ggsvelte/core/headless";
-import { aes, gg } from "@ggsvelte/spec/portable";
+import type { SpecInput } from "@ggsvelte/spec/portable";
 
 import {
   PLOT_HEIGHT,
@@ -35,29 +35,35 @@ const DATA_NAME = "main";
  * draw marks only). Keep axis guides on so the panel size stays near the
  * LayerCake padding box — disabling axes expands the canvas and slowed paint.
  * Guide form must be `{ type: "none" }` (string `"none"` is not normalized). */
-function scatterPortable() {
-  return gg({ name: DATA_NAME }, aes({ x: "x", y: "y", color: "cls" }))
-    .geomPoint({ size: 1.5, alpha: 0.7, render: "canvas" })
-    .theme("void")
-    .guides({ color: { type: "none" } })
-    .toPortable();
+function scatterPortable(): SpecInput {
+  return {
+    data: { name: DATA_NAME },
+    aes: { x: "x", y: "y", color: "cls" },
+    layers: [{ geom: "point", render: "canvas", params: { size: 1.5, alpha: 0.7 } }],
+    theme: "void",
+    guides: { color: { type: "none" } },
+  };
 }
 
-function linePortable() {
-  return gg({ name: DATA_NAME }, aes({ x: "x", y: "y", color: "series", group: "series" }))
-    .geomLine({ render: "canvas" })
-    .theme("void")
-    .guides({ color: { type: "none" } })
-    .toPortable();
+function linePortable(): SpecInput {
+  return {
+    data: { name: DATA_NAME },
+    aes: { x: "x", y: "y", color: "series", group: "series" },
+    layers: [{ geom: "line", render: "canvas" }],
+    theme: "void",
+    guides: { color: { type: "none" } },
+  };
 }
 
-function areaPortable() {
+function areaPortable(): SpecInput {
   // Identity (not stack): competitors overlay series; default geomArea is stack.
-  return gg({ name: DATA_NAME }, aes({ x: "x", y: "y", fill: "series", group: "series" }))
-    .geomArea({ position: "identity", render: "canvas" })
-    .theme("void")
-    .guides({ fill: { type: "none" } })
-    .toPortable();
+  return {
+    data: { name: DATA_NAME },
+    aes: { x: "x", y: "y", fill: "series", group: "series" },
+    layers: [{ geom: "area", position: "identity", render: "canvas" }],
+    theme: "void",
+    guides: { fill: { type: "none" } },
+  };
 }
 
 function portableFor(scenario: ScenarioId) {

--- a/benchmarks/competitive/adapters/ggsvelte-svg.ts
+++ b/benchmarks/competitive/adapters/ggsvelte-svg.ts
@@ -2,7 +2,7 @@
  * Lean SVG-only ggsvelte mounts (keeps @ggsvelte/core/dom and planStrata out of the graph).
  */
 import { renderToSVGString } from "@ggsvelte/core/headless";
-import { aes, gg } from "@ggsvelte/spec/portable";
+import type { SpecInput } from "@ggsvelte/spec/portable";
 
 import {
   PLOT_HEIGHT,
@@ -22,29 +22,40 @@ export type MountHandle = {
 
 export type MountResult = { markHint: number; handle: MountHandle };
 
-function scatterSpec(data: ScatterColumns) {
-  return gg(data, aes({ x: "x", y: "y", color: "cls" }))
-    .geomPoint({ size: 1.5, alpha: 0.7 })
-    .toPortable();
+// These deterministic fixtures contain plain number/string columns and never
+// mutate input after mount, so direct SpecInput avoids optional builder sugar
+// without changing Date conversion or defensive-copy semantics relevant here.
+function scatterSpec(data: ScatterColumns): SpecInput {
+  return {
+    data: { columns: data },
+    aes: { x: "x", y: "y", color: "cls" },
+    layers: [{ geom: "point", params: { size: 1.5, alpha: 0.7 } }],
+  };
 }
 
-function lineSpec(data: SeriesColumns) {
-  return gg(data, aes({ x: "x", y: "y", color: "series", group: "series" }))
-    .geomLine()
-    .toPortable();
+function lineSpec(data: SeriesColumns): SpecInput {
+  return {
+    data: { columns: data },
+    aes: { x: "x", y: "y", color: "series", group: "series" },
+    layers: [{ geom: "line" }],
+  };
 }
 
-function areaSpec(data: SeriesColumns) {
+function areaSpec(data: SeriesColumns): SpecInput {
   // Identity (not stack): competitors overlay series; default geomArea is stack.
-  return gg(data, aes({ x: "x", y: "y", fill: "series", group: "series" }))
-    .geomArea({ position: "identity" })
-    .toPortable();
+  return {
+    data: { columns: data },
+    aes: { x: "x", y: "y", fill: "series", group: "series" },
+    layers: [{ geom: "area", position: "identity" }],
+  };
 }
 
-function barsSpec(data: BarsColumns) {
-  return gg(data, aes({ x: "category", y: "value", fill: "stack" }))
-    .geomCol()
-    .toPortable();
+function barsSpec(data: BarsColumns): SpecInput {
+  return {
+    data: { columns: data },
+    aes: { x: "category", y: "value", fill: "stack" },
+    layers: [{ geom: "col" }],
+  };
 }
 
 export function mountGgsvelteSvg(

--- a/benchmarks/competitive/direct-spec-equivalence.test.ts
+++ b/benchmarks/competitive/direct-spec-equivalence.test.ts
@@ -1,0 +1,126 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+
+import {
+  registerBasicAreas,
+  registerBasicBars,
+  registerBasicLines,
+  registerBasicPoints,
+} from "@ggsvelte/core/headless/register";
+import {
+  bundleAreaCanvas,
+  bundleLineCanvas,
+  bundleScatterCanvas,
+} from "./adapters/ggsvelte-canvas";
+import {
+  bundleAreaSvg,
+  bundleBarsSvg,
+  bundleLineSvg,
+  bundleScatterSvg,
+} from "./adapters/ggsvelte-svg";
+import { aes, gg } from "@ggsvelte/spec/portable";
+import {
+  makeMultiSeries,
+  makeScatter,
+  makeStackedBars,
+  PLOT_HEIGHT,
+  PLOT_WIDTH,
+} from "./scenarios";
+import { renderToSVGString, runPipeline } from "@ggsvelte/core/headless";
+
+beforeAll(() => {
+  registerBasicPoints();
+  registerBasicLines();
+  registerBasicAreas();
+  registerBasicBars();
+});
+
+const options = { width: PLOT_WIDTH, height: PLOT_HEIGHT };
+
+describe("competitive direct specs", () => {
+  it("render the same charts as fluent builder sugar", () => {
+    const scatter = makeScatter(1_000);
+    const series = makeMultiSeries(3, 1_000);
+    const bars = makeStackedBars(50, 4);
+
+    expect(bundleScatterSvg(scatter)).toBe(
+      renderToSVGString(
+        gg(scatter, aes({ x: "x", y: "y", color: "cls" }))
+          .geomPoint({ size: 1.5, alpha: 0.7 })
+          .toPortable(),
+        options,
+      ),
+    );
+    expect(bundleLineSvg(series)).toBe(
+      renderToSVGString(
+        gg(series, aes({ x: "x", y: "y", color: "series", group: "series" }))
+          .geomLine()
+          .toPortable(),
+        options,
+      ),
+    );
+    expect(bundleAreaSvg(series)).toBe(
+      renderToSVGString(
+        gg(series, aes({ x: "x", y: "y", fill: "series", group: "series" }))
+          .geomArea({ position: "identity" })
+          .toPortable(),
+        options,
+      ),
+    );
+    expect(bundleBarsSvg(bars)).toBe(
+      renderToSVGString(
+        gg(bars, aes({ x: "category", y: "value", fill: "stack" }))
+          .geomCol()
+          .toPortable(),
+        options,
+      ),
+    );
+  });
+
+  it("build the same canvas models as named-data builder sugar", () => {
+    const scatter = makeScatter(1_000);
+    const series = makeMultiSeries(3, 1_000);
+    const dataName = "main";
+
+    const scatterDirect = bundleScatterCanvas(scatter) as ReturnType<typeof runPipeline>;
+    const scatterBuilder = runPipeline(
+      gg({ name: dataName }, aes({ x: "x", y: "y", color: "cls" }))
+        .geomPoint({ size: 1.5, alpha: 0.7, render: "canvas" })
+        .theme("void")
+        .guides({ color: { type: "none" } })
+        .toPortable(),
+      { ...options, data: { [dataName]: scatter } },
+    );
+    expect({ scene: scatterDirect.scene, layerBackends: scatterDirect.layerBackends }).toEqual({
+      scene: scatterBuilder.scene,
+      layerBackends: scatterBuilder.layerBackends,
+    });
+
+    const lineDirect = bundleLineCanvas(series) as ReturnType<typeof runPipeline>;
+    const lineBuilder = runPipeline(
+      gg({ name: dataName }, aes({ x: "x", y: "y", color: "series", group: "series" }))
+        .geomLine({ render: "canvas" })
+        .theme("void")
+        .guides({ color: { type: "none" } })
+        .toPortable(),
+      { ...options, data: { [dataName]: series } },
+    );
+    expect({ scene: lineDirect.scene, layerBackends: lineDirect.layerBackends }).toEqual({
+      scene: lineBuilder.scene,
+      layerBackends: lineBuilder.layerBackends,
+    });
+
+    const areaDirect = bundleAreaCanvas(series) as ReturnType<typeof runPipeline>;
+    const areaBuilder = runPipeline(
+      gg({ name: dataName }, aes({ x: "x", y: "y", fill: "series", group: "series" }))
+        .geomArea({ position: "identity", render: "canvas" })
+        .theme("void")
+        .guides({ fill: { type: "none" } })
+        .toPortable(),
+      { ...options, data: { [dataName]: series } },
+    );
+    expect({ scene: areaDirect.scene, layerBackends: areaDirect.layerBackends }).toEqual({
+      scene: areaBuilder.scene,
+      layerBackends: areaBuilder.layerBackends,
+    });
+  });
+});

--- a/benchmarks/competitive/lean-candidates-graph.test.ts
+++ b/benchmarks/competitive/lean-candidates-graph.test.ts
@@ -16,6 +16,7 @@ const root = import.meta.dir;
 const LEAN_BANNED = /candidate-store|candidate-hit-|build-candidates|candidate-construction/;
 const SCATTER_BANNED =
   /geometry-(?:paths-line|paths-area|ribbon|rects|edge-rects|segments|segment-finite|glyphs)/;
+const AUTHORING_BANNED = /(?:portable-)?builder(?:-|\.)/;
 
 async function buildEntry(entryName: string): Promise<{ moduleIds: string[]; rawBytes: number }> {
   const outDir = path.join(root, "results", "bundles", `_lean-candidates-test-${entryName}`);
@@ -65,15 +66,17 @@ function expectCandidateFree(
 describe("lean competitive SVG graph", () => {
   it("excludes the candidate-store graph after minify", async () => {
     const built = await buildEntry("ggsvelte-svg__scatter-color.ts");
-    expectCandidateFree(built, 525_000);
+    expectCandidateFree(built, 500_000);
     expect(built.moduleIds.filter((id) => SCATTER_BANNED.test(id))).toEqual([]);
+    expect(built.moduleIds.filter((id) => AUTHORING_BANNED.test(id))).toEqual([]);
   }, 120_000);
 });
 
 describe("lean competitive canvas graph", () => {
   it("excludes the candidate-store graph after minify", async () => {
     const built = await buildEntry("ggsvelte-canvas__scatter-color.ts");
-    expectCandidateFree(built, 500_000);
+    expectCandidateFree(built, 475_000);
     expect(built.moduleIds.filter((id) => SCATTER_BANNED.test(id))).toEqual([]);
+    expect(built.moduleIds.filter((id) => AUTHORING_BANNED.test(id))).toEqual([]);
   }, 120_000);
 });

--- a/benchmarks/competitive/scenarios.test.ts
+++ b/benchmarks/competitive/scenarios.test.ts
@@ -98,8 +98,8 @@ describe("competitive scenario catalog", () => {
     // Competitors draw overlaid areas; geomArea defaults to stack.
     const svg = readFileSync(new URL("./adapters/ggsvelte-svg.ts", import.meta.url), "utf8");
     const canvas = readFileSync(new URL("./adapters/ggsvelte-canvas.ts", import.meta.url), "utf8");
-    expect(svg).toMatch(/geomArea\(\s*\{\s*position:\s*["']identity["']/);
-    expect(canvas).toMatch(/geomArea\(\s*\{[^}]*position:\s*["']identity["']/s);
+    expect(svg).toMatch(/geom:\s*["']area["'],\s*position:\s*["']identity["']/);
+    expect(canvas).toMatch(/geom:\s*["']area["'],\s*position:\s*["']identity["']/);
   });
 
   test("SSR bench entries exist for ggsvelte + Svelte peers (server-render matrix cannot collapse)", () => {


### PR DESCRIPTION
## Summary

- feed supported direct `SpecInput` objects to lean SVG/canvas competitive entries
- keep fluent builder costs visible in the separate full/GGPlot bundle cells
- lock byte-identical SVG output, canvas scene/backend equivalence, and builder-free lean graphs

## Bundle measurements

Vite library build, esbuild minify, gzip -9, Bun 1.3.14 on linux-x64. Before is merged #1599; after is this PR.

| cell | before gzip | after gzip | change |
|---|---:|---:|---:|
| SVG scatter | 132.4 KB | 127.3 KB | -3.9% |
| SVG line | 133.9 KB | 128.8 KB | -3.8% |
| SVG area | 134.7 KB | 129.6 KB | -3.8% |
| SVG bars | 133.2 KB | 128.1 KB | -3.8% |
| Canvas scatter | 125.1 KB | 120.1 KB | -4.0% |
| Canvas line | 126.7 KB | 121.5 KB | -4.1% |
| Canvas area | 127.6 KB | 122.4 KB | -4.1% |

Full and GGPlot cells are unchanged (362.2 KB and 315.2 KB gzip). This isolates the renderer graph from optional fluent authoring sugar; the README records that benchmark posture.

## Verification

- `bun test benchmarks/competitive` — 20 passed
- `bun run check`
- exact SVG equality for scatter/line/area/bars
- exact canvas Scene + `layerBackends` equality for scatter/line/area
- lean graph gates exclude builder, candidate, Temporal-polyfill, and unrelated geom modules