### PR TITLE
chore: bump temporal-guide type check export to minor

### DIFF
--- a/.changeset/temporal-guide-mismatch-export-minor.md
+++ b/.changeset/temporal-guide-mismatch-export-minor.md
@@ -1,0 +1,8 @@
+---
+"@ggsvelte/spec": minor
+"@ggsvelte/core": minor
+---
+
+Export `temporalGuideTypeMismatchError` so render and validate share one temporal-guide type check.
+
+Migration: none — additive


### PR DESCRIPTION
## Summary

PR #1619 added `temporalGuideTypeMismatchError` on `@ggsvelte/spec` with a patch changeset. New public names use minor.

This follow-up adds a minor changeset. The lockstep packages take the highest pending bump.

## Verification

- changeset file only