### PR TITLE
docs: animate the click-opened search dialog

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -250,11 +250,13 @@ pill shapes.
   never depends on motion.
 - The documentation shell may use short, functional motion only (not continuous loops):
   edge-docked drawer enter/exit (`transform` + backdrop opacity), origin-aware popover
-  open (opacity + light scale from the trigger), press scale on controls (`scale(0.97)`),
-  and opacity icon crossfades. Shared tokens live under `:root` in
-  `apps/docs/src/styles/tokens.css` (`--ease-out`, `--ease-drawer`, duration tokens).
-  Under `prefers-reduced-motion: reduce` (and VR / visual-test), durations collapse —
-  including `::backdrop`, which is not matched by `*`. Meaning never depends on motion.
+  open (opacity + light scale from the trigger), click-opened search dialog (opacity +
+  `scale(0.97)` from center on wide viewports; opacity only on the full-viewport dialog),
+  press scale on controls (`scale(0.97)`), and opacity icon crossfades. Shared tokens live
+  under `:root` in `apps/docs/src/styles/tokens.css` (`--ease-out`, `--ease-drawer`,
+  duration tokens). Under `prefers-reduced-motion: reduce` (and VR / visual-test),
+  durations collapse — including `::backdrop`, which is not matched by `*`. Meaning never
+  depends on motion.
 
 ## Rejected patterns
 
@@ -282,6 +284,7 @@ release evidence, not optional decoration.
 
 | Date       | Decision                                                | Rationale                                                                                                      |
 | ---------- | ------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| 2026-08-16 | Allow click-opened search dialog motion                 | Centered scale on wide viewports; opacity only when the dialog is full-viewport; no keyboard toggle            |
 | 2026-08-06 | Allow restrained functional docs-shell motion only      | Spatial drawers, press feedback, and opacity state crossfades; chart marks stay motion-free                    |
 | 2026-07-14 | Establish quiet editorial data graphics as the system   | Matches the audited ggplot2/hrbrthemes/ggthemes references and makes good defaults the product advantage       |
 | 2026-07-14 | Keep `theme.ts` as executable token truth               | Prevents prose from becoming a parallel styling implementation                                                 |

--- a/apps/docs/src/lib/components/SiteSearch.svelte
+++ b/apps/docs/src/lib/components/SiteSearch.svelte
@@ -219,10 +219,56 @@
     background: var(--paper);
     color: var(--ink);
     box-shadow: 0 18px 60px color-mix(in srgb, #000 24%, transparent);
+    pointer-events: none;
+    opacity: 0;
+    transform: scale(0.97);
+    transform-origin: center;
+    transition:
+      opacity var(--duration-modal-exit) var(--ease-out),
+      transform var(--duration-modal-exit) var(--ease-out),
+      overlay var(--duration-modal-exit) allow-discrete,
+      display var(--duration-modal-exit) allow-discrete;
+  }
+
+  .site-search[open] {
+    pointer-events: auto;
+    opacity: 1;
+    transform: scale(1);
+    transition:
+      opacity var(--duration-modal-enter) var(--ease-out),
+      transform var(--duration-modal-enter) var(--ease-out),
+      overlay var(--duration-modal-enter) allow-discrete,
+      display var(--duration-modal-enter) allow-discrete;
+  }
+
+  @starting-style {
+    .site-search[open] {
+      opacity: 0;
+      transform: scale(0.97);
+    }
   }
 
   .site-search::backdrop {
     background: color-mix(in srgb, #000 45%, transparent);
+    opacity: 0;
+    transition:
+      opacity var(--duration-modal-exit) var(--ease-out),
+      overlay var(--duration-modal-exit) allow-discrete,
+      display var(--duration-modal-exit) allow-discrete;
+  }
+
+  .site-search[open]::backdrop {
+    opacity: 1;
+    transition:
+      opacity var(--duration-backdrop) var(--ease-out),
+      overlay var(--duration-modal-enter) allow-discrete,
+      display var(--duration-modal-enter) allow-discrete;
+  }
+
+  @starting-style {
+    .site-search[open]::backdrop {
+      opacity: 0;
+    }
   }
 
   .site-search__panel {
@@ -366,6 +412,26 @@
       margin: 0;
       border: 0;
       border-radius: 0;
+      transform: none;
+      transition:
+        opacity var(--duration-modal-exit) var(--ease-out),
+        overlay var(--duration-modal-exit) allow-discrete,
+        display var(--duration-modal-exit) allow-discrete;
+    }
+
+    .site-search[open] {
+      transform: none;
+      transition:
+        opacity var(--duration-modal-enter) var(--ease-out),
+        overlay var(--duration-modal-enter) allow-discrete,
+        display var(--duration-modal-enter) allow-discrete;
+    }
+
+    @starting-style {
+      .site-search[open] {
+        opacity: 0;
+        transform: none;
+      }
     }
 
     .site-search__panel {

--- a/apps/docs/src/styles/tokens.css
+++ b/apps/docs/src/styles/tokens.css
@@ -70,6 +70,8 @@
   --duration-drawer-exit: 220ms;
   --duration-backdrop: 250ms;
   --duration-icon: 140ms;
+  --duration-modal-enter: 200ms;
+  --duration-modal-exit: 150ms;
   color-scheme: light;
 }
 

--- a/scripts/search-dialog-motion.test.ts
+++ b/scripts/search-dialog-motion.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Click-opened search is a centered modal on wide viewports and opacity-only
+ * on the full-viewport mobile dialog. Tokens and discrete display must exist.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "bun:test";
+
+const ROOT = join(import.meta.dir, "..");
+const TOKENS = join(ROOT, "apps/docs/src/styles/tokens.css");
+const SEARCH = join(ROOT, "apps/docs/src/lib/components/SiteSearch.svelte");
+const DESIGN = join(ROOT, "DESIGN.md");
+
+function styleBlock(source: string): string {
+  const match = source.match(/<style[^>]*>([\s\S]*?)<\/style>/);
+  return match?.[1] ?? "";
+}
+
+describe("search dialog motion", () => {
+  const tokens = readFileSync(TOKENS, "utf8");
+  const css = styleBlock(readFileSync(SEARCH, "utf8"));
+  const design = readFileSync(DESIGN, "utf8");
+
+  it("defines modal enter/exit duration tokens", () => {
+    expect(tokens).toMatch(/--duration-modal-enter\s*:\s*200ms/);
+    expect(tokens).toMatch(/--duration-modal-exit\s*:\s*150ms/);
+  });
+
+  it("opens the wide dialog from center scale 0.97 with discrete display", () => {
+    const head = css.slice(0, css.indexOf("@media (max-width: 40rem)"));
+    expect(head).toMatch(/\.site-search\s*\{[^}]*transform:\s*scale\(0\.97\)/s);
+    expect(head).toMatch(/\.site-search\s*\{[^}]*transform-origin:\s*center/s);
+    expect(head).toMatch(/\.site-search\[open\]\s*\{[^}]*transform:\s*scale\(1\)/s);
+    expect(head).toMatch(
+      /\.site-search\s*\{[^}]*display\s+var\(--duration-modal-exit\)\s+allow-discrete/s,
+    );
+    expect(head).toMatch(/\.site-search::backdrop\s*\{[^}]*opacity:\s*0/s);
+    expect(head).toMatch(/\.site-search\[open\]::backdrop\s*\{[^}]*opacity:\s*1/s);
+  });
+
+  it("uses opacity-only motion on the full-viewport dialog", () => {
+    const mobile = css.slice(css.indexOf("@media (max-width: 40rem)"));
+    expect(mobile).toMatch(/\.site-search\s*\{[^}]*transform:\s*none/s);
+    expect(mobile).not.toMatch(/scale\(0\.97\)/);
+  });
+
+  it("names click-opened search in the DESIGN.md motion allowlist", () => {
+    expect(design).toMatch(/click-opened search/i);
+    expect(design).toMatch(/full-viewport/);
+  });
+});

--- a/tests/visual/docs-progressive-search.spec.ts
+++ b/tests/visual/docs-progressive-search.spec.ts
@@ -236,3 +236,27 @@ test("mobile getting-started guide remains contained", async ({ page }) => {
   await expect(page.locator("pre code").first()).toBeVisible();
   await expectNoDocumentOverflow(page);
 });
+
+test("click-opened search uses modal motion when reduced motion is off", async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: "no-preference" });
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await page.goto("/docs?theme=light");
+  await page.getByRole("button", { name: "Search documentation" }).first().click();
+  const dialog = page.locator("dialog.site-search");
+  await expect(dialog).toBeVisible();
+  const wide = await dialog.evaluate((el) => {
+    const style = getComputedStyle(el);
+    return { property: style.transitionProperty, transform: style.transform };
+  });
+  expect(wide.property).toMatch(/opacity/);
+  expect(wide.property).toMatch(/transform/);
+
+  await page.keyboard.press("Escape");
+  await expect(dialog).toBeHidden();
+  await page.setViewportSize({ width: 375, height: 812 });
+  await page.getByRole("button", { name: "Search documentation" }).first().click();
+  await expect(dialog).toBeVisible();
+  const narrow = await dialog.evaluate((el) => getComputedStyle(el).transitionProperty);
+  expect(narrow).toMatch(/opacity/);
+  expect(narrow.split(",").some((part) => part.trim() === "transform")).toBe(false);
+});


### PR DESCRIPTION
## Summary

Search opened from the Search button with no enter or exit. Drawers already slide.

Wide viewports now use a centered `scale(0.97)` modal plus a fading backdrop. At `max-width: 40rem` the dialog is full viewport, so motion is opacity only.

`--duration-modal-enter` is 200ms. `--duration-modal-exit` is 150ms. `DESIGN.md` names this motion.

## Test plan

- [x] `bun test scripts/search-dialog-motion.test.ts` (red, then green)
- [ ] CI journeys: click-opened search motion when reduced motion is off
- [ ] Desktop: Search click scales from center; Escape exit is faster
- [ ] 375px: fade only, no screen shrink
- [ ] `prefers-reduced-motion`: snap