### PR TITLE
docs: play On this page popover exit

### DIFF
--- a/apps/docs/src/styles/base.css
+++ b/apps/docs/src/styles/base.css
@@ -361,4 +361,10 @@ pre {
     transition-duration: 0.01ms !important;
     animation-duration: 0.01ms !important;
   }
+
+  /* ::details-content is also not matched by * */
+  *::details-content {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+  }
 }

--- a/apps/docs/src/styles/shell.css
+++ b/apps/docs/src/styles/shell.css
@@ -486,6 +486,20 @@
     position: relative;
   }
 
+  /*
+   * Keep the card painted on close. Chromium/WebKit interpolate
+   * content-visibility with allow-discrete; Firefox still snap-closes.
+   */
+  .docs-mobile-tools details::details-content {
+    content-visibility: hidden;
+    transition: content-visibility var(--duration-popover-exit) allow-discrete;
+  }
+
+  .docs-mobile-tools details[open]::details-content {
+    content-visibility: visible;
+    transition: content-visibility var(--duration-popover) allow-discrete;
+  }
+
   .docs-mobile-tools details .on-this-page {
     position: absolute;
     right: 0;
@@ -498,6 +512,7 @@
     background: var(--paper);
     box-shadow: 0 8px 24px color-mix(in srgb, #000 12%, transparent);
     transform-origin: top right;
+    pointer-events: none;
     opacity: 0;
     transform: scale(0.97);
     transition:
@@ -506,6 +521,7 @@
   }
 
   .docs-mobile-tools details[open] .on-this-page {
+    pointer-events: auto;
     opacity: 1;
     transform: scale(1);
     transition:

--- a/scripts/on-this-page-popover-exit.test.ts
+++ b/scripts/on-this-page-popover-exit.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Mobile On this page <details> popover: enter already uses @starting-style.
+ * Exit needs discrete content-visibility on ::details-content so the card
+ * stays painted for --duration-popover-exit. * does not match that pseudo.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "bun:test";
+
+const ROOT = join(import.meta.dir, "..");
+const SHELL = join(ROOT, "apps/docs/src/styles/shell.css");
+const BASE = join(ROOT, "apps/docs/src/styles/base.css");
+
+describe("On this page popover exit", () => {
+  const shell = readFileSync(SHELL, "utf8");
+  const base = readFileSync(BASE, "utf8");
+
+  it("closes ::details-content with discrete content-visibility", () => {
+    expect(shell).toMatch(
+      /\.docs-mobile-tools\s+details::details-content\s*\{[^}]*content-visibility\s*:\s*hidden/s,
+    );
+    expect(shell).toMatch(
+      /\.docs-mobile-tools\s+details::details-content\s*\{[^}]*content-visibility\s+var\(--duration-popover-exit\)\s+allow-discrete/s,
+    );
+    expect(shell).toMatch(
+      /\.docs-mobile-tools\s+details\[open\]::details-content\s*\{[^}]*content-visibility\s*:\s*visible/s,
+    );
+    expect(shell).toMatch(
+      /\.docs-mobile-tools\s+details\[open\]::details-content\s*\{[^}]*content-visibility\s+var\(--duration-popover\)\s+allow-discrete/s,
+    );
+  });
+
+  it("blocks hits on the card unless the details element is open", () => {
+    expect(shell).toMatch(
+      /\.docs-mobile-tools\s+details\s+\.on-this-page\s*\{[^}]*pointer-events\s*:\s*none/s,
+    );
+    expect(shell).toMatch(
+      /\.docs-mobile-tools\s+details\[open\]\s+\.on-this-page\s*\{[^}]*pointer-events\s*:\s*auto/s,
+    );
+  });
+
+  it("collapses ::details-content duration under reduced motion", () => {
+    expect(base).toMatch(
+      /prefers-reduced-motion:\s*reduce[\s\S]*::details-content\s*\{[^}]*transition-duration\s*:\s*0\.01ms/s,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

The mobile **On this page** card already entered with `@starting-style` and `scale(0.97)`. Close snapped because `<details>` hid the box on the same frame.

This keeps `::details-content` painted with discrete `content-visibility` for `--duration-popover-exit`. Clicks pass through the fading card (`pointer-events: none` as soon as `[open]` drops). `*` does not match `::details-content`, so reduced motion now names that pseudo.

Firefox still snap-closes (no discrete `content-visibility` transition). Chromium and WebKit play the exit.

## Test plan

- [x] `bun test scripts/on-this-page-popover-exit.test.ts` (red, then green)
- [ ] Viewport below `74.99rem`, guide page: open/close On this page; exit visible at 10% playback in Chromium
- [ ] During exit, clicks hit the page, not the fading card
- [ ] `prefers-reduced-motion`: open/close snap