### PR TITLE
deps-dev: bump @sveltejs/vite-plugin-svelte from 7.2.0 to 7.3.0

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@sveltejs/adapter-static": "^3.0.10",
     "@sveltejs/kit": "^2.70.2",
-    "@sveltejs/vite-plugin-svelte": "^7.2.0",
+    "@sveltejs/vite-plugin-svelte": "^7.3.0",
     "@testing-library/svelte-core": "^1.1.3",
     "@vitest/browser-playwright": "^4.1.10",
     "playwright": "1.61.1",

--- a/benchmarks/competitive/package.json
+++ b/benchmarks/competitive/package.json
@@ -35,7 +35,7 @@
     "uplot": "^1.6.32"
   },
   "devDependencies": {
-    "@sveltejs/vite-plugin-svelte": "^7.2.0",
+    "@sveltejs/vite-plugin-svelte": "^7.3.0",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
     "@vitejs/plugin-react": "^6.0.5",

--- a/bun.lock
+++ b/bun.lock
@@ -4,9 +4,6 @@
   "workspaces": {
     "": {
       "name": "ggsvelte-monorepo",
-      "dependencies": {
-        "svelte": "^5.56.9",
-      },
       "devDependencies": {
         "@arethetypeswrong/cli": "0.18.5",
         "@changesets/cli": "2.31.1",
@@ -46,11 +43,11 @@
       "devDependencies": {
         "@sveltejs/adapter-static": "^3.0.10",
         "@sveltejs/kit": "^2.70.2",
-        "@sveltejs/vite-plugin-svelte": "^7.2.0",
+        "@sveltejs/vite-plugin-svelte": "^7.3.0",
         "@testing-library/svelte-core": "^1.1.3",
         "@vitest/browser-playwright": "^4.1.10",
         "playwright": "1.61.1",
-        "svelte": "^5.56.7",
+        "svelte": "^5.56.9",
         "svelte-check": "^4.7.4",
         "typescript": "^6.0.3",
         "vite": "^8.2.0",
@@ -87,12 +84,12 @@
         "layercake": "^10.0.3",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
-        "svelte": "^5.56.7",
+        "svelte": "^5.56.9",
         "svelteplot": "^0.14.2",
         "uplot": "^1.6.32",
       },
       "devDependencies": {
-        "@sveltejs/vite-plugin-svelte": "^7.2.0",
+        "@sveltejs/vite-plugin-svelte": "^7.3.0",
         "@types/react": "^19.2.18",
         "@types/react-dom": "^19.2.4",
         "@vitejs/plugin-react": "^6.0.5",
@@ -108,13 +105,13 @@
         "@ggsvelte/svelte": "workspace:*",
       },
       "devDependencies": {
-        "svelte": "^5.56.7",
+        "svelte": "^5.56.9",
         "typescript": "^6.0.3",
       },
     },
     "packages/cli": {
       "name": "@ggsvelte/cli",
-      "version": "0.38.1",
+      "version": "0.38.2",
       "bin": {
         "ggsvelte-render": "bin/ggsvelte-render.js",
       },
@@ -124,9 +121,9 @@
     },
     "packages/core": {
       "name": "@ggsvelte/core",
-      "version": "0.38.1",
+      "version": "0.38.2",
       "dependencies": {
-        "@ggsvelte/spec": "^0.38.1",
+        "@ggsvelte/spec": "^0.38.2",
       },
       "devDependencies": {
         "typescript": "^6.0.3",
@@ -134,11 +131,11 @@
     },
     "packages/skill": {
       "name": "@ggsvelte/skill",
-      "version": "0.38.1",
+      "version": "0.38.2",
     },
     "packages/spec": {
       "name": "@ggsvelte/spec",
-      "version": "0.38.1",
+      "version": "0.38.2",
       "dependencies": {
         "@js-temporal/polyfill": "^0.5.1",
         "typebox": "^1.3.8",
@@ -150,23 +147,23 @@
     },
     "packages/svelte": {
       "name": "@ggsvelte/svelte",
-      "version": "0.38.1",
+      "version": "0.38.2",
       "bin": {
         "ggsvelte-codemod": "bin/ggsvelte-codemod.js",
       },
       "dependencies": {
-        "@ggsvelte/core": "^0.38.1",
-        "@ggsvelte/spec": "^0.38.1",
+        "@ggsvelte/core": "^0.38.2",
+        "@ggsvelte/spec": "^0.38.2",
       },
       "devDependencies": {
         "@sveltejs/package": "^2.5.8",
-        "@sveltejs/vite-plugin-svelte": "^7.2.0",
+        "@sveltejs/vite-plugin-svelte": "^7.3.0",
         "@testing-library/svelte-core": "^1.1.3",
         "@vitest/browser-playwright": "^4.1.10",
         "@vitest/coverage-v8": "^4.1.10",
         "axe-core": "^4.13.0",
         "playwright": "1.61.1",
-        "svelte": "^5.56.7",
+        "svelte": "^5.56.9",
         "svelte-check": "^4.7.4",
         "typescript": "^6.0.3",
         "vite": "^8.2.0",
@@ -180,11 +177,11 @@
       "name": "@ggsvelte-spike/browser",
       "version": "0.0.0",
       "devDependencies": {
-        "@sveltejs/vite-plugin-svelte": "^7.2.0",
+        "@sveltejs/vite-plugin-svelte": "^7.3.0",
         "@testing-library/svelte-core": "^1.1.3",
         "@vitest/browser-playwright": "^4.1.10",
         "playwright": "1.61.1",
-        "svelte": "^5.56.7",
+        "svelte": "^5.56.9",
         "typescript": "^6.0.3",
         "vite": "^8.2.0",
         "vitest": "^4.1.10",
@@ -729,7 +726,7 @@
 
     "@sveltejs/package": ["@sveltejs/package@2.5.8", "", { "dependencies": { "chokidar": "^5.0.0", "kleur": "^4.1.5", "sade": "^1.8.1", "semver": "^7.5.4", "svelte2tsx": "~0.7.55" }, "peerDependencies": { "svelte": "^3.44.0 || ^4.0.0 || ^5.0.0-next.1" }, "bin": { "svelte-package": "svelte-package.js" } }, "sha512-zeBbsXYvHiBu56v4gJaGQoEHzg96w0E1j3dOMX8vo56s6vI5eQ57ZEZhudjwjnegnVitRRu5MrmhO0eNvaonIw=="],
 
-    "@sveltejs/vite-plugin-svelte": ["@sveltejs/vite-plugin-svelte@7.2.0", "", { "dependencies": { "deepmerge": "^4.3.1", "magic-string": "^0.30.21", "obug": "^2.1.0", "vitefu": "^1.1.2" }, "peerDependencies": { "svelte": "^5.46.4", "vite": "^8.0.0-beta.7 || ^8.0.0" } }, "sha512-1SpkuMSRLfugrVX+IrKfE1RUegzo8AQzKQ6qQPfVzbcWi5IhuTPaKb5ZrLpucleFznkc4/RTeSPoRnGWFxX+EQ=="],
+    "@sveltejs/vite-plugin-svelte": ["@sveltejs/vite-plugin-svelte@7.3.0", "", { "dependencies": { "deepmerge": "^4.3.1", "magic-string": "^1.0.0", "obug": "^2.1.0", "vitefu": "^1.1.2" }, "peerDependencies": { "svelte": "^5.46.4", "vite": "^8.0.0-beta.7 || ^8.0.0" } }, "sha512-QbRoJyD92e9R0ufeQIWRHrCC0ObcqSv/aBDdrQMoU+sypav3cDx5wytdQ6GLdXjEMO6xjrXGzfkUygng8JMv0A=="],
 
     "@swc/helpers": ["@swc/helpers@0.5.23", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw=="],
 
@@ -1329,7 +1326,7 @@
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 
-    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+    "magic-string": ["magic-string@1.2.0", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-ptco+HFxTLgjafSLim2LojBSwfg5feBjd+SqyiwdGkzC38UPdZy3zgrHMI2CoTf5fJL38tbHMYWVzIH8BxGqJw=="],
 
     "magicast": ["magicast@0.5.3", "", { "dependencies": { "@babel/parser": "^7.29.3", "@babel/types": "^7.29.0", "source-map-js": "^1.2.1" } }, "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw=="],
 
@@ -1765,9 +1762,17 @@
 
     "@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
 
+    "@sveltejs/kit/magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
     "@sveltejs/package/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
     "@types/d3-sankey/@types/d3-shape": ["@types/d3-shape@1.3.12", "", { "dependencies": { "@types/d3-path": "^1" } }, "sha512-8oMzcd4+poSLGgV0R1Q1rOlx/xdmozS4Xab7np0eamFFUYq71AU9pOCJEFnkXW2aI/oXdVYJzw6pssbSut7Z9Q=="],
+
+    "@vitest/browser/magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "@vitest/mocker/magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "@vitest/snapshot/magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "bun-types/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
 
@@ -1821,7 +1826,11 @@
 
     "strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
+    "svelte/magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
     "topojson-client/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
+
+    "vitest/magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "youch/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -61,7 +61,7 @@
   },
   "devDependencies": {
     "@sveltejs/package": "^2.5.8",
-    "@sveltejs/vite-plugin-svelte": "^7.2.0",
+    "@sveltejs/vite-plugin-svelte": "^7.3.0",
     "@testing-library/svelte-core": "^1.1.3",
     "@vitest/browser-playwright": "^4.1.10",
     "@vitest/coverage-v8": "^4.1.10",

--- a/spikes/browser/package.json
+++ b/spikes/browser/package.json
@@ -9,7 +9,7 @@
     "test:ssr": "vitest run --project ssr"
   },
   "devDependencies": {
-    "@sveltejs/vite-plugin-svelte": "^7.2.0",
+    "@sveltejs/vite-plugin-svelte": "^7.3.0",
     "@testing-library/svelte-core": "^1.1.3",
     "@vitest/browser-playwright": "^4.1.10",
     "playwright": "1.61.1",


### PR DESCRIPTION
## Summary

Bump \`@sveltejs/vite-plugin-svelte\` from 7.2.0 to 7.3.0 across the workspace manifests that pin it.

This replaces #1640. Dependabot cannot rebase that branch (the \`unknown\` group is gone from the config). The replacement starts from current \`main\` after the \`@types/node\`, oxfmt, and svelte landings.

The 7.3.0 release passes \`environment\` into \`dynamicCompileOptions\` and stops logging unexpected inline config. CI on #1640 was already green for this bump.

## Test plan

- [ ] CI \`ci-gate\` and \`vr-gate\` on this PR (the same gates that passed on #1640)