### PR TITLE
fix(spec): reject temporal guides on band scales at render

### DIFF
--- a/.changeset/temporal-guide-type-mismatch.md
+++ b/.changeset/temporal-guide-type-mismatch.md
@@ -1,0 +1,6 @@
+---
+"@ggsvelte/spec": patch
+"@ggsvelte/core": patch
+---
+
+Reject temporal break and label options on an explicit band scale during render, matching validate().

--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -12381,8 +12381,8 @@ export const DOCS_ROUTES = [
         level: 2,
       },
       {
-        id: "experimental-925",
-        title: "experimental (925)",
+        id: "experimental-926",
+        title: "experimental (926)",
         level: 3,
       },
       {

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -20444,14 +20444,14 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["@ggsvelte/spec"],
   },
   {
-    id: "heading:guide-lifecycle:experimental-925",
+    id: "heading:guide-lifecycle:experimental-926",
     kind: "heading",
-    title: "experimental (925)",
+    title: "experimental (926)",
     summary:
-      "experimental (925) in Lifecycle & editions. API stability tags per export, and the defaults-edition mechanism.",
-    href: "/guide/lifecycle#experimental-925",
+      "experimental (926) in Lifecycle & editions. API stability tags per export, and the defaults-edition mechanism.",
+    href: "/guide/lifecycle#experimental-926",
     keywords: ["Lifecycle & editions", "Reference"],
-    exact: ["experimental (925)"],
+    exact: ["experimental (926)"],
   },
   {
     id: "heading:guide-lifecycle:stable-intent-8",
@@ -30971,6 +30971,15 @@ export const DOCS_SEARCH_INDEX = [
     href: "/guide/lifecycle#ggsvelte-spec",
     keywords: ["@ggsvelte/spec", ".", "value", "experimental"],
     exact: ["structuralGateErrors"],
+  },
+  {
+    id: "api:ggsvelte-spec:temporalGuideTypeMismatchError",
+    kind: "api",
+    title: "temporalGuideTypeMismatchError",
+    summary: "@ggsvelte/spec · value · experimental.",
+    href: "/guide/lifecycle#ggsvelte-spec",
+    keywords: ["@ggsvelte/spec", ".", "value", "experimental"],
+    exact: ["temporalGuideTypeMismatchError"],
   },
   {
     id: "api:ggsvelte-spec:temporalIntervalTicks",

--- a/lifecycle.json
+++ b/lifecycle.json
@@ -3676,6 +3676,10 @@
           "kind": "value",
           "lifecycle": "experimental"
         },
+        "temporalGuideTypeMismatchError": {
+          "kind": "value",
+          "lifecycle": "experimental"
+        },
         "temporalIntervalTicks": {
           "kind": "value",
           "lifecycle": "experimental"

--- a/packages/core/src/pipeline/setup-run-normalize.ts
+++ b/packages/core/src/pipeline/setup-run-normalize.ts
@@ -63,6 +63,7 @@ function preflightTemporalLabels(spec: PortableSpec): void {
 }
 
 export function normalizeAndValidateSpec(spec: SpecInput | PortableSpec): NormalizedSpec {
+  const authoredScales = spec.scales as Record<string, unknown> | undefined;
   const normalized = normalize(spec);
   // Preserve the stable pipeline diagnostic before the portable schema rejects
   // the same closed-token violation as a generic shape error.
@@ -72,13 +73,19 @@ export function normalizeAndValidateSpec(spec: SpecInput | PortableSpec): Normal
   assertStructuralGate(normalized);
 
   const temporalScaleErrors: SpecError[] = [];
-  for (const axis of ["x", "y"] as const) {
-    const mismatch = temporalGuideTypeMismatchError(
-      normalized.scales as Record<string, unknown> | undefined,
-      axis,
-    );
-    if (mismatch !== null) temporalScaleErrors.push(mismatch);
-  }
+  const seen = new Set<string>();
+  const collect = (scales: Record<string, unknown> | undefined) => {
+    for (const axis of ["x", "y"] as const) {
+      const mismatch = temporalGuideTypeMismatchError(scales, axis);
+      if (mismatch === null || seen.has(mismatch.path)) continue;
+      seen.add(mismatch.path);
+      temporalScaleErrors.push(mismatch);
+    }
+  };
+  // After normalize first so log→linear reports the canonical type. Then the
+  // authored spec, because normalize strips temporal options from band scales.
+  collect(normalized.scales as Record<string, unknown> | undefined);
+  collect(authoredScales);
   if (temporalScaleErrors.length > 0) throw new SpecValidationError(temporalScaleErrors);
 
   for (const axis of ["x", "y"] as const) {

--- a/packages/core/src/pipeline/setup-run-normalize.ts
+++ b/packages/core/src/pipeline/setup-run-normalize.ts
@@ -11,6 +11,7 @@ import {
   assertStructuralGate,
   normalize,
   SpecValidationError,
+  temporalGuideTypeMismatchError,
   temporalLabelConfigurationError,
   temporalLocaleConfigurationError,
 } from "@ggsvelte/spec";
@@ -70,27 +71,13 @@ export function normalizeAndValidateSpec(spec: SpecInput | PortableSpec): Normal
   // Color scheme / binned-style / guide / coord-facet gates without TypeBox.
   assertStructuralGate(normalized);
 
-  const scaleTypeMismatchCode: SpecError["code"] = "scale-type-mismatch";
   const temporalScaleErrors: SpecError[] = [];
   for (const axis of ["x", "y"] as const) {
-    const config = normalized.scales?.[axis];
-    const hasTemporalGuideOption =
-      config?.dateBreaks !== undefined ||
-      config?.dateMinorBreaks !== undefined ||
-      config?.dateLabels !== undefined ||
-      config?.locale !== undefined ||
-      config?.weekStart !== undefined;
-    if (hasTemporalGuideOption && (config?.type === "linear" || config?.type === "log")) {
-      temporalScaleErrors.push({
-        code: scaleTypeMismatchCode,
-        path: `/scales/${axis}`,
-        message: `scales.${axis} uses temporal break or label options with explicit type "${config.type}".`,
-        fix: {
-          description:
-            'Use type "time", a date/datetime scale helper, or remove the temporal option.',
-        },
-      });
-    }
+    const mismatch = temporalGuideTypeMismatchError(
+      normalized.scales as Record<string, unknown> | undefined,
+      axis,
+    );
+    if (mismatch !== null) temporalScaleErrors.push(mismatch);
   }
   if (temporalScaleErrors.length > 0) throw new SpecValidationError(temporalScaleErrors);
 

--- a/packages/core/src/pipeline/setup-run-normalize.ts
+++ b/packages/core/src/pipeline/setup-run-normalize.ts
@@ -84,7 +84,7 @@ export function normalizeAndValidateSpec(spec: SpecInput | PortableSpec): Normal
   };
   // After normalize first so log→linear reports the canonical type. Then the
   // authored spec, because normalize strips temporal options from band scales.
-  collect(normalized.scales as Record<string, unknown> | undefined);
+  collect(normalized.scales);
   collect(authoredScales);
   if (temporalScaleErrors.length > 0) throw new SpecValidationError(temporalScaleErrors);
 

--- a/packages/core/tests/pipeline-temporal/guides.test.ts
+++ b/packages/core/tests/pipeline-temporal/guides.test.ts
@@ -164,7 +164,7 @@ describe("temporal pipeline: guides", () => {
   });
 
   it("rejects temporal guides on explicitly non-time runtime scales", () => {
-    for (const type of ["linear", "log"] as const) {
+    for (const type of ["linear", "log", "band"] as const) {
       let thrown: unknown;
       try {
         runPipeline(

--- a/packages/spec/src/index.ts
+++ b/packages/spec/src/index.ts
@@ -913,6 +913,7 @@ export { validate } from "./validate.js";
 export type { ValidateResult } from "./validate.js";
 /** TypeBox-free structural gate used by the render pipeline. */
 export { assertStructuralGate, structuralGateErrors } from "./structural-gate.js";
+export { temporalGuideTypeMismatchError } from "./validate-data-checks-position.js";
 export { LINT_CATALOG, lintSpec } from "./lint.js";
 export type { LintAdvisoryCode, LintCatalogEntry, SpecAdvisory } from "./lint.js";
 export { ERROR_CATALOG } from "./errors.js";

--- a/packages/spec/src/normalize-scales.ts
+++ b/packages/spec/src/normalize-scales.ts
@@ -46,9 +46,20 @@ function normalizeColorScale(scale: ColorScaleSpec): ColorScaleSpec {
 
 function normalizePositionScale(scale: PositionScaleSpec): PositionScaleSpec {
   if (scale.type === "band") {
-    // Keep contradictory temporal guide options so the TypeBox-free render
-    // gate can reject them the same way validate() does (band + dateLabels).
-    return { ...scale };
+    const {
+      temporalKind: _,
+      parse: __,
+      parseFailure: ___,
+      timezone: ____,
+      disambiguation: _____,
+      dateBreaks: ______,
+      dateMinorBreaks: _______,
+      dateLabels: ________,
+      locale: _________,
+      weekStart: __________,
+      ...band
+    } = scale;
+    return band;
   }
   // Canonical log10: an authored `type: "log"` (base-10) IS the linear family
   // with the log10 transform. A conflicting explicit transform (identity/sqrt)

--- a/packages/spec/src/normalize-scales.ts
+++ b/packages/spec/src/normalize-scales.ts
@@ -46,20 +46,9 @@ function normalizeColorScale(scale: ColorScaleSpec): ColorScaleSpec {
 
 function normalizePositionScale(scale: PositionScaleSpec): PositionScaleSpec {
   if (scale.type === "band") {
-    const {
-      temporalKind: _,
-      parse: __,
-      parseFailure: ___,
-      timezone: ____,
-      disambiguation: _____,
-      dateBreaks: ______,
-      dateMinorBreaks: _______,
-      dateLabels: ________,
-      locale: _________,
-      weekStart: __________,
-      ...band
-    } = scale;
-    return band;
+    // Keep contradictory temporal guide options so the TypeBox-free render
+    // gate can reject them the same way validate() does (band + dateLabels).
+    return { ...scale };
   }
   // Canonical log10: an authored `type: "log"` (base-10) IS the linear family
   // with the log10 transform. A conflicting explicit transform (identity/sqrt)

--- a/packages/spec/src/validate-data-checks-position.ts
+++ b/packages/spec/src/validate-data-checks-position.ts
@@ -27,6 +27,40 @@ import {
 
 const AXIS_CHANNELS = ["x", "y"] as const;
 
+const NON_TIME_TYPES_WITH_TEMPORAL_GUIDES = new Set(["band", "linear", "log"]);
+
+/**
+ * Temporal break/label options on an explicit non-time scale.
+ * Shared by agent `validate()` and the TypeBox-free render gate.
+ */
+export function temporalGuideTypeMismatchError(
+  scales: Record<string, unknown> | undefined,
+  axis: "x" | "y",
+): SpecError | null {
+  const config = scales?.[axis] as PositionScaleSpec | undefined;
+  const hasGuideTemporalOption =
+    config?.dateBreaks !== undefined ||
+    config?.dateMinorBreaks !== undefined ||
+    config?.dateLabels !== undefined ||
+    config?.locale !== undefined ||
+    config?.weekStart !== undefined;
+  if (
+    !hasGuideTemporalOption ||
+    config?.type === undefined ||
+    !NON_TIME_TYPES_WITH_TEMPORAL_GUIDES.has(config.type)
+  ) {
+    return null;
+  }
+  return {
+    code: "scale-type-mismatch",
+    path: `/scales/${axis}`,
+    message: `scales.${axis} uses temporal break or label options with explicit type "${config.type}".`,
+    fix: {
+      description: 'Use type "time", a date/datetime scale helper, or remove the temporal option.',
+    },
+  };
+}
+
 /** True when the axis scale config requests temporal semantics (not band). */
 export function scaleRequestsTime(
   scales: Record<string, unknown> | undefined,
@@ -62,26 +96,10 @@ export function validateTemporalAxisConfiguration(scales: Record<string, unknown
   const invalidTemporalAxes = new Set<"x" | "y">();
   for (const axis of AXIS_CHANNELS) {
     const config = scales?.[axis] as PositionScaleSpec | undefined;
-    const hasGuideTemporalOption =
-      config?.dateBreaks !== undefined ||
-      config?.dateMinorBreaks !== undefined ||
-      config?.dateLabels !== undefined ||
-      config?.locale !== undefined ||
-      config?.weekStart !== undefined;
-    if (
-      hasGuideTemporalOption &&
-      (config?.type === "band" || config?.type === "linear" || config?.type === "log")
-    ) {
+    const mismatch = temporalGuideTypeMismatchError(scales, axis);
+    if (mismatch !== null) {
       invalidTemporalAxes.add(axis);
-      errors.push({
-        code: "scale-type-mismatch",
-        path: `/scales/${axis}`,
-        message: `scales.${axis} uses temporal break or label options with explicit type "${config.type}".`,
-        fix: {
-          description:
-            'Use type "time", a date/datetime scale helper, or remove the temporal option.',
-        },
-      });
+      errors.push(mismatch);
       continue;
     }
     if (config?.type === "band" || !scaleRequestsTime(scales, axis)) continue;


### PR DESCRIPTION
## Summary

`validate()` rejected temporal break and label options on an explicit band, linear, or log scale. The render path only rejected linear and log, because normalize stripped those options from band scales.

One `temporalGuideTypeMismatchError` check now serves both paths. Normalize keeps the contradictory band options so the TypeBox-free render gate can see them. TypeBox stays off the render path.

## Verification

- `bun test packages/core/tests/pipeline-temporal/guides.test.ts packages/spec/tests/temporal-scale-schema.test.ts packages/spec/tests/validate-tier2-temporal-position.test.ts packages/spec/tests/validate-tier2-temporal-reuse.test.ts` — pass
- `bun scripts/gen-lifecycle.ts --check` — current
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1619" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->