### PR TITLE
fix(inspect): identity fill cols report post-position shares

### DIFF
--- a/.changeset/inspect-y-source-backed-fill.md
+++ b/.changeset/inspect-y-source-backed-fill.md
@@ -1,0 +1,6 @@
+---
+"@ggsvelte/core": patch
+"@ggsvelte/svelte": patch
+---
+
+Identity-stat stacked and filled columns now inspect the post-position height, so fill tooltips show shares and Total sums those shares.

--- a/packages/core/src/pipeline/build-candidates.ts
+++ b/packages/core/src/pipeline/build-candidates.ts
@@ -21,6 +21,7 @@ import type { Scene } from "../scene.js";
 import type { CellValue, ColumnTable } from "../table.js";
 import type { SourceRegistry } from "./source-registry.js";
 import { createIdentityCandidateDatumResolver } from "./candidate-construction/datum.js";
+import { stackOrFillInspectY } from "./candidate-construction/datum-values.js";
 import { createLazyIdentityIndex } from "./candidate-construction/identity-index.js";
 import type { FacetPanelDef } from "./facets.js";
 import { candidateAutoMode } from "./frame-candidates-auto-mode.js";
@@ -135,13 +136,44 @@ function createRawResolverState(
   return { stateFor, constantsFor, colorOrdinal, fillOrdinal };
 }
 
+function sourceBackedRewritesInspectY(
+  frame: FinalizedLayerFrame | undefined,
+  batchKind: Scene["batches"][number]["kind"] | undefined,
+): boolean {
+  if (frame === undefined || batchKind === "paths") return false;
+  const geom = frame.binding.layer.geom;
+  if (geom !== "bar" && geom !== "col") return false;
+  const position = frame.binding.layer.position ?? "identity";
+  return (position === "stack" || position === "fill") && frame.binding.yTransform === undefined;
+}
+
+function sourceBackedInspectY(
+  panelFrames: readonly (readonly FinalizedLayerFrame[])[],
+  scene: Scene,
+  facts: {
+    panelIndex: number;
+    layerIndex: number;
+    batchIndex: number;
+    primitiveIndex: number;
+  },
+  fallback: CellValue,
+): CellValue {
+  const batch = scene.batches[facts.batchIndex];
+  const frame = panelFrames[facts.panelIndex]?.[facts.layerIndex];
+  if (!sourceBackedRewritesInspectY(frame, batch?.kind)) return fallback;
+  const frameRow = Math.min(facts.primitiveIndex, Math.max(0, (frame?.n ?? 1) - 1));
+  return stackOrFillInspectY(frame, frameRow, fallback);
+}
+
 function createRawCandidateDatumResolver(
   bindings: readonly LayerBinding[],
   sources: SourceRegistry,
   color: ResolvedColorScale | null,
   fill: ResolvedColorScale | null,
   lineage: LineageStore<number>,
-  shared?: ReturnType<typeof createRawResolverState>,
+  shared: ReturnType<typeof createRawResolverState>,
+  scene: Scene,
+  panelFrames: readonly (readonly FinalizedLayerFrame[])[],
 ): (facts: CandidateBuildFacts) => CandidateDatum {
   const { stateFor, constantsFor, colorOrdinal, fillOrdinal } =
     shared ?? createRawResolverState(bindings, color, fill);
@@ -179,7 +211,7 @@ function createRawCandidateDatumResolver(
     const autoMode = candidateAutoMode(binding, facts.primitiveIndex);
     return {
       xValue: read(state.x),
-      yValue: read(state.y),
+      yValue: sourceBackedInspectY(panelFrames, scene, facts, read(state.y)),
       sizeValue: readStyle(state.size),
       linewidthValue: readStyle(state.linewidth),
       alphaValue: readStyle(state.alpha),
@@ -294,8 +326,9 @@ function createRawCandidateDatumColumnsResolver(input: {
   fill: ResolvedColorScale | null;
   lineage: LineageStore<number>;
   shared: ReturnType<typeof createRawResolverState>;
+  panelFrames: readonly (readonly FinalizedLayerFrame[])[];
 }): (facts: CandidateBatchFacts) => CandidateDatumColumns | null {
-  const { scene, bindings, sources, lineage, shared } = input;
+  const { scene, bindings, sources, lineage, shared, panelFrames } = input;
   const { stateFor, constantsFor, colorOrdinal, fillOrdinal } = shared;
 
   const contiguousColumns = (
@@ -340,9 +373,33 @@ function createRawCandidateDatumColumnsResolver(input: {
     const lineageCol = new Uint32Array(count);
     for (let i = 0; i < count; i++) lineageCol[i] = lineage.internSingleton(facts.rowIds[i]!);
 
+    const sourceY = state.y === null ? null : slice(state.y);
+    const rewriteY = sourceBackedRewritesInspectY(
+      panelFrames[facts.panelIndex]?.[facts.layerIndex],
+      scene.batches[facts.batchIndex]?.kind,
+    );
+    let yValue: CandidateDatumColumns["yValue"] = sourceY;
+    if (rewriteY && sourceY !== null) {
+      const rewritten = Array.from<CellValue>({ length: count });
+      for (let i = 0; i < count; i++) {
+        rewritten[i] = sourceBackedInspectY(
+          panelFrames,
+          scene,
+          {
+            panelIndex: facts.panelIndex,
+            layerIndex: facts.layerIndex,
+            batchIndex: facts.batchIndex,
+            primitiveIndex: facts.semanticIds[i]!,
+          },
+          sourceY[i] ?? null,
+        );
+      }
+      yValue = rewritten;
+    }
+
     return {
       xValue: state.x === null ? null : slice(state.x),
-      yValue: state.y === null ? null : slice(state.y),
+      yValue,
       sizeValue: styleColumn(state.size, slice),
       linewidthValue: styleColumn(state.linewidth, slice),
       alphaValue: styleColumn(state.alpha, slice),
@@ -399,7 +456,17 @@ function createRawCandidateDatumColumnsResolver(input: {
       const readStyle = (style: StyleRead): CellValue =>
         style.column === null ? style.constant : localRow < 0 ? null : style.column[localRow]!;
       xValues[i] = read(state.x);
-      yValues[i] = read(state.y);
+      yValues[i] = sourceBackedInspectY(
+        panelFrames,
+        scene,
+        {
+          panelIndex: facts.panelIndex,
+          layerIndex: facts.layerIndex,
+          batchIndex: facts.batchIndex,
+          primitiveIndex: facts.semanticIds[i]!,
+        },
+        read(state.y),
+      );
       styleScratch.size[i] = readStyle(state.size) ?? null;
       styleScratch.linewidth[i] = readStyle(state.linewidth) ?? null;
       styleScratch.alpha[i] = readStyle(state.alpha) ?? null;
@@ -496,18 +563,28 @@ function buildSourceBackedCandidates(input: {
   runId: number;
   flip: boolean;
   bindings: readonly LayerBinding[];
+  panelFrames: readonly (readonly FinalizedLayerFrame[])[];
   sources: SourceRegistry;
   color: ResolvedColorScale | null;
   fill: ResolvedColorScale | null;
   lineage: LineageStore<number>;
 }): CandidateStore {
-  const { scene, runId, flip, bindings, sources, color, fill, lineage } = input;
+  const { scene, runId, flip, bindings, panelFrames, sources, color, fill, lineage } = input;
   const shared = createRawResolverState(bindings, color, fill);
   return buildCandidateStore(scene, {
     epoch: runId,
     flip,
     uninspectableLayers: uninspectableLayers(bindings),
-    datum: createRawCandidateDatumResolver(bindings, sources, color, fill, lineage, shared),
+    datum: createRawCandidateDatumResolver(
+      bindings,
+      sources,
+      color,
+      fill,
+      lineage,
+      shared,
+      scene,
+      panelFrames,
+    ),
     datumColumns: createRawCandidateDatumColumnsResolver({
       scene,
       bindings,
@@ -516,6 +593,7 @@ function buildSourceBackedCandidates(input: {
       fill,
       lineage,
       shared,
+      panelFrames,
     }),
   });
 }

--- a/packages/core/src/pipeline/build-candidates.ts
+++ b/packages/core/src/pipeline/build-candidates.ts
@@ -147,6 +147,20 @@ function sourceBackedRewritesInspectY(
   return (position === "stack" || position === "fill") && frame.binding.yTransform === undefined;
 }
 
+function frameRowForSourceRow(
+  frame: FinalizedLayerFrame,
+  sourceRow: number | null,
+  primitiveIndex: number,
+): number {
+  const fallback = Math.min(primitiveIndex, Math.max(0, frame.n - 1));
+  if (sourceRow === null) return fallback;
+  // Dense path: primitive still indexes the same frame row.
+  if (frame.rowIndex[fallback] === sourceRow) return fallback;
+  // Compacted rects (dropped earlier slots): recover the original frame row.
+  const idx = frame.rowIndex.indexOf(sourceRow);
+  return idx >= 0 ? idx : fallback;
+}
+
 function sourceBackedInspectY(
   panelFrames: readonly (readonly FinalizedLayerFrame[])[],
   scene: Scene,
@@ -155,14 +169,18 @@ function sourceBackedInspectY(
     layerIndex: number;
     batchIndex: number;
     primitiveIndex: number;
+    sourceRow: number | null;
   },
   fallback: CellValue,
 ): CellValue {
   const batch = scene.batches[facts.batchIndex];
   const frame = panelFrames[facts.panelIndex]?.[facts.layerIndex];
-  if (!sourceBackedRewritesInspectY(frame, batch?.kind)) return fallback;
-  const frameRow = Math.min(facts.primitiveIndex, Math.max(0, (frame?.n ?? 1) - 1));
-  return stackOrFillInspectY(frame, frameRow, fallback);
+  if (frame === undefined || !sourceBackedRewritesInspectY(frame, batch?.kind)) return fallback;
+  return stackOrFillInspectY(
+    frame,
+    frameRowForSourceRow(frame, facts.sourceRow, facts.primitiveIndex),
+    fallback,
+  );
 }
 
 function createRawCandidateDatumResolver(
@@ -175,8 +193,7 @@ function createRawCandidateDatumResolver(
   scene: Scene,
   panelFrames: readonly (readonly FinalizedLayerFrame[])[],
 ): (facts: CandidateBuildFacts) => CandidateDatum {
-  const { stateFor, constantsFor, colorOrdinal, fillOrdinal } =
-    shared ?? createRawResolverState(bindings, color, fill);
+  const { stateFor, constantsFor, colorOrdinal, fillOrdinal } = shared;
   return (facts) => {
     const binding = bindings[facts.layerIndex];
     const sourceRow = facts.rowIndex;
@@ -211,7 +228,18 @@ function createRawCandidateDatumResolver(
     const autoMode = candidateAutoMode(binding, facts.primitiveIndex);
     return {
       xValue: read(state.x),
-      yValue: sourceBackedInspectY(panelFrames, scene, facts, read(state.y)),
+      yValue: sourceBackedInspectY(
+        panelFrames,
+        scene,
+        {
+          panelIndex: facts.panelIndex,
+          layerIndex: facts.layerIndex,
+          batchIndex: facts.batchIndex,
+          primitiveIndex: facts.primitiveIndex,
+          sourceRow: facts.rowIndex,
+        },
+        read(state.y),
+      ),
       sizeValue: readStyle(state.size),
       linewidthValue: readStyle(state.linewidth),
       alphaValue: readStyle(state.alpha),
@@ -390,6 +418,7 @@ function createRawCandidateDatumColumnsResolver(input: {
             layerIndex: facts.layerIndex,
             batchIndex: facts.batchIndex,
             primitiveIndex: facts.semanticIds[i]!,
+            sourceRow: facts.rowIds[i] === NO_ROW ? null : facts.rowIds[i]!,
           },
           sourceY[i] ?? null,
         );
@@ -464,6 +493,7 @@ function createRawCandidateDatumColumnsResolver(input: {
           layerIndex: facts.layerIndex,
           batchIndex: facts.batchIndex,
           primitiveIndex: facts.semanticIds[i]!,
+          sourceRow: rowId === NO_ROW ? null : rowId,
         },
         read(state.y),
       );

--- a/packages/core/src/pipeline/candidate-construction/datum-values.ts
+++ b/packages/core/src/pipeline/candidate-construction/datum-values.ts
@@ -98,22 +98,31 @@ export function resolveCandidateLogicalValues(input: {
         : sourceValue(xField)
       : (frame?.box?.outlierX[primitiveIndex] ?? null);
 
-  // Stack/fill rewrite ymin/ymax (and yNumeric after position-bar). Prefer the
-  // post-position segment height so identity cols and stat bars both report the
-  // drawn share/contribution — not the pre-position source column.
-  const stackHeight = stackOrFillSegmentHeight(frame, frameRow);
+  const fallbackY =
+    sourceRow === null || yField === undefined
+      ? frameLogicalY(frame, frameRow)
+      : sourceValue(yField);
 
   const yValue = annotationRule
     ? annotationY
     : outlierSourceRow === null
-      ? stackHeight === undefined
-        ? sourceRow === null || yField === undefined
-          ? frameLogicalY(frame, frameRow)
-          : sourceValue(yField)
-        : semanticFrameNumber(frame, "y", stackHeight)
+      ? stackOrFillInspectY(frame, frameRow, fallbackY)
       : semanticFrameNumber(frame, "y", frame?.box?.outlierY[primitiveIndex]);
 
   return { xValue, yValue };
+}
+
+/**
+ * Inspect y after stack/fill: post-position height when the layer is a
+ * bar-like stack/fill without a y transform; otherwise `fallback`.
+ */
+export function stackOrFillInspectY(
+  frame: LayerFrame | undefined,
+  frameRow: number,
+  fallback: CellValue,
+): CellValue {
+  const stackHeight = stackOrFillSegmentHeight(frame, frameRow);
+  return stackHeight === undefined ? fallback : semanticFrameNumber(frame, "y", stackHeight);
 }
 
 /**

--- a/packages/core/tests/pipeline-position-fill-candidates.test.ts
+++ b/packages/core/tests/pipeline-position-fill-candidates.test.ts
@@ -81,6 +81,34 @@ describe("position fill — candidate y matches axis space", () => {
     expect(model.axisFormatters.y(yValues[0])).toBe("35%");
   });
 
+  it("maps compacted fill rects back to the original frame row", () => {
+    // First x is outside the trained domain → no rect. Remaining candidates
+    // must still read their own post-position shares, not the dropped slot.
+    const model = runPipeline(
+      gg(
+        [
+          { squadron: "Ghost", role: "Ghost", men: 1000 },
+          { squadron: "Naples", role: "Soldiers", men: 2 },
+          { squadron: "Naples", role: "Sailors", men: 8 },
+        ],
+        aes({ x: "squadron", y: "men", fill: "role" }),
+      )
+        .geomCol({ position: "fill" })
+        .scales({ x: { domain: ["Naples"] } })
+        .spec(),
+      size,
+    );
+    const yValues = Array.from({ length: model.candidates.size }, (_, id) =>
+      model.candidates.candidate(id),
+    )
+      .filter((c) => c !== null)
+      .map((c) => c.yValue as number)
+      .toSorted((a, b) => a - b);
+    expect(yValues).toHaveLength(2);
+    expect(yValues[0]).toBeCloseTo(2 / 10, 8);
+    expect(yValues[1]).toBeCloseTo(8 / 10, 8);
+  });
+
   it("publishes stack segment heights for identity-stat cols (source-backed)", () => {
     const model = runPipeline(
       gg(

--- a/packages/core/tests/pipeline-position-fill-candidates.test.ts
+++ b/packages/core/tests/pipeline-position-fill-candidates.test.ts
@@ -55,6 +55,52 @@ describe("position fill — candidate y matches axis space", () => {
     expect(model.axisFormatters.y(soldiers.yValue)).not.toContain("873");
   });
 
+  it("publishes the same fill shares for identity-stat cols (source-backed)", () => {
+    // geomCol + mapped y keeps stat identity, so construction is source-backed.
+    // Inspect y must still be the post-position share, not the source column.
+    const model = runPipeline(
+      gg(
+        naples.map((row) => ({ squadron: row.squadron, role: row.role, men: row.men })),
+        aes({ x: "squadron", y: "men", fill: "role" }),
+      )
+        .geomCol({ position: "fill" })
+        .scales({ y: { labels: ".0%" } })
+        .spec(),
+      size,
+    );
+
+    const candidates = Array.from({ length: model.candidates.size }, (_, id) =>
+      model.candidates.candidate(id),
+    ).filter((c) => c !== null);
+
+    expect(candidates.length).toBe(2);
+    const yValues = candidates.map((c) => c.yValue as number).toSorted((a, b) => a - b);
+    expect(yValues[0]).toBeCloseTo(468 / (873 + 468), 8);
+    expect(yValues[1]).toBeCloseTo(873 / (873 + 468), 8);
+    expect(model.axisFormatters.y(yValues[1])).toBe("65%");
+    expect(model.axisFormatters.y(yValues[0])).toBe("35%");
+  });
+
+  it("publishes stack segment heights for identity-stat cols (source-backed)", () => {
+    const model = runPipeline(
+      gg(
+        naples.map((row) => ({ squadron: row.squadron, role: row.role, men: row.men })),
+        aes({ x: "squadron", y: "men", fill: "role" }),
+      )
+        .geomCol({ position: "stack" })
+        .spec(),
+      size,
+    );
+    const yValues = Array.from({ length: model.candidates.size }, (_, id) =>
+      model.candidates.candidate(id),
+    )
+      .filter((c) => c !== null)
+      .map((c) => c.yValue as number)
+      .toSorted((a, b) => a - b);
+    expect(yValues[0]).toBeCloseTo(468, 8);
+    expect(yValues[1]).toBeCloseTo(873, 8);
+  });
+
   it("keeps stack candidate y as the segment height (raw contribution)", () => {
     const model = runPipeline(
       gg([...naples], aes({ x: "squadron", fill: "role", weight: "men" }))

--- a/packages/svelte/src/lib/inspection/resolver.ts
+++ b/packages/svelte/src/lib/inspection/resolver.ts
@@ -315,6 +315,14 @@ function datum<Row extends Record<string, CellValue>, Key extends PropertyKey>(
       if (fromCandidate !== undefined) return { ...field, value: fromCandidate };
       return { ...field, value: null };
     }
+    // Stack/fill publish the post-position measure on the candidate. The source
+    // row still holds the pre-position column (counts / raw y), so identity
+    // cols would otherwise show 873 while Total sums shares.
+    const position = model.layerPositions?.[candidate.layerIndex];
+    if ((position === "stack" || position === "fill") && field.channel === "y") {
+      const fromCandidate = candidateValue(field.channel);
+      if (fromCandidate !== undefined) return { ...field, value: fromCandidate };
+    }
     if (row !== null) {
       return { ...field, value: row[field.field] ?? null };
     }

--- a/packages/svelte/tests/inspection/resolve-snapshot.test.ts
+++ b/packages/svelte/tests/inspection/resolve-snapshot.test.ts
@@ -739,9 +739,14 @@ describe("selectTransientMembers top-k by value (#1274)", () => {
     }
     expect(filledInspection.mode).toBe("x");
     if (filledInspection.mode === "x" || filledInspection.mode === "y") {
-      // Fill still contributes source y magnitudes for the stack Total.
-      expect(filledInspection.groupTotal).toBe(15);
+      // Fill inspect y is the post-position share; Total sums those shares.
+      expect(filledInspection.groupTotal).toBeCloseTo(1, 8);
       expect(filledInspection.groupMemberCount).toBe(5);
+      const fillYs = filledInspection.members
+        .map((m) => Number(m.fields.find((f) => f.channel === "y")?.value))
+        .toSorted((a, b) => a - b);
+      expect(fillYs[0]).toBeCloseTo(1 / 15, 8);
+      expect(fillYs[4]).toBeCloseTo(5 / 15, 8);
     }
     expect(dodgedInspection.mode).toBe("x");
     if (dodgedInspection.mode === "x" || dodgedInspection.mode === "y") {

--- a/packages/svelte/tests/inspection/resolve-snapshot.test.ts
+++ b/packages/svelte/tests/inspection/resolve-snapshot.test.ts
@@ -747,7 +747,7 @@ describe("selectTransientMembers top-k by value (#1274)", () => {
         const yField = member.fields.find((field) => field.channel === "y");
         const value = yField?.value;
         if (typeof value !== "number") {
-          throw new Error("expected numeric fill inspect y");
+          throw new TypeError("expected numeric fill inspect y");
         }
         fillYs.push(value);
       }

--- a/packages/svelte/tests/inspection/resolve-snapshot.test.ts
+++ b/packages/svelte/tests/inspection/resolve-snapshot.test.ts
@@ -742,9 +742,16 @@ describe("selectTransientMembers top-k by value (#1274)", () => {
       // Fill inspect y is the post-position share; Total sums those shares.
       expect(filledInspection.groupTotal).toBeCloseTo(1, 8);
       expect(filledInspection.groupMemberCount).toBe(5);
-      const fillYs = filledInspection.members
-        .map((m) => Number(m.fields.find((f) => f.channel === "y")?.value))
-        .toSorted((a, b) => a - b);
+      const fillYs: number[] = [];
+      for (const member of filledInspection.members) {
+        const yField = member.fields.find((field) => field.channel === "y");
+        const value = yField?.value;
+        if (typeof value !== "number") {
+          throw new Error("expected numeric fill inspect y");
+        }
+        fillYs.push(value);
+      }
+      fillYs.sort((a, b) => a - b);
       expect(fillYs[0]).toBeCloseTo(1 / 15, 8);
       expect(fillYs[4]).toBeCloseTo(5 / 15, 8);
     }


### PR DESCRIPTION
## Summary

Identity-stat columns (`geomCol` with mapped `y`) build inspect candidates from the source table. After `position: "fill"`, that path still published the raw count. Percent labels then printed values like `87300%`, and tooltip Total summed the counts.

`geomBar` with a count or weight stat already published the post-position height. Both construction paths now use the same inspect y rule. Fill tooltips show shares. Total sums those shares. Stack still reports the raw segment height.

Dropped out-of-domain rects compact the batch. Inspect y recovers the source row's frame index so a dropped first slot does not steal the next bar's share.

## Verification

- `bun test packages/core/tests/pipeline-position-fill-candidates.test.ts` — 10 pass
- `bun test packages/core/tests` — 2408 pass
- `bun run --bun test:browser -- --project chromium tests/inspection/` in `packages/svelte` — 174 pass
- `oxlint` on the touched files — clean