### PR TITLE
docs: add press scale to chrome controls

### DIFF
--- a/apps/docs/src/lib/components/ExampleLiveFrame.svelte
+++ b/apps/docs/src/lib/components/ExampleLiveFrame.svelte
@@ -294,6 +294,11 @@
     font: inherit;
     font-size: 0.85rem;
     cursor: pointer;
+    transition: transform var(--duration-press) var(--ease-out);
+  }
+
+  .load-interactive:active:not([aria-disabled="true"]) {
+    transform: scale(0.97);
   }
 
   .load-interactive:focus-visible {

--- a/apps/docs/src/lib/components/GrammarDemo.svelte
+++ b/apps/docs/src/lib/components/GrammarDemo.svelte
@@ -186,6 +186,11 @@
     font: inherit;
     font-size: 0.85rem;
     cursor: pointer;
+    transition: transform var(--duration-press) var(--ease-out);
+  }
+
+  .load-interactive:active:not([aria-disabled="true"]) {
+    transform: scale(0.97);
   }
 
   .load-interactive:focus-visible {

--- a/apps/docs/src/lib/components/SiteSearch.svelte
+++ b/apps/docs/src/lib/components/SiteSearch.svelte
@@ -258,6 +258,11 @@
     color: var(--muted);
     cursor: pointer;
     font-weight: 600;
+    transition: transform var(--duration-press) var(--ease-out);
+  }
+
+  header button:active {
+    transform: scale(0.97);
   }
 
   label {

--- a/apps/docs/src/styles/shell.css
+++ b/apps/docs/src/styles/shell.css
@@ -89,6 +89,28 @@
   cursor: pointer;
 }
 
+.search-trigger,
+.appearance,
+.menu-trigger,
+.mobile-search-trigger,
+.site-menu__heading button,
+.chapter-dialog__heading button,
+.docs-mobile-tools > button,
+.docs-mobile-tools summary {
+  transition: transform var(--duration-press) var(--ease-out);
+}
+
+.search-trigger:active,
+.appearance:active,
+.menu-trigger:active,
+.mobile-search-trigger:active,
+.site-menu__heading button:active,
+.chapter-dialog__heading button:active,
+.docs-mobile-tools > button:active,
+.docs-mobile-tools summary:active {
+  transform: scale(0.97);
+}
+
 .github-link {
   justify-content: center;
   width: 44px;

--- a/scripts/chrome-press-scale.test.ts
+++ b/scripts/chrome-press-scale.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Docs chrome press scale must match copy buttons and apply on desktop.
+ * The shared shell rules must sit outside @media (max-width: 74.99rem).
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "bun:test";
+
+const ROOT = join(import.meta.dir, "..");
+const SHELL = join(ROOT, "apps/docs/src/styles/shell.css");
+const SEARCH = join(ROOT, "apps/docs/src/lib/components/SiteSearch.svelte");
+const GRAMMAR = join(ROOT, "apps/docs/src/lib/components/GrammarDemo.svelte");
+const EXAMPLE = join(ROOT, "apps/docs/src/lib/components/ExampleLiveFrame.svelte");
+
+const PRESS_TRANSITION = /transition:\s*transform\s+var\(--duration-press\)\s+var\(--ease-out\)/;
+const PRESS_SCALE = /:active[^{]*\{[^}]*transform:\s*scale\(0\.97\)/s;
+
+function styleBlock(source: string): string {
+  const match = source.match(/<style[^>]*>([\s\S]*?)<\/style>/);
+  return match?.[1] ?? "";
+}
+
+describe("docs chrome press scale", () => {
+  const shell = readFileSync(SHELL, "utf8");
+  const media = shell.indexOf("@media (max-width: 74.99rem)");
+
+  it("defines desktop-visible chrome press before the mobile docs media query", () => {
+    const group = shell.indexOf(".search-trigger,");
+    expect(group).toBeGreaterThan(-1);
+    expect(media).toBeGreaterThan(-1);
+    expect(group).toBeLessThan(media);
+    const head = shell.slice(group, media);
+    expect(head).toMatch(PRESS_TRANSITION);
+    expect(head).toMatch(/\.appearance/);
+    expect(head).toMatch(/\.menu-trigger/);
+    expect(head).toMatch(/\.mobile-search-trigger/);
+    expect(head).toMatch(/\.site-menu__heading button/);
+    expect(head).toMatch(/\.chapter-dialog__heading button/);
+    expect(head).toMatch(/\.docs-mobile-tools > button/);
+    expect(head).toMatch(/\.docs-mobile-tools summary/);
+    expect(head).toMatch(/:active/);
+    expect(head).toMatch(/transform:\s*scale\(0\.97\)/);
+  });
+
+  it("search close button presses", () => {
+    const css = styleBlock(readFileSync(SEARCH, "utf8"));
+    expect(css).toMatch(/header button[^{]*\{[^}]*transform\s+var\(--duration-press\)/s);
+    expect(css).toMatch(PRESS_SCALE);
+  });
+
+  it("load-interactive buttons press unless aria-disabled", () => {
+    for (const path of [GRAMMAR, EXAMPLE]) {
+      const css = styleBlock(readFileSync(path, "utf8"));
+      expect(css).toMatch(/\.load-interactive[^{]*\{[^}]*transform\s+var\(--duration-press\)/s);
+      expect(css).toMatch(
+        /\.load-interactive:active:not\(\[aria-disabled="true"\]\)[^{]*\{[^}]*scale\(0\.97\)/s,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Copy buttons already press with `scale(0.97)` over `--duration-press`. Header Search, appearance (desktop and mobile), Menu, dialog Close, and **Load interactive chart** now do the same.

Shared chrome rules live **above** `@media (max-width: 74.99rem)` so desktop Search and appearance are not skipped. The load button does not press while `aria-disabled="true"`.

## Test plan

- [x] `bun test scripts/chrome-press-scale.test.ts` (red, then green)
- [ ] Desktop: click Search, Light/Dark — 0.97 press
- [ ] Mobile: Menu, Close, appearance
- [ ] Load interactive: press works, then no press while Loading…