### PR TITLE
docs: fade outgoing static chart shells

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -252,7 +252,8 @@ pill shapes.
   edge-docked drawer enter/exit (`transform` + backdrop opacity), origin-aware popover
   open (opacity + light scale from the trigger), click-opened search dialog (opacity +
   `scale(0.97)` from center on wide viewports; opacity only on the full-viewport dialog),
-  press scale on controls (`scale(0.97)`), and opacity icon crossfades. Shared tokens live
+  press scale on controls (`scale(0.97)`), outgoing static chart-shell fade (live
+  plots snap in; marks do not fade), and opacity icon crossfades. Shared tokens live
   under `:root` in `apps/docs/src/styles/tokens.css` (`--ease-out`, `--ease-drawer`,
   duration tokens). Under `prefers-reduced-motion: reduce` (and VR / visual-test),
   durations collapse — including `::backdrop`, which is not matched by `*`. Meaning never

--- a/apps/docs/src/lib/components/ExampleLiveFrame.svelte
+++ b/apps/docs/src/lib/components/ExampleLiveFrame.svelte
@@ -56,10 +56,20 @@
   let host = $state<HTMLDivElement | null>(null);
   let Live = $state<Component | null>(null);
   let liveReady = $state(false);
+  let shellVisible = $state(true);
   /** True when the user tabbed into the shell; hand focus to .gg-capture on ready. */
   let restoreKeyboardFocus = $state(false);
   let loadStarted = false;
   let cancelled = false;
+
+  function hideShellIfReady(): void {
+    if (liveReady) shellVisible = false;
+  }
+
+  function onPreviewTransitionEnd(event: TransitionEvent): void {
+    if (event.propertyName !== "opacity") return;
+    hideShellIfReady();
+  }
 
   function startLoad(): void {
     if (loadStarted || Live !== null) return;
@@ -173,6 +183,17 @@
     };
   });
 
+  $effect(() => {
+    if (!liveReady) {
+      shellVisible = true;
+      return;
+    }
+    const fallback = window.setTimeout(hideShellIfReady, 250);
+    return () => {
+      window.clearTimeout(fallback);
+    };
+  });
+
   // After keyboard-triggered upgrade, move focus into the plot so Tab order
   // does not jump to <body> when the load button unmounts (#1362).
   // Retry after READY_FALLBACK_MS reveals before the plot has a focus target.
@@ -212,17 +233,21 @@
   onfocusout={onShellFocusOut}
   style={frameStyle}
 >
-  {#if !liveReady}
+  {#if shellVisible}
     <img
       class="example-preview"
       class:under-live={Live !== null}
+      class:fade-out={liveReady}
       src={`${base}${previewPath}`}
       alt={title}
       {width}
       {height}
       decoding="async"
       fetchpriority="high"
+      ontransitionend={onPreviewTransitionEnd}
     />
+  {/if}
+  {#if !liveReady}
     <!-- Stay mounted and focusable while the import resolves (no disabled blur). -->
     <button
       type="button"
@@ -269,6 +294,11 @@
     width: 100%;
     height: auto;
     background: #fff;
+    transition: opacity var(--duration-popover) var(--ease-out);
+  }
+
+  .example-preview.fade-out {
+    opacity: 0;
   }
 
   .example-preview.under-live {

--- a/apps/docs/src/lib/components/ExampleLiveFrame.svelte
+++ b/apps/docs/src/lib/components/ExampleLiveFrame.svelte
@@ -299,6 +299,7 @@
 
   .example-preview.fade-out {
     opacity: 0;
+    pointer-events: none;
   }
 
   .example-preview.under-live {

--- a/apps/docs/src/lib/components/GrammarDemo.svelte
+++ b/apps/docs/src/lib/components/GrammarDemo.svelte
@@ -27,6 +27,8 @@
     typeof import("$lib/components/GrammarDemoPlot.svelte").default | null
   >(null);
   let loadStarted = $state(false);
+  let liveReady = $state(false);
+  let shellVisible = $state(true);
   /** True when the user tabbed into the shell; hand focus to .gg-capture on ready. */
   let restoreKeyboardFocus = $state(false);
 
@@ -38,8 +40,17 @@
     });
   }
 
+  function hideShellIfReady(): void {
+    if (liveReady) shellVisible = false;
+  }
+
+  function onStaticTransitionEnd(event: TransitionEvent): void {
+    if (event.propertyName !== "opacity") return;
+    hideShellIfReady();
+  }
+
   function onShellFocusIn(): void {
-    if (Plot === null) restoreKeyboardFocus = true;
+    if (!liveReady) restoreKeyboardFocus = true;
   }
 
   function onShellFocusOut(event: FocusEvent): void {
@@ -81,10 +92,56 @@
     return observeUserIntent(el, ensureLive);
   });
 
+  const READY_FALLBACK_MS = 10_000;
+  $effect(() => {
+    if (Plot === null || host === null) {
+      liveReady = false;
+      return;
+    }
+    const root = host;
+    const markReady = (): void => {
+      liveReady = true;
+    };
+    const already = root.querySelector('.gg-plot-root[data-gg-ready="true"]');
+    if (already !== null) {
+      markReady();
+      return;
+    }
+    liveReady = false;
+    const observer = new MutationObserver(() => {
+      if (root.querySelector('.gg-plot-root[data-gg-ready="true"]') !== null) {
+        markReady();
+        observer.disconnect();
+      }
+    });
+    observer.observe(root, {
+      attributes: true,
+      attributeFilter: ["data-gg-ready"],
+      subtree: true,
+      childList: true,
+    });
+    const fallback = window.setTimeout(markReady, READY_FALLBACK_MS);
+    return () => {
+      observer.disconnect();
+      window.clearTimeout(fallback);
+    };
+  });
+
+  $effect(() => {
+    if (!liveReady) {
+      shellVisible = true;
+      return;
+    }
+    const fallback = window.setTimeout(hideShellIfReady, 250);
+    return () => {
+      window.clearTimeout(fallback);
+    };
+  });
+
   // After keyboard-triggered upgrade, move focus into the plot so Tab order
   // does not jump to <body> when the load button unmounts (#1362).
   $effect(() => {
-    if (Plot === null || host === null || !restoreKeyboardFocus) return;
+    if (!liveReady || host === null || !restoreKeyboardFocus) return;
     const root = host;
     const tryFocus = (): boolean => {
       if (!focusAfterUpgrade(root)) return false;
@@ -109,23 +166,31 @@
 
 <div
   class="grammar-output"
+  class:live-ready={liveReady}
   bind:this={host}
   onfocusin={onShellFocusIn}
   onfocusout={onShellFocusOut}
 >
-  {#if Plot !== null}
-    <Plot />
-  {:else}
-    <!--
-      theme.js sets data-theme before paint. Mirror contrastChartTheme():
-      fivethirtyeight on the light site, light chart on dark — no theme flash.
-    -->
-    <div class="grammar-static grammar-static--light-site">
-      {@html staticSvgLightSite}
+  {#if shellVisible}
+    <div
+      class="grammar-static-wrap"
+      class:under-live={liveReady}
+      class:fade-out={liveReady}
+      ontransitionend={onStaticTransitionEnd}
+    >
+      <!--
+        theme.js sets data-theme before paint. Mirror contrastChartTheme():
+        fivethirtyeight on the light site, light chart on dark — no theme flash.
+      -->
+      <div class="grammar-static grammar-static--light-site">
+        {@html staticSvgLightSite}
+      </div>
+      <div class="grammar-static grammar-static--dark-site">
+        {@html staticSvgDarkSite}
+      </div>
     </div>
-    <div class="grammar-static grammar-static--dark-site">
-      {@html staticSvgDarkSite}
-    </div>
+  {/if}
+  {#if !liveReady}
     <!-- Stay mounted and focusable while the import resolves (no disabled blur). -->
     <button
       type="button"
@@ -136,6 +201,11 @@
     >
       {loadStarted ? "Loading…" : "Load interactive chart"}
     </button>
+  {/if}
+  {#if Plot !== null}
+    <div class="grammar-live" class:revealed={liveReady}>
+      <Plot />
+    </div>
   {/if}
 </div>
 
@@ -160,6 +230,22 @@
     height: auto;
   }
 
+  .grammar-static-wrap {
+    transition: opacity var(--duration-popover) var(--ease-out);
+  }
+
+  .grammar-static-wrap.under-live {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    overflow: hidden;
+  }
+
+  .grammar-static-wrap.fade-out {
+    opacity: 0;
+    pointer-events: none;
+  }
+
   .grammar-static--dark-site {
     display: none;
   }
@@ -170,6 +256,19 @@
 
   :global(:root[data-theme="dark"]) .grammar-static--dark-site {
     display: block;
+  }
+
+  .grammar-live:not(.revealed) {
+    position: absolute;
+    inset: 0;
+    opacity: 0;
+    pointer-events: none;
+    z-index: 0;
+  }
+
+  .grammar-live.revealed {
+    position: relative;
+    opacity: 1;
   }
 
   .load-interactive {

--- a/scripts/static-to-live-fade.test.ts
+++ b/scripts/static-to-live-fade.test.ts
@@ -25,6 +25,7 @@ describe("static-to-live shell fade", () => {
       /\.example-preview[^{]*\{[^}]*opacity\s+var\(--duration-popover\)\s+var\(--ease-out\)/s,
     );
     expect(css).toMatch(/\.example-preview\.fade-out[^{]*\{[^}]*opacity:\s*0/s);
+    expect(css).toMatch(/\.example-preview\.fade-out[^{]*\{[^}]*pointer-events:\s*none/s);
     expect(css).not.toMatch(/\.live-host[^{]*\{[^}]*transition/s);
   });
 

--- a/scripts/static-to-live-fade.test.ts
+++ b/scripts/static-to-live-fade.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Static chart shells fade out. Live plots snap in so marks do not fade.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "bun:test";
+
+const ROOT = join(import.meta.dir, "..");
+const FRAME = join(ROOT, "apps/docs/src/lib/components/ExampleLiveFrame.svelte");
+const GRAMMAR = join(ROOT, "apps/docs/src/lib/components/GrammarDemo.svelte");
+
+function styleBlock(source: string): string {
+  const match = source.match(/<style[^>]*>([\s\S]*?)<\/style>/);
+  return match?.[1] ?? "";
+}
+
+describe("static-to-live shell fade", () => {
+  const frame = readFileSync(FRAME, "utf8");
+  const grammar = readFileSync(GRAMMAR, "utf8");
+
+  it("fades the example preview, not the live host", () => {
+    const css = styleBlock(frame);
+    expect(css).toMatch(
+      /\.example-preview[^{]*\{[^}]*opacity\s+var\(--duration-popover\)\s+var\(--ease-out\)/s,
+    );
+    expect(css).toMatch(/\.example-preview\.fade-out[^{]*\{[^}]*opacity:\s*0/s);
+    expect(css).not.toMatch(/\.live-host[^{]*\{[^}]*transition/s);
+  });
+
+  it("keeps the example preview until fade-out completes", () => {
+    expect(frame).toMatch(/shellVisible/);
+    expect(frame).toMatch(/ontransitionend/);
+    expect(frame).toMatch(/\{#if shellVisible\}/);
+  });
+
+  it("overlaps GrammarDemo static and live without fading marks", () => {
+    const css = styleBlock(grammar);
+    expect(css).toMatch(
+      /\.grammar-static-wrap[^{]*\{[^}]*opacity\s+var\(--duration-popover\)\s+var\(--ease-out\)/s,
+    );
+    expect(css).toMatch(/\.grammar-static-wrap\.fade-out[^{]*\{[^}]*opacity:\s*0/s);
+    expect(css).not.toMatch(/\.grammar-live[^{]*\{[^}]*transition/s);
+    expect(grammar).toMatch(/liveReady/);
+    expect(grammar).toMatch(/if \(!liveReady\) restoreKeyboardFocus = true/);
+  });
+});


### PR DESCRIPTION
## Summary

Static PNG/SVG shells used to cut to the live plot. The example frame and homepage grammar demo now fade **only the outgoing shell**. The live plot snaps in so marks, axes, and legends do not fade.

Overlap is explicit: the static wrap is absolutely positioned on top while it fades. GrammarDemo waits for `data-gg-ready` before restoring keyboard focus (same as the example frame).

Theme, palette, and sequential labs are out of scope.

## Test plan

- [x] `bun test scripts/static-to-live-fade.test.ts` (red, then green)
- [x] `bun run check:docs`
- [ ] Example detail: Load interactive — PNG fades, live plot does not fade in
- [ ] Homepage grammar demo: same; Tab focus after load lands on `.gg-capture` when ready
- [ ] `prefers-reduced-motion` / `?vr`: cut, not fade