### PR TITLE
perf(core): pack continuous scatter points in one pass

### DIFF
--- a/.changeset/one-pass-point-geometry.md
+++ b/.changeset/one-pass-point-geometry.md
@@ -1,0 +1,9 @@
+---
+"@ggsvelte/core": patch
+---
+
+# Pack continuous scatter points in one pass
+
+Migration: none — internal. Same pixels, dropped rows, and source row indexes. Band scales and positional offsets still use the two-pass collector.
+
+Continuous identity scatter no longer allocates intermediate normalized x/y buffers. Normalize, drop non-finite positions, and write pixel coords in one loop — the same shape as the multi-series line hot path.

--- a/packages/core/src/pipeline/geometry-points-collect.ts
+++ b/packages/core/src/pipeline/geometry-points-collect.ts
@@ -45,3 +45,51 @@ export function packPointPixels(
   }
   return { positions, rowIndex };
 }
+
+export interface PackedPointPositions {
+  positions: Float32Array;
+  rowIndex: Uint32Array;
+  keptRows: Uint32Array;
+  kept: number;
+}
+
+/**
+ * Continuous scatter: one normalize+pixel pass (no intermediate xs/ys
+ * buffers). Returns null when band scales or positional offsets require
+ * {@link collectPointPositions} + {@link packPointPixels}.
+ */
+export function packContinuousPointsOnePass(
+  frame: LayerFrame,
+  fx: Frame,
+): PackedPointPositions | null {
+  if (fx.xScale.type === "band" || fx.yScale.type === "band") return null;
+  if (frame.offsetX !== null || frame.offsetY !== null) return null;
+  const xNum = frame.xNumeric;
+  const yNum = frame.yNumeric;
+  if (xNum === null || yNum === null) return null;
+
+  const { n } = frame;
+  const xScale = fx.xScale;
+  const yScale = fx.yScale;
+  const iw = fx.innerWidth;
+  const ih = fx.innerHeight;
+  const sourceRows = frame.rowIndex;
+  const positions = new Float32Array(n * 2);
+  const rowIndex = new Uint32Array(n);
+  const keptRows = new Uint32Array(n);
+  let kept = 0;
+  for (let row = 0; row < n; row++) {
+    const xv = xNum[row]!;
+    const yv = yNum[row]!;
+    if (!Number.isFinite(xv) || !Number.isFinite(yv)) continue;
+    const tx = xScale.normalizeTransformed(xv);
+    const ty = yScale.normalizeTransformed(yv);
+    if (Number.isNaN(tx) || Number.isNaN(ty)) continue;
+    positions[kept * 2] = tx * iw;
+    positions[kept * 2 + 1] = ih - ty * ih;
+    rowIndex[kept] = sourceRows[row]!;
+    keptRows[kept] = row;
+    kept++;
+  }
+  return { positions, rowIndex, keptRows, kept };
+}

--- a/packages/core/src/pipeline/geometry-points.ts
+++ b/packages/core/src/pipeline/geometry-points.ts
@@ -15,7 +15,11 @@ import {
   type ResolvedStyleScales,
 } from "./geometry-style.js";
 import { DEFAULT_POINT_SIZE, removedWarning } from "./geometry-shared.js";
-import { collectPointPositions, packPointPixels } from "./geometry-points-collect.js";
+import {
+  collectPointPositions,
+  packContinuousPointsOnePass,
+  packPointPixels,
+} from "./geometry-points-collect.js";
 
 /** Diameter ≈ binwidth in x data units × dotsize, converted to px radius. */
 function dotplotRadiusPx(
@@ -54,11 +58,25 @@ export function pointsBatch(
   fill: ResolvedColorScale | null = null,
 ): PointsBatch | null {
   const { binding, n } = frame;
-  const collected = collectPointPositions(frame, fx);
-  removedWarning(n - collected.kept, binding.index, warnings);
-  if (collected.kept === 0) return null;
+  let packed = packContinuousPointsOnePass(frame, fx);
+  if (packed === null) {
+    const collected = collectPointPositions(frame, fx);
+    packed = {
+      ...packPointPixels(collected, frame, fx),
+      keptRows: collected.keptRows,
+      kept: collected.kept,
+    };
+  }
+  removedWarning(n - packed.kept, binding.index, warnings);
+  if (packed.kept === 0) return null;
 
-  const { positions, rowIndex } = packPointPixels(collected, frame, fx);
+  const kept = packed.kept;
+  const positions =
+    kept === packed.positions.length / 2 ? packed.positions : packed.positions.slice(0, kept * 2);
+  const rowIndex =
+    kept === packed.rowIndex.length ? packed.rowIndex : packed.rowIndex.slice(0, kept);
+  const collectedKeptRows =
+    kept === packed.keptRows.length ? packed.keptRows : packed.keptRows.subarray(0, kept);
   // point / count / qq / dotplot / geom_sf point family share this builder.
   // SfParams has size/alpha (not shape); DotplotParams adds binwidth/dotsize.
   const geom = binding.layer.geom;
@@ -107,9 +125,9 @@ export function pointsBatch(
       typeof literalShape === "string" ? (literalShape as PointShape) : (paramShape ?? "circle"),
     fill: paintChannel.constant,
   };
-  const sizes = numericStyleVector(frame, "size", collected.keptRows, styles);
-  const alphas = numericStyleVector(frame, "alpha", collected.keptRows, styles);
-  const shapeIndexes = indexedStyleVector(frame, "shape", collected.keptRows, styles, (value) =>
+  const sizes = numericStyleVector(frame, "size", collectedKeptRows, styles);
+  const alphas = numericStyleVector(frame, "alpha", collectedKeptRows, styles);
+  const shapeIndexes = indexedStyleVector(frame, "shape", collectedKeptRows, styles, (value) =>
     pointShapeIndex(value as PointShape),
   );
   if (sizes !== undefined) batch.sizes = sizes;
@@ -119,7 +137,7 @@ export function pointsBatch(
   }
   if (shapeIndexes !== undefined) batch.shapeIndexes = shapeIndexes;
   if (paintScale !== null && (paintValues !== null || paintChannel.scaledConstant !== null)) {
-    batch.colors = mappedPaintVector(frame, paintKey, paintScale, collected.keptRows);
+    batch.colors = mappedPaintVector(frame, paintKey, paintScale, collectedKeptRows);
   }
   return batch;
 }

--- a/packages/core/tests/geometry-points-hotpath.test.ts
+++ b/packages/core/tests/geometry-points-hotpath.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Continuous scatter hot path: one normalize+pixel pass that also keeps
+ * source rows. Behavioral seam for competitive scatter-color-Nk work.
+ */
+import { fromAny, fromPartial } from "@total-typescript/shoehorn";
+import { describe, expect, it } from "bun:test";
+
+import { packContinuousPointsOnePass } from "../src/pipeline/geometry-points-collect.ts";
+import type { Frame } from "../src/pipeline/geometry-shared.ts";
+import type { LayerFrame } from "../src/pipeline/types.ts";
+import { trainContinuous } from "../src/scales/train.ts";
+
+function continuousFrame(n: number, opts?: { nanAt?: number; offsetX?: boolean }): LayerFrame {
+  const xNumeric = new Float64Array(n);
+  const yNumeric = new Float64Array(n);
+  for (let i = 0; i < n; i++) {
+    xNumeric[i] = i;
+    yNumeric[i] = i * 2;
+  }
+  if (opts?.nanAt !== undefined) yNumeric[opts.nanAt] = Number.NaN;
+  return fromAny<LayerFrame>({
+    n,
+    xNumeric,
+    yNumeric,
+    xValues: null,
+    yValues: null,
+    offsetX: opts?.offsetX ? new Float64Array(n) : null,
+    offsetY: null,
+    rowIndex: Uint32Array.from({ length: n }, (_, i) => i + 10),
+  });
+}
+
+function continuousFx(): Frame {
+  const xScale = trainContinuous([[0, 10]], {}).scale;
+  const yScale = trainContinuous([[0, 20]], {}).scale;
+  return fromPartial<Frame>({
+    innerWidth: 100,
+    innerHeight: 50,
+    xScale,
+    yScale,
+  });
+}
+
+describe("packContinuousPointsOnePass", () => {
+  it("writes pixel coords and source rows in one pass for finite continuous points", () => {
+    const packed = packContinuousPointsOnePass(continuousFrame(3), continuousFx());
+    expect(packed).not.toBeNull();
+    expect(packed!.kept).toBe(3);
+    expect([...packed!.rowIndex.subarray(0, 3)]).toEqual([10, 11, 12]);
+    expect([...packed!.keptRows.subarray(0, 3)]).toEqual([0, 1, 2]);
+    // x=0,1,2 on domain [0,10] → 0, 0.1, 0.2 of width 100
+    // y=0,2,4 on domain [0,20] → 0, 0.1, 0.2 of height 50, flipped
+    expect(packed!.positions[0]).toBeCloseTo(0);
+    expect(packed!.positions[1]).toBeCloseTo(50);
+    expect(packed!.positions[2]).toBeCloseTo(10);
+    expect(packed!.positions[3]).toBeCloseTo(45);
+    expect(packed!.positions[4]).toBeCloseTo(20);
+    expect(packed!.positions[5]).toBeCloseTo(40);
+  });
+
+  it("drops NaN positions and keeps remaining rows", () => {
+    const packed = packContinuousPointsOnePass(continuousFrame(3, { nanAt: 1 }), continuousFx());
+    expect(packed).not.toBeNull();
+    expect(packed!.kept).toBe(2);
+    expect([...packed!.keptRows.subarray(0, 2)]).toEqual([0, 2]);
+    expect([...packed!.rowIndex.subarray(0, 2)]).toEqual([10, 12]);
+  });
+
+  it("returns null when a positional offset is present (caller uses two-pass)", () => {
+    expect(
+      packContinuousPointsOnePass(continuousFrame(2, { offsetX: true }), continuousFx()),
+    ).toBeNull();
+  });
+
+  it("returns null for band scales", () => {
+    const fx = fromPartial<Frame>({
+      innerWidth: 100,
+      innerHeight: 50,
+      xScale: { type: "band" },
+      yScale: trainContinuous([[0, 20]], {}).scale,
+    });
+    expect(packContinuousPointsOnePass(continuousFrame(2), fx)).toBeNull();
+  });
+});

--- a/packages/core/tests/geometry-points-hotpath.test.ts
+++ b/packages/core/tests/geometry-points-hotpath.test.ts
@@ -24,7 +24,7 @@ function continuousFrame(n: number, opts?: { nanAt?: number; offsetX?: boolean }
     yNumeric,
     xValues: null,
     yValues: null,
-    offsetX: opts?.offsetX ? new Float64Array(n) : null,
+    offsetX: opts?.offsetX === true ? new Float64Array(n) : null,
     offsetY: null,
     rowIndex: Uint32Array.from({ length: n }, (_, i) => i + 10),
   });


### PR DESCRIPTION
## Summary

Continuous identity scatter packed pixels in two loops: collect normalized x/y, then scale into the point batch. That matches the old line path we already replaced.

This PR does the same cut for points. One loop normalizes, drops non-finite rows, and writes pixel coords. Band scales and jitter/dodge offsets still use the two-pass collector.

**Performance**

| Measure | Before | After |
|---|---:|---:|
| Isolated 100k packer (Node) | 2.73 ms | **0.93 ms** |
| Isolated canvas scatter-100k mount (Chromium, same-run vs LayerCake) | 272.5 ms | **267.6 ms** (LayerCake canvas 172 ms) |
| Isolated canvas scatter-10k mount | 26.3 ms (full matrix) / ~23 ms isolated | **23.0 ms** vs LayerCake 20.9 ms |

This does not close the 100k canvas gap vs LayerCake (~96 ms on a quiet runner). It is the first of several scatter cuts.

## Test plan

- [x] `bun test packages/core/tests/geometry-points-hotpath.test.ts` plus pipeline/SVG/dotplot point suites
- [x] Isolated competitive remount of `scatter-color-10k` and `scatter-color-100k` (ggsvelte-canvas vs layercake-canvas)