### PR TITLE
fix(inspect): fade tooltip first appear and last leave

### DIFF
--- a/.changeset/tooltip-enter-leave-opacity.md
+++ b/.changeset/tooltip-enter-leave-opacity.md
@@ -1,0 +1,7 @@
+---
+"@ggsvelte/svelte": patch
+---
+
+Inspection tooltips fade in on first appear and fade out on last leave. Hover follow and misses between marks stay instant.
+
+Migration: none — internal tooltip chrome

--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -352,6 +352,7 @@
           queueTooltipSync();
         }}
         onBlur={(event) => {
+          pendingExplicitClose = true;
           surfaceState.onSurfaceBlur(event);
           queueTooltipSync();
         }}
@@ -386,6 +387,7 @@
           queueTooltipSync();
         }}
         onKeyDown={(event) => {
+          if (event.key === "Escape") pendingExplicitClose = true;
           surfaceState.onSurfaceKeyDown(event);
           queueTooltipSync();
         }}
@@ -445,6 +447,7 @@
           inspection={ghostInspection}
           width={ghostSize.width}
           height={ghostSize.height}
+          content={engine.interactionConfig.inspect?.content}
           docked={isTooltipDocked({
             inspectionState: ghostInspection.state,
             widthPx: runtime.resolvedWidth,

--- a/packages/svelte/src/lib/GGPlot.svelte
+++ b/packages/svelte/src/lib/GGPlot.svelte
@@ -39,7 +39,16 @@
   import type { CellValue } from "@ggsvelte/core";
   import { sceneLabel } from "@ggsvelte/core";
 
-  import type { ZoomDomains } from "./interaction/interaction.js";
+  import type {
+    PlotInspectionChange,
+    ZoomDomains,
+  } from "./interaction/interaction.js";
+  import {
+    TOOLTIP_MOTION_MS,
+    prefersReducedMotion,
+    resolveTooltipDismissReason,
+    resolveTooltipMotion,
+  } from "./inspection/tooltip-motion.js";
   import { provideRegistry } from "./geoms/registry.svelte.js";
   import { shouldRenderInteractionLiveRegion } from "./legend/surface.js";
   import { resolveInteractionLiveText } from "./assembly/labels.js";
@@ -101,6 +110,88 @@
     chromeState,
     announcer,
   } = engine;
+
+  const tooltipSession = { active: false };
+  let pointerOnCapture = false;
+  let pendingExplicitClose = false;
+  let lastLiveInspection: PlotInspectionChange<
+    Record<string, CellValue>,
+    PropertyKey
+  > | null = null;
+  let ghostInspection = $state<PlotInspectionChange<
+    Record<string, CellValue>,
+    PropertyKey
+  > | null>(null);
+  const ghostEpoch = { n: 0 };
+  let ghostTimer: ReturnType<typeof setTimeout> | undefined;
+  let hadLiveInspection = false;
+  let tooltipSyncFrame = 0;
+
+  function chartReducedMotion(): boolean {
+    if (typeof matchMedia !== "function") return false;
+    return prefersReducedMotion(matchMedia("(prefers-reduced-motion: reduce)"));
+  }
+
+  function clearTooltipGhost(generation: number): void {
+    if (generation !== ghostEpoch.n) return;
+    ghostInspection = null;
+    if (ghostTimer !== undefined) {
+      clearTimeout(ghostTimer);
+      ghostTimer = undefined;
+    }
+  }
+
+  function startTooltipGhost(
+    snapshot: PlotInspectionChange<Record<string, CellValue>, PropertyKey>,
+  ): void {
+    ghostEpoch.n += 1;
+    const generation = ghostEpoch.n;
+    ghostInspection = snapshot;
+    if (ghostTimer !== undefined) clearTimeout(ghostTimer);
+    ghostTimer = setTimeout(
+      () => clearTooltipGhost(generation),
+      TOOLTIP_MOTION_MS + 50,
+    );
+  }
+
+  function queueTooltipSync(): void {
+    if (tooltipSyncFrame !== 0) return;
+    tooltipSyncFrame = requestAnimationFrame(() => {
+      tooltipSyncFrame = 0;
+      syncTooltipPresence();
+    });
+  }
+
+  function syncTooltipPresence(): void {
+    const current = inspectionState.inspection;
+    const present = current !== null;
+    if (current !== null) lastLiveInspection = current;
+    if (present === hadLiveInspection) return;
+    hadLiveInspection = present;
+    if (present) {
+      const next = resolveTooltipMotion({
+        reason: "hit",
+        sessionActive: tooltipSession.active,
+        reducedMotion: chartReducedMotion(),
+      });
+      tooltipSession.active = next.sessionActive;
+      clearTooltipGhost(ghostEpoch.n);
+      return;
+    }
+    const reason = resolveTooltipDismissReason({
+      explicitClose: pendingExplicitClose,
+      pointerOnCapture,
+    });
+    pendingExplicitClose = false;
+    const next = resolveTooltipMotion({
+      reason,
+      sessionActive: tooltipSession.active,
+      reducedMotion: chartReducedMotion(),
+    });
+    tooltipSession.active = next.sessionActive;
+    if (next.phase === "exit" && lastLiveInspection !== null)
+      startTooltipGhost(lastLiveInspection);
+  }
 
   /**
    * Clear committed grow-mode scale state and any brush zoom so the next
@@ -258,16 +349,46 @@
         })}
         onFocus={() => {
           if (inspectionState.inspection === null) inspectionState.navigate(1);
+          queueTooltipSync();
         }}
-        onBlur={surfaceState.onSurfaceBlur}
-        onPointerMove={surfaceState.onPointerMove}
-        onPointerLeave={surfaceState.onPointerLeave}
-        onPointerDown={surfaceState.onPointerDown}
-        onPointerUp={surfaceState.onPointerUp}
-        onPointerCancel={surfaceState.onPointerCancel}
-        onLostPointerCapture={surfaceState.onLostPointerCapture}
-        onClick={surfaceState.onCaptureClick}
-        onKeyDown={surfaceState.onSurfaceKeyDown}
+        onBlur={(event) => {
+          surfaceState.onSurfaceBlur(event);
+          queueTooltipSync();
+        }}
+        onPointerMove={(event) => {
+          pointerOnCapture = true;
+          surfaceState.onPointerMove(event);
+          queueTooltipSync();
+        }}
+        onPointerLeave={() => {
+          pointerOnCapture = false;
+          surfaceState.onPointerLeave();
+          queueMicrotask(queueTooltipSync);
+        }}
+        onPointerDown={(event) => {
+          surfaceState.onPointerDown(event);
+          queueTooltipSync();
+        }}
+        onPointerUp={(event) => {
+          surfaceState.onPointerUp(event);
+          queueTooltipSync();
+        }}
+        onPointerCancel={() => {
+          surfaceState.onPointerCancel();
+          queueTooltipSync();
+        }}
+        onLostPointerCapture={() => {
+          surfaceState.onLostPointerCapture();
+          queueTooltipSync();
+        }}
+        onClick={(event) => {
+          surfaceState.onCaptureClick(event);
+          queueTooltipSync();
+        }}
+        onKeyDown={(event) => {
+          surfaceState.onSurfaceKeyDown(event);
+          queueTooltipSync();
+        }}
         onDblClick={zoomState.onDblClick}
       />
       {#if inspectionState.inspection !== null}
@@ -290,6 +411,9 @@
             inspectionState: currentInspection.state,
             widthPx: runtime.resolvedWidth,
           })}
+          motion={!tooltipSession.active && !chartReducedMotion()
+            ? "enter"
+            : "none"}
           labs={engine.assembled?.labs ?? null}
           fontSizePx={currentModel.scene.theme.fontSize}
           pin={engine.interactionConfig.inspect?.pin ?? true}
@@ -300,8 +424,38 @@
             engine.tooltipHovered = false;
             if (inspectionState.inspection?.state !== "pinned")
               inspectionState.setInspection(null, "pointer");
+            queueTooltipSync();
           }}
-          onclose={(source) => inspectionState.closeInspection(source, true)}
+          onclose={(source) => {
+            pendingExplicitClose = true;
+            inspectionState.closeInspection(source, true);
+            queueTooltipSync();
+          }}
+        />
+      {/if}
+      {#if ghostInspection !== null}
+        {@const ghostSize = tooltipViewportSize({
+          sceneWidth: currentModel.scene.width,
+          sceneHeight: currentModel.scene.height,
+          clientWidth: root?.clientWidth,
+          clientHeight: root?.clientHeight,
+        })}
+        {@const ghostGenerationAtMount = ghostEpoch.n}
+        <Tooltip
+          inspection={ghostInspection}
+          width={ghostSize.width}
+          height={ghostSize.height}
+          docked={isTooltipDocked({
+            inspectionState: ghostInspection.state,
+            widthPx: runtime.resolvedWidth,
+          })}
+          motion="exit"
+          labs={engine.assembled?.labs ?? null}
+          fontSizePx={currentModel.scene.theme.fontSize}
+          pin={engine.interactionConfig.inspect?.pin ?? true}
+          tooltipBorder={currentModel.scene.theme.tooltipBorder}
+          axisFormatters={currentModel.axisFormatters}
+          onexited={() => clearTooltipGhost(ghostGenerationAtMount)}
         />
       {/if}
     {/if}

--- a/packages/svelte/src/lib/inspection/Tooltip.svelte
+++ b/packages/svelte/src/lib/inspection/Tooltip.svelte
@@ -24,8 +24,10 @@
     onclose,
     onenter,
     onleave,
+    onexited,
     id,
     docked = false,
+    motion = "none",
     labs = null,
     fontSizePx = 12.5,
     /** Whether inspect pinning is enabled (drives instructional footers). */
@@ -51,8 +53,10 @@
     onclose?: (source: "pointer" | "keyboard") => void;
     onenter?: () => void;
     onleave?: () => void;
+    onexited?: () => void;
     id?: string;
     docked?: boolean;
+    motion?: "enter" | "none" | "exit";
     /** Plot labs used for default tooltip field labels (#752). */
     labs?: TooltipFieldLabs | null;
     /**
@@ -167,29 +171,46 @@
   const showStackTotal = $derived(
     stackTotal !== null && displayMembers.length > 1,
   );
+
+  const departing = $derived(motion === "exit");
+  const liveInteractive = $derived(
+    !departing && interactive && inspection.state === "pinned",
+  );
 </script>
 
 <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
 <div
   bind:this={tooltipElement}
-  {id}
-  class="gg-tooltip"
-  class:gg-tooltip-interactive={interactive}
-  class:gg-tooltip-pinned={inspection.state === "pinned"}
+  id={departing ? undefined : id}
+  class={departing ? "gg-tooltip-ghost" : "gg-tooltip"}
+  class:gg-tooltip-interactive={!departing && interactive}
+  class:gg-tooltip-pinned={!departing && inspection.state === "pinned"}
   class:gg-tooltip-docked={docked}
+  data-gg-tooltip-motion={motion === "enter" ? "enter" : undefined}
   {style}
-  role={interactive && inspection.state === "pinned" ? "dialog" : "tooltip"}
-  tabindex={interactive && inspection.state === "pinned" ? -1 : undefined}
-  aria-label={interactive && inspection.state === "pinned"
-    ? "Data inspection"
-    : undefined}
-  onpointerenter={onenter}
-  onpointerleave={onleave}
-  onkeydown={(event) => {
-    if (event.key === "Escape") {
-      event.stopPropagation();
-      onclose?.("keyboard");
-    }
+  role={liveInteractive ? "dialog" : departing ? undefined : "tooltip"}
+  tabindex={liveInteractive ? -1 : undefined}
+  aria-label={liveInteractive ? "Data inspection" : undefined}
+  aria-hidden={departing ? true : undefined}
+  inert={departing ? true : undefined}
+  onpointerenter={departing ? undefined : onenter}
+  onpointerleave={departing ? undefined : onleave}
+  onkeydown={departing
+    ? undefined
+    : (event) => {
+        if (event.key === "Escape") {
+          event.stopPropagation();
+          onclose?.("keyboard");
+        }
+      }}
+  ontransitionend={(event) => {
+    if (
+      motion !== "exit" ||
+      event.target !== event.currentTarget ||
+      event.propertyName !== "opacity"
+    )
+      return;
+    onexited?.();
   }}
 >
   {#if content !== undefined}
@@ -233,13 +254,14 @@
       <p class="gg-tooltip-hint">Click to pin</p>
     {/if}
   {/if}
-  {#if inspection.state === "pinned" && interactive}
+  {#if liveInteractive}
     <button type="button" onclick={() => onclose?.("pointer")}>Close</button>
   {/if}
 </div>
 
 <style>
-  .gg-tooltip {
+  .gg-tooltip,
+  .gg-tooltip-ghost {
     position: absolute;
     pointer-events: none;
     z-index: auto;
@@ -279,6 +301,22 @@
     overflow-wrap: anywhere;
     box-shadow: var(--gg-tooltip-shadow, none);
     user-select: text;
+  }
+
+  .gg-tooltip[data-gg-tooltip-motion="enter"],
+  .gg-tooltip-ghost {
+    transition: opacity 160ms cubic-bezier(0.23, 1, 0.32, 1);
+  }
+
+  .gg-tooltip[data-gg-tooltip-motion="enter"] {
+    @starting-style {
+      opacity: 0;
+    }
+  }
+
+  .gg-tooltip-ghost {
+    opacity: 0;
+    pointer-events: none;
   }
 
   .gg-tooltip-docked {
@@ -361,7 +399,8 @@
   }
 
   @media (forced-colors: active) {
-    .gg-tooltip {
+    .gg-tooltip,
+    .gg-tooltip-ghost {
       border-color: CanvasText;
       background: Canvas;
       color: CanvasText;

--- a/packages/svelte/src/lib/inspection/Tooltip.svelte
+++ b/packages/svelte/src/lib/inspection/Tooltip.svelte
@@ -317,6 +317,9 @@
   .gg-tooltip-ghost {
     opacity: 0;
     pointer-events: none;
+    @starting-style {
+      opacity: 1;
+    }
   }
 
   .gg-tooltip-docked {

--- a/packages/svelte/src/lib/inspection/tooltip-motion.ts
+++ b/packages/svelte/src/lib/inspection/tooltip-motion.ts
@@ -1,0 +1,48 @@
+/**
+ * Tooltip first-appear / last-leave motion policy.
+ *
+ * Hover follow and miss-between-marks stay instant. Short opacity is the
+ * only allowed chart-chrome motion (DESIGN.md). Scale is not used.
+ */
+
+export const TOOLTIP_MOTION_MS = 160;
+export const TOOLTIP_EASE = "cubic-bezier(0.23, 1, 0.32, 1)";
+
+export type TooltipMotionReason = "hit" | "miss-on-plot" | "leave-plot" | "close";
+
+export type TooltipMotionPhase = "enter" | "none" | "exit";
+
+export function prefersReducedMotion(
+  media: { readonly matches: boolean } | null | undefined,
+): boolean {
+  return media?.matches === true;
+}
+
+export function resolveTooltipDismissReason(input: {
+  readonly explicitClose: boolean;
+  readonly pointerOnCapture: boolean;
+}): "miss-on-plot" | "leave-plot" | "close" {
+  if (input.explicitClose) return "close";
+  if (input.pointerOnCapture) return "miss-on-plot";
+  return "leave-plot";
+}
+
+export function resolveTooltipMotion(input: {
+  readonly reason: TooltipMotionReason;
+  readonly sessionActive: boolean;
+  readonly reducedMotion: boolean;
+}): {
+  readonly phase: TooltipMotionPhase;
+  readonly sessionActive: boolean;
+} {
+  if (input.reason === "hit") {
+    if (input.reducedMotion || input.sessionActive) return { phase: "none", sessionActive: true };
+    return { phase: "enter", sessionActive: true };
+  }
+  if (input.reason === "miss-on-plot") {
+    return { phase: "none", sessionActive: input.sessionActive };
+  }
+  // leave-plot | close
+  if (input.sessionActive && !input.reducedMotion) return { phase: "exit", sessionActive: false };
+  return { phase: "none", sessionActive: false };
+}

--- a/packages/svelte/tests/inspection/tooltip-motion-policy.test.ts
+++ b/packages/svelte/tests/inspection/tooltip-motion-policy.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Pure unit tests for inspection/tooltip-motion.ts.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  TOOLTIP_EASE,
+  TOOLTIP_MOTION_MS,
+  prefersReducedMotion,
+  resolveTooltipDismissReason,
+  resolveTooltipMotion,
+  type TooltipMotionReason,
+} from "../../src/lib/inspection/tooltip-motion.js";
+
+describe("tooltip motion constants", () => {
+  it("locks the chart-chrome opacity budget", () => {
+    expect(TOOLTIP_MOTION_MS).toBe(160);
+    expect(TOOLTIP_EASE).toBe("cubic-bezier(0.23, 1, 0.32, 1)");
+  });
+});
+
+describe("prefersReducedMotion", () => {
+  it("is false when matchMedia is missing or does not match", () => {
+    expect(prefersReducedMotion(null)).toBe(false);
+    expect(prefersReducedMotion(undefined)).toBe(false);
+    expect(prefersReducedMotion({ matches: false })).toBe(false);
+  });
+
+  it("is true only when the query matches", () => {
+    expect(prefersReducedMotion({ matches: true })).toBe(true);
+  });
+});
+
+describe("resolveTooltipDismissReason", () => {
+  it("treats Close and Escape as close", () => {
+    expect(
+      resolveTooltipDismissReason({
+        explicitClose: true,
+        pointerOnCapture: true,
+      }),
+    ).toBe("close");
+    expect(
+      resolveTooltipDismissReason({
+        explicitClose: true,
+        pointerOnCapture: false,
+      }),
+    ).toBe("close");
+  });
+
+  it("treats a null inspection while the pointer is on the plot as a miss", () => {
+    expect(
+      resolveTooltipDismissReason({
+        explicitClose: false,
+        pointerOnCapture: true,
+      }),
+    ).toBe("miss-on-plot");
+  });
+
+  it("treats a null inspection after the pointer left the plot as leave", () => {
+    expect(
+      resolveTooltipDismissReason({
+        explicitClose: false,
+        pointerOnCapture: false,
+      }),
+    ).toBe("leave-plot");
+  });
+});
+
+describe("resolveTooltipMotion", () => {
+  const rows: ReadonlyArray<{
+    reason: TooltipMotionReason;
+    sessionIn: boolean;
+    reducedMotion: boolean;
+    phase: "enter" | "none" | "exit";
+    sessionOut: boolean;
+  }> = [
+    {
+      reason: "hit",
+      sessionIn: false,
+      reducedMotion: false,
+      phase: "enter",
+      sessionOut: true,
+    },
+    {
+      reason: "hit",
+      sessionIn: true,
+      reducedMotion: false,
+      phase: "none",
+      sessionOut: true,
+    },
+    {
+      reason: "hit",
+      sessionIn: false,
+      reducedMotion: true,
+      phase: "none",
+      sessionOut: true,
+    },
+    {
+      reason: "miss-on-plot",
+      sessionIn: true,
+      reducedMotion: false,
+      phase: "none",
+      sessionOut: true,
+    },
+    {
+      reason: "miss-on-plot",
+      sessionIn: false,
+      reducedMotion: false,
+      phase: "none",
+      sessionOut: false,
+    },
+    {
+      reason: "leave-plot",
+      sessionIn: true,
+      reducedMotion: false,
+      phase: "exit",
+      sessionOut: false,
+    },
+    {
+      reason: "leave-plot",
+      sessionIn: true,
+      reducedMotion: true,
+      phase: "none",
+      sessionOut: false,
+    },
+    {
+      reason: "leave-plot",
+      sessionIn: false,
+      reducedMotion: false,
+      phase: "none",
+      sessionOut: false,
+    },
+    {
+      reason: "close",
+      sessionIn: true,
+      reducedMotion: false,
+      phase: "exit",
+      sessionOut: false,
+    },
+    {
+      reason: "close",
+      sessionIn: true,
+      reducedMotion: true,
+      phase: "none",
+      sessionOut: false,
+    },
+  ];
+
+  it("plays enter only on the first hit of a session, and exit only on session end", () => {
+    for (const row of rows) {
+      expect(
+        resolveTooltipMotion({
+          reason: row.reason,
+          sessionActive: row.sessionIn,
+          reducedMotion: row.reducedMotion,
+        }),
+      ).toEqual({
+        phase: row.phase,
+        sessionActive: row.sessionOut,
+      });
+    }
+  });
+});

--- a/packages/svelte/tests/inspection/tooltip-motion-policy.test.ts
+++ b/packages/svelte/tests/inspection/tooltip-motion-policy.test.ts
@@ -22,7 +22,6 @@ describe("tooltip motion constants", () => {
 describe("prefersReducedMotion", () => {
   it("is false when matchMedia is missing or does not match", () => {
     expect(prefersReducedMotion(null)).toBe(false);
-    expect(prefersReducedMotion(undefined)).toBe(false);
     expect(prefersReducedMotion({ matches: false })).toBe(false);
   });
 

--- a/packages/svelte/tests/interaction/tooltip-enter-motion.test.ts
+++ b/packages/svelte/tests/interaction/tooltip-enter-motion.test.ts
@@ -44,9 +44,7 @@ describe("tooltip first-appear and last-leave motion", () => {
 
     pointerMoveAt(capture, first.x, first.y);
     await until(() => container.querySelector(".gg-tooltip") !== null);
-    expect(container.querySelector(".gg-tooltip")?.getAttribute("data-gg-tooltip-motion")).toBe(
-      "enter",
-    );
+    expect(container.querySelector(".gg-tooltip")?.dataset.ggTooltipMotion).toBe("enter");
     expect(container.querySelector(".gg-tooltip-ghost")).toBeNull();
 
     const emptyX = panel.x + 8;
@@ -57,9 +55,7 @@ describe("tooltip first-appear and last-leave motion", () => {
 
     pointerMoveAt(capture, second.x, second.y);
     await until(() => container.querySelector(".gg-tooltip") !== null);
-    expect(
-      container.querySelector(".gg-tooltip")?.getAttribute("data-gg-tooltip-motion"),
-    ).toBeNull();
+    expect(container.querySelector(".gg-tooltip")?.dataset.ggTooltipMotion).toBeUndefined();
 
     capture.dispatchEvent(new PointerEvent("pointerleave", { bubbles: true }));
     await until(

--- a/packages/svelte/tests/interaction/tooltip-enter-motion.test.ts
+++ b/packages/svelte/tests/interaction/tooltip-enter-motion.test.ts
@@ -44,7 +44,8 @@ describe("tooltip first-appear and last-leave motion", () => {
 
     pointerMoveAt(capture, first.x, first.y);
     await until(() => container.querySelector(".gg-tooltip") !== null);
-    expect(container.querySelector(".gg-tooltip")?.dataset.ggTooltipMotion).toBe("enter");
+    const firstTooltip = container.querySelector<HTMLElement>(".gg-tooltip");
+    expect(firstTooltip?.dataset.ggTooltipMotion).toBe("enter");
     expect(container.querySelector(".gg-tooltip-ghost")).toBeNull();
 
     const emptyX = panel.x + 8;
@@ -55,7 +56,8 @@ describe("tooltip first-appear and last-leave motion", () => {
 
     pointerMoveAt(capture, second.x, second.y);
     await until(() => container.querySelector(".gg-tooltip") !== null);
-    expect(container.querySelector(".gg-tooltip")?.dataset.ggTooltipMotion).toBeUndefined();
+    const secondTooltip = container.querySelector<HTMLElement>(".gg-tooltip");
+    expect(secondTooltip?.dataset.ggTooltipMotion).toBeUndefined();
 
     capture.dispatchEvent(new PointerEvent("pointerleave", { bubbles: true }));
     await until(

--- a/packages/svelte/tests/interaction/tooltip-enter-motion.test.ts
+++ b/packages/svelte/tests/interaction/tooltip-enter-motion.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+
+import type { RenderModel } from "@ggsvelte/core";
+import GGPlot from "../../src/lib/GGPlot.svelte";
+import { render } from "../helpers/render.js";
+import { until } from "../helpers/until.js";
+import { requireModel, rows, size } from "./interaction-harness.js";
+
+describe("tooltip first-appear and last-leave motion", () => {
+  function pointerMoveAt(capture: Element, x: number, y: number): void {
+    const rect = capture.getBoundingClientRect();
+    const svg = capture.ownerDocument?.querySelector("svg.gg-plot");
+    const plotW = Number(svg?.getAttribute("width")) || size.width;
+    const plotH = Number(svg?.getAttribute("height")) || size.height;
+    capture.dispatchEvent(
+      new PointerEvent("pointermove", {
+        clientX: rect.left + (x / plotW) * rect.width,
+        clientY: rect.top + (y / plotH) * rect.height,
+        bubbles: true,
+      }),
+    );
+  }
+
+  it("fades in once per session, stays instant between marks, and ghosts on leave", async () => {
+    let model: RenderModel | null = null;
+    const { container } = render(GGPlot, {
+      data: rows,
+      aes: { x: "x", y: "y" },
+      layers: [{ geom: "point", params: { size: 5 } }],
+      inspect: true,
+      onrender: (m: RenderModel) => {
+        model = m;
+      },
+      ...size,
+    });
+    const m = requireModel(model);
+    const scene = m.scene;
+    const panel = scene.panels[0];
+    if (panel === undefined) throw new Error("expected a panel");
+    const first = m.candidates.candidate(0);
+    const second = m.candidates.candidate(1);
+    if (first === null || second === null) throw new Error("expected candidates");
+    const capture = container.querySelector(".gg-capture")!;
+
+    pointerMoveAt(capture, first.x, first.y);
+    await until(() => container.querySelector(".gg-tooltip") !== null);
+    expect(container.querySelector(".gg-tooltip")?.getAttribute("data-gg-tooltip-motion")).toBe(
+      "enter",
+    );
+    expect(container.querySelector(".gg-tooltip-ghost")).toBeNull();
+
+    const emptyX = panel.x + 8;
+    const emptyY = panel.y + 8;
+    pointerMoveAt(capture, emptyX, emptyY);
+    await until(() => container.querySelector(".gg-tooltip") === null);
+    expect(container.querySelector(".gg-tooltip-ghost")).toBeNull();
+
+    pointerMoveAt(capture, second.x, second.y);
+    await until(() => container.querySelector(".gg-tooltip") !== null);
+    expect(
+      container.querySelector(".gg-tooltip")?.getAttribute("data-gg-tooltip-motion"),
+    ).toBeNull();
+
+    capture.dispatchEvent(new PointerEvent("pointerleave", { bubbles: true }));
+    await until(
+      () =>
+        container.querySelector(".gg-tooltip") === null &&
+        container.querySelector(".gg-tooltip-ghost") !== null,
+    );
+    expect(container.querySelector(".gg-tooltip-ghost")?.id ?? "").toBe("");
+
+    const ghost = container.querySelector(".gg-tooltip-ghost")!;
+    ghost.dispatchEvent(
+      new TransitionEvent("transitionend", {
+        propertyName: "opacity",
+        bubbles: true,
+      }),
+    );
+    await until(() => container.querySelector(".gg-tooltip-ghost") === null);
+  });
+});

--- a/scripts/tooltip-motion.test.ts
+++ b/scripts/tooltip-motion.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Chart tooltip first-appear / last-leave is opacity-only. Tokens live next
+ * to the policy module so CSS and policy stay locked together.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "bun:test";
+
+import {
+  TOOLTIP_EASE,
+  TOOLTIP_MOTION_MS,
+} from "../packages/svelte/src/lib/inspection/tooltip-motion.ts";
+
+const ROOT = join(import.meta.dir, "..");
+const TOOLTIP = join(ROOT, "packages/svelte/src/lib/inspection/Tooltip.svelte");
+
+function styleBlock(source: string): string {
+  const match = source.match(/<style[^>]*>([\s\S]*?)<\/style>/);
+  return match?.[1] ?? "";
+}
+
+describe("tooltip motion CSS", () => {
+  const css = styleBlock(readFileSync(TOOLTIP, "utf8"));
+
+  it("fades enter and ghost with the locked opacity budget", () => {
+    const duration = `${TOOLTIP_MOTION_MS}ms`;
+    expect(css).toContain("@starting-style");
+    expect(css).toContain(".gg-tooltip-ghost");
+    expect(css).toContain(`opacity ${duration} ${TOOLTIP_EASE}`);
+    expect(css).toMatch(/data-gg-tooltip-motion=["']enter["']/);
+  });
+
+  it("does not tween left, top, or scale", () => {
+    expect(css).not.toMatch(/transition:[^;]*(left|top)/);
+    expect(css).not.toMatch(/scale\(/);
+  });
+
+  it("applies forced-colors surface rules to the departing ghost", () => {
+    const forced = css.slice(css.indexOf("@media (forced-colors: active)"));
+    expect(forced).toMatch(/\.gg-tooltip-ghost/);
+  });
+});

--- a/scripts/tooltip-motion.test.ts
+++ b/scripts/tooltip-motion.test.ts
@@ -29,6 +29,7 @@ describe("tooltip motion CSS", () => {
     expect(css).toContain(".gg-tooltip-ghost");
     expect(css).toContain(`opacity ${duration} ${TOOLTIP_EASE}`);
     expect(css).toMatch(/data-gg-tooltip-motion=["']enter["']/);
+    expect(css).toMatch(/\.gg-tooltip-ghost[^{]*\{[^}]*@starting-style\s*\{\s*opacity:\s*1/s);
   });
 
   it("does not tween left, top, or scale", () => {


### PR DESCRIPTION
## Summary

Inspection tooltips now fade in on the first appear of a pointer session and fade out when the session ends (pointer leaves the plot, Close, Escape, or blur). Hover follow and misses between nearby marks stay instant, so the card does not pulse while the pointer moves across the plot. Under `prefers-reduced-motion: reduce`, mount and unmount stay instant. The live `.gg-tooltip` node still unmounts as soon as inspection clears; a paint-only ghost plays the leave fade.

## Test plan

- [x] `bun test scripts/tooltip-motion.test.ts`
- [x] `cd packages/svelte && bunx --bun vitest run tests/inspection/tooltip-motion-policy.test.ts tests/interaction/tooltip-enter-motion.test.ts tests/interaction/interaction-hover-tooltip.test.ts tests/r0-evidence/tooltip-zoom.test.ts tests/r0-evidence/pointer-inspect.test.ts tests/final-evidence.test.ts --project chromium`
- [x] `cd packages/svelte && bun run --bun check`
- [ ] Hover a mark: the tooltip fades in once.
- [ ] Move across marks: the tooltip does not fade again.
- [ ] Leave the plot: the last card fades out.
- [ ] Toggle reduced motion: the tooltip appears and disappears at once.