### PR TITLE
docs: mark SveltePlot bundle size as a warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ and Windows.
 
 | Capability                                 | ggsvelte   | TanStack | SveltePlot           | Unovis                 | LayerCake            |
 | ------------------------------------------ | ---------- | -------- | -------------------- | ---------------------- | -------------------- |
-| **Bundle size** (min+gzip, 1k scatter app) | ⚠️ 108 KB  | ✅ 57 KB | ✅ 109 KB            | ✅ 80 KB               | ✅ 41 KB             |
+| **Bundle size** (min+gzip, 1k scatter app) | ⚠️ 108 KB  | ✅ 57 KB | ⚠️ 109 KB            | ✅ 80 KB               | ✅ 41 KB             |
 | **API stability**                          | ⚠️ v0.38.1 | ⚠️ v0.14 | ⚠️ v0.14             | ✅ v1.6                | ✅ v10               |
 | **Headless server-side SVG** (no DOM)      | ✅         | ✅       | ❌ empty shell       | ❌ client `onMount`    | ⚠️ opt-in `ssr` flag |
 | **Portable JSON spec + schema**            | ✅         | ❌       | ❌                   | ❌                     | ❌                   |

--- a/apps/docs/src/lib/components/Benchmarks.svelte
+++ b/apps/docs/src/lib/components/Benchmarks.svelte
@@ -47,7 +47,7 @@
       ts: { mark: "yes", note: kb(BENCHMARK_BUNDLE_KB.tanstackKb) },
       lc: { mark: "yes", note: kb(BENCHMARK_BUNDLE_KB.layercakeKb) },
       uv: { mark: "yes", note: kb(BENCHMARK_BUNDLE_KB.unovisKb) },
-      sp: { mark: "yes", note: kb(BENCHMARK_BUNDLE_KB.svelteplotKb) },
+      sp: { mark: "partial", note: kb(BENCHMARK_BUNDLE_KB.svelteplotKb) },
     },
     {
       feature: "API stability",


### PR DESCRIPTION
## Summary

ggsvelte 1k scatter gzip is **108 KB**. SveltePlot is **109 KB**. The Why ggsvelte tables no longer give SveltePlot a green tick on that row. Both now use the yellow warning mark.

Rebased onto main after #1633 added TanStack. TanStack (57 KB), Unovis (80 KB), and LayerCake (41 KB) stay green.

No changeset: docs site + root README only.

## Test plan

- [x] README SveltePlot bundle cell is ⚠️ 109 KB (TanStack column kept)
- [x] Homepage Bundle size row: ggsvelte and SveltePlot are `mark--partial`; TanStack, Unovis, LayerCake stay `mark--yes`
- [x] Local docs homepage at 1280 and 375
- [x] `bun test scripts/sync-comparison-versions.test.ts` — 13 pass