### PR TITLE
perf(core): omit palette catalogs from lean colors

### DIFF
--- a/.changeset/lean-default-palette-registration.md
+++ b/.changeset/lean-default-palette-registration.md
@@ -3,3 +3,5 @@
 ---
 
 Add `registerDefaultOrdinalColor()` for headless charts that use the built-in categorical palette or an explicit range. This registration keeps named categorical, ColorBrewer, sequential, and Crameri catalogs out of lean bundles; use `registerOrdinalColor()` when a spec selects a named scheme.
+
+Migration: none — additive.

--- a/.changeset/lean-default-palette-registration.md
+++ b/.changeset/lean-default-palette-registration.md
@@ -1,0 +1,5 @@
+---
+"@ggsvelte/core": minor
+---
+
+Add `registerDefaultOrdinalColor()` for headless charts that use the built-in categorical palette or an explicit range. This registration keeps named categorical, ColorBrewer, sequential, and Crameri catalogs out of lean bundles; use `registerOrdinalColor()` when a spec selects a named scheme.

--- a/apps/docs/src/lib/generated/routes.ts
+++ b/apps/docs/src/lib/generated/routes.ts
@@ -12441,8 +12441,8 @@ export const DOCS_ROUTES = [
         level: 2,
       },
       {
-        id: "experimental-19",
-        title: "experimental (19)",
+        id: "experimental-20",
+        title: "experimental (20)",
         level: 3,
       },
       {

--- a/apps/docs/src/lib/generated/search-index.ts
+++ b/apps/docs/src/lib/generated/search-index.ts
@@ -20564,14 +20564,14 @@ export const DOCS_SEARCH_INDEX = [
     exact: ["@ggsvelte/core (./headless/register)"],
   },
   {
-    id: "heading:guide-lifecycle:experimental-19",
+    id: "heading:guide-lifecycle:experimental-20",
     kind: "heading",
-    title: "experimental (19)",
+    title: "experimental (20)",
     summary:
-      "experimental (19) in Lifecycle & editions. API stability tags per export, and the defaults-edition mechanism.",
-    href: "/guide/lifecycle#experimental-19",
+      "experimental (20) in Lifecycle & editions. API stability tags per export, and the defaults-edition mechanism.",
+    href: "/guide/lifecycle#experimental-20",
     keywords: ["Lifecycle & editions", "Reference"],
-    exact: ["experimental (19)"],
+    exact: ["experimental (20)"],
   },
   {
     id: "heading:guide-lifecycle:ggsvelte-core-temporal",
@@ -35786,6 +35786,15 @@ export const DOCS_SEARCH_INDEX = [
     href: "/guide/lifecycle#ggsvelte-core-headless-register",
     keywords: ["@ggsvelte/core", "./headless/register", "value", "experimental"],
     exact: ["registerContinuousLegend"],
+  },
+  {
+    id: "api:ggsvelte-core-headless-register:registerDefaultOrdinalColor",
+    kind: "api",
+    title: "registerDefaultOrdinalColor",
+    summary: "@ggsvelte/core ./headless/register · value · experimental.",
+    href: "/guide/lifecycle#ggsvelte-core-headless-register",
+    keywords: ["@ggsvelte/core", "./headless/register", "value", "experimental"],
+    exact: ["registerDefaultOrdinalColor"],
   },
   {
     id: "api:ggsvelte-core-headless-register:registerDiscreteLegend",

--- a/benchmarks/competitive/entries/ggsvelte-canvas__area-multiseries.ts
+++ b/benchmarks/competitive/entries/ggsvelte-canvas__area-multiseries.ts
@@ -1,9 +1,9 @@
-import { registerBasicAreas, registerOrdinalColor } from "@ggsvelte/core/headless/register";
+import { registerBasicAreas, registerDefaultOrdinalColor } from "@ggsvelte/core/headless/register";
 
 import { bundleAreaCanvas } from "../adapters/ggsvelte-canvas";
 
 registerBasicAreas();
-registerOrdinalColor();
+registerDefaultOrdinalColor();
 import { makeMultiSeries } from "../scenarios";
 
 export const out = bundleAreaCanvas(makeMultiSeries(3, 1000));

--- a/benchmarks/competitive/entries/ggsvelte-canvas__line-multiseries.ts
+++ b/benchmarks/competitive/entries/ggsvelte-canvas__line-multiseries.ts
@@ -1,9 +1,9 @@
-import { registerBasicLines, registerOrdinalColor } from "@ggsvelte/core/headless/register";
+import { registerBasicLines, registerDefaultOrdinalColor } from "@ggsvelte/core/headless/register";
 
 import { bundleLineCanvas } from "../adapters/ggsvelte-canvas";
 
 registerBasicLines();
-registerOrdinalColor();
+registerDefaultOrdinalColor();
 import { makeMultiSeries } from "../scenarios";
 
 export const out = bundleLineCanvas(makeMultiSeries(3, 1000));

--- a/benchmarks/competitive/entries/ggsvelte-canvas__scatter-color.ts
+++ b/benchmarks/competitive/entries/ggsvelte-canvas__scatter-color.ts
@@ -1,9 +1,9 @@
-import { registerBasicPoints, registerOrdinalColor } from "@ggsvelte/core/headless/register";
+import { registerBasicPoints, registerDefaultOrdinalColor } from "@ggsvelte/core/headless/register";
 
 import { bundleScatterCanvas } from "../adapters/ggsvelte-canvas";
 
 registerBasicPoints();
-registerOrdinalColor();
+registerDefaultOrdinalColor();
 import { makeScatter } from "../scenarios";
 
 export const out = bundleScatterCanvas(makeScatter(1000));

--- a/benchmarks/competitive/entries/ggsvelte-svg__area-multiseries.ts
+++ b/benchmarks/competitive/entries/ggsvelte-svg__area-multiseries.ts
@@ -1,9 +1,9 @@
-import { registerBasicAreas, registerOrdinalColor } from "@ggsvelte/core/headless/register";
+import { registerBasicAreas, registerDefaultOrdinalColor } from "@ggsvelte/core/headless/register";
 
 import { bundleAreaSvg } from "../adapters/ggsvelte-svg";
 
 registerBasicAreas();
-registerOrdinalColor();
+registerDefaultOrdinalColor();
 import { makeMultiSeries } from "../scenarios";
 
 export const out = bundleAreaSvg(makeMultiSeries(3, 1000));

--- a/benchmarks/competitive/entries/ggsvelte-svg__bars-stacked.ts
+++ b/benchmarks/competitive/entries/ggsvelte-svg__bars-stacked.ts
@@ -1,13 +1,13 @@
 import {
   registerBandGuide,
   registerBasicBars,
-  registerOrdinalColor,
+  registerDefaultOrdinalColor,
 } from "@ggsvelte/core/headless/register";
 
 import { bundleBarsSvg } from "../adapters/ggsvelte-svg";
 
 registerBasicBars();
-registerOrdinalColor();
+registerDefaultOrdinalColor();
 registerBandGuide();
 import { makeStackedBars } from "../scenarios";
 

--- a/benchmarks/competitive/entries/ggsvelte-svg__line-multiseries.ts
+++ b/benchmarks/competitive/entries/ggsvelte-svg__line-multiseries.ts
@@ -1,9 +1,9 @@
-import { registerBasicLines, registerOrdinalColor } from "@ggsvelte/core/headless/register";
+import { registerBasicLines, registerDefaultOrdinalColor } from "@ggsvelte/core/headless/register";
 
 import { bundleLineSvg } from "../adapters/ggsvelte-svg";
 
 registerBasicLines();
-registerOrdinalColor();
+registerDefaultOrdinalColor();
 import { makeMultiSeries } from "../scenarios";
 
 export const out = bundleLineSvg(makeMultiSeries(3, 1000));

--- a/benchmarks/competitive/entries/ggsvelte-svg__scatter-color.ts
+++ b/benchmarks/competitive/entries/ggsvelte-svg__scatter-color.ts
@@ -1,9 +1,9 @@
-import { registerBasicPoints, registerOrdinalColor } from "@ggsvelte/core/headless/register";
+import { registerBasicPoints, registerDefaultOrdinalColor } from "@ggsvelte/core/headless/register";
 
 import { bundleScatterSvg } from "../adapters/ggsvelte-svg";
 
 registerBasicPoints();
-registerOrdinalColor();
+registerDefaultOrdinalColor();
 import { makeScatter } from "../scenarios";
 
 export const out = bundleScatterSvg(makeScatter(1000));

--- a/benchmarks/competitive/lean-candidates-graph.test.ts
+++ b/benchmarks/competitive/lean-candidates-graph.test.ts
@@ -22,6 +22,8 @@ const COLOR_KIND_BANNED = /scale-color-(?:binned|sequential|manual|identity)\.[c
 const BAND_GUIDE_BANNED = /band-guide\.[cm]?[jt]s$/;
 const CONTINUOUS_LEGEND_BANNED = /legend-build-continuous\.[cm]?[jt]s$/;
 const STYLE_SEQUENTIAL_BANNED = /scale-style-numeric-sequential\.[cm]?[jt]s$/;
+const PALETTE_CATALOG_BANNED =
+  /categorical-palettes|colorbrewer-palettes|crameri-ramps|sequential-schemes|hue-grey-palettes/;
 
 async function buildEntry(entryName: string): Promise<{ moduleIds: string[]; rawBytes: number }> {
   const outDir = path.join(root, "results", "bundles", `_lean-candidates-test-${entryName}`);
@@ -79,6 +81,7 @@ describe("lean competitive SVG graph", () => {
     expect(built.moduleIds.filter((id) => BAND_GUIDE_BANNED.test(id))).toEqual([]);
     expect(built.moduleIds.filter((id) => CONTINUOUS_LEGEND_BANNED.test(id))).toEqual([]);
     expect(built.moduleIds.filter((id) => STYLE_SEQUENTIAL_BANNED.test(id))).toEqual([]);
+    expect(built.moduleIds.filter((id) => PALETTE_CATALOG_BANNED.test(id))).toEqual([]);
   }, 120_000);
 });
 
@@ -93,5 +96,6 @@ describe("lean competitive canvas graph", () => {
     expect(built.moduleIds.filter((id) => BAND_GUIDE_BANNED.test(id))).toEqual([]);
     expect(built.moduleIds.filter((id) => CONTINUOUS_LEGEND_BANNED.test(id))).toEqual([]);
     expect(built.moduleIds.filter((id) => STYLE_SEQUENTIAL_BANNED.test(id))).toEqual([]);
+    expect(built.moduleIds.filter((id) => PALETTE_CATALOG_BANNED.test(id))).toEqual([]);
   }, 120_000);
 });

--- a/lifecycle.json
+++ b/lifecycle.json
@@ -5851,6 +5851,10 @@
           "kind": "value",
           "lifecycle": "experimental"
         },
+        "registerDefaultOrdinalColor": {
+          "kind": "value",
+          "lifecycle": "experimental"
+        },
         "registerDiscreteLegend": {
           "kind": "value",
           "lifecycle": "experimental"

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -51,6 +51,11 @@ import { registerBasicPoints } from "@ggsvelte/core/headless/register";
 registerBasicPoints();
 ```
 
+Mapped colors can stay catalog-free too: call `registerDefaultOrdinalColor()`
+for the built-in palette or an explicit `range`. Call `registerOrdinalColor()`
+instead when the spec selects a named categorical, ColorBrewer, sequential, or
+Crameri scheme.
+
 Bare PortableSpec JSON works the same way — channel mappings use
 `{ field: "col" }`, not bare strings:
 

--- a/packages/core/src/editions-slim.ts
+++ b/packages/core/src/editions-slim.ts
@@ -2,7 +2,7 @@
  * Slim defaults-edition tables: default + void themes only.
  */
 import { VIRIDIS_RAMP_10 } from "./scales/viridis-ramp.js";
-import { CATEGORICAL_PALETTE_10 } from "./scales/categorical-palettes.js";
+import { CATEGORICAL_PALETTE_10 } from "./scales/categorical-palette-default.js";
 import { SLIM_THEMES, SLIM_THEMES_LEGACY } from "./theme-slim.js";
 import type { EditionDefaults } from "./editions-resolve.js";
 

--- a/packages/core/src/headless-register-entry.ts
+++ b/packages/core/src/headless-register-entry.ts
@@ -10,6 +10,7 @@ export { registerBasicSegments } from "./pipeline/register-basic-segments.js";
 export { registerBinnedColor } from "./pipeline/register-color-binned.js";
 export { registerIdentityColor } from "./pipeline/register-color-identity.js";
 export { registerManualColor } from "./pipeline/register-color-manual.js";
+export { registerDefaultOrdinalColor } from "./pipeline/register-color-ordinal-default.js";
 export { registerOrdinalColor } from "./pipeline/register-color-ordinal.js";
 export { registerSequentialColor } from "./pipeline/register-color-sequential.js";
 export { registerFiniteStyle } from "./pipeline/register-style-finite.js";

--- a/packages/core/src/pipeline/register-color-ordinal-default.ts
+++ b/packages/core/src/pipeline/register-color-ordinal-default.ts
@@ -1,0 +1,29 @@
+import { registerDiscreteLegend } from "../legend-register-discrete.js";
+import { getColorScaleResolver, registerColorScaleResolver } from "./scale-color-registry.js";
+import { resolveDefaultOrdinalColorScale } from "./scale-color-ordinal-default.js";
+
+let registered = false;
+
+/**
+ * Register ordinal color/fill for the built-in default palette or an explicit range.
+ * Named schemes require {@link registerOrdinalColor} instead.
+ */
+export function registerDefaultOrdinalColor(): void {
+  if (registered) return;
+  registered = true;
+  registerDiscreteLegend();
+  if (getColorScaleResolver("ordinal") !== undefined) return;
+  registerColorScaleResolver("ordinal", (input) => {
+    const domainValues = input.catalogValues.length > 0 ? input.catalogValues : input.values;
+    return resolveDefaultOrdinalColorScale({
+      name: input.name,
+      values: domainValues.filter((value) => value !== null),
+      config: input.config,
+      prevState: input.prevState,
+      legendTitle: input.legendTitle,
+      warnings: input.warnings,
+      advisories: input.advisories,
+      editionDefaults: input.editionDefaults,
+    });
+  });
+}

--- a/packages/core/src/pipeline/scale-color-ordinal-default.ts
+++ b/packages/core/src/pipeline/scale-color-ordinal-default.ts
@@ -1,0 +1,64 @@
+import type { ColorScaleSpec } from "@ggsvelte/spec";
+
+import { CATEGORICAL_PALETTE_10 } from "../scales/categorical-palette-default.js";
+import type { ScaleState } from "../scales/state.js";
+import { PaletteExhaustedError } from "../scales/state.js";
+import type { ColorScale } from "../scales/train-types.js";
+import { trainDefaultColor } from "../scales/train-color-default.js";
+import type { CellValue } from "../table.js";
+import type { EditionDefaults } from "../editions.js";
+
+import { ordinalColorResolution } from "./scale-color-ordinal-result.js";
+import type { ColorResolution } from "./scale-color-types.js";
+import { PipelineError, type Advisory, type PipelineWarning } from "./types.js";
+
+/** Resolve ordinal color for default/explicit ranges without named palette catalogs. */
+export function resolveDefaultOrdinalColorScale(input: {
+  name: "color" | "fill";
+  values: readonly CellValue[];
+  config: ColorScaleSpec | undefined;
+  prevState: ScaleState | null;
+  legendTitle: string;
+  warnings: PipelineWarning[];
+  advisories: Advisory[];
+  editionDefaults: EditionDefaults;
+}): ColorResolution {
+  const { name, values, config, prevState, legendTitle, warnings, advisories, editionDefaults } =
+    input;
+  if (config?.scheme !== undefined && config.scheme !== "observable10") {
+    throw new PipelineError(
+      "unsupported-param",
+      `/scales/${name}/scheme`,
+      `Named color scheme ${JSON.stringify(config.scheme)} is not registered in this build. Call registerOrdinalColor() from @ggsvelte/core/headless/register once at startup.`,
+    );
+  }
+  const editionRange =
+    editionDefaults.categoricalPalette === CATEGORICAL_PALETTE_10
+      ? undefined
+      : editionDefaults.categoricalPalette;
+  const range = config?.range ?? editionRange;
+  let scale: ColorScale;
+  try {
+    scale = trainDefaultColor(values, prevState, {
+      ...(config?.domain !== undefined && { domain: config.domain }),
+      ...(config?.domainMode !== undefined && { domainMode: config.domainMode }),
+      ...(range !== undefined && { range }),
+      ...(config?.reverse !== undefined && { reverse: config.reverse }),
+      ...(config?.onExhaust !== undefined && { onExhaust: config.onExhaust }),
+    });
+  } catch (error) {
+    if (error instanceof PaletteExhaustedError) {
+      throw new PipelineError("palette-exhausted", `/scales/${name}`, error.message);
+    }
+    throw error;
+  }
+  return ordinalColorResolution({
+    name,
+    values,
+    config,
+    legendTitle,
+    scale,
+    warnings,
+    advisories,
+  });
+}

--- a/packages/core/src/scales/categorical-palette-default.ts
+++ b/packages/core/src/scales/categorical-palette-default.ts
@@ -1,0 +1,18 @@
+/**
+ * Default categorical palette: 10 colors in the Observable 10 family.
+ *
+ * Kept separate from the named palette catalog so consumers that use only the
+ * default or an explicit range do not bundle every named scheme.
+ */
+export const CATEGORICAL_PALETTE_10: readonly string[] = [
+  "#4269d0",
+  "#efb118",
+  "#ff725c",
+  "#6cc5b0",
+  "#3ca951",
+  "#ff8ab7",
+  "#a463f2",
+  "#97bbf5",
+  "#9c6b4e",
+  "#9498a0",
+];

--- a/packages/core/src/scales/categorical-palettes.ts
+++ b/packages/core/src/scales/categorical-palettes.ts
@@ -8,24 +8,9 @@
 import { HUE_PALETTE_10 } from "@ggsvelte/spec";
 
 import { COLORBREWER_QUALITATIVE } from "./colorbrewer-palettes.js";
+import { CATEGORICAL_PALETTE_10 } from "./categorical-palette-default.js";
 
-/**
- * Default categorical palette: 10 colors in the Observable 10 family.
- * The palette is a plain value — its fingerprint (not its identity) keys
- * scale-state invalidation.
- */
-export const CATEGORICAL_PALETTE_10: readonly string[] = [
-  "#4269d0",
-  "#efb118",
-  "#ff725c",
-  "#6cc5b0",
-  "#3ca951",
-  "#ff8ab7",
-  "#a463f2",
-  "#97bbf5",
-  "#9c6b4e",
-  "#9498a0",
-];
+export { CATEGORICAL_PALETTE_10 };
 
 /** hrbrthemes::ipsum_palette, in its published source order. */
 export const IPSUM_PALETTE: readonly string[] = [

--- a/packages/core/src/scales/train-color-default.ts
+++ b/packages/core/src/scales/train-color-default.ts
@@ -1,0 +1,42 @@
+import { CATEGORICAL_PALETTE_10 } from "./categorical-palette-default.js";
+import type { OrdinalColorConfig } from "./train-color.js";
+import type { ScaleState, TrainResult } from "./state.js";
+import { trainDiscrete } from "./state.js";
+import type { ColorScale } from "./train-types.js";
+
+/** Train default/explicit-range ordinal colors without loading named scheme catalogs. */
+export function trainDefaultColor(
+  values: Iterable<unknown>,
+  prevState?: ScaleState | null,
+  config: OrdinalColorConfig = {},
+): ColorScale {
+  const baseRange = config.range ?? CATEGORICAL_PALETTE_10;
+  const range = config.reverse === true ? baseRange.toReversed() : baseRange;
+  const scheme =
+    config.range === undefined
+      ? config.reverse === true
+        ? "observable10-reversed"
+        : "observable10"
+      : undefined;
+  const result: TrainResult = trainDiscrete(
+    values,
+    {
+      type: "ordinal",
+      range,
+      ...(scheme !== undefined && { scheme }),
+      ...(config.domain !== undefined && { domain: config.domain }),
+      ...(config.domainMode !== undefined && { domainMode: config.domainMode }),
+      ...(config.onExhaust !== undefined && { onExhaust: config.onExhaust }),
+    },
+    prevState ?? null,
+  );
+
+  return {
+    type: "ordinal",
+    domain: result.domain,
+    indexOf: (value: unknown) => result.indexOf(value),
+    colorOf: (value: unknown) => result.rangeValueOf(value) as string | undefined,
+    state: result.state,
+    warnings: result.warnings,
+  };
+}

--- a/packages/core/tests/headless-registration.test.ts
+++ b/packages/core/tests/headless-registration.test.ts
@@ -40,6 +40,44 @@ describe("granular headless registration", () => {
     expect(out.lineAfterLine).toBe("rendered");
   });
 
+  it("upgrades default ordinal color registration when named schemes are requested", () => {
+    const coreRoot = path.resolve(import.meta.dir, "..");
+    const script = `
+      import { renderToSVGString } from ${JSON.stringify(path.join(coreRoot, "src", "headless-entry.ts"))};
+      import { registerBasicPoints, registerDefaultOrdinalColor, registerOrdinalColor } from ${JSON.stringify(path.join(coreRoot, "src", "headless-register-entry.ts"))};
+      registerBasicPoints();
+      registerDefaultOrdinalColor();
+      const rows = [{ x: 1, y: 2, group: "a" }, { x: 2, y: 3, group: "b" }];
+      const spec = (color) => ({
+        data: { values: rows },
+        layers: [{ geom: "point", aes: { x: { field: "x" }, y: { field: "y" }, color: { field: "group" } } }],
+        ...(color === undefined ? {} : { scales: { color } }),
+      });
+      const attempt = (color) => {
+        try { return renderToSVGString(spec(color), { width: 200, height: 120 }); }
+        catch (error) { return String(error instanceof Error ? error.message : error); }
+      };
+      const out = {
+        defaultSvg: attempt(undefined),
+        explicitSvg: attempt({ type: "ordinal", range: ["#112233", "#445566"] }),
+        namedBeforeFull: attempt({ type: "ordinal", scheme: "Dark2" }),
+      };
+      registerOrdinalColor();
+      out.namedAfterFull = attempt({ type: "ordinal", scheme: "Dark2" });
+      console.log(JSON.stringify(out));
+    `;
+    const proc = spawnSync(process.execPath, ["-e", script], {
+      cwd: coreRoot,
+      encoding: "utf8",
+    });
+    expect(proc.status).toBe(0);
+    const out = JSON.parse(proc.stdout.trim().split("\n").at(-1) ?? "{}") as Record<string, string>;
+    expect(out.defaultSvg).toContain("gg-points");
+    expect(out.explicitSvg).toContain("#112233");
+    expect(out.namedBeforeFull).toContain("Call registerOrdinalColor()");
+    expect(out.namedAfterFull).toContain("gg-points");
+  });
+
   it("registers the default count stat with the bar family", () => {
     const coreRoot = path.resolve(import.meta.dir, "..");
     const script = `


### PR DESCRIPTION
## Summary

- add `registerDefaultOrdinalColor()` for headless charts using the built-in categorical palette or an explicit range
- keep named categorical, ColorBrewer, sequential, and Crameri catalogs behind `registerOrdinalColor()`
- move the default palette into a catalog-free module and lock the lean graph with attribution tests

## Bundle evidence

Fresh package distributions on `488756c6`, then identical `bun run measure:bundles` builds (Vite ES library mode, esbuild minify, gzip -9):

| Scenario | Before raw/gzip | After raw/gzip | Gzip change |
| --- | ---: | ---: | ---: |
| SVG scatter | 410,297 / 110,452 B | 394,740 / 104,539 B | -5,913 B (-5.35%) |
| SVG line | 413,763 / 111,325 B | 398,206 / 105,360 B | -5,965 B (-5.36%) |
| SVG area | 417,606 / 112,218 B | 402,049 / 106,178 B | -6,040 B (-5.38%) |
| SVG stacked bars | 421,748 / 113,859 B | 406,191 / 107,984 B | -5,875 B (-5.16%) |
| Canvas scatter | 405,211 / 109,520 B | 389,654 / 103,564 B | -5,956 B (-5.44%) |
| Canvas line | 408,689 / 110,429 B | 393,132 / 104,391 B | -6,038 B (-5.47%) |
| Canvas area | 412,519 / 111,347 B | 396,962 / 105,328 B | -6,019 B (-5.41%) |

Every lean row drops exactly 15,557 raw bytes. The full registration row is byte-identical (1,724,480 raw / 367,255 gzip), so named-scheme behavior remains on the existing full surface.

## Verification

- `bun run build` — pass
- `bun test packages/core/tests/headless-registration.test.ts packages/core/tests/palettes.test.ts packages/core/tests/colorbrewer-schemes.test.ts benchmarks/competitive/lean-candidates-graph.test.ts benchmarks/competitive/direct-spec-equivalence.test.ts` — 41 pass, 0 fail
- `coderabbit review --agent -t uncommitted` — 0 findings
- `cd benchmarks/competitive && bun run measure:bundles` — pass; metrics above
