### PR TITLE
fix(inspect): paint flip guides from one remap

### DIFF
--- a/.changeset/inspect-guide-axes-flip.md
+++ b/.changeset/inspect-guide-axes-flip.md
@@ -1,0 +1,5 @@
+---
+"@ggsvelte/svelte": patch
+---
+
+Paint inspect crosshairs from one coord-flip remap so x/y guides stay consistent under flip.

--- a/packages/svelte/src/lib/inspection/inspect-guide-axes.ts
+++ b/packages/svelte/src/lib/inspection/inspect-guide-axes.ts
@@ -1,0 +1,27 @@
+import type { ResolvedInspectMode } from "../interaction/interaction.js";
+
+export type InspectGuideAxes = {
+  readonly vertical: boolean;
+  readonly horizontal: boolean;
+};
+
+/**
+ * Which screen-space crosshairs an inspect mode paints.
+ * `coord_flip` swaps x/y guides; exact paints none; xy paints both.
+ */
+export function inspectGuideAxes(mode: ResolvedInspectMode, flipped: boolean): InspectGuideAxes {
+  switch (mode) {
+    case "exact":
+      return { vertical: false, horizontal: false };
+    case "xy":
+      return { vertical: true, horizontal: true };
+    case "x":
+      return flipped
+        ? { vertical: false, horizontal: true }
+        : { vertical: true, horizontal: false };
+    case "y":
+      return flipped
+        ? { vertical: true, horizontal: false }
+        : { vertical: false, horizontal: true };
+  }
+}

--- a/packages/svelte/src/lib/inspection/inspect-guide-axes.ts
+++ b/packages/svelte/src/lib/inspection/inspect-guide-axes.ts
@@ -23,5 +23,9 @@ export function inspectGuideAxes(mode: ResolvedInspectMode, flipped: boolean): I
       return flipped
         ? { vertical: true, horizontal: false }
         : { vertical: false, horizontal: true };
+    default: {
+      const unexpected: never = mode;
+      throw new TypeError(`unexpected inspect mode ${String(unexpected)}`);
+    }
   }
 }

--- a/packages/svelte/src/lib/scene/InteractionOverlay.svelte
+++ b/packages/svelte/src/lib/scene/InteractionOverlay.svelte
@@ -10,6 +10,7 @@
     PresentationAnchor,
     PresentationChrome,
   } from "../selection/selection.js";
+  import { inspectGuideAxes } from "../inspection/inspect-guide-axes.js";
   import {
     crosshairGapForBox,
     gappedCrosshairSegmentsWithObstacles,
@@ -122,6 +123,11 @@
         )
       : [],
   );
+  const guideAxes = $derived(
+    inspection === null
+      ? { vertical: false, horizontal: false }
+      : inspectGuideAxes(inspection.mode, coordFlipped),
+  );
 </script>
 
 <svg
@@ -132,7 +138,7 @@
   aria-hidden="true"
 >
   {#if interactive && inspection !== null}
-    {#if inspection.mode === "xy" || (inspection.mode === "x" && !coordFlipped) || (inspection.mode === "y" && coordFlipped)}
+    {#if guideAxes.vertical}
       {#if inspectionPanel}
         {#each verticalCrosshair as segment, i (`v-${i}`)}
           <line
@@ -153,7 +159,7 @@
         {/if}
       {/if}
     {/if}
-    {#if inspection.mode === "xy" || (inspection.mode === "y" && !coordFlipped) || (inspection.mode === "x" && coordFlipped)}
+    {#if guideAxes.horizontal}
       {#if inspectionPanel}
         {#each horizontalCrosshair as segment, i (`h-${i}`)}
           <line

--- a/packages/svelte/tests/inspection/inspect-guide-axes.test.ts
+++ b/packages/svelte/tests/inspection/inspect-guide-axes.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { inspectGuideAxes } from "../../src/lib/inspection/inspect-guide-axes.js";
+import type { ResolvedInspectMode } from "../../src/lib/interaction/interaction.js";
+
+const cases: readonly {
+  mode: ResolvedInspectMode;
+  flipped: boolean;
+  vertical: boolean;
+  horizontal: boolean;
+}[] = [
+  { mode: "exact", flipped: false, vertical: false, horizontal: false },
+  { mode: "exact", flipped: true, vertical: false, horizontal: false },
+  { mode: "x", flipped: false, vertical: true, horizontal: false },
+  { mode: "x", flipped: true, vertical: false, horizontal: true },
+  { mode: "y", flipped: false, vertical: false, horizontal: true },
+  { mode: "y", flipped: true, vertical: true, horizontal: false },
+  { mode: "xy", flipped: false, vertical: true, horizontal: true },
+  { mode: "xy", flipped: true, vertical: true, horizontal: true },
+];
+
+describe("inspectGuideAxes", () => {
+  it.each(cases)(
+    "$mode flipped=$flipped → vertical=$vertical horizontal=$horizontal",
+    ({ mode, flipped, vertical, horizontal }) => {
+      expect(inspectGuideAxes(mode, flipped)).toEqual({ vertical, horizontal });
+    },
+  );
+});

--- a/packages/svelte/tests/inspection/pointer-inspect-queue.test.ts
+++ b/packages/svelte/tests/inspection/pointer-inspect-queue.test.ts
@@ -319,6 +319,59 @@ describe("createPointerInspectQueue", () => {
     barModel.dispose();
   });
 
+  it("does not teleport between qq_line endpoints mid-stroke under coord_flip auto", () => {
+    const qqModel = runPipeline(
+      gg(
+        [
+          { value: 1.1 },
+          { value: 2.0 },
+          { value: 2.6 },
+          { value: 3.1 },
+          { value: 3.4 },
+          { value: 3.9 },
+          { value: 4.2 },
+          { value: 4.8 },
+          { value: 5.3 },
+          { value: 5.9 },
+          { value: 6.7 },
+          { value: 8.1 },
+        ],
+        aes({ sample: "value" }),
+      )
+        .geomQqLine({ linewidth: 3.2 })
+        .coordFlip()
+        .spec(),
+      { width: 640, height: 400 },
+    );
+    expect(qqModel.candidates.size).toBe(2);
+    const left = qqModel.candidates.candidate(0)!;
+    const right = qqModel.candidates.candidate(1)!;
+    const midX = (left.x + right.x) / 2;
+    const midY = (left.y + right.y) / 2;
+    const queued: QueuedInspect[] = [];
+    const queue = createPointerInspectQueue({
+      model: () => qqModel,
+      reducer: () =>
+        makeReducer({
+          frameToken: () => token(21),
+          queuePointer: (action) => {
+            if (action.type === "inspect") queued.push(action);
+          },
+        }),
+      inspectionState: () => "none",
+      setInspection: noopCancel,
+    });
+    queue.schedule({
+      point: { x: midX, y: midY },
+      source: "pointer",
+      mode: "auto",
+      maxDistance: 24,
+    });
+    // Flip must not invent a second hit authority: mid-stroke stays quiet.
+    expect(queued[0]?.candidate ?? null).toBeNull();
+    qqModel.dispose();
+  });
+
   it("does not teleport between qq_line endpoints mid-stroke under mode x or auto", () => {
     // Regression: nearest(mode=x) misses mid-line (anchor maxDistance), then
     // hitTest returned the path stroke and flipped left/right endpoints.

--- a/packages/svelte/tests/scene/interaction-overlay-gaps.test.ts
+++ b/packages/svelte/tests/scene/interaction-overlay-gaps.test.ts
@@ -21,17 +21,21 @@ function emptyDatum(anchor: { x: number; y: number }) {
   };
 }
 
-function xyInspection(focus: { x: number; y: number }) {
+function modeInspection(mode: "exact" | "x" | "y" | "xy", focus: { x: number; y: number }) {
   return {
     type: "inspect" as const,
     phase: "change" as const,
     state: "transient" as const,
     source: "keyboard" as const,
     panelId: "p0",
-    mode: "xy" as const,
+    mode,
     focus: emptyDatum(focus),
     members: [emptyDatum(focus)] as const,
   };
+}
+
+function xyInspection(focus: { x: number; y: number }) {
+  return modeInspection("xy", focus);
 }
 
 describe("InteractionOverlay crosshair glyph gaps (#1207)", () => {
@@ -156,5 +160,45 @@ describe("InteractionOverlay glyph box chrome", () => {
     expect(Number(selectedBox?.getAttribute("width"))).toBe(selected.width);
     expect(Number(emphasizedBox?.getAttribute("x"))).toBeCloseTo(expectedEmphasized.x, 5);
     expect(Number(emphasizedBox?.getAttribute("width"))).toBe(emphasized.width);
+  });
+});
+
+describe("InteractionOverlay inspect guide axes", () => {
+  const panel = { x: 40, y: 20, width: 200, height: 160 };
+  const focus = { x: 120, y: 100 };
+
+  function countGuides(mode: "exact" | "x" | "y" | "xy", coordFlipped: boolean) {
+    const { container } = render(InteractionOverlay, {
+      width: 280,
+      height: 220,
+      interactive: true,
+      inspection: modeInspection(mode, focus),
+      inspectionPanel: panel,
+      coordFlipped,
+      hoverChrome: "none",
+    });
+    const lines = [...container.querySelectorAll<SVGLineElement>(".gg-crosshair")];
+    const vertical = lines.filter(
+      (line) => Number(line.getAttribute("x1")) === Number(line.getAttribute("x2")),
+    ).length;
+    const horizontal = lines.filter(
+      (line) => Number(line.getAttribute("y1")) === Number(line.getAttribute("y2")),
+    ).length;
+    return { vertical, horizontal };
+  }
+
+  it("paints no guides for exact, both for xy, and swaps x/y under flip", () => {
+    expect(countGuides("exact", false)).toEqual({ vertical: 0, horizontal: 0 });
+    expect(countGuides("exact", true)).toEqual({ vertical: 0, horizontal: 0 });
+    expect(countGuides("xy", false).vertical).toBeGreaterThan(0);
+    expect(countGuides("xy", false).horizontal).toBeGreaterThan(0);
+    expect(countGuides("x", false).vertical).toBeGreaterThan(0);
+    expect(countGuides("x", false).horizontal).toBe(0);
+    expect(countGuides("x", true).vertical).toBe(0);
+    expect(countGuides("x", true).horizontal).toBeGreaterThan(0);
+    expect(countGuides("y", false).vertical).toBe(0);
+    expect(countGuides("y", false).horizontal).toBeGreaterThan(0);
+    expect(countGuides("y", true).vertical).toBeGreaterThan(0);
+    expect(countGuides("y", true).horizontal).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

`InteractionOverlay` remapped inspect x/y crosshairs under `coord_flip` with two boolean conditions. That policy now lives in `inspectGuideAxes`. Overlay paints from that result.

Advisories still fire on data-x (#1409). Pointer rescue still ignores flip: a flipped `qq_line` mid-stroke does not invent a second hit.

## Verification

- `bun run --bun test:browser -- --project chromium tests/inspection/inspect-guide-axes.test.ts tests/scene/interaction-overlay-gaps.test.ts tests/inspection/pointer-inspect-queue.test.ts` in `packages/svelte` — 19 pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1618" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->