### PR TITLE
perf(core): rasterize oversized indexed scatter batches

### DIFF
--- a/.changeset/canvas-indexed-circle-composite.md
+++ b/.changeset/canvas-indexed-circle-composite.md
@@ -1,0 +1,5 @@
+---
+"@ggsvelte/core": patch
+---
+
+Cut high-volume categorical Canvas scatter paint time by rasterizing oversized circle batches through a cached scratch canvas.

--- a/packages/core/src/dom/canvas-marks-points.ts
+++ b/packages/core/src/dom/canvas-marks-points.ts
@@ -70,6 +70,105 @@ function isFilledCircleBatch(batch: PointsBatch): boolean {
   return batch.shape === "circle";
 }
 
+/** Chromium's fill cost rises sharply beyond this many circle subpaths. */
+const MAX_CIRCLES_PER_PATH = 2_048;
+const OPAQUE_HEX_COLOR = /^#[\da-f]{3}(?:[\da-f]{3})?$/i;
+
+type ScratchCanvas = {
+  canvas: HTMLCanvasElement;
+  ctx: CanvasRenderingContext2D;
+};
+
+const scratchByTarget = new WeakMap<CanvasRenderingContext2D, ScratchCanvas>();
+
+function scratchCanvasFor(ctx: CanvasRenderingContext2D): ScratchCanvas | null {
+  if (typeof ctx.getTransform !== "function" || typeof ctx.drawImage !== "function") return null;
+  const target = ctx.canvas;
+  const ownerDocument = target.ownerDocument;
+  if (ownerDocument === null || ownerDocument === undefined) return null;
+  let scratch = scratchByTarget.get(ctx);
+  if (scratch === undefined) {
+    const canvas = ownerDocument.createElement("canvas");
+    const scratchCtx = canvas.getContext("2d");
+    if (scratchCtx === null) return null;
+    scratch = { canvas, ctx: scratchCtx };
+    scratchByTarget.set(ctx, scratch);
+  }
+  if (scratch.canvas.width !== target.width) scratch.canvas.width = target.width;
+  if (scratch.canvas.height !== target.height) scratch.canvas.height = target.height;
+  return scratch;
+}
+
+function resolvedOpaquePalette(
+  palette: readonly string[],
+  buckets: readonly number[][],
+  resolve: ColorResolver,
+): (string | undefined)[] | null {
+  const resolved = Array.from<string | undefined>({ length: palette.length });
+  for (let p = 0; p < palette.length; p++) {
+    if (buckets[p]!.length === 0) continue;
+    const color = resolve(palette[p]!);
+    // Per-circle scratch fills preserve one-path alpha semantics only when
+    // the source color itself is opaque. Keep the giant path for every other
+    // CSS color form rather than guessing at embedded alpha.
+    if (!OPAQUE_HEX_COLOR.test(color)) return null;
+    resolved[p] = color;
+  }
+  return resolved;
+}
+
+/**
+ * Paint each opaque palette color onto a cleared scratch bitmap, then apply
+ * the batch alpha once when compositing that color onto the target. This
+ * preserves the giant path's same-color overlap semantics without asking
+ * Chromium to rasterize tens of thousands of circle subpaths at once.
+ */
+function drawIndexedCirclesViaScratch(
+  ctx: CanvasRenderingContext2D,
+  batch: PointsBatch,
+  buckets: readonly number[][],
+  resolvedPalette: readonly (string | undefined)[],
+  scratch: ScratchCanvas,
+): void {
+  const targetTransform = ctx.getTransform();
+  const positions = batch.positions;
+  const r = batch.size;
+  const scratchCtx = scratch.ctx;
+  for (let p = 0; p < buckets.length; p++) {
+    const list = buckets[p]!;
+    const color = resolvedPalette[p];
+    if (list.length === 0 || color === undefined) continue;
+    scratchCtx.setTransform(1, 0, 0, 1, 0, 0);
+    scratchCtx.clearRect(0, 0, scratch.canvas.width, scratch.canvas.height);
+    scratchCtx.setTransform(
+      targetTransform.a,
+      targetTransform.b,
+      targetTransform.c,
+      targetTransform.d,
+      targetTransform.e,
+      targetTransform.f,
+    );
+    scratchCtx.globalAlpha = 1;
+    scratchCtx.globalCompositeOperation = "source-over";
+    scratchCtx.fillStyle = color;
+    for (const j of list) {
+      scratchCtx.beginPath();
+      scratchCtx.arc(positions[j * 2]!, positions[j * 2 + 1]!, r, 0, Math.PI * 2);
+      scratchCtx.fill();
+    }
+    // The scratch bitmap is already in device pixels. Reset only the target
+    // transform for drawImage; the target's device-space panel clip survives.
+    ctx.save();
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.drawImage(scratch.canvas, 0, 0);
+    ctx.restore();
+  }
+  // Retain the element/context but release its full backing bitmap between
+  // draws. High-DPR charts can otherwise pin tens of MB per target canvas.
+  scratch.canvas.width = 0;
+  scratch.canvas.height = 0;
+}
+
 /** One fill per palette entry. `include` is null for the full batch. */
 function drawIndexedColorPoints(
   ctx: CanvasRenderingContext2D,
@@ -81,12 +180,23 @@ function drawIndexedColorPoints(
   const indexes = batch.colorIndexes!;
   const n = batch.rowIndex.length;
   const buckets: number[][] = Array.from({ length: palette.length }, () => []);
+  let largestBucket = 0;
   for (let j = 0; j < n; j++) {
     if (include !== null && !include(j)) continue;
     const id = indexes[j]!;
-    (buckets[id] ??= []).push(j);
+    const bucket = (buckets[id] ??= []);
+    bucket.push(j);
+    if (bucket.length > largestBucket) largestBucket = bucket.length;
   }
   const circles = isFilledCircleBatch(batch);
+  if (circles && largestBucket > MAX_CIRCLES_PER_PATH) {
+    const resolvedPalette = resolvedOpaquePalette(palette, buckets, resolve);
+    const scratch = resolvedPalette === null ? null : scratchCanvasFor(ctx);
+    if (resolvedPalette !== null && scratch !== null) {
+      drawIndexedCirclesViaScratch(ctx, batch, buckets, resolvedPalette, scratch);
+      return;
+    }
+  }
   for (let p = 0; p < palette.length; p++) {
     const list = buckets[p]!;
     if (list.length === 0) continue;

--- a/packages/core/tests/dom/canvas-styles.test.ts
+++ b/packages/core/tests/dom/canvas-styles.test.ts
@@ -20,11 +20,13 @@ function styleContext() {
   const methods = new Set([
     "arc",
     "beginPath",
+    "clearRect",
     "closePath",
     "fill",
     "lineTo",
     "moveTo",
     "rect",
+    "setTransform",
     "stroke",
   ]);
   const ctx = new Proxy(state, {
@@ -60,6 +62,44 @@ function styleContext() {
     },
   }) as unknown as CanvasRenderingContext2D;
   return { ctx, calls, state, dash: () => dash };
+}
+
+function styleContextsWithScratch(transform?: {
+  a: number;
+  b: number;
+  c: number;
+  d: number;
+  e: number;
+  f: number;
+}) {
+  const resolvedTransform = transform ?? { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 };
+  const scratch = styleContext();
+  const target = styleContext();
+  const targetRecord = target.ctx as unknown as Record<string, unknown>;
+  targetRecord["canvas"] = {
+    width: 800,
+    height: 500,
+    ownerDocument: {
+      createElement: () => ({
+        width: 0,
+        height: 0,
+        getContext: () => scratch.ctx,
+      }),
+    },
+  };
+  targetRecord["getTransform"] = () => resolvedTransform;
+  targetRecord["save"] = () => {};
+  targetRecord["restore"] = () => {};
+  targetRecord["drawImage"] = () => {
+    target.calls.push({
+      name: "drawImage",
+      alpha: target.state.globalAlpha,
+      width: target.state.lineWidth,
+      dash: target.dash(),
+      args: [],
+    });
+  };
+  return { scratch, target };
 }
 
 const theme = fromPartial<ThemeTokens>({ ink: "black", accent: "blue" });
@@ -147,6 +187,131 @@ describe("canvas mapped style vectors", () => {
     drawBatch(ctx, batch, theme, resolve);
     expect(calls.filter(({ name }) => name === "fill")).toHaveLength(5);
     expect(calls.filter(({ name }) => name === "arc")).toHaveLength(n);
+  });
+
+  it("composites oversized indexed-circle batches by palette without changing alpha order", () => {
+    const colors = ["#000001", "#000002", "#000003", "#000004", "#000005"];
+    const perColor = 2_049;
+    const n = colors.length * perColor;
+    const positions = new Float32Array(n * 2);
+    const indexes = new Uint8Array(n);
+    for (let i = 0; i < n; i++) {
+      positions[i * 2] = i % 800;
+      positions[i * 2 + 1] = i % 500;
+      indexes[i] = i % colors.length;
+    }
+    const batch: PointsBatch = {
+      kind: "points",
+      layerIndex: 0,
+      panelIndex: 0,
+      positions,
+      rowIndex: Uint32Array.from({ length: n }, (_, i) => i),
+      size: 1.5,
+      alpha: 0.7,
+      shape: "circle",
+      fill: null,
+      colorPalette: colors,
+      colorIndexes: indexes,
+    };
+    const { scratch, target } = styleContextsWithScratch({
+      a: 1,
+      b: 0,
+      c: 0,
+      d: 1,
+      e: 12,
+      f: 34,
+    });
+    const resolved: string[] = [];
+    drawBatch(target.ctx, batch, theme, (color) => {
+      resolved.push(color);
+      return color;
+    });
+
+    const composites = target.calls.filter(({ name }) => name === "drawImage");
+    expect(composites).toHaveLength(colors.length);
+    expect(composites.map(({ alpha }) => alpha)).toEqual(colors.map(() => 0.8 * 0.7));
+    expect(target.calls.filter(({ name }) => name === "fill")).toHaveLength(0);
+    expect(scratch.calls.filter(({ name }) => name === "clearRect")).toHaveLength(colors.length);
+    expect(scratch.calls.filter(({ name }) => name === "arc")).toHaveLength(n);
+    expect(scratch.calls.filter(({ name }) => name === "fill")).toHaveLength(n);
+    expect(resolved.slice(1)).toEqual(colors);
+    expect(target.state.globalAlpha).toBe(0.8);
+  });
+
+  it("uses one compositing strategy when only one indexed palette bucket is oversized", () => {
+    const n = 2_050;
+    const indexes = new Uint8Array(n);
+    indexes[n - 1] = 1;
+    const batch: PointsBatch = {
+      kind: "points",
+      layerIndex: 0,
+      panelIndex: 0,
+      positions: new Float32Array(n * 2),
+      rowIndex: Uint32Array.from({ length: n }, (_, i) => i),
+      size: 1.5,
+      alpha: 0.7,
+      shape: "circle",
+      fill: null,
+      colorPalette: ["#000001", "#000002"],
+      colorIndexes: indexes,
+    };
+    const { scratch, target } = styleContextsWithScratch();
+
+    drawBatch(target.ctx, batch, theme, resolve);
+
+    expect(target.calls.filter(({ name }) => name === "drawImage")).toHaveLength(2);
+    expect(scratch.calls.filter(({ name }) => name === "fill")).toHaveLength(n);
+  });
+
+  it("falls back without crashing when the target canvas has no ownerDocument", () => {
+    const n = 2_049;
+    const batch: PointsBatch = {
+      kind: "points",
+      layerIndex: 0,
+      panelIndex: 0,
+      positions: new Float32Array(n * 2),
+      rowIndex: Uint32Array.from({ length: n }, (_, i) => i),
+      size: 1.5,
+      alpha: 1,
+      shape: "circle",
+      fill: null,
+      colorPalette: ["#000001"],
+      colorIndexes: new Uint8Array(n),
+    };
+    const target = styleContext();
+    const targetRecord = target.ctx as unknown as Record<string, unknown>;
+    targetRecord["canvas"] = { width: 800, height: 500 };
+    targetRecord["getTransform"] = () => ({ a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 });
+    targetRecord["drawImage"] = () => {};
+
+    expect(() => {
+      drawBatch(target.ctx, batch, theme, resolve);
+    }).not.toThrow();
+    expect(target.calls.filter(({ name }) => name === "fill")).toHaveLength(1);
+  });
+
+  it("keeps the giant path for oversized palette colors with embedded alpha", () => {
+    const n = 2_049;
+    const batch: PointsBatch = {
+      kind: "points",
+      layerIndex: 0,
+      panelIndex: 0,
+      positions: new Float32Array(n * 2),
+      rowIndex: Uint32Array.from({ length: n }, (_, i) => i),
+      size: 1.5,
+      alpha: 0.7,
+      shape: "circle",
+      fill: null,
+      colorPalette: ["#00000080"],
+      colorIndexes: new Uint8Array(n),
+    };
+    const { target } = styleContextsWithScratch();
+
+    drawBatch(target.ctx, batch, theme, resolve);
+
+    expect(target.calls.filter(({ name }) => name === "drawImage")).toHaveLength(0);
+    expect(target.calls.filter(({ name }) => name === "fill")).toHaveLength(1);
+    expect(target.calls.filter(({ name }) => name === "arc")).toHaveLength(n);
   });
 
   it("traces constant-size circles with moveTo(x+r,y) + arc, no per-point style objects", () => {


### PR DESCRIPTION
## Summary

Chromium slows when one Canvas path holds tens of thousands of circle subpaths. Categorical scatter built one path per palette color, which meant five 20k-circle paths at 100k points.

This change paints oversized indexed-circle batches through one scratch canvas. It composites each palette color once, which keeps the batch alpha and palette order. Opaque hex palettes take the fast path. Colors with embedded alpha and contexts without a DOM canvas keep the old path. The renderer releases the scratch bitmap after each draw.

## Benchmarks

Chromium via Playwright, Bun 1.3.14, two warmups and median of 11. Main and branch used built package output on the same machine.

| Cell | Main | Branch | Change | LayerCake Canvas |
|---|---:|---:|---:|---:|
| scatter 10k mount | 19.8 ms | 19.4 ms | -2% | 18.7 ms |
| scatter 10k update | 15.4 ms | 16.1 ms | +5% | 14.3 ms |
| scatter 100k mount | 213.1 ms | 140.3 ms | **-34%** | 163.5 ms |
| scatter 100k update | 215.1 ms | 125.8 ms | **-42%** | 147.6 ms |

The 100k cell moves from 1.49–1.55× slower than LayerCake Canvas to 14–15% faster on this run.

Cross-engine 100k check, median of 7 after two warmups:

| Engine | Main mount/update | Branch mount/update |
|---|---:|---:|
| Firefox | 291 / 285 ms | **242 / 232 ms** |
| WebKit | 179 / 174 ms | 179 / 177 ms |

A PNG comparison of the 100k plot found no visible change. Scratch compositing changes edge rounding: PSNR 35.96 dB and mean absolute channel error 2.15/255.

## Verification

- `bun test packages/core/tests/dom/canvas-styles.test.ts`
- `bun test packages/core` — 2,402 pass
- `bun run check`
- `bun run lint:type-aware`
- focused competitive browser benchmarks above
