### PR TITLE
chore: bump temporal-guide type check export to minor

### DIFF
--- a/.changeset/temporal-guide-mismatch-export-minor.md
+++ b/.changeset/temporal-guide-mismatch-export-minor.md
@@ -1,0 +1,8 @@
+---
+"@ggsvelte/spec": minor
+"@ggsvelte/core": minor
+---
+
+Export `temporalGuideTypeMismatchError` so render and validate share one temporal-guide type check.
+
+Migration: none — additive

--- a/packages/spec/src/index.ts
+++ b/packages/spec/src/index.ts
@@ -913,6 +913,7 @@ export { validate } from "./validate.js";
 export type { ValidateResult } from "./validate.js";
 /** TypeBox-free structural gate used by the render pipeline. */
 export { assertStructuralGate, structuralGateErrors } from "./structural-gate.js";
+/** Shared temporal-guide vs explicit scale-type check for validate and render. */
 export { temporalGuideTypeMismatchError } from "./validate-data-checks-position.js";
 export { LINT_CATALOG, lintSpec } from "./lint.js";
 export type { LintAdvisoryCode, LintCatalogEntry, SpecAdvisory } from "./lint.js";


### PR DESCRIPTION
## Summary

PR #1619 exported `temporalGuideTypeMismatchError` with a patch changeset. New public names use minor.

This PR documents the export and adds a minor changeset. The lockstep packages take the highest pending bump.

## Verification

- changeset + one-line JSDoc on the spec barrel