### PR TITLE
perf(core): register the band-axis planner like geoms

### DIFF
--- a/.changeset/band-guide-registry.md
+++ b/.changeset/band-guide-registry.md
@@ -1,0 +1,5 @@
+---
+"@ggsvelte/core": patch
+---
+
+Headless charts now register the categorical axis planner only when they need a band axis. `@ggsvelte/core/render` and `registerBasic()` still install it.

--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -12406,8 +12406,8 @@ export const DOCS_ROUTES = [
         level: 2,
       },
       {
-        id: "experimental-394",
-        title: "experimental (394)",
+        id: "experimental-395",
+        title: "experimental (395)",
         level: 3,
       },
       {
@@ -12441,8 +12441,8 @@ export const DOCS_ROUTES = [
         level: 2,
       },
       {
-        id: "experimental-14",
-        title: "experimental (14)",
+        id: "experimental-15",
+        title: "experimental (15)",
         level: 3,
       },
       {

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -20494,14 +20494,14 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["@ggsvelte/core"],
   },
   {
-    id: "heading:guide-lifecycle:experimental-394",
+    id: "heading:guide-lifecycle:experimental-395",
     kind: "heading",
-    title: "experimental (394)",
+    title: "experimental (395)",
     summary:
-      "experimental (394) in Lifecycle & editions. API stability tags per export, and the defaults-edition mechanism.",
-    href: "/guide/lifecycle#experimental-394",
+      "experimental (395) in Lifecycle & editions. API stability tags per export, and the defaults-edition mechanism.",
+    href: "/guide/lifecycle#experimental-395",
     keywords: ["Lifecycle & editions", "Reference"],
-    exact: ["experimental (394)"],
+    exact: ["experimental (395)"],
   },
   {
     id: "heading:guide-lifecycle:stable-intent-2",
@@ -20564,14 +20564,14 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["@ggsvelte/core (./headless/register)"],
   },
   {
-    id: "heading:guide-lifecycle:experimental-14",
+    id: "heading:guide-lifecycle:experimental-15",
     kind: "heading",
-    title: "experimental (14)",
+    title: "experimental (15)",
     summary:
-      "experimental (14) in Lifecycle & editions. API stability tags per export, and the defaults-edition mechanism.",
-    href: "/guide/lifecycle#experimental-14",
+      "experimental (15) in Lifecycle & editions. API stability tags per export, and the defaults-edition mechanism.",
+    href: "/guide/lifecycle#experimental-15",
     keywords: ["Lifecycle & editions", "Reference"],
-    exact: ["experimental (14)"],
+    exact: ["experimental (15)"],
   },
   {
     id: "heading:guide-lifecycle:ggsvelte-core-temporal",
@@ -34150,6 +34150,15 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["registerAllStatFrames"],
   },
   {
+    id: "api:ggsvelte-core:registerBandGuide",
+    kind: "api",
+    title: "registerBandGuide",
+    summary: "@ggsvelte/core · value · experimental.",
+    href: "/guide/lifecycle#ggsvelte-core",
+    keywords: ["@ggsvelte/core", ".", "value", "experimental"],
+    exact: ["registerBandGuide"],
+  },
+  {
     id: "api:ggsvelte-core:registerBasic",
     kind: "api",
     title: "registerBasic",
@@ -35642,6 +35651,15 @@ export const DOCS_SEARCH_INDEX = [
     href: "/guide/lifecycle#ggsvelte-core-headless",
     keywords: ["@ggsvelte/core", "./headless", "value", "experimental"],
     exact: ["sceneToSVGString"],
+  },
+  {
+    id: "api:ggsvelte-core-headless-register:registerBandGuide",
+    kind: "api",
+    title: "registerBandGuide",
+    summary: "@ggsvelte/core ./headless/register · value · experimental.",
+    href: "/guide/lifecycle#ggsvelte-core-headless-register",
+    keywords: ["@ggsvelte/core", "./headless/register", "value", "experimental"],
+    exact: ["registerBandGuide"],
   },
   {
     id: "api:ggsvelte-core-headless-register:registerBasicAreas",

--- a/benchmarks/competitive/direct-spec-equivalence.test.ts
+++ b/benchmarks/competitive/direct-spec-equivalence.test.ts
@@ -5,6 +5,7 @@ import {
   registerBasicBars,
   registerBasicLines,
   registerBasicPoints,
+  registerBandGuide,
   registerOrdinalColor,
 } from "@ggsvelte/core/headless/register";
 import {
@@ -34,6 +35,7 @@ beforeAll(() => {
   registerBasicAreas();
   registerBasicBars();
   registerOrdinalColor();
+  registerBandGuide();
 });
 
 const options = { width: PLOT_WIDTH, height: PLOT_HEIGHT };

--- a/benchmarks/competitive/entries/ggsvelte-svg__bars-stacked.ts
+++ b/benchmarks/competitive/entries/ggsvelte-svg__bars-stacked.ts
@@ -1,9 +1,14 @@
-import { registerBasicBars, registerOrdinalColor } from "@ggsvelte/core/headless/register";
+import {
+  registerBandGuide,
+  registerBasicBars,
+  registerOrdinalColor,
+} from "@ggsvelte/core/headless/register";
 
 import { bundleBarsSvg } from "../adapters/ggsvelte-svg";
 
 registerBasicBars();
 registerOrdinalColor();
+registerBandGuide();
 import { makeStackedBars } from "../scenarios";
 
 export const out = bundleBarsSvg(makeStackedBars(50, 4));

--- a/benchmarks/competitive/fixtures/main.ts
+++ b/benchmarks/competitive/fixtures/main.ts
@@ -24,6 +24,7 @@ import {
   registerBasicBars,
   registerBasicLines,
   registerBasicPoints,
+  registerBandGuide,
   registerOrdinalColor,
 } from "@ggsvelte/core/headless/register";
 
@@ -57,6 +58,7 @@ registerBasicLines();
 registerBasicAreas();
 registerBasicBars();
 registerOrdinalColor();
+registerBandGuide();
 
 type MountHandle = {
   destroy: () => void;

--- a/benchmarks/competitive/lean-candidates-graph.test.ts
+++ b/benchmarks/competitive/lean-candidates-graph.test.ts
@@ -19,6 +19,7 @@ const SCATTER_BANNED =
 const AUTHORING_BANNED = /(?:portable-)?builder(?:-|\.)/;
 const THEME_CATALOG_BANNED = /theme-builtins/;
 const COLOR_KIND_BANNED = /scale-color-(?:binned|sequential|manual|identity)\.[cm]?[jt]s$/;
+const BAND_GUIDE_BANNED = /band-guide\.[cm]?[jt]s$/;
 
 async function buildEntry(entryName: string): Promise<{ moduleIds: string[]; rawBytes: number }> {
   const outDir = path.join(root, "results", "bundles", `_lean-candidates-test-${entryName}`);
@@ -73,6 +74,7 @@ describe("lean competitive SVG graph", () => {
     expect(built.moduleIds.filter((id) => AUTHORING_BANNED.test(id))).toEqual([]);
     expect(built.moduleIds.filter((id) => THEME_CATALOG_BANNED.test(id))).toEqual([]);
     expect(built.moduleIds.filter((id) => COLOR_KIND_BANNED.test(id))).toEqual([]);
+    expect(built.moduleIds.filter((id) => BAND_GUIDE_BANNED.test(id))).toEqual([]);
   }, 120_000);
 });
 
@@ -84,5 +86,6 @@ describe("lean competitive canvas graph", () => {
     expect(built.moduleIds.filter((id) => AUTHORING_BANNED.test(id))).toEqual([]);
     expect(built.moduleIds.filter((id) => THEME_CATALOG_BANNED.test(id))).toEqual([]);
     expect(built.moduleIds.filter((id) => COLOR_KIND_BANNED.test(id))).toEqual([]);
+    expect(built.moduleIds.filter((id) => BAND_GUIDE_BANNED.test(id))).toEqual([]);
   }, 120_000);
 });

--- a/lifecycle.json
+++ b/lifecycle.json
@@ -5102,6 +5102,10 @@
           "kind": "value",
           "lifecycle": "experimental"
         },
+        "registerBandGuide": {
+          "kind": "value",
+          "lifecycle": "experimental"
+        },
         "registerBasic": {
           "kind": "value",
           "lifecycle": "experimental"
@@ -5787,6 +5791,10 @@
       "entry": "./headless/register",
       "source": "packages/core/src/headless-register-entry.ts",
       "exports": {
+        "registerBandGuide": {
+          "kind": "value",
+          "lifecycle": "experimental"
+        },
         "registerBasicAreas": {
           "kind": "value",
           "lifecycle": "experimental"

--- a/packages/core/src/headless-entry.ts
+++ b/packages/core/src/headless-entry.ts
@@ -2,9 +2,10 @@
 /**
  * Side-effect-free headless pipeline and pure renderers.
  *
- * Unlike `@ggsvelte/core/render`, this entry registers no geom, stat, or
- * color-kind families. Import the required `registerBasic*` / `register*Color`
- * functions from `@ggsvelte/core/headless/register` before running a spec.
+ * Unlike `@ggsvelte/core/render`, this entry registers no geom, stat,
+ * color-kind, or band-guide families. Import the required `registerBasic*` /
+ * `register*Color` / `registerBandGuide` functions from
+ * `@ggsvelte/core/headless/register` before running a spec.
  */
 export { batchMarkCount, CANVAS_AUTO_THRESHOLD, PipelineError } from "./pipeline/public-api.js";
 export { runPipeline } from "./pipeline/run-pipeline.js";

--- a/packages/core/src/headless-register-entry.ts
+++ b/packages/core/src/headless-register-entry.ts
@@ -12,5 +12,6 @@ export { registerIdentityColor } from "./pipeline/register-color-identity.js";
 export { registerManualColor } from "./pipeline/register-color-manual.js";
 export { registerOrdinalColor } from "./pipeline/register-color-ordinal.js";
 export { registerSequentialColor } from "./pipeline/register-color-sequential.js";
+export { registerBandGuide } from "./layout/register-band-guide.js";
 export { registerGeomBatch } from "./pipeline/geometry-registry.js";
 export { registerStatFrame } from "./pipeline/frame-stats-registry.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,6 +29,7 @@ export { installCandidates } from "./install-candidates.js";
 
 // Per-family registration: granular opt-in for spec-driven apps, and the
 // mechanism <Geom*> components use to self-register (#1422-generated shells).
+export { registerBandGuide } from "./layout/register-band-guide.js";
 export { registerAllColorKinds } from "./pipeline/register-color-all.js";
 export { registerBinnedColor } from "./pipeline/register-color-binned.js";
 export { registerIdentityColor } from "./pipeline/register-color-identity.js";

--- a/packages/core/src/layout/band-guide-registry.ts
+++ b/packages/core/src/layout/band-guide-registry.ts
@@ -1,0 +1,19 @@
+/**
+ * Band-axis planner registry.
+ *
+ * Continuous-x/y charts never call the planner. Register it only when a
+ * categorical axis needs measured wrap/rotate/thin layout.
+ */
+import type { BandAxisPlan, BandAxisPlanInput } from "./band-guide-types.js";
+
+export type BandAxisPlanner = (input: BandAxisPlanInput) => BandAxisPlan;
+
+let planner: BandAxisPlanner | undefined;
+
+export function registerBandAxisPlanner(plan: BandAxisPlanner): void {
+  planner = plan;
+}
+
+export function getBandAxisPlanner(): BandAxisPlanner | undefined {
+  return planner;
+}

--- a/packages/core/src/layout/guide-plan-types.ts
+++ b/packages/core/src/layout/guide-plan-types.ts
@@ -7,7 +7,7 @@
 import type { StyleAesthetic, TemporalScaleKind } from "@ggsvelte/spec";
 
 import type { CellValue } from "../table.js";
-import type { BandLabelMode } from "./band-guide.js";
+import type { BandLabelMode } from "./band-guide-types.js";
 import type { GuideDegradedCode } from "./guide-degraded-codes.js";
 
 export interface AxisGuideTick {

--- a/packages/core/src/layout/layout-derive-ticks.ts
+++ b/packages/core/src/layout/layout-derive-ticks.ts
@@ -5,7 +5,8 @@
 import { encodeKey } from "../scales/state.js";
 import type { CellValue } from "../table.js";
 import type { AxisGuidePlan } from "./temporal-guide.js";
-import { planBandAxis, type BandAxisPlan, type BandGuideConfig } from "./band-guide.js";
+import { getBandAxisPlanner } from "./band-guide-registry.js";
+import type { BandAxisPlan, BandGuideConfig } from "./band-guide-types.js";
 import { getTemporalRuntime } from "../temporal-runtime.js";
 import type { TextMeasurer } from "./measure.js";
 import { truncateToFit } from "./truncate.js";
@@ -153,6 +154,16 @@ function bandGuideConfig(value: unknown): BandGuideConfig | undefined {
   return value;
 }
 
+function requireBandAxisPlanner(): NonNullable<ReturnType<typeof getBandAxisPlanner>> {
+  const plan = getBandAxisPlanner();
+  if (plan === undefined) {
+    throw new Error(
+      `Band axis guide is not registered in this build. Call registerBandGuide() from @ggsvelte/core/headless/register once at startup, or registerBasic() from @ggsvelte/core.`,
+    );
+  }
+  return plan;
+}
+
 function ellipsizeBandPlan(
   plan: BandAxisPlan,
   categoryCount: number,
@@ -230,7 +241,7 @@ export function deriveTicks(
     // mode:off must apply before the horizontal-only measured branch so vertical
     // band axes (native Y, or x after coord_flip) also hide labels.
     if (domain.band !== undefined && guide?.mode === "off") {
-      const plan = planBandAxis({
+      const plan = requireBandAxisPlanner()({
         aesthetic: domain.band.aesthetic,
         panelIndex: domain.band.panelIndex,
         categoryCount: domain.categories.length,
@@ -285,7 +296,7 @@ export function deriveTicks(
         context.bandCollision === "ellipsis" || context.bandCollision === "preserve"
           ? { ...guide, mode: "single" as const }
           : guide;
-      const planned = planBandAxis({
+      const planned = requireBandAxisPlanner()({
         aesthetic: domain.band.aesthetic,
         panelIndex: domain.band.panelIndex,
         categoryCount: domain.categories.length,

--- a/packages/core/src/layout/register-band-guide.ts
+++ b/packages/core/src/layout/register-band-guide.ts
@@ -1,0 +1,11 @@
+import { planBandAxis } from "./band-guide.js";
+import { registerBandAxisPlanner } from "./band-guide-registry.js";
+
+let registered = false;
+
+/** Register the measured categorical axis planner. Idempotent. */
+export function registerBandGuide(): void {
+  if (registered) return;
+  registered = true;
+  registerBandAxisPlanner(planBandAxis);
+}

--- a/packages/core/src/pipeline/assemble-render-model.ts
+++ b/packages/core/src/pipeline/assemble-render-model.ts
@@ -2,7 +2,7 @@
  * Assemble the public RenderModel (scene, scales, contracts, dispose/row).
  */
 import type { PanelCoordProjector } from "../coord-projector.js";
-import type { BandLabelMode } from "../layout/band-guide.js";
+import type { BandLabelMode } from "../layout/band-guide-types.js";
 import type { GuideDegradedCode } from "../layout/guide-degraded-codes.js";
 import type { TickFormatter } from "../layout/layout.js";
 import type { GuidePlan } from "../layout/temporal-guide.js";

--- a/packages/core/src/pipeline/register-basic-bars.ts
+++ b/packages/core/src/pipeline/register-basic-bars.ts
@@ -2,6 +2,7 @@ import type { GeometryBatch } from "../scene.js";
 
 import { buildCountFrame } from "./frame-stats-count.js";
 import { buildSumFrame } from "./frame-stats-sum.js";
+import { registerBandGuide } from "../layout/register-band-guide.js";
 import { registerStatFrame } from "./frame-stats-registry.js";
 import { registerGeomBatch, type GeometryBatchBuilder } from "./geometry-registry.js";
 import { rectsBatch } from "./geometry-rects.js";
@@ -12,10 +13,11 @@ function single(batch: GeometryBatch | null): GeometryBatch[] {
 
 let registered = false;
 
-/** Register col/bar geometry plus their count/sum stats. Idempotent. */
+/** Register col/bar geometry, count/sum stats, and the band-axis planner. Idempotent. */
 export function registerBasicBars(): void {
   if (registered) return;
   registered = true;
+  registerBandGuide();
   const rects: GeometryBatchBuilder = (frame, fx, _color, fill, styles, warnings) =>
     single(rectsBatch(frame, fx, fill, styles, warnings));
   registerGeomBatch("col", rects);

--- a/packages/core/src/register.ts
+++ b/packages/core/src/register.ts
@@ -5,8 +5,8 @@
  * stat frames, no geom batches, and no Temporal runtime. Callers opt in:
  *
  *   - `registerBasic()` — identity-chart geoms/stats (scatter, line, bar,
- *     area, …) plus every color scale kind. Same tier `@ggsvelte/core/render`
- *     installs on import.
+ *     area, …) plus every color scale kind and the band-axis planner. Same
+ *     tier `@ggsvelte/core/render` installs on import.
  *   - `registerAll()` — the full grammar (every stat frame + geom batch) plus
  *     the Temporal polyfill parse path and the interaction-candidate runtime
  *     (#1421). One-call migration path for apps that relied on the pre-#1420
@@ -25,12 +25,14 @@ import { registerAllStatFrames } from "./pipeline/frame-stats-register-all.js";
 import { registerBasicGeomBatches } from "./pipeline/geometry-register-basic.js";
 import { registerAllGeomBatches } from "./pipeline/geometry-register-all.js";
 import { registerAllColorKinds } from "./pipeline/register-color-all.js";
+import { registerBandGuide } from "./layout/register-band-guide.js";
 
 /** Register basic geom batches + basic stat frames (identity charts). */
 export function registerBasic(): void {
   registerBasicStatFrames();
   registerBasicGeomBatches();
   registerAllColorKinds();
+  registerBandGuide();
 }
 
 /** Register every stat frame + geom batch; install Temporal + candidates. */
@@ -38,6 +40,7 @@ export function registerAll(): void {
   registerAllStatFrames();
   registerAllGeomBatches();
   registerAllColorKinds();
+  registerBandGuide();
   installTemporal();
   installCandidates();
 }

--- a/packages/core/src/render-entry.ts
+++ b/packages/core/src/render-entry.ts
@@ -16,10 +16,12 @@
 import { registerBasicStatFrames } from "./pipeline/frame-stats-register-basic.js";
 import { registerBasicGeomBatches } from "./pipeline/geometry-register-basic.js";
 import { registerAllColorKinds } from "./pipeline/register-color-all.js";
+import { registerBandGuide } from "./layout/register-band-guide.js";
 
 registerBasicStatFrames();
 registerBasicGeomBatches();
 registerAllColorKinds();
+registerBandGuide();
 
 export { batchMarkCount, CANVAS_AUTO_THRESHOLD, PipelineError } from "./pipeline/public-api.js";
 export { runPipeline } from "./pipeline/run-pipeline-full.js";

--- a/packages/core/tests/band-guide-registry.test.ts
+++ b/packages/core/tests/band-guide-registry.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Band-guide registration: continuous axes stay off the planner module.
+ *
+ * Seam A (in-process) cannot assert a missing planner because bunfig preload
+ * calls registerAll(). Seam B uses a fresh process.
+ */
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+
+import { describe, expect, it } from "bun:test";
+
+import { getBandAxisPlanner } from "../src/layout/band-guide-registry.ts";
+import { registerBandGuide } from "../src/layout/register-band-guide.ts";
+import { registerAll, registerBasic } from "../src/register.ts";
+
+describe("band-guide registration (Seam A)", () => {
+  it("registerAll and registerBasic install the band planner", () => {
+    registerBasic();
+    registerAll();
+    expect(getBandAxisPlanner()).toBeDefined();
+    expect(() => {
+      registerBandGuide();
+    }).not.toThrow();
+  });
+});
+
+describe("band-guide registration (Seam B)", () => {
+  it("unregistered band-x throws; registerBandGuide unlocks it", () => {
+    const coreRoot = path.resolve(import.meta.dir, "..");
+    const script = `
+      import { renderToSVGString } from ${JSON.stringify(path.join(coreRoot, "src", "headless-entry.ts"))};
+      import { registerBasicPoints, registerOrdinalColor } from ${JSON.stringify(path.join(coreRoot, "src", "headless-register-entry.ts"))};
+      import { registerBandGuide } from ${JSON.stringify(path.join(coreRoot, "src", "layout", "register-band-guide.ts"))};
+      import { aes, gg } from "@ggsvelte/spec/portable";
+
+      const continuous = [
+        { x: 1, y: 2, g: "a" },
+        { x: 2, y: 3, g: "b" },
+      ];
+      const band = [
+        { x: "a", y: 1 },
+        { x: "b", y: 2 },
+      ];
+      const attempt = (fn) => {
+        try {
+          fn();
+          return "rendered";
+        } catch (error) {
+          return String(error instanceof Error ? error.message : error);
+        }
+      };
+      registerBasicPoints();
+      registerOrdinalColor();
+      const out = {
+        continuous: attempt(() =>
+          renderToSVGString(gg(continuous, aes({ x: "x", y: "y", color: "g" })).geomPoint(), {
+            width: 200,
+            height: 120,
+          }),
+        ),
+        bandFresh: attempt(() =>
+          renderToSVGString(gg(band, aes({ x: "x", y: "y" })).geomPoint(), {
+            width: 200,
+            height: 120,
+          }),
+        ),
+      };
+      registerBandGuide();
+      out.bandAfter = attempt(() =>
+        renderToSVGString(gg(band, aes({ x: "x", y: "y" })).geomPoint(), {
+          width: 200,
+          height: 120,
+        }),
+      );
+      console.log(JSON.stringify(out));
+    `;
+    const proc = spawnSync(process.execPath, ["-e", script], {
+      cwd: coreRoot,
+      encoding: "utf8",
+    });
+    expect(proc.status).toBe(0, proc.stderr || proc.stdout);
+    const out = JSON.parse(proc.stdout.trim().split("\n").at(-1) ?? "{}") as Record<string, string>;
+    expect(out.continuous).toBe("rendered");
+    expect(out.bandFresh).toContain("not registered");
+    expect(out.bandFresh).toContain("registerBandGuide");
+    expect(out.bandAfter).toBe("rendered");
+  }, 60_000);
+});

--- a/packages/core/tests/register-hints.test.ts
+++ b/packages/core/tests/register-hints.test.ts
@@ -88,6 +88,8 @@ describe("register hints: error messages (fresh process)", () => {
     const coreRoot = path.resolve(import.meta.dir, "..");
     const script = `
       import { renderToSVGString } from ${JSON.stringify(path.join(coreRoot, "src", "index.ts"))};
+      import { registerBandGuide } from ${JSON.stringify(path.join(coreRoot, "src", "layout", "register-band-guide.ts"))};
+      registerBandGuide();
 
       const rows = [
         { x: 1, y: 10 }, { x: 2, y: 20 }, { x: 3, y: 15 }, { x: 4, y: 25 }, { x: 5, y: 22 },

--- a/packages/svelte/tests/setup-register-all.ts
+++ b/packages/svelte/tests/setup-register-all.ts
@@ -24,9 +24,11 @@ import {
   registerAllColorKinds,
   registerAllGeomBatches,
   registerAllStatFrames,
+  registerBandGuide,
 } from "@ggsvelte/core";
 
 registerAllStatFrames();
 registerAllGeomBatches();
 registerAllColorKinds();
+registerBandGuide();
 installCandidates();


### PR DESCRIPTION
## Summary

The measured categorical axis planner (`planBandAxis`) now registers the same way geoms do.

- `registerBandGuide()` lives on `@ggsvelte/core` and `@ggsvelte/core/headless/register`.
- `registerBasicBars()` installs it (bar/col charts need a band axis).
- `@ggsvelte/core/render` and `registerBasic()` still install it (point + discrete x still works).
- Lean scatter/line/area entries do not register it.

## Gzip (same machine, vs color-kind on main)

| cell | before | after | delta |
|---|---:|---:|---:|
| ggsvelte-svg scatter | 118990 | 115968 | −3022 |
| ggsvelte-canvas scatter | 118182 | 115176 | −3006 |
| ggsvelte-svg line | 119951 | 116929 | −3022 |
| ggsvelte-svg area | 120729 | 117753 | −2976 |
| ggsvelte-svg bars | 119196 | 119571 | +375 |
| ggsvelte-ggplot scatter | 329393 | 329724 | +331 |
| ggsvelte-full scatter | 366939 | 367327 | +388 |

Two `bun run bench:competitive:bundles` runs matched. Lean continuous cells drop ~3 KB gzip. Bars, GGPlot, and full keep the planner, so they pay the register seam.

Graph tests ban `band-guide.ts` / `band-guide.js` on lean scatter.

## Test plan

- [x] Fresh-process: continuous scatter works without the planner; band-x throws until `registerBandGuide()`
- [x] `registerBasic()` / `registerAll()` install the planner
- [x] Lean SVG/canvas graph tests
- [x] `bun run bench:competitive:bundles` twice