### PR TITLE
perf(core): defer identity-scatter grouping until inspect

### DIFF
--- a/.changeset/defer-identity-scatter-groups.md
+++ b/.changeset/defer-identity-scatter-groups.md
@@ -1,0 +1,9 @@
+---
+"@ggsvelte/core": patch
+---
+
+# Defer identity-scatter grouping until inspect
+
+Migration: none — internal. Same group ids when inspect or the identity index reads them. Lines, stats, and dodge/stack still group during bind.
+
+Identity `geom_point` never buckets by group to draw. `buildFrame` no longer interns discrete color into a per-row id vector on that path. The first read of `groups` / `inputGroups` derives the same first-seen ids as before.

--- a/packages/core/src/pipeline/frame.ts
+++ b/packages/core/src/pipeline/frame.ts
@@ -15,6 +15,36 @@ import { buildNonIdentityFrame } from "./frame-stats.js";
 
 export { deriveLayerGroups } from "./frame-helpers.js";
 
+/** Identity scatter never buckets by group at draw/position time. */
+function layerDefersGroups(binding: LayerBinding): boolean {
+  if ((binding.layer.stat ?? "identity") !== "identity") return false;
+  if ((binding.layer.position ?? "identity") !== "identity") return false;
+  return binding.layer.geom === "point";
+}
+
+function attachDeferredGroups(
+  frame: LayerFrame,
+  binding: LayerBinding,
+  table: ColumnTable,
+): LayerFrame {
+  let resolved: number[] | undefined;
+  const read = (): number[] => {
+    resolved ??= deriveLayerGroups(binding, table);
+    return resolved;
+  };
+  Object.defineProperty(frame, "groups", {
+    configurable: true,
+    enumerable: true,
+    get: read,
+  });
+  Object.defineProperty(frame, "inputGroups", {
+    configurable: true,
+    enumerable: true,
+    get: read,
+  });
+  return frame;
+}
+
 export function buildFrame(
   binding: LayerBinding,
   table: ColumnTable,
@@ -30,6 +60,12 @@ export function buildFrame(
   // source memberships for a layer with no source rows.
   if (binding.ruleForm === "annotation" || binding.layer.geom === "abline") {
     return buildAnnotationFrame(binding, table);
+  }
+
+  if (layerDefersGroups(binding)) {
+    const frame = buildIdentityFrame(binding, table, []);
+    expandEdgeFrame(frame, warnings);
+    return attachDeferredGroups(frame, binding, table);
   }
 
   // Derive once per frame; identity index + bin lineage consume frame.inputGroups.

--- a/packages/core/tests/pipeline-frame/identity-defer-groups.test.ts
+++ b/packages/core/tests/pipeline-frame/identity-defer-groups.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Identity scatter does not bucket by group at draw time. buildFrame must
+ * not intern discrete color into a per-row id vector unless something
+ * reads groups (inspect / identity index).
+ */
+import { describe, expect, it } from "bun:test";
+
+import { bindLayer } from "../../src/pipeline/bind-layer.ts";
+import { buildFrame, deriveLayerGroups } from "../../src/pipeline/frame.ts";
+import { ColumnTable } from "../../src/table.ts";
+
+function pointBinding(table: ColumnTable) {
+  return bindLayer(
+    {
+      geom: "point",
+      aes: { x: { field: "x" }, y: { field: "y" }, color: { field: "c" } },
+    },
+    0,
+    table,
+    [],
+  );
+}
+
+function isDeferredGroups(frame: { groups: readonly number[] }): boolean {
+  return typeof Object.getOwnPropertyDescriptor(frame, "groups")?.get === "function";
+}
+
+describe("buildFrame — defer groups on identity scatter", () => {
+  const table = ColumnTable.fromRows([
+    { x: 1, y: 2, c: "red" },
+    { x: 3, y: 4, c: "blue" },
+    { x: 5, y: 6, c: "red" },
+  ]);
+
+  it("does not intern group ids until groups are read", () => {
+    const binding = pointBinding(table);
+    const frame = buildFrame(binding, table, [], []);
+    expect(isDeferredGroups(frame)).toBe(true);
+    expect(typeof Object.getOwnPropertyDescriptor(frame, "inputGroups")?.get).toBe("function");
+  });
+
+  it("still interns groups eagerly for identity geom_line", () => {
+    const binding = bindLayer(
+      {
+        geom: "line",
+        aes: { x: { field: "x" }, y: { field: "y" }, color: { field: "c" } },
+      },
+      0,
+      table,
+      [],
+    );
+    const frame = buildFrame(binding, table, [], []);
+    expect(isDeferredGroups(frame)).toBe(false);
+    expect(frame.groups).toEqual([0, 1, 0]);
+  });
+
+  it("resolves the same first-seen ids as eager deriveLayerGroups", () => {
+    const binding = pointBinding(table);
+    const frame = buildFrame(binding, table, [], []);
+    expect([...frame.inputGroups]).toEqual([0, 1, 0]);
+    expect([...frame.groups]).toEqual(deriveLayerGroups(binding, table));
+  });
+});


### PR DESCRIPTION
## Summary

Identity `geom_point` never buckets by group to draw. `buildFrame` no longer interns discrete color into a 100k-long id vector on that path. The first read of `groups` / `inputGroups` (inspect, identity index) still derives the same first-seen ids.

Lines, stats, dodge, and stack still group during bind.

**Node 100k canvas scatter** (same-machine A/B, median of 15):

| stage | before | after |
| --- | --- | --- |
| bind | 6.37 ms | 3.12 ms |
| runPipeline | 12.38 ms | 9.91 ms |

## Test plan

- [x] `bun test packages/core/tests/pipeline-frame packages/core/tests/candidate-construction packages/core/tests/grouping.test.ts`
- [x] New tests: deferred getters on identity point; eager groups on identity line; resolved ids match `deriveLayerGroups`
- [x] Existing `#217` inputGroups + candidate cache tests still pass