### PR TITLE
perf(core): store categorical point colors as palette indexes

### DIFF
--- a/.changeset/palette-index-paint.md
+++ b/.changeset/palette-index-paint.md
@@ -1,0 +1,9 @@
+---
+"@ggsvelte/core": patch
+---
+
+# Store categorical point colors as palette indexes
+
+Migration: none — internal. Same resolved fills. Continuous high-cardinality ramps still emit a string per mark.
+
+Categorical identity scatter no longer allocates a hex string per point. The batch keeps a short palette and a `Uint8Array` of indexes. Canvas fills once per palette entry.

--- a/packages/core/src/dom/canvas-marks-points.ts
+++ b/packages/core/src/dom/canvas-marks-points.ts
@@ -70,6 +70,34 @@ function isFilledCircleBatch(batch: PointsBatch): boolean {
   return batch.shape === "circle";
 }
 
+/** One fill per palette entry. `include` is null for the full batch. */
+function drawIndexedColorPoints(
+  ctx: CanvasRenderingContext2D,
+  batch: PointsBatch,
+  resolve: ColorResolver,
+  include: ((index: number) => boolean) | null,
+): void {
+  const palette = batch.colorPalette!;
+  const indexes = batch.colorIndexes!;
+  const n = batch.rowIndex.length;
+  const buckets: number[][] = Array.from({ length: palette.length }, () => []);
+  for (let j = 0; j < n; j++) {
+    if (include !== null && !include(j)) continue;
+    const id = indexes[j]!;
+    (buckets[id] ??= []).push(j);
+  }
+  const circles = isFilledCircleBatch(batch);
+  for (let p = 0; p < palette.length; p++) {
+    const list = buckets[p]!;
+    if (list.length === 0) continue;
+    ctx.fillStyle = resolve(palette[p]!);
+    ctx.beginPath();
+    if (circles) traceFilledCircles(ctx, batch, list);
+    else for (const j of list) tracePoint(ctx, batch, j);
+    ctx.fill();
+  }
+}
+
 export function drawPoints(
   ctx: CanvasRenderingContext2D,
   batch: PointsBatch,
@@ -104,6 +132,10 @@ export function drawPoints(
       }
     }
     ctx.globalAlpha = baseAlpha;
+    return;
+  }
+  if (batch.colorIndexes !== undefined && batch.colorPalette !== undefined) {
+    drawIndexedColorPoints(ctx, batch, resolve, null);
     return;
   }
   if (batch.colors === undefined) {
@@ -205,6 +237,10 @@ export function drawPointsSubset(
       }
     }
     ctx.globalAlpha = baseAlpha;
+    return;
+  }
+  if (batch.colorIndexes !== undefined && batch.colorPalette !== undefined) {
+    drawIndexedColorPoints(ctx, batch, resolve, includes);
     return;
   }
   if (batch.colors === undefined) {

--- a/packages/core/src/mark-style.ts
+++ b/packages/core/src/mark-style.ts
@@ -176,6 +176,24 @@ export function markLinetype(
   return linetypeAt(batch, index);
 }
 
+/** Resolve one point mark's fill from palette indexes, string[], or constant. */
+export function pointFillAt(batch: PointsBatch, index: number, themeInk: string): string {
+  const palette = batch.colorPalette;
+  const indexes = batch.colorIndexes;
+  if (palette !== undefined && indexes !== undefined) {
+    return palette[indexes[index]!] ?? batch.fill ?? themeInk;
+  }
+  return batch.colors?.[index] ?? batch.fill ?? themeInk;
+}
+
+/** Expand per-mark fills (palette indexes or string[]). */
+export function pointFills(batch: PointsBatch, themeInk = ""): string[] {
+  const n = batch.rowIndex.length;
+  const out: string[] = [];
+  for (let i = 0; i < n; i++) out.push(pointFillAt(batch, i, themeInk));
+  return out;
+}
+
 /** Resolve one point mark's fill/shape/alpha for any serializer. */
 export function resolvePointMark(
   batch: PointsBatch,
@@ -186,7 +204,7 @@ export function resolvePointMark(
   const shape =
     batch.shapeIndexes === undefined ? batch.shape : POINT_SHAPE_NAMES[batch.shapeIndexes[index]!]!;
   return {
-    fill: batch.colors?.[index] ?? batch.fill ?? themeInk,
+    fill: pointFillAt(batch, index, themeInk),
     alpha: batch.alphas?.[index] ?? 1,
     size,
     shape,

--- a/packages/core/src/pipeline/geometry-points.ts
+++ b/packages/core/src/pipeline/geometry-points.ts
@@ -10,6 +10,7 @@ import type { Frame } from "./geometry-shared.js";
 import {
   indexedStyleVector,
   constantStyle,
+  mappedPaintIndexVector,
   mappedPaintVector,
   numericStyleVector,
   type ResolvedStyleScales,
@@ -137,7 +138,15 @@ export function pointsBatch(
   }
   if (shapeIndexes !== undefined) batch.shapeIndexes = shapeIndexes;
   if (paintScale !== null && (paintValues !== null || paintChannel.scaledConstant !== null)) {
-    batch.colors = mappedPaintVector(frame, paintKey, paintScale, collectedKeptRows);
+    const indexed = mappedPaintIndexVector(frame, paintKey, paintScale, collectedKeptRows);
+    if (indexed === null) {
+      batch.colors = mappedPaintVector(frame, paintKey, paintScale, collectedKeptRows);
+    } else if (indexed.palette.length === 1) {
+      batch.fill = indexed.palette[0]!;
+    } else {
+      batch.colorPalette = indexed.palette;
+      batch.colorIndexes = indexed.indexes;
+    }
   }
   return batch;
 }

--- a/packages/core/src/pipeline/geometry-style.ts
+++ b/packages/core/src/pipeline/geometry-style.ts
@@ -159,6 +159,94 @@ export function mappedPaintVector(
   );
 }
 
+/** Palette + per-row indexes when cardinality fits a Uint8. Null if not. */
+export interface IndexedPaint {
+  readonly palette: string[];
+  readonly indexes: Uint8Array;
+}
+
+const MAX_INDEXED_PALETTE = 256;
+
+function indexUniqueThenFanOut(
+  rows: ArrayLike<number>,
+  valueAt: (row: number) => unknown,
+  mapOne: (value: unknown) => string,
+): IndexedPaint | null {
+  const n = rows.length;
+  if (n === 0) return { palette: [], indexes: new Uint8Array(0) };
+
+  const first = valueAt(rows[0]!);
+  let allSame = true;
+  for (let i = 1; i < n; i++) {
+    if (!Object.is(valueAt(rows[i]!), first)) {
+      allSame = false;
+      break;
+    }
+  }
+  if (allSame) {
+    return { palette: [mapOne(first)], indexes: new Uint8Array(n) };
+  }
+
+  const probe = Math.min(n, UNIQUE_PROBE);
+  const probeSeen = new Set<unknown>();
+  let probeUniques = 0;
+  for (let i = 0; i < probe; i++) {
+    const value = valueAt(rows[i]!);
+    if (typeof value === "object" && value !== null) {
+      probeUniques++;
+      continue;
+    }
+    if (!probeSeen.has(value)) {
+      probeSeen.add(value);
+      probeUniques++;
+    }
+  }
+  // Small columns: 3/4 uniques is still a 3-color palette. Only skip when
+  // the probe is full-length and nearly every sample is distinct.
+  if (n >= UNIQUE_PROBE && probeUniques >= probe * HIGH_CARDINALITY_RATIO) return null;
+
+  const palette: string[] = [];
+  const indexOf = new Map<unknown, number>();
+  const indexes = new Uint8Array(n);
+  for (let i = 0; i < n; i++) {
+    const value = valueAt(rows[i]!);
+    if (typeof value === "object" && value !== null) return null;
+    let id = indexOf.get(value);
+    if (id === undefined && !indexOf.has(value)) {
+      if (palette.length >= MAX_INDEXED_PALETTE) return null;
+      id = palette.length;
+      indexOf.set(value, id);
+      palette.push(mapOne(value));
+    }
+    indexes[i] = id!;
+  }
+  return { palette, indexes };
+}
+
+/**
+ * Same colors as {@link mappedPaintVector}, packed as palette + indexes
+ * when the column is low-cardinality (categorical scatter). High-cardinality
+ * continuous ramps return null so the caller keeps the string[] path.
+ */
+export function mappedPaintIndexVector(
+  frame: LayerFrame,
+  channel: PaintChannel,
+  scale: ResolvedColorScale,
+  rows: ArrayLike<number>,
+): IndexedPaint | null {
+  const binding = frame.binding[channel];
+  const values = paintValues(frame, channel);
+  if (values === null) {
+    const color = colorOf(scale, binding.scaledConstant);
+    return { palette: [color], indexes: new Uint8Array(rows.length) };
+  }
+  return indexUniqueThenFanOut(
+    rows,
+    (row) => values[row]!,
+    (value) => colorOf(scale, value as CellValue),
+  );
+}
+
 /**
  * Per-subpath / per-row paint vector. Honour mapped field values ·
  * scaledConstant · literal constant. `rows` is required: style vectors index

--- a/packages/core/src/render-svg-marks.ts
+++ b/packages/core/src/render-svg-marks.ts
@@ -5,6 +5,7 @@
 import { renderPrimitiveCount } from "./candidate-geometry.js";
 import { type ResolvedGlow, type ResolvedGradientPaint } from "./mark-paint.js";
 import {
+  pointFillAt,
   pointShapeGeometry,
   pointShapePathD,
   resolveGlyphMark,
@@ -108,7 +109,7 @@ function renderPoints(batch: PointsBatch, theme: ThemeTokens): string {
     const size = batch.sizes?.[j] ?? batch.size;
     const shape =
       batch.shapeIndexes === undefined ? batch.shape : POINT_SHAPE_NAMES[batch.shapeIndexes[j]!]!;
-    const fill = batch.colors?.[j] ?? batch.fill ?? themeInk;
+    const fill = pointFillAt(batch, j, themeInk);
     const opacity = batch.alphas === undefined ? "" : alphaAttr(batch.alphas?.[j] ?? 1);
     const x = positions[j * 2]!;
     const y = positions[j * 2 + 1]!;

--- a/packages/core/src/scene.ts
+++ b/packages/core/src/scene.ts
@@ -45,10 +45,14 @@ export interface PointsBatch {
   shape: PointShape;
   /** Canonical POINT_SHAPE_NAMES indexes when aes.shape is mapped. */
   shapeIndexes?: Uint8Array;
-  /** Constant color, or null when `colors` carries per-mark values. */
+  /** Constant color, or null when `colors` / palette indexes carry per-mark values. */
   fill: string | null;
-  /** Per-mark resolved colors (when the color channel is data-mapped). */
+  /** Per-mark resolved colors (high-cardinality / continuous ramps). */
   colors?: string[];
+  /** Unique resolved colors when the mapped channel is low-cardinality. */
+  colorPalette?: string[];
+  /** Palette index per mark; paired with `colorPalette`. */
+  colorIndexes?: Uint8Array;
 }
 
 export interface PathsBatch {

--- a/packages/core/tests/dom/canvas-styles.test.ts
+++ b/packages/core/tests/dom/canvas-styles.test.ts
@@ -121,6 +121,34 @@ describe("canvas mapped style vectors", () => {
     expect(calls.filter(({ name }) => name === "arc")).toHaveLength(n);
   });
 
+  it("buckets palette-index colors into one fill per palette entry", () => {
+    const n = 10;
+    const positions = new Float32Array(n * 2);
+    const indexes = new Uint8Array(n);
+    for (let i = 0; i < n; i++) {
+      positions[i * 2] = i;
+      positions[i * 2 + 1] = i;
+      indexes[i] = i % 5;
+    }
+    const batch: PointsBatch = {
+      kind: "points",
+      layerIndex: 0,
+      panelIndex: 0,
+      positions,
+      rowIndex: Uint32Array.from({ length: n }, (_, i) => i),
+      size: 1.5,
+      alpha: 0.7,
+      shape: "circle",
+      fill: null,
+      colorPalette: ["c0", "c1", "c2", "c3", "c4"],
+      colorIndexes: indexes,
+    };
+    const { ctx, calls } = styleContext();
+    drawBatch(ctx, batch, theme, resolve);
+    expect(calls.filter(({ name }) => name === "fill")).toHaveLength(5);
+    expect(calls.filter(({ name }) => name === "arc")).toHaveLength(n);
+  });
+
   it("traces constant-size circles with moveTo(x+r,y) + arc, no per-point style objects", () => {
     const batch: PointsBatch = {
       kind: "points",

--- a/packages/core/tests/editions.test.ts
+++ b/packages/core/tests/editions.test.ts
@@ -53,6 +53,9 @@ const RUN = { width: 400, height: 300 } as const;
 
 function pointColors(model: ReturnType<typeof runPipeline>): string[] {
   const batch = model.scene.batches.find((b) => b.kind === "points") as PointsBatch;
+  if (batch.colorPalette !== undefined && batch.colorIndexes !== undefined) {
+    return [...batch.colorIndexes].map((id) => batch.colorPalette![id]!);
+  }
   return batch.colors ?? (batch.fill === null ? [] : [batch.fill]);
 }
 

--- a/packages/core/tests/facets/wrap.test.ts
+++ b/packages/core/tests/facets/wrap.test.ts
@@ -3,6 +3,7 @@
  */
 import { describe, expect, it } from "bun:test";
 import { aes, gg } from "@ggsvelte/spec";
+import { pointFills } from "../../src/mark-style.ts";
 import { PipelineError, runPipeline } from "../../src/pipeline.ts";
 import type { PointsBatch, RectsBatch } from "../../src/scene.ts";
 import { STRIP_BAND } from "../../src/scene.ts";
@@ -88,7 +89,7 @@ describe("facet wrap — panel grid", () => {
     expect(model.scene.legends).toHaveLength(1);
     const points = model.scene.batches.filter((b): b is PointsBatch => b.kind === "points");
     // Row order within each panel is u, v — colors match across panels.
-    const colorPairs = points.map((b) => b.colors!.join("|"));
+    const colorPairs = points.map((b) => pointFills(b).join("|"));
     expect(new Set(colorPairs).size).toBe(1);
   });
 

--- a/packages/core/tests/geometry-points-paint.test.ts
+++ b/packages/core/tests/geometry-points-paint.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Categorical identity scatter stores palette indexes, not a string per point.
+ */
+import { aes, gg } from "@ggsvelte/spec";
+import { describe, expect, it } from "bun:test";
+
+import { registerBasicPoints } from "../src/pipeline/register-basic-points.ts";
+import { runPipeline } from "../src/pipeline/run-pipeline.ts";
+import type { PointsBatch } from "../src/scene.ts";
+
+registerBasicPoints();
+
+const size = { width: 200, height: 150 };
+
+describe("pointsBatch categorical paint", () => {
+  it("stores low-cardinality colors as palette + indexes", () => {
+    const model = runPipeline(
+      gg(
+        { x: [1, 2, 3, 4], y: [1, 2, 3, 4], c: ["a", "b", "a", "b"] },
+        aes({ x: "x", y: "y", color: "c" }),
+      )
+        .geomPoint()
+        .spec(),
+      size,
+    );
+    const batch = model.scene.batches[0] as PointsBatch;
+    expect(batch.kind).toBe("points");
+    expect(batch.colors).toBeUndefined();
+    expect(batch.colorPalette).toHaveLength(2);
+    expect([...batch.colorIndexes!]).toEqual([0, 1, 0, 1]);
+  });
+});

--- a/packages/core/tests/pipeline-color-scales/fixtures.ts
+++ b/packages/core/tests/pipeline-color-scales/fixtures.ts
@@ -2,6 +2,7 @@ import { fromAny } from "@total-typescript/shoehorn";
 
 import type { PortableSpec } from "@ggsvelte/spec";
 
+import { pointFills } from "../../src/mark-style.ts";
 import { runPipeline } from "../../src/pipeline.js";
 
 export const size = { width: 640, height: 400 };
@@ -24,8 +25,11 @@ export function pointSpec(
 
 export function pointColors(model: ReturnType<typeof runPipeline>): string[] {
   const points = model.scene.batches.find((batch) => batch.kind === "points");
-  if (points?.kind !== "points" || points.colors === undefined) {
+  if (
+    points?.kind !== "points" ||
+    (points.colors === undefined && points.colorPalette === undefined)
+  ) {
     throw new Error("expected mapped point colors");
   }
-  return points.colors;
+  return pointFills(points);
 }

--- a/packages/core/tests/pipeline-m2/count.test.ts
+++ b/packages/core/tests/pipeline-m2/count.test.ts
@@ -51,7 +51,7 @@ describe("geom_count / stat_sum", () => {
     );
     const batch = model.scene.batches[0] as PointsBatch;
     expect(batch.positions.length / 2).toBe(4);
-    expect(new Set(batch.colors ?? []).size).toBe(2);
+    expect(new Set(batch.colorPalette ?? batch.colors ?? []).size).toBe(2);
   });
 
   it("point + stat sum is equivalent mark count", () => {

--- a/packages/core/tests/pipeline-m2/dotplot.test.ts
+++ b/packages/core/tests/pipeline-m2/dotplot.test.ts
@@ -84,7 +84,7 @@ describe("dotplot geom (histodot bindot)", () => {
     );
     const batch = model.scene.batches[0] as PointsBatch;
     expect(batch.kind).toBe("points");
-    const colors = batch.colors;
+    const colors = batch.colorPalette ?? batch.colors;
     expect(colors).toBeDefined();
     expect(new Set(colors).size).toBe(2);
   });
@@ -99,7 +99,7 @@ describe("dotplot geom (histodot bindot)", () => {
     );
     const batch = model.scene.batches[0] as PointsBatch;
     expect(batch.kind).toBe("points");
-    const colors = batch.colors;
+    const colors = batch.colorPalette ?? batch.colors;
     expect(colors).toBeDefined();
     expect(new Set(colors).size).toBe(2);
   });
@@ -115,9 +115,9 @@ describe("dotplot geom (histodot bindot)", () => {
       size,
     );
     const batch = model.scene.batches[0] as PointsBatch;
-    expect(batch.colors).toBeDefined();
+    expect(batch.colorPalette ?? batch.colors).toBeDefined();
     // fill has 2 levels; color is constant — paint must follow fill.
-    expect(new Set(batch.colors).size).toBe(2);
+    expect(new Set(batch.colorPalette ?? batch.colors).size).toBe(2);
   });
 
   it("exposes per-dot xValue/yValue for inspect tooltips (hybrid source row + after_stat)", () => {

--- a/packages/core/tests/pipeline-m2/manual.test.ts
+++ b/packages/core/tests/pipeline-m2/manual.test.ts
@@ -24,8 +24,8 @@ describe("stat manual (#814)", () => {
     const batch = model.scene.batches[0] as PointsBatch;
     expect(batch.kind).toBe("points");
     expect(batch.positions.length / 2).toBe(2);
-    expect(batch.colors).toBeDefined();
-    expect(new Set(batch.colors).size).toBe(2);
+    expect(batch.colorPalette ?? batch.colors).toBeDefined();
+    expect(new Set(batch.colorPalette ?? batch.colors).size).toBe(2);
   });
 
   it("first keeps one source row per group", () => {

--- a/packages/core/tests/pipeline/geometry-style-paint.test.ts
+++ b/packages/core/tests/pipeline/geometry-style-paint.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "bun:test";
 
 import {
   constantStyle,
+  mappedPaintIndexVector,
   mappedPaintVector,
   paintVector,
 } from "../../src/pipeline/geometry-style.ts";
@@ -151,6 +152,41 @@ describe("mappedPaintVector", () => {
     expect(painted[0]).toBe("#000000");
     expect(painted[255]).toBe("#ffffff");
     expect(colorOfCalls).toBe(600);
+  });
+});
+
+describe("mappedPaintIndexVector", () => {
+  it("packs low-cardinality colors as a palette plus per-row indexes", () => {
+    const frame = makeFrame({ colorValues: ["a", "b", "a", "c", "b"] });
+    const packed = mappedPaintIndexVector(frame, "color", stubScale(), [0, 1, 2, 3, 4]);
+    expect(packed).not.toBeNull();
+    expect(packed!.palette).toEqual(["#ff0000", "#00ff00", "#0000ff"]);
+    expect([...packed!.indexes]).toEqual([0, 1, 0, 2, 1]);
+  });
+
+  it("expands to the same colors as mappedPaintVector", () => {
+    const frame = makeFrame({ colorValues: ["a", "b", "c", "a"] });
+    const scale = stubScale();
+    const rows = [0, 1, 2, 3];
+    const packed = mappedPaintIndexVector(frame, "color", scale, rows);
+    const strings = mappedPaintVector(frame, "color", scale, rows);
+    expect(packed).not.toBeNull();
+    expect([...packed!.indexes].map((id) => packed!.palette[id])).toEqual(strings);
+  });
+
+  it("returns null for high-cardinality continuous columns", () => {
+    const values = Array.from({ length: 600 }, (_, i) => i);
+    const frame = makeFrame({ colorValues: values });
+    const rows = Array.from({ length: 600 }, (_, i) => i);
+    const scale = fromPartial<ResolvedColorScale>({
+      kind: "sequential",
+      scale: {
+        colorOf: (value: unknown) => `#${String(value)}`,
+        naValue: DEFAULT_MISSING_COLOR,
+        unknownValue: DEFAULT_MISSING_COLOR,
+      },
+    });
+    expect(mappedPaintIndexVector(frame, "color", scale, rows)).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

Categorical identity scatter no longer allocates a hex string per point. The batch keeps a short palette and a `Uint8Array` of indexes. Canvas fills once per palette entry.

Continuous high-cardinality ramps still emit `string[]`. One unique color collapses to `batch.fill`.

**Node 100k canvas scatter** (same-machine A/B):

| step | string[] | palette indexes |
| --- | --- | --- |
| mapped paint | 2.26 ms | 1.81 ms |
| stub draw | 1.47 ms | 1.18 ms |

The scene no longer retains 100k color strings.

## Test plan

- [x] `mappedPaintIndexVector` packs 5-level color and returns null on a 600-distinct ramp
- [x] `pointsBatch` stores palette + indexes for categorical scatter
- [x] Canvas indexed path: one fill per palette entry
- [x] Color-scale, facet, edition, count/dotplot/manual tests still pass