### PR TITLE
docs: drop README Line 100k and bust bench chart cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ graphics, inspired by ggplot2.
 
 ![Bar chart of cold-mount time for a 3-series by 10,000-point line chart: ggsvelte 54.8 ms, LayerCake 63.2 ms, TanStack 223.7 ms, Unovis 205.3 ms, SveltePlot 2,101 ms. Lower is better.](apps/docs/static/benchmarks/bench-line-mount.svg)
 
-![Bar chart of cold-mount time for a 10-series by 10,000-point line chart: ggsvelte SVG 114.8 ms, ggsvelte canvas 167.8 ms, LayerCake 458 ms, LayerCake canvas 186.2 ms, TanStack 1,025 ms, Unovis 1,588 ms. Lower is better. SveltePlot is omitted because it is too slow for this scale.](apps/docs/static/benchmarks/bench-line-100k-mount.svg)
-
 ![Bar chart of cold-mount time for a 1,000-point colored scatter: ggsvelte 15.8 ms, LayerCake 54.7 ms, TanStack 51.2 ms, Unovis 173.7 ms, SveltePlot 647.6 ms. Lower is better.](apps/docs/static/benchmarks/bench-scatter-1k-mount.svg)
 
 ![Bar chart of cold-mount time for a 10,000-point colored scatter: ggsvelte 138.9 ms, LayerCake 383.5 ms, TanStack 387.7 ms, Unovis 1,083 ms, SveltePlot 9,032 ms. Lower is better.](apps/docs/static/benchmarks/bench-scatter-mount.svg)

--- a/apps/docs/src/lib/benchmarks/asset-url.ts
+++ b/apps/docs/src/lib/benchmarks/asset-url.ts
@@ -1,0 +1,4 @@
+/** Static bench SVG path plus content hash. A regen must change this URL. */
+export function benchmarkChartSrc(path: string, sha256: string): string {
+  return `${path}?v=${sha256}`;
+}

--- a/apps/docs/src/lib/components/BenchmarkTabs.svelte
+++ b/apps/docs/src/lib/components/BenchmarkTabs.svelte
@@ -9,6 +9,7 @@
 
   import { Tabs } from "bits-ui";
 
+  import { benchmarkChartSrc } from "$lib/benchmarks/asset-url";
   import { BENCHMARK_CHART_CARDS } from "$lib/generated/benchmark-charts";
 
   const cards = BENCHMARK_CHART_CARDS;
@@ -30,7 +31,7 @@
         <div class="bench-tabs-chart">
           <img
             class="bench-chart-img bench-chart--light"
-            src={`${base}${card.path}`}
+            src={`${base}${benchmarkChartSrc(card.path, card.sha256)}`}
             alt={card.alt}
             width={card.width}
             height={card.height}
@@ -38,7 +39,7 @@
           />
           <img
             class="bench-chart-img bench-chart--dark"
-            src={`${base}${card.darkPath}`}
+            src={`${base}${benchmarkChartSrc(card.darkPath, card.sha256)}`}
             alt={card.alt}
             width={card.width}
             height={card.height}

--- a/scripts/benchmark-charts.test.ts
+++ b/scripts/benchmark-charts.test.ts
@@ -2,10 +2,24 @@
  * Homepage bench cards: band domain is always speed order, and the tab
  * list stays Area → Bars → Line → Line 100k → Scatter → Scatter 10k.
  */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
 import { describe, expect, it } from "bun:test";
 
-import { benchmarkChartSpec } from "../apps/docs/src/lib/benchmarks/charts.ts";
+import { benchmarkChartSrc } from "../apps/docs/src/lib/benchmarks/asset-url.ts";
+import { benchmarkChartSpec, benchmarkChartSvg } from "../apps/docs/src/lib/benchmarks/charts.ts";
 import { BENCHMARK_CHART_CARDS } from "../apps/docs/src/lib/generated/benchmark-charts.ts";
+
+const STATIC_BENCHMARKS = join(import.meta.dir, "..", "apps", "docs", "static", "benchmarks");
+
+/** Tick titles from top to bottom (`translate(0, y)` on `.gg-tick`). */
+function tickTitlesTopToBottom(svg: string): readonly string[] {
+  return [...svg.matchAll(/transform="translate\(0,([0-9.]+)\)"><title>([^<]*)<\/title>/g)]
+    .map((match) => ({ y: Number(match[1]), title: match[2]! }))
+    .toSorted((a, b) => a.y - b.y)
+    .map((tick) => tick.title);
+}
 
 function bandX(spec: ReturnType<typeof benchmarkChartSpec>) {
   const x = spec.scales?.x;
@@ -47,6 +61,74 @@ describe("benchmarkChartSpec band order", () => {
       ariaLabel: "a",
     });
     expect(bandX(spec).domain).toEqual(["Alpha", "Zebra"]);
+  });
+
+  it("renders those domain values from fastest at the top after coord flip", () => {
+    const bars = [
+      { lib: "LayerCake", value: 54.7, kind: "peer" as const, label: "54.7 ms" },
+      { lib: "TanStack", value: 51.2, kind: "peer" as const, label: "51.2 ms" },
+      { lib: "ggsvelte", value: 15.8, kind: "ggsvelte" as const, label: "15.8 ms" },
+      { lib: "SveltePlot", value: 647.6, kind: "peer" as const, label: "647.6 ms" },
+      { lib: "Unovis", value: 173.7, kind: "peer" as const, label: "173.7 ms" },
+    ];
+    const svg = benchmarkChartSvg(
+      {
+        id: "order-render",
+        bars,
+        title: "order test",
+        subtitle: "Cold-mount milliseconds · lower is better",
+        ariaLabel: "order test",
+      },
+      { width: 560, height: 335 },
+    );
+    expect(tickTitlesTopToBottom(svg)).toEqual([
+      "ggsvelte",
+      "TanStack",
+      "LayerCake",
+      "Unovis",
+      "SveltePlot",
+    ]);
+  });
+});
+
+describe("committed bench SVGs", () => {
+  it("draw the 1,000-point scatter ticks fastest to slowest, top to bottom", () => {
+    const svg = readFileSync(join(STATIC_BENCHMARKS, "bench-scatter-1k-mount.svg"), "utf8");
+    expect(tickTitlesTopToBottom(svg)).toEqual([
+      "ggsvelte",
+      "TanStack",
+      "LayerCake",
+      "Unovis",
+      "SveltePlot",
+    ]);
+  });
+
+  it("draw every card's ticks in increasing mount time, top to bottom", () => {
+    for (const card of BENCHMARK_CHART_CARDS) {
+      const filename = card.path.replace("/benchmarks/", "");
+      const svg = readFileSync(join(STATIC_BENCHMARKS, filename), "utf8");
+      const titles = tickTitlesTopToBottom(svg);
+      expect(titles.length, card.id).toBeGreaterThan(1);
+      const values = [...svg.matchAll(/y="([0-9.]+)"[^>]*>(([0-9][0-9.,]*) ms)</g)]
+        .map((match) => ({ y: Number(match[1]), value: Number(match[3]!.replaceAll(",", "")) }))
+        .toSorted((a, b) => a.y - b.y)
+        .map((row) => row.value);
+      expect(values.length, card.id).toBe(titles.length);
+      expect(values, card.id).toEqual([...values].toSorted((a, b) => a - b));
+    }
+  });
+});
+
+describe("benchmarkChartSrc", () => {
+  it("appends the SVG sha so a regen busts the docs-site cache", () => {
+    expect(
+      benchmarkChartSrc(
+        "/benchmarks/bench-scatter-1k-mount.svg",
+        "fd2cb838c7c94b785796e5521f4920fb7ac75ecebced390e87789db548ee9df1",
+      ),
+    ).toBe(
+      "/benchmarks/bench-scatter-1k-mount.svg?v=fd2cb838c7c94b785796e5521f4920fb7ac75ecebced390e87789db548ee9df1",
+    );
   });
 });
 

--- a/scripts/gen-benchmark-charts.ts
+++ b/scripts/gen-benchmark-charts.ts
@@ -217,15 +217,18 @@ function buildCards(browser: BrowserResults, peers100k: BrowserResults): readonl
 
   const subtitle = "Cold-mount milliseconds · lower is better";
   const formSubtitle = "Cold-mount milliseconds · lower is better · SveltePlot omitted";
-  // Any array order is fine: benchmarkChartSpec ranks bars by value.
+  // Sort by mount time so first-seen data order matches the pinned band
+  // domain. The spec still owns display rank (domain + reverse).
   const bars = (c: PeerCell): readonly BenchmarkBar[] =>
-    [
-      { lib: "ggsvelte", value: c.gg, kind: "ggsvelte", label: msLabel(c.gg) },
-      { lib: "LayerCake", value: c.lc, kind: "peer", label: msLabel(c.lc) },
-      { lib: "TanStack", value: c.ts, kind: "peer", label: msLabel(c.ts) },
-      { lib: "Unovis", value: c.uv, kind: "peer", label: msLabel(c.uv) },
-      { lib: "SveltePlot", value: c.sp, kind: "peer", label: msLabel(c.sp) },
-    ] as const;
+    (
+      [
+        { lib: "ggsvelte", value: c.gg, kind: "ggsvelte", label: msLabel(c.gg) },
+        { lib: "LayerCake", value: c.lc, kind: "peer", label: msLabel(c.lc) },
+        { lib: "TanStack", value: c.ts, kind: "peer", label: msLabel(c.ts) },
+        { lib: "Unovis", value: c.uv, kind: "peer", label: msLabel(c.uv) },
+        { lib: "SveltePlot", value: c.sp, kind: "peer", label: msLabel(c.sp) },
+      ] as const satisfies readonly BenchmarkBar[]
+    ).toSorted((a, b) => a.value - b.value || a.lib.localeCompare(b.lib));
 
   /**
    * Six form-factor rows ordered by cold-mount rank (fastest top). ggsvelte

--- a/tests/visual/docs-home-gallery.spec.ts
+++ b/tests/visual/docs-home-gallery.spec.ts
@@ -28,6 +28,10 @@ test("homepage first viewport leads with title, bench tabs, then featured exampl
   await expect(page.getByRole("tab", { name: "Scatter", exact: true })).toBeVisible();
   await expect(page.getByRole("tab", { name: "Scatter 10k" })).toBeVisible();
   await expect(page.getByRole("tab", { name: "Scatter 100k" })).toHaveCount(0);
+  await expect(page.locator(".bench-chart--light").first()).toHaveAttribute(
+    "src",
+    /\/benchmarks\/bench-area-mount\.svg\?v=[0-9a-f]{64}$/,
+  );
   await expect(page.getByRole("button", { name: "Copy install" })).toHaveCount(0);
   await expect(page.getByRole("link", { name: "Getting started" })).toHaveCount(0);
   await expect(page.getByRole("heading", { name: "Examples", level: 2 })).toHaveCount(0);


### PR DESCRIPTION
## Summary

Remove the Line 100k cold-mount image from the root README. The homepage still has that tab.

The homepage Scatter chart already ranks TanStack above LayerCake in the committed SVG. The image URL did not change when those bytes changed, so a browser could keep the old file for four hours. The homepage image URL now includes the SVG content hash.

No changeset: docs only.

## Test plan

- [x] README no longer embeds `bench-line-100k-mount.svg`
- [x] Area, Bars, Line, Scatter, and Scatter 10k images stay
- [x] `bun test scripts/benchmark-charts.test.ts` — rendered ticks are fastest at the top
- [x] Homepage Scatter tab on the local docs server shows TanStack (51.2 ms) above LayerCake (54.7 ms)
- [x] Light image `src` includes `?v=<sha256>`