### PR TITLE
docs: add TanStack to Why ggsvelte? comparison tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,18 +55,18 @@ and Windows.
 
 ## Why ggsvelte?
 
-| Capability                                 | ggsvelte   | SveltePlot           | Unovis                 | LayerCake            |
-| ------------------------------------------ | ---------- | -------------------- | ---------------------- | -------------------- |
-| **Bundle size** (min+gzip, 1k scatter app) | ⚠️ 122 KB  | ✅ 109 KB            | ✅ 80 KB               | ✅ 41 KB             |
-| **API stability**                          | ⚠️ v0.38.1 | ⚠️ v0.14             | ✅ v1.6                | ✅ v10               |
-| **Headless server-side SVG** (no DOM)      | ✅         | ❌ empty shell       | ❌ client `onMount`    | ⚠️ opt-in `ssr` flag |
-| **Portable JSON spec + schema**            | ✅         | ❌                   | ❌                     | ❌                   |
-| **CLI validator + renderer**               | ✅         | ❌                   | ❌                     | ❌                   |
-| **Agent skill**                            | ✅         | ❌                   | ❌                     | ❌                   |
-| **Automatic temporal detection**           | ✅         | ⚠️ Date objects only | ❌                     | ❌                   |
-| **Built-in interactions**                  | ✅         | ⚠️ tooltip + brush   | ⚠️ tooltip + crosshair | ❌                   |
-| **ggplot2 API**                            | ✅         | ❌                   | ❌                     | ❌                   |
-| **Scale, axis & coord control**            | ✅         | ✅                   | ✅                     | ⚠️ d3 scales         |
+| Capability                                 | ggsvelte   | TanStack | SveltePlot           | Unovis                 | LayerCake            |
+| ------------------------------------------ | ---------- | -------- | -------------------- | ---------------------- | -------------------- |
+| **Bundle size** (min+gzip, 1k scatter app) | ⚠️ 122 KB  | ✅ 57 KB | ✅ 109 KB            | ✅ 80 KB               | ✅ 41 KB             |
+| **API stability**                          | ⚠️ v0.38.1 | ⚠️ v0.14 | ⚠️ v0.14             | ✅ v1.6                | ✅ v10               |
+| **Headless server-side SVG** (no DOM)      | ✅         | ✅       | ❌ empty shell       | ❌ client `onMount`    | ⚠️ opt-in `ssr` flag |
+| **Portable JSON spec + schema**            | ✅         | ❌       | ❌                   | ❌                     | ❌                   |
+| **CLI validator + renderer**               | ✅         | ❌       | ❌                   | ❌                     | ❌                   |
+| **Agent skill**                            | ✅         | ✅       | ❌                   | ❌                     | ❌                   |
+| **Automatic temporal detection**           | ✅         | ❌       | ⚠️ Date objects only | ❌                     | ❌                   |
+| **Built-in interactions**                  | ✅         | ✅       | ⚠️ tooltip + brush   | ⚠️ tooltip + crosshair | ❌                   |
+| **ggplot2 API**                            | ✅         | ❌       | ❌                   | ❌                     | ❌                   |
+| **Scale, axis & coord control**            | ✅         | ✅       | ✅                   | ✅                     | ⚠️ d3 scales         |
 
 ## Reference
 

--- a/apps/docs/src/lib/components/Benchmarks.svelte
+++ b/apps/docs/src/lib/components/Benchmarks.svelte
@@ -15,6 +15,7 @@
     readonly feature: string;
     readonly desc?: string;
     readonly gg: Cell;
+    readonly ts: Cell;
     readonly lc: Cell;
     readonly uv: Cell;
     readonly sp: Cell;
@@ -33,16 +34,17 @@
   const kb = (value: number): string => `${String(Math.round(value))} KB`;
 
   /*
-   * Column order: ggsvelte → SveltePlot → Unovis → LayerCake. Bun's
-   * homepage table leads with its flaw before the wins; same here: bundle
-   * size and pre-1.0 up top. Claims verified against svelteplot@0.14 /
-   * @unovis/svelte@1.6 / layercake@10 sources.
+   * Column order ggsvelte → TanStack → SveltePlot → Unovis → LayerCake.
+   * Bun's homepage table leads with its flaw before the wins; same here:
+   * bundle size and pre-1.0 up top. Claims verified against svelteplot@0.14
+   * / @tanstack/charts@0.14 / @unovis/svelte@1.6 / layercake@10 sources.
    */
   const rows: readonly Row[] = [
     {
       feature: "Bundle size",
       desc: "Min+gzip, 1k scatter app",
       gg: { mark: "partial", note: kb(BENCHMARK_BUNDLE_KB.ggsvelteKb) },
+      ts: { mark: "yes", note: kb(BENCHMARK_BUNDLE_KB.tanstackKb) },
       lc: { mark: "yes", note: kb(BENCHMARK_BUNDLE_KB.layercakeKb) },
       uv: { mark: "yes", note: kb(BENCHMARK_BUNDLE_KB.unovisKb) },
       sp: { mark: "yes", note: kb(BENCHMARK_BUNDLE_KB.svelteplotKb) },
@@ -51,6 +53,7 @@
       feature: "API stability",
       desc: "Pre-1.0: minors can still break",
       gg: { mark: "partial", note: `v${BENCHMARK_VERSIONS.ggsvelte}` },
+      ts: { mark: "partial", note: `v${BENCHMARK_VERSIONS.tanstack}` },
       lc: { mark: "yes", note: `v${BENCHMARK_VERSIONS.layercake}` },
       uv: { mark: "yes", note: `v${BENCHMARK_VERSIONS.unovis}` },
       sp: { mark: "partial", note: `v${BENCHMARK_VERSIONS.svelteplot}` },
@@ -59,6 +62,7 @@
       feature: "Headless server-side SVG",
       desc: "data → SVG string, no DOM",
       gg: yes,
+      ts: yes,
       lc: { mark: "partial", note: "opt-in ssr" },
       uv: { mark: "no", note: "client onMount" },
       sp: { mark: "no", note: "empty shell" },
@@ -66,6 +70,7 @@
     {
       feature: "Portable JSON spec + schema",
       gg: yes,
+      ts: no,
       lc: no,
       uv: no,
       sp: no,
@@ -73,6 +78,7 @@
     {
       feature: "CLI validator + renderer",
       gg: yes,
+      ts: no,
       lc: no,
       uv: no,
       sp: no,
@@ -80,6 +86,7 @@
     {
       feature: "Agent skill",
       gg: yes,
+      ts: yes,
       lc: no,
       uv: no,
       sp: no,
@@ -87,6 +94,7 @@
     {
       feature: "Automatic temporal detection",
       gg: yes,
+      ts: no,
       lc: no,
       uv: no,
       sp: { mark: "partial", note: "Date only" },
@@ -95,6 +103,7 @@
       feature: "Built-in interactions",
       desc: "Tooltip, select, zoom, link",
       gg: yes,
+      ts: yes,
       lc: { mark: "no", note: "bring your own" },
       uv: { mark: "partial", note: "tooltip + crosshair" },
       sp: { mark: "partial", note: "tooltip + brush" },
@@ -102,6 +111,7 @@
     {
       feature: "ggplot2 API",
       gg: yes,
+      ts: no,
       lc: no,
       uv: no,
       sp: no,
@@ -109,6 +119,7 @@
     {
       feature: "Scale, axis & coord control",
       gg: yes,
+      ts: yes,
       lc: { mark: "partial", note: "d3 scales" },
       uv: yes,
       sp: yes,
@@ -125,12 +136,13 @@
     <table>
       <colgroup>
         <col class="bench-col-feature" />
-        <col class="bench-col-lib" span="4" />
+        <col class="bench-col-lib" span="5" />
       </colgroup>
       <thead>
         <tr>
           <th scope="col">Capability</th>
           <th scope="col">ggsvelte</th>
+          <th scope="col">TanStack</th>
           <th scope="col">SveltePlot</th>
           <th scope="col">Unovis</th>
           <th scope="col">LayerCake</th>
@@ -143,7 +155,7 @@
               {row.feature}
               {#if row.desc !== undefined}<small>{row.desc}</small>{/if}
             </th>
-            {#each [row.gg, row.sp, row.uv, row.lc] as cell, i (i)}
+            {#each [row.gg, row.ts, row.sp, row.uv, row.lc] as cell, i (i)}
               <td>
                 <span class={`mark mark--${cell.mark}`} aria-hidden="true"
                   >{GLYPH[cell.mark]}</span

--- a/apps/docs/src/styles/shell.css
+++ b/apps/docs/src/styles/shell.css
@@ -793,7 +793,7 @@
  * circles like bun's green/amber/red dots. */
 .bench-table-wrap {
   display: block;
-  max-width: 44rem;
+  max-width: 56rem;
   margin-inline: auto;
   overflow-x: auto;
   border: 1px solid var(--line);
@@ -803,8 +803,8 @@
 
 .benchmarks table {
   width: 100%;
-  /* Four peer columns (ggsvelte + SveltePlot + LayerCake + Unovis). */
-  min-width: 40rem;
+  /* Five lib columns (ggsvelte + TanStack + SveltePlot + Unovis + LayerCake). */
+  min-width: 44rem;
   table-layout: fixed;
   border-collapse: collapse;
   font-size: 0.88rem;
@@ -820,7 +820,7 @@
 
 .benchmarks th,
 .benchmarks td {
-  padding: 0.6rem 1rem;
+  padding: 0.6rem 0.7rem;
   border-bottom: 1px solid var(--line);
   vertical-align: middle;
 }
@@ -835,6 +835,7 @@
   font-size: 0.78rem;
   font-weight: 700;
   letter-spacing: 0.02em;
+  white-space: nowrap;
 }
 
 .benchmarks thead th:not(:first-child),

--- a/scripts/comparison-table.test.ts
+++ b/scripts/comparison-table.test.ts
@@ -42,7 +42,7 @@ function parseReadmeTable(markdown: string): {
       .map((col) => col.trim());
     const feature = (cols[0] ?? "").replaceAll("*", "");
     const cells = cols.slice(1).map((raw) => {
-      const mark = raw.startsWith("✅") ? "✅" : raw.startsWith("⚠️") ? "⚠️" : "❌";
+      const mark: Mark = raw.startsWith("✅") ? "✅" : raw.startsWith("⚠️") ? "⚠️" : "❌";
       return { mark, note: raw.slice(mark.length).trim() };
     });
     return { feature, cells };

--- a/scripts/comparison-table.test.ts
+++ b/scripts/comparison-table.test.ts
@@ -1,0 +1,106 @@
+/**
+ * "Why ggsvelte?" capability tables (README + docs homepage).
+ *
+ * Column order is ggsvelte, then TanStack, then the original peer order.
+ * TanStack cells are locked to the capability verdicts researched against
+ * @tanstack/charts@0.14 (renderChartSvg + shipped skills; no JSON schema,
+ * no CLI, no automatic time scale, not a ggplot2 API).
+ */
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = join(import.meta.dir, "..");
+
+const LIBS = ["ggsvelte", "TanStack", "SveltePlot", "Unovis", "LayerCake"] as const;
+
+type Mark = "✅" | "⚠️" | "❌";
+
+function parseReadmeTable(markdown: string): {
+  headers: string[];
+  rows: { feature: string; cells: { mark: Mark; note: string }[] }[];
+} {
+  const section = markdown.split("## Why ggsvelte?")[1];
+  if (section === undefined) throw new Error("README.md is missing ## Why ggsvelte?");
+  const lines = section
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("|"));
+  const headerLine = lines[0];
+  const body = lines.slice(2);
+  if (headerLine === undefined || body.length === 0) {
+    throw new Error("README.md comparison table is missing");
+  }
+  const headers = headerLine
+    .split("|")
+    .slice(1, -1)
+    .map((col) => col.trim());
+  const rows = body.map((line) => {
+    const cols = line
+      .split("|")
+      .slice(1, -1)
+      .map((col) => col.trim());
+    const feature = (cols[0] ?? "").replaceAll("*", "");
+    const cells = cols.slice(1).map((raw) => {
+      const mark = raw.startsWith("✅") ? "✅" : raw.startsWith("⚠️") ? "⚠️" : "❌";
+      return { mark, note: raw.slice(mark.length).trim() };
+    });
+    return { feature, cells };
+  });
+  return { headers, rows };
+}
+
+function tableCell(
+  table: ReturnType<typeof parseReadmeTable>,
+  feature: string,
+  lib: (typeof LIBS)[number],
+): { mark: Mark; note: string } {
+  const row = table.rows.find((r) => r.feature.startsWith(feature));
+  if (row === undefined) throw new Error(`missing row ${feature}`);
+  const index = table.headers.indexOf(lib);
+  const found = row.cells[index - 1];
+  if (found === undefined) throw new Error(`missing ${lib} cell for ${feature}`);
+  return found;
+}
+
+describe("README Why ggsvelte? table", () => {
+  const table = parseReadmeTable(readFileSync(join(ROOT, "README.md"), "utf8"));
+
+  it("puts TanStack immediately after ggsvelte", () => {
+    expect(table.headers).toEqual(["Capability", ...LIBS]);
+  });
+
+  it("records TanStack capability verdicts from the 0.14 research pass", () => {
+    expect(tableCell(table, "Bundle size", "TanStack").mark).toBe("✅");
+    expect(tableCell(table, "Bundle size", "TanStack").note).toMatch(/^\d+ KB$/);
+    expect(tableCell(table, "API stability", "TanStack")).toEqual({
+      mark: "⚠️",
+      note: "v0.14",
+    });
+    expect(tableCell(table, "Headless server-side SVG", "TanStack").mark).toBe("✅");
+    expect(tableCell(table, "Portable JSON spec + schema", "TanStack").mark).toBe("❌");
+    expect(tableCell(table, "CLI validator + renderer", "TanStack").mark).toBe("❌");
+    expect(tableCell(table, "Agent skill", "TanStack").mark).toBe("✅");
+    expect(tableCell(table, "Automatic temporal detection", "TanStack").mark).toBe("❌");
+    expect(tableCell(table, "Built-in interactions", "TanStack").mark).toBe("✅");
+    expect(tableCell(table, "ggplot2 API", "TanStack").mark).toBe("❌");
+    expect(tableCell(table, "Scale, axis & coord control", "TanStack").mark).toBe("✅");
+  });
+});
+
+describe("docs homepage comparison table", () => {
+  const source = readFileSync(join(ROOT, "apps/docs/src/lib/components/Benchmarks.svelte"), "utf8");
+
+  it("renders TanStack as the column after ggsvelte", () => {
+    expect(source).toMatch(
+      /<th scope="col">ggsvelte<\/th>\s*<th scope="col">TanStack<\/th>\s*<th scope="col">SveltePlot<\/th>/,
+    );
+    expect(source).toMatch(/\[row\.gg, row\.ts, row\.sp, row\.uv, row\.lc\]/);
+    expect(source).toMatch(/span="5"/);
+  });
+
+  it("uses the generated TanStack version and 1k-scatter bundle", () => {
+    expect(source).toContain("BENCHMARK_VERSIONS.tanstack");
+    expect(source).toContain("BENCHMARK_BUNDLE_KB.tanstackKb");
+  });
+});

--- a/tests/visual/docs-home-gallery.spec.ts
+++ b/tests/visual/docs-home-gallery.spec.ts
@@ -35,6 +35,14 @@ test("homepage first viewport leads with title, bench tabs, then featured exampl
   await expect(page.getByRole("button", { name: "Copy install" })).toHaveCount(0);
   await expect(page.getByRole("link", { name: "Getting started" })).toHaveCount(0);
   await expect(page.getByRole("heading", { name: "Examples", level: 2 })).toHaveCount(0);
+  await expect(page.locator(".benchmarks thead th")).toHaveText([
+    "Capability",
+    "ggsvelte",
+    "TanStack",
+    "SveltePlot",
+    "Unovis",
+    "LayerCake",
+  ]);
   await expect(page.locator(".home-featured ol li")).toHaveCount(6);
   await expect(page.locator(".home-featured header a")).toHaveText("Gallery");
   await expectNoOverflow(page);


### PR DESCRIPTION
## Summary

Add a TanStack Charts column next to ggsvelte on the README and docs homepage comparison tables.

Verdicts use `@tanstack/charts@0.14` docs, source, and this repo's 1k-scatter bundle plus SSR bench:

- Bundle size: 57 KB (same measured 1k scatter cell as the other columns)
- API stability: pre-1.0 (`v0.14`)
- Headless server-side SVG: yes (`renderChartSvg` and complete Svelte SSR)
- Portable JSON spec + schema: no
- CLI validator + renderer: no
- Agent skill: yes (package ships `skills/` and `llms.txt`)
- Automatic temporal detection: no (you must set `scaleUtc`)
- Built-in interactions: yes
- ggplot2 API: no (Observable Plot-like marks, not ggplot2)
- Scale, axis, and coord control: yes

No changeset: docs only.

## Test plan

- [x] README column order is ggsvelte, TanStack, SveltePlot, Unovis, LayerCake
- [x] `bun test scripts/comparison-table.test.ts scripts/sync-comparison-versions.test.ts`
- [x] Homepage table on the local docs server shows TanStack after ggsvelte at 1280 and 375
- [x] svelte-autofixer reported no issues on `Benchmarks.svelte`