### PR TITLE
docs: update bundle size claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ and Windows.
 
 | Capability                                 | ggsvelte   | SveltePlot           | Unovis                 | LayerCake            |
 | ------------------------------------------ | ---------- | -------------------- | ---------------------- | -------------------- |
-| **Bundle size** (min+gzip, 1k scatter app) | ⚠️ 141 KB  | ✅ 109 KB            | ✅ 80 KB               | ✅ 41 KB             |
+| **Bundle size** (min+gzip, 1k scatter app) | ⚠️ 127 KB  | ✅ 109 KB            | ✅ 80 KB               | ✅ 41 KB             |
 | **API stability**                          | ⚠️ v0.37.0 | ⚠️ v0.14             | ✅ v1.6                | ✅ v10               |
 | **Headless server-side SVG** (no DOM)      | ✅         | ❌ empty shell       | ❌ client `onMount`    | ⚠️ opt-in `ssr` flag |
 | **Portable JSON spec + schema**            | ✅         | ❌                   | ❌                     | ❌                   |

--- a/apps/docs/src/lib/generated/benchmark-charts.ts
+++ b/apps/docs/src/lib/generated/benchmark-charts.ts
@@ -112,7 +112,7 @@ export const BENCHMARK_VERSIONS = {
 
 /** Min+gzip KB of the 1,000-point colored-scatter app bundle. */
 export const BENCHMARK_BUNDLE_KB = {
-  ggsvelteKb: 140.8,
+  ggsvelteKb: 127.3,
   svelteplotKb: 108.7,
   layercakeKb: 40.8,
   unovisKb: 80.3,


### PR DESCRIPTION
## Summary

- update the README bundle claim from 141 KB to 127 KB
- refresh the generated homepage benchmark value from 140.8 KB to 127.3 KB
- preserve peer values from the same competitive bundle run

The new value reflects the lean SVG scatter bundle after #1599 and #1601.

## Verification

- `bun run check`
- `bun run benchmark:charts:check` with ignored result files hidden
- `bun run build:docs` with ignored result files hidden
- Svelte autofixer: no issues