### PR TITLE
docs: publish the 108 KB scatter bundle size

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ and Windows.
 
 | Capability                                 | ggsvelte   | SveltePlot           | Unovis                 | LayerCake            |
 | ------------------------------------------ | ---------- | -------------------- | ---------------------- | -------------------- |
-| **Bundle size** (min+gzip, 1k scatter app) | ⚠️ 122 KB  | ✅ 109 KB            | ✅ 80 KB               | ✅ 41 KB             |
+| **Bundle size** (min+gzip, 1k scatter app) | ⚠️ 108 KB  | ✅ 109 KB            | ✅ 80 KB               | ✅ 41 KB             |
 | **API stability**                          | ⚠️ v0.38.1 | ⚠️ v0.14             | ✅ v1.6                | ✅ v10               |
 | **Headless server-side SVG** (no DOM)      | ✅         | ❌ empty shell       | ❌ client `onMount`    | ⚠️ opt-in `ssr` flag |
 | **Portable JSON spec + schema**            | ✅         | ❌                   | ❌                     | ❌                   |

--- a/apps/docs/src/lib/generated/benchmark-charts.ts
+++ b/apps/docs/src/lib/generated/benchmark-charts.ts
@@ -101,7 +101,7 @@ export const BENCHMARK_VERSIONS = {
 
 /** Min+gzip KB of the 1,000-point colored-scatter app bundle. */
 export const BENCHMARK_BUNDLE_KB = {
-  ggsvelteKb: 122,
+  ggsvelteKb: 107.6,
   svelteplotKb: 108.7,
   layercakeKb: 40.8,
   unovisKb: 80.3,

--- a/scripts/sync-comparison-versions.test.ts
+++ b/scripts/sync-comparison-versions.test.ts
@@ -126,6 +126,22 @@ describe("live comparison tables match the published lockstep version", () => {
     expect(syncBenchmarkGgsvelteVersion(proj, version)).toBe(proj);
     expect(proj).toContain(`ggsvelte: "${version}"`);
   });
+
+  it("README bundle-size cell matches the rounded docs projection", () => {
+    const readme = readFileSync(join(ROOT, "README.md"), "utf8");
+    const proj = readFileSync(
+      join(ROOT, "apps/docs/src/lib/generated/benchmark-charts.ts"),
+      "utf8",
+    );
+    const match = /ggsvelteKb:\s*([0-9]+(?:\.[0-9]+)?)/.exec(proj);
+    expect(match).not.toBeNull();
+    const rounded = Math.round(Number(match![1]));
+    expect(readme).toMatch(
+      new RegExp(
+        String.raw`\|\s*\*\*Bundle size\*\* \(min\+gzip, 1k scatter app\)\s*\|\s*⚠️ ${String(rounded)} KB\s*\|`,
+      ),
+    );
+  });
 });
 
 describe("release wiring auto-bumps comparison tables on Version Packages", () => {


### PR DESCRIPTION
## Summary

Update the published 1k-scatter min+gzip number after the register-seam cuts on main.

The Why ggsvelte tables still said **122 KB**. Two `bun run bench:competitive:bundles` runs on current main measured `ggsvelte-svg` / `scatter-color` at **107.6 KB gzip (110199 bytes)**. Both runs matched. The homepage rounds that to **108 KB**. Peer cells did not change (SveltePlot 109, Unovis 80, LayerCake 41).

I did not regenerate the mount SVGs. Local `browser.json` is older than the committed charts.

A lockstep test now requires the README integer to match `Math.round(BENCHMARK_BUNDLE_KB.ggsvelteKb)`.

No changeset: docs site + root README only.

## Test plan

- [x] Two competitive bundle runs: `ggsvelte-svg` scatter-color gzip 110199 / 107.6 KB both times
- [x] `bun test scripts/sync-comparison-versions.test.ts scripts/readme-showcase.test.ts` — 16 pass
- [x] `bun scripts/gen-benchmark-charts.ts --check` with results hidden — CI consistency path passes
- [x] Local docs homepage at 1280 and 375: table shows **108 KB** (not 122)
- [x] `/docs` and `/guide/getting-started` do not show the stale 122 KB string