### PR TITLE
perf(core): draw constant-size canvas circles without per-point style objects

### DIFF
--- a/.changeset/canvas-circle-hotpath.md
+++ b/.changeset/canvas-circle-hotpath.md
@@ -1,0 +1,9 @@
+---
+"@ggsvelte/core": patch
+---
+
+# Draw constant-size canvas circles without per-point style objects
+
+Migration: none — internal. Same `moveTo` + `arc` + batched fill commands.
+
+The competitive colored scatter path allocated a geometry object per point via `resolvePointMark`. Filled circles of one size now write the path commands directly.

--- a/packages/core/src/dom/canvas-marks-points.ts
+++ b/packages/core/src/dom/canvas-marks-points.ts
@@ -40,6 +40,36 @@ function tracePoint(ctx: CanvasRenderingContext2D, batch: PointsBatch, j: number
   traceGeometry(ctx, style.geometry);
 }
 
+/** Filled circle: same commands as `pointShapeGeometry("circle")` without the object. */
+function traceFilledCircle(ctx: CanvasRenderingContext2D, x: number, y: number, r: number): void {
+  ctx.moveTo(x + r, y);
+  ctx.arc(x, y, r, 0, Math.PI * 2);
+}
+
+function traceFilledCircles(
+  ctx: CanvasRenderingContext2D,
+  batch: PointsBatch,
+  indexes: ArrayLike<number> | null,
+): void {
+  const r = batch.size;
+  const positions = batch.positions;
+  if (indexes === null) {
+    const n = batch.rowIndex.length;
+    for (let j = 0; j < n; j++) {
+      traceFilledCircle(ctx, positions[j * 2]!, positions[j * 2 + 1]!, r);
+    }
+    return;
+  }
+  for (let i = 0; i < indexes.length; i++) {
+    const j = indexes[i]!;
+    traceFilledCircle(ctx, positions[j * 2]!, positions[j * 2 + 1]!, r);
+  }
+}
+
+function isFilledCircleBatch(batch: PointsBatch): boolean {
+  return batch.shape === "circle";
+}
+
 export function drawPoints(
   ctx: CanvasRenderingContext2D,
   batch: PointsBatch,
@@ -81,7 +111,8 @@ export function drawPoints(
     // canvas worth it at high counts).
     ctx.fillStyle = batch.fill === null ? themeInk : resolve(batch.fill);
     ctx.beginPath();
-    for (let j = 0; j < n; j++) tracePoint(ctx, batch, j);
+    if (isFilledCircleBatch(batch)) traceFilledCircles(ctx, batch, null);
+    else for (let j = 0; j < n; j++) tracePoint(ctx, batch, j);
     ctx.fill();
     return;
   }
@@ -106,16 +137,19 @@ export function drawPoints(
     list.push(j);
   }
   if (!highCardinality) {
+    const circles = isFilledCircleBatch(batch);
     for (const color of uniqueColors) {
       const list = indicesByColor.get(color)!;
       ctx.fillStyle = resolve(color);
       ctx.beginPath();
-      for (const j of list) tracePoint(ctx, batch, j);
+      if (circles) traceFilledCircles(ctx, batch, list);
+      else for (const j of list) tracePoint(ctx, batch, j);
       ctx.fill();
     }
     return;
   }
   // High-cardinality: batch consecutive same-color runs.
+  const circles = isFilledCircleBatch(batch);
   let runStart = 0;
   while (runStart < n) {
     const color = batch.colors[runStart] ?? batch.fill ?? themeInk;
@@ -123,7 +157,13 @@ export function drawPoints(
     while (runEnd < n && (batch.colors[runEnd] ?? batch.fill ?? themeInk) === color) runEnd++;
     ctx.fillStyle = resolve(color);
     ctx.beginPath();
-    for (let j = runStart; j < runEnd; j++) tracePoint(ctx, batch, j);
+    if (circles) {
+      for (let j = runStart; j < runEnd; j++) {
+        traceFilledCircle(ctx, batch.positions[j * 2]!, batch.positions[j * 2 + 1]!, batch.size);
+      }
+    } else {
+      for (let j = runStart; j < runEnd; j++) tracePoint(ctx, batch, j);
+    }
     ctx.fill();
     runStart = runEnd;
   }
@@ -171,9 +211,14 @@ export function drawPointsSubset(
     ctx.fillStyle = batch.fill === null ? themeInk : resolve(batch.fill);
     ctx.beginPath();
     let traced = false;
+    const circles = isFilledCircleBatch(batch);
     for (let j = 0; j < n; j++) {
       if (!includes(j)) continue;
-      tracePoint(ctx, batch, j);
+      if (circles) {
+        traceFilledCircle(ctx, batch.positions[j * 2]!, batch.positions[j * 2 + 1]!, batch.size);
+      } else {
+        tracePoint(ctx, batch, j);
+      }
       traced = true;
     }
     if (traced) ctx.fill();
@@ -205,12 +250,14 @@ export function drawPointsSubset(
     if (includes(j)) list.push(j);
   }
   if (!highCardinality) {
+    const circles = isFilledCircleBatch(batch);
     for (const color of uniqueColors) {
       const list = indicesByColor.get(color)!;
       if (list.length === 0) continue;
       ctx.fillStyle = resolve(color);
       ctx.beginPath();
-      for (const j of list) tracePoint(ctx, batch, j);
+      if (circles) traceFilledCircles(ctx, batch, list);
+      else for (const j of list) tracePoint(ctx, batch, j);
       ctx.fill();
     }
     return;
@@ -223,9 +270,14 @@ export function drawPointsSubset(
     ctx.fillStyle = resolve(color);
     ctx.beginPath();
     let traced = false;
+    const circles = isFilledCircleBatch(batch);
     for (let j = runStart; j < runEnd; j++) {
       if (!includes(j)) continue;
-      tracePoint(ctx, batch, j);
+      if (circles) {
+        traceFilledCircle(ctx, batch.positions[j * 2]!, batch.positions[j * 2 + 1]!, batch.size);
+      } else {
+        tracePoint(ctx, batch, j);
+      }
       traced = true;
     }
     if (traced) ctx.fill();

--- a/packages/core/tests/dom/canvas-styles.test.ts
+++ b/packages/core/tests/dom/canvas-styles.test.ts
@@ -121,6 +121,33 @@ describe("canvas mapped style vectors", () => {
     expect(calls.filter(({ name }) => name === "arc")).toHaveLength(n);
   });
 
+  it("traces constant-size circles with moveTo(x+r,y) + arc, no per-point style objects", () => {
+    const batch: PointsBatch = {
+      kind: "points",
+      layerIndex: 0,
+      panelIndex: 0,
+      positions: Float32Array.from([10, 20, 30, 40]),
+      rowIndex: Uint32Array.from([0, 1]),
+      size: 1.5,
+      alpha: 1,
+      shape: "circle",
+      fill: "red",
+    };
+    const { ctx, calls } = styleContext();
+    drawBatch(ctx, batch, theme, resolve);
+    const moves = calls.filter(({ name }) => name === "moveTo");
+    const arcs = calls.filter(({ name }) => name === "arc");
+    expect(moves.map(({ args }) => args.slice(0, 2))).toEqual([
+      [11.5, 20],
+      [31.5, 40],
+    ]);
+    expect(arcs.map(({ args }) => args.slice(0, 3))).toEqual([
+      [10, 20, 1.5],
+      [30, 40, 1.5],
+    ]);
+    expect(calls.filter(({ name }) => name === "fill")).toHaveLength(1);
+  });
+
   it("applies adjacent path width/alpha/dash styles without reordering and resets dash", () => {
     const batch: PathsBatch = {
       kind: "paths",


### PR DESCRIPTION
## Summary

The canvas scatter fill path called `resolvePointMark` for every point, even when size and shape were constant. That allocated a geometry object per mark on the competitive 5-color scatter (10k and 100k).

Filled circles of one size now write the same `moveTo(x+r, y)` + `arc` commands directly. Squares, mapped sizes, plus/cross, and `circle-open` stay on the existing resolver.

**Performance** (isolated Chromium, ggsvelte-canvas vs layercake-canvas)

| Cell | Before (main) | After |
|---|---:|---:|
| scatter-10k mount | 26.3 ms (full matrix) | **23.2 ms** vs LayerCake 20.6 ms |
| scatter-100k mount | 272.5 ms | **260.9 ms** vs LayerCake 163 ms |
| Node stub draw 100k | ~11 ms (in-pipeline) | **3.2 ms** isolated |

Does not close the 100k canvas gap (~98 ms). Stacks with #1603 (one-pass point packing).

## Test plan

- [x] `bun test packages/core/tests/dom/canvas-styles.test.ts` (new moveTo+arc lock) plus canvas-focus and canvas-routing
- [x] Isolated remount of scatter-10k and scatter-100k vs LayerCake canvas