### PR TITLE
perf(core): skip model contracts in SVG export

### DIFF
--- a/.changeset/headless-scene-finalize.md
+++ b/.changeset/headless-scene-finalize.md
@@ -1,0 +1,5 @@
+---
+"@ggsvelte/core": patch
+---
+
+Skip RenderModel-only contract assembly when rendering a plot to an SVG string.

--- a/packages/core/src/pipeline/finalize.ts
+++ b/packages/core/src/pipeline/finalize.ts
@@ -12,7 +12,9 @@ import { getCandidateRuntime, RELEASED_CANDIDATE_STORE } from "../candidate-runt
 import type { CandidateBuildInput, LazyInteraction } from "../candidate-runtime.js";
 import type { CandidateStore } from "../candidate-store.js";
 import { buildPanelCoordProjector, scalesForCoordExpand } from "../coord-projector.js";
+import type { PanelCoordProjector } from "../coord-projector.js";
 import { LineageStore } from "../identity.js";
+import type { Scene } from "../scene.js";
 import type { ThemeTokens } from "../theme.js";
 
 import { assembleRenderModel } from "./assemble-render-model.js";
@@ -20,6 +22,7 @@ import { computeBaselineDomains, computeEffectiveDomains } from "./compute-domai
 import { dedupeScaleDiagnostics } from "./diagnostics-emit.js";
 import { finalizeGeometryAndScene } from "./finalize-geometry-scene.js";
 import { finalizePanelLayoutPass } from "./finalize-layout-pass.js";
+import type { PanelLayoutResult } from "./panel-layout.js";
 import { resolveLayerBackends } from "./layer-backends.js";
 import { resolveLayerFields, resolveLayerScaledConstants } from "./layer-fields.js";
 import type { PreparedPanels } from "./prepare-panels.js";
@@ -39,14 +42,15 @@ export interface PipelineRunState {
   readonly advisories: Advisory[];
 }
 
-/**
- * Layout → geometry → scene → render model. Owns the two-pass layout call,
- * contract resolution, candidate construction and model assembly.
- */
-export function finalize(run: PipelineRunState): RenderModel {
-  const { runId, normalized, options, theme, flip, prepared, trained, warnings, advisories } = run;
+export interface FinalizedScene {
+  readonly scene: Scene;
+  readonly panelLayout: PanelLayoutResult;
+  readonly coordProjectors: readonly PanelCoordProjector[];
+}
 
-  // --- layout + geometry + scene (real work in dedicated modules) ---
+/** Layout → geometry → scene, without RenderModel-only contracts. */
+export function finalizeScene(run: PipelineRunState): FinalizedScene {
+  const { normalized, options, theme, flip, prepared, trained, warnings } = run;
   const panelLayout = finalizePanelLayoutPass({
     normalized,
     options,
@@ -74,6 +78,16 @@ export function finalize(run: PipelineRunState): RenderModel {
     coordProjectors,
     warnings,
   });
+  return { scene, panelLayout, coordProjectors };
+}
+
+/**
+ * Layout → geometry → scene → render model. Owns the two-pass layout call,
+ * contract resolution, candidate construction and model assembly.
+ */
+export function finalize(run: PipelineRunState): RenderModel {
+  const { runId, normalized, options, flip, prepared, trained, warnings, advisories } = run;
+  const { scene, panelLayout, coordProjectors } = finalizeScene(run);
 
   // --- layer contracts ---
   const { bindings } = prepared;

--- a/packages/core/src/pipeline/prepare-run.ts
+++ b/packages/core/src/pipeline/prepare-run.ts
@@ -1,0 +1,79 @@
+import type { PortableSpec, SpecInput } from "@ggsvelte/spec";
+
+import {
+  needsUncensoredBaselinePass,
+  trainUncensoredBaselineDomains,
+} from "./baseline-uncensored.js";
+import type { PipelineRunState } from "./finalize.js";
+import { preparePanels } from "./prepare-panels.js";
+import { allocatePipelineRunId } from "./run-id.js";
+import { setupPipelineRun } from "./setup-run.js";
+import { trainPipelineScales } from "./train-pipeline-scales.js";
+import type { Advisory, PipelineWarning, RunOptions } from "./types.js";
+import { perfMark, perfMeasure } from "../perf.js";
+
+/** Setup, bind, and train the shared run state consumed by either finalizer. */
+export function preparePipelineRun(
+  spec: SpecInput | PortableSpec,
+  options: RunOptions,
+): PipelineRunState {
+  const runId = allocatePipelineRunId();
+  const warnings: PipelineWarning[] = [];
+  const advisories: Advisory[] = [];
+
+  const { normalized, editionDefaults, theme, flip } = setupPipelineRun(
+    spec,
+    options.editions,
+    warnings,
+  );
+
+  let runOptions = options;
+  if (needsUncensoredBaselinePass(options, normalized.scales)) {
+    perfMark("ggsvelte:baseline:start");
+    const baselineDomains = trainUncensoredBaselineDomains({
+      normalized,
+      options,
+      editionDefaults,
+    });
+    runOptions = { ...options, baselineDomains };
+    perfMark("ggsvelte:baseline:end");
+    perfMeasure("ggsvelte:baseline", "ggsvelte:baseline:start", "ggsvelte:baseline:end");
+  }
+
+  perfMark("ggsvelte:bind:start");
+  const prepared = preparePanels(normalized, runOptions, warnings, advisories);
+  perfMark("ggsvelte:bind:end");
+  perfMeasure("ggsvelte:bind", "ggsvelte:bind:start", "ggsvelte:bind:end");
+
+  perfMark("ggsvelte:scales:start");
+  const trained = trainPipelineScales({
+    normalized,
+    options: runOptions,
+    table: prepared.table,
+    sourceTable: prepared.sourceTable,
+    bindings: prepared.bindings,
+    facetPanels: prepared.facetPanels,
+    panelFrames: prepared.panelFrames,
+    freeX: prepared.freeX,
+    freeY: prepared.freeY,
+    xConversion: prepared.xConversion,
+    yConversion: prepared.yConversion,
+    editionDefaults,
+    warnings,
+    advisories,
+  });
+  perfMark("ggsvelte:scales:end");
+  perfMeasure("ggsvelte:scales", "ggsvelte:scales:start", "ggsvelte:scales:end");
+
+  return {
+    runId,
+    normalized,
+    options: runOptions,
+    theme,
+    flip,
+    prepared,
+    trained,
+    warnings,
+    advisories,
+  };
+}

--- a/packages/core/src/pipeline/run-pipeline.ts
+++ b/packages/core/src/pipeline/run-pipeline.ts
@@ -1,90 +1,18 @@
 /**
- * Core runPipeline orchestration: setup → prepare → train → finalize.
+ * Core runPipeline orchestration: prepare shared state, then build the full
+ * RenderModel contract.
  */
 import type { SpecInput, PortableSpec } from "@ggsvelte/spec";
 
 import { perfMark, perfMeasure } from "../perf.js";
 
-import {
-  needsUncensoredBaselinePass,
-  trainUncensoredBaselineDomains,
-} from "./baseline-uncensored.js";
-import type { Advisory, PipelineWarning, RenderModel, RunOptions } from "./types.js";
-import { allocatePipelineRunId } from "./run-id.js";
-import { setupPipelineRun } from "./setup-run.js";
-import { preparePanels } from "./prepare-panels.js";
-import { trainPipelineScales } from "./train-pipeline-scales.js";
 import { finalize } from "./finalize.js";
+import { preparePipelineRun } from "./prepare-run.js";
+import type { RenderModel, RunOptions } from "./types.js";
 
 export function runPipeline(spec: SpecInput | PortableSpec, options: RunOptions): RenderModel {
-  const runId = allocatePipelineRunId();
   perfMark("ggsvelte:pipeline:start");
-
-  const warnings: PipelineWarning[] = [];
-  const advisories: Advisory[] = [];
-
-  const { normalized, editionDefaults, theme, flip } = setupPipelineRun(
-    spec,
-    options.editions,
-    warnings,
-  );
-
-  // Natural baseline under domain pins: train from uncensored frames so
-  // zoom-out is not starved by pre-stat pin censoring (#449). baselineDomains
-  // still wins when the host already computed them (e.g. Svelte double pass).
-  let runOptions = options;
-  if (needsUncensoredBaselinePass(options, normalized.scales)) {
-    perfMark("ggsvelte:baseline:start");
-    const baselineDomains = trainUncensoredBaselineDomains({
-      normalized,
-      options,
-      editionDefaults,
-    });
-    runOptions = { ...options, baselineDomains };
-    perfMark("ggsvelte:baseline:end");
-    perfMeasure("ggsvelte:baseline", "ggsvelte:baseline:start", "ggsvelte:baseline:end");
-  }
-
-  // bind + facet partition + per-panel frames
-  perfMark("ggsvelte:bind:start");
-  const prepared = preparePanels(normalized, runOptions, warnings, advisories);
-  perfMark("ggsvelte:bind:end");
-  perfMeasure("ggsvelte:bind", "ggsvelte:bind:start", "ggsvelte:bind:end");
-
-  // train scales — fixed: union across panels; free: positional domains per
-  // panel; discrete color/fill assignment ALWAYS global (one legend).
-  perfMark("ggsvelte:scales:start");
-  const trained = trainPipelineScales({
-    normalized,
-    options: runOptions,
-    table: prepared.table,
-    sourceTable: prepared.sourceTable,
-    bindings: prepared.bindings,
-    facetPanels: prepared.facetPanels,
-    panelFrames: prepared.panelFrames,
-    freeX: prepared.freeX,
-    freeY: prepared.freeY,
-    xConversion: prepared.xConversion,
-    yConversion: prepared.yConversion,
-    editionDefaults,
-    warnings,
-    advisories,
-  });
-  perfMark("ggsvelte:scales:end");
-  perfMeasure("ggsvelte:scales", "ggsvelte:scales:start", "ggsvelte:scales:end");
-
-  const model = finalize({
-    runId,
-    normalized,
-    options: runOptions,
-    theme,
-    flip,
-    prepared,
-    trained,
-    warnings,
-    advisories,
-  });
-
+  const model = finalize(preparePipelineRun(spec, options));
   perfMark("ggsvelte:pipeline:end");
   perfMeasure("ggsvelte:pipeline", "ggsvelte:pipeline:start", "ggsvelte:pipeline:end");
   return model;

--- a/packages/core/src/pipeline/run-scene.ts
+++ b/packages/core/src/pipeline/run-scene.ts
@@ -1,0 +1,17 @@
+/** Lean pipeline endpoint for renderers that consume only the computed Scene. */
+import type { PortableSpec, SpecInput } from "@ggsvelte/spec";
+
+import { perfMark, perfMeasure } from "../perf.js";
+import type { Scene } from "../scene.js";
+
+import { finalizeScene } from "./finalize.js";
+import { preparePipelineRun } from "./prepare-run.js";
+import type { RunOptions } from "./types.js";
+
+export function runScene(spec: SpecInput | PortableSpec, options: RunOptions): Scene {
+  perfMark("ggsvelte:pipeline:start");
+  const { scene } = finalizeScene(preparePipelineRun(spec, options));
+  perfMark("ggsvelte:pipeline:end");
+  perfMeasure("ggsvelte:pipeline", "ggsvelte:pipeline:start", "ggsvelte:pipeline:end");
+  return scene;
+}

--- a/packages/core/src/render-svg.ts
+++ b/packages/core/src/render-svg.ts
@@ -26,12 +26,12 @@
  */
 import type { GGBuilder, SpecInput } from "@ggsvelte/spec";
 
-import type { RenderModel, RunOptions } from "./pipeline/public-api.js";
+import type { RunOptions } from "./pipeline/public-api.js";
 import { PipelineError } from "./pipeline/public-api.js";
-// Import runPipeline without the full pipeline barrel (which registers every
-// geom/stat). Entry points that need the full grammar import `./pipeline.js`
-// or `./index.js` first; `@ggsvelte/core/render` registers basic geoms only.
-import { runPipeline } from "./pipeline/run-pipeline.js";
+// Import the scene-only runner without the full pipeline barrel (which
+// registers every geom/stat). The SVG renderer does not build RenderModel-only
+// interaction, domain snapshot, viewport, or lifecycle contracts.
+import { runScene } from "./pipeline/run-scene.js";
 import { countMarks } from "./render-svg-marks.js";
 import { sceneToSVGString } from "./render-svg-scene.js";
 
@@ -64,12 +64,12 @@ function isBuilder(spec: SpecInput | GGBuilder): spec is GGBuilder {
 export function renderToSVGString(spec: SpecInput | GGBuilder, options: RenderSVGOptions): string {
   const resolved: SpecInput = isBuilder(spec) ? spec.spec() : spec;
   const { maxMarks, height, paintMode, ...run } = options;
-  const model: RenderModel = runPipeline(resolved, {
+  const scene = runScene(resolved, {
     ...run,
     height: height ?? resolved.height ?? DEFAULT_HEIGHT,
   });
   const limit = maxMarks ?? DEFAULT_MAX_MARKS;
-  const marks = countMarks(model.scene);
+  const marks = countMarks(scene);
   if (marks > limit) {
     throw new PipelineError(
       "max-marks-exceeded",
@@ -79,7 +79,7 @@ export function renderToSVGString(spec: SpecInput | GGBuilder, options: RenderSV
     );
   }
   try {
-    return sceneToSVGString(model.scene, { paintMode: paintMode ?? "full" });
+    return sceneToSVGString(scene, { paintMode: paintMode ?? "full" });
   } catch (error) {
     // Failure policy: renderer errors are structured, never blank output.
     throw new PipelineError(

--- a/packages/core/tests/pipeline-scene-only.test.ts
+++ b/packages/core/tests/pipeline-scene-only.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "bun:test";
+import { aes, gg } from "@ggsvelte/spec";
+
+import { runPipeline } from "../src/pipeline.ts";
+import { runScene } from "../src/pipeline/run-scene.ts";
+import { sceneToSVGString } from "../src/render-svg-scene.ts";
+
+const size = { width: 420, height: 320 };
+
+function expectSceneParity(
+  spec: Parameters<typeof runScene>[0],
+  options: Parameters<typeof runScene>[1] = size,
+): void {
+  const full = runPipeline(spec, options).scene;
+  const lean = runScene(spec, options);
+  expect(sceneToSVGString(lean)).toBe(sceneToSVGString(full));
+}
+
+describe("scene-only pipeline", () => {
+  it("matches full-model scenes for facets and free scales", () => {
+    const spec = gg(
+      [
+        { x: 1, y: 10, panel: "a", cls: "one" },
+        { x: 2, y: 20, panel: "a", cls: "two" },
+        { x: 100, y: 2, panel: "b", cls: "one" },
+        { x: 200, y: 4, panel: "b", cls: "two" },
+      ],
+      aes({ x: "x", y: "y", color: "cls" }),
+    )
+      .geomPoint()
+      .facet({ wrap: "panel", scales: "free" })
+      .spec();
+
+    expectSceneParity(spec);
+  });
+
+  it("matches full-model scenes for radial coordinates", () => {
+    const spec = gg(
+      [
+        { pie: "all", category: "a", value: 1 },
+        { pie: "all", category: "b", value: 2 },
+        { pie: "all", category: "c", value: 3 },
+      ],
+      aes({ x: "pie", y: "value", fill: "category" }),
+    )
+      .geomCol({ width: 1, position: "stack" })
+      .coordRadial({ theta: "y", expand: false })
+      .spec();
+
+    expectSceneParity(spec, { width: 400, height: 400 });
+  });
+
+  it("matches full-model scenes through the uncensored baseline pass", () => {
+    const spec = gg(
+      [
+        { x: 1, y: 1 },
+        { x: 2, y: 4 },
+        { x: 3, y: 9 },
+      ],
+      aes({ x: "x", y: "y" }),
+    )
+      .geomPoint()
+      .scales({ x: { domain: [1.5, 2.5] } })
+      .spec();
+
+    expectSceneParity(spec, {
+      ...size,
+      baselineScales: { x: {} },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`renderToSVGString` consumed only `model.scene`, but paid for the full `RenderModel`: layer contracts, domain snapshots, semantic viewports, lineage ownership, lazy interaction closures, formatters, and lifecycle assembly.

This change splits pipeline work at the scene boundary. `runPipeline` still builds the full model. SVG export calls an internal scene-only path. A parity suite locks facets with free scales, radial coordinates, and the uncensored baseline pass.

## Benchmarks

Bun 1.3.14, competitive SSR harness, median of 15 after three warmups. Three alternating main/branch rounds:

| Case | Main | Branch | Median change |
|---|---:|---:|---:|
| scatter-color-1k | 1.826 / 1.938 / 1.839 ms | 1.756 / 1.783 / 1.627 ms | **1.839 → 1.756 ms (-5%)** |
| line-3x1k | 2.252 / 2.576 / 2.319 ms | 2.259 / 2.222 / 2.048 ms | **2.319 → 2.222 ms (-4%)** |

The line result misses the planned 5% gate by one point on the median-of-runs, but two branch rounds beat every prior main round except one 7 µs tie. The isolated pipeline benchmark shows the intended cut: scatter 0.508 → 0.432 ms (-15%), line 0.585 → 0.517 ms (-12%). Output bytes remain unchanged across direct-spec, facet, radial, and baseline-pass tests.

This narrows the LayerCake SSR gap but does not close it.

## Verification

- `bun test packages/core` — 2,406 pass
- `bun test benchmarks/competitive/lean-candidates-graph.test.ts benchmarks/competitive/lean-polyfill-graph.test.ts benchmarks/competitive/direct-spec-equivalence.test.ts`
- `bun run check`
- `bun run lint:type-aware`
- three alternating `COMPETITIVE_LIBS=ggsvelte,layercake bun run measure:ssr` rounds
