### PR TITLE
perf(core): skip trimming ASCII labels

### DIFF
--- a/.changeset/faster-ascii-label-detection.md
+++ b/.changeset/faster-ascii-label-detection.md
@@ -1,0 +1,5 @@
+---
+"@ggsvelte/core": patch
+---
+
+Skip trimmed-string allocation when classifying ordinary ASCII categorical labels.

--- a/packages/core/src/table.ts
+++ b/packages/core/src/table.ts
@@ -287,6 +287,13 @@ function allInvalidSemantic(length: number): { semantic: Float64Array; valid: Ui
  * text). Labels like "s0" / "series-1" are false (letter first after trim).
  */
 function stringLooksNumeric(value: string): boolean {
+  const first = value.charCodeAt(0);
+  // Most nominal labels start with printable ASCII ("s0", "series-1").
+  // Decide those without allocating a trimmed copy; keep the full trim path
+  // for leading whitespace and non-ASCII input.
+  if (first > 0x20 && first < 0x7f) {
+    return (first >= 48 && first <= 57) || first === 43 || first === 45 || first === 46;
+  }
   const trimmed = value.trim();
   if (trimmed.length === 0) return false;
   const c0 = trimmed.codePointAt(0);

--- a/packages/core/src/table.ts
+++ b/packages/core/src/table.ts
@@ -287,11 +287,11 @@ function allInvalidSemantic(length: number): { semantic: Float64Array; valid: Ui
  * text). Labels like "s0" / "series-1" are false (letter first after trim).
  */
 function stringLooksNumeric(value: string): boolean {
-  const first = value.charCodeAt(0);
+  const first = value.codePointAt(0);
   // Most nominal labels start with printable ASCII ("s0", "series-1").
   // Decide those without allocating a trimmed copy; keep the full trim path
   // for leading whitespace and non-ASCII input.
-  if (first > 0x20 && first < 0x7f) {
+  if (first !== undefined && first > 0x20 && first < 0x7f) {
     return (first >= 48 && first <= 57) || first === 43 || first === 45 || first === 46;
   }
   const trimmed = value.trim();


### PR DESCRIPTION
## Summary

- classify ordinary printable-ASCII labels without allocating a trimmed copy
- preserve the existing trim path for leading whitespace and non-ASCII input
- keep numeric-text coercion unchanged

This attacks the `stringLooksNumeric`/`trim` hotspot from #1468 after #1637's catalog win.

## Before / after

All comparisons are against merged `main` (`18b49bd3`) on the same machine.

### 30k categorical-column parse seam

Six alternating processes, 240 samples per process:

- before median-of-medians: **0.489 ms**
- after median-of-medians: **0.156 ms**
- change: **-68.1%**

### Full `line-3x10k` pipeline

Seven alternating processes, 180 samples per process:

- before median-of-medians: **4.247 ms**
- after median-of-medians: **3.873 ms**
- change: **-8.8%**
- every paired run improved

### Chromium competitive harness

Three paired `ggsvelte-canvas` / `layercake-canvas` runs after #1637:

- ggsvelte mount median: **48.9 -> 47.4 ms** (`-3.1%`)
- ggsvelte in-place update median: **41.8 -> 38.8 ms** (`-7.2%`)

## Correctness

- exhaustive old/new predicate comparison: **458,752 inputs**, no mismatch
- covers all 65,536 UTF-16 first code units across seven suffix shapes
- existing tests cover ASCII labels, numeric prefixes, and leading-whitespace numeric text

## Verification

- `bun test packages/core/tests` — **2,429 pass, 0 fail**
- `bun run check`
- `bun run --bun lint:type-aware:run`
- focused coverage review — no findings
- maintainability review — no findings
- performance review — no findings

Related to #1468.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ljodea/ggsvelte/pull/1639" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->