### PR TITLE
docs: snap CodeTabs selected wash on keyboard

### DIFF
--- a/apps/docs/src/lib/CodeTabs.svelte
+++ b/apps/docs/src/lib/CodeTabs.svelte
@@ -162,10 +162,7 @@
     color: color-mix(in srgb, var(--code-ink) 55%, transparent);
     cursor: pointer;
     font: 600 0.82rem/1 var(--body-font);
-    transition:
-      background-color 120ms ease,
-      color 120ms ease,
-      transform var(--duration-press) var(--ease-out);
+    transition: transform var(--duration-press) var(--ease-out);
   }
 
   /* 36px visual height, 44px hit height (DESIGN.md hit-region floor). */

--- a/scripts/code-tabs-motion.test.ts
+++ b/scripts/code-tabs-motion.test.ts
@@ -1,0 +1,42 @@
+/**
+ * CodeTabs tab triggers must snap selected wash (keyboard list nav).
+ * Press scale may still transition transform.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "bun:test";
+
+const TABS = join(import.meta.dir, "../apps/docs/src/lib/CodeTabs.svelte");
+
+function styleBlock(source: string): string {
+  const match = source.match(/<style[^>]*>([\s\S]*?)<\/style>/);
+  return match?.[1] ?? "";
+}
+
+function ruleBody(css: string, selector: string): string {
+  const escaped = selector.replaceAll(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = css.match(new RegExp(`${escaped}\\s*\\{([^}]+)\\}`));
+  return match?.[1] ?? "";
+}
+
+describe("CodeTabs tab motion", () => {
+  const css = styleBlock(readFileSync(TABS, "utf8"));
+
+  it("tab buttons transition transform only so selected wash snaps", () => {
+    const body = ruleBody(css, '.bar button[role="tab"]');
+    expect(body).not.toBe("");
+    expect(body).toMatch(
+      /transition\s*:\s*transform\s+var\(--duration-press\)\s+var\(--ease-out\)\s*;/,
+    );
+    expect(body).not.toMatch(/background-color/);
+    expect(body).not.toMatch(/color\s+120ms/);
+  });
+
+  it("copy button still transitions color and background", () => {
+    const body = ruleBody(css, ".bar .copy");
+    expect(body).toMatch(/background-color\s+120ms\s+ease/);
+    expect(body).toMatch(/color\s+120ms\s+ease/);
+    expect(body).toMatch(/transform\s+var\(--duration-press\)\s+var\(--ease-out\)/);
+  });
+});


### PR DESCRIPTION
## Summary

Keyboard list navigation on the docs code tabs was fading the selected wash for 120ms. That delay is gone. The selected tab now changes on the same frame as the arrow key.

Pointer press scale is unchanged. The copy button still fades color and background.

## Test plan

- [x] `bun test scripts/code-tabs-motion.test.ts` (red, then green)
- [x] `bun run check:docs`
- [x] `bun run check:scripts`
- [ ] Homepage code tabs: ArrowRight snaps the wash; click still scales 0.97