### PR TITLE
docs: update bundle size comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ and Windows.
 
 | Capability                                 | ggsvelte   | TanStack | SveltePlot | Unovis   | LayerCake |
 | ------------------------------------------ | ---------- | -------- | ---------- | -------- | --------- |
-| **Bundle size** (min+gzip, 1k scatter app) | ⚠️ 108 KB  | ✅ 57 KB | ⚠️ 109 KB  | ✅ 80 KB | ✅ 41 KB  |
+| **Bundle size** (min+gzip, 1k scatter app) | ⚠️ 102 KB  | ✅ 57 KB | ⚠️ 109 KB  | ✅ 80 KB | ✅ 41 KB  |
 | **API stability**                          | ⚠️ v0.38.2 | ⚠️ v0.14 | ⚠️ v0.14   | ✅ v1.6  | ✅ v10    |
 | **Headless server-side SVG** (no DOM)      | ✅         | ✅       | ❌         | ❌       | ⚠️ opt-in |
 | **Portable JSON spec + schema**            | ✅         | ❌       | ❌         | ❌       | ❌        |

--- a/apps/docs/src/lib/generated/benchmark-charts.ts
+++ b/apps/docs/src/lib/generated/benchmark-charts.ts
@@ -101,7 +101,7 @@ export const BENCHMARK_VERSIONS = {
 
 /** Min+gzip KB of the 1,000-point colored-scatter app bundle. */
 export const BENCHMARK_BUNDLE_KB = {
-  ggsvelteKb: 107.6,
+  ggsvelteKb: 102.1,
   svelteplotKb: 108.7,
   layercakeKb: 40.8,
   unovisKb: 80.3,


### PR DESCRIPTION
## Summary

- update the README bundle-size comparison from 108 KB to 102 KB
- update the docs homepage benchmark projection from 107.6 KB to 102.1 KB
- preserve peer measurements and the existing rounded display format

## Measurement evidence

Merged-main `ggsvelte-svg__scatter-color`: 104,539 gzip bytes. The benchmark projection records 102.1 KiB; README and homepage display round that value to 102 KB.

## Verification

- `bun test scripts/sync-comparison-versions.test.ts scripts/comparison-table.test.ts` — 19 pass, 0 fail
- Svelte autofixer on `Benchmarks.svelte` — 0 issues, 0 suggestions
- `cd apps/docs && bun run build` with local ignored benchmark results hidden — pass
- Browser check against the production preview — homepage bundle row displayed `102 KB`
- `git diff --check` — pass

Migration: none — documentation-only measurement update.
