### PR TITLE
docs(skill): teach every opt-in registration agents must call

### DIFF
--- a/.changeset/skill-registration-contract.md
+++ b/.changeset/skill-registration-contract.md
@@ -1,0 +1,7 @@
+---
+"@ggsvelte/skill": patch
+---
+
+Teach agents the opt-in registration contract in `@ggsvelte/skill`. SKILL.md now lists every register/install call that fails at render when omitted: spec-driven `registerAll()`, stat overrides, `installTemporal()`, lean color/style/band/legend families, and named themes on `@ggsvelte/core/headless`.
+
+Migration: none — skill text

--- a/packages/skill/SKILL.md
+++ b/packages/skill/SKILL.md
@@ -12,19 +12,67 @@ same grammar — never build SVG or canvas output yourself:
   `<GeomPoint/>`, `<ThemeMinimal/>`, `<ScaleXLog10/>`, `<FacetWrap/>`, `<Labs/>`.
 - **Agents / headless:** emit a JSON `PortableSpec`, check it with
   `validate(spec)`, render with `renderToSVGString(spec, {width, height})`
-  (Node-safe; call `registerAll()` once first — the core barrel is
-  side-effect-free since 0.27), `ggsvelte-render spec.json > out.svg` (CLI),
-  or `<GGPlot spec>` (spec-driven GGPlot also needs one `registerAll()` for
-  specialty geoms/stats). `<Geom*>` children self-register their DEFAULT
-  stat only: a `stat="…"` override on a child additionally needs the
-  matching `register<Family>()` call (from `@ggsvelte/svelte`) — e.g.
-  `<GeomErrorbar stat="summary" />` → `registerSummary()`.
+  (Node-safe). Call `registerAll()` once first unless a Svelte child
+  self-registers the piece — see **Registration** below. Then
+  `ggsvelte-render spec.json > out.svg` (CLI), or `<GGPlot spec>`.
   A third skin, the `gg()` builder, produces the same spec in TypeScript.
   The CLI is part of the install contract for agent-driven chart generation:
   install `@ggsvelte/cli` in every sandbox where an agent authors specs
   (`npm i -g @ggsvelte/cli`). It is the only way the agent sees the
   pipeline's warnings and advisories before a chart ships; a JSON-only
   workflow renders blind. Do not drop it to slim an install.
+
+## Registration (call these)
+
+The `@ggsvelte/core` barrel is side-effect-free. A missing opt-in throws
+`not registered in this build` and names the fix. **Default for agents:**
+call `registerAll()` once at startup for every spec-driven, `layers`,
+`<GGPlot spec>`, `runPipeline`, or `renderToSVGString` path. Do not invent
+a lean register list unless the user asked for a small bundle.
+
+`ggsvelte-render` already registers the full grammar. Svelte **children**
+self-register only the piece they are.
+
+| Surface                                                             | What is already registered                                                                                                    | What you must still call                                                                                                                |
+| ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `<Geom*>` child                                                     | that geom + its **default** stat                                                                                              | `register<Family>()` for a `stat="…"` override (from `@ggsvelte/svelte`) — e.g. `<GeomErrorbar stat="summary" />` → `registerSummary()` |
+| `<ScaleXDate>` / `<ScaleYDatetime>` / other Temporal scale children | `installTemporal()`                                                                                                           | nothing                                                                                                                                 |
+| `<GGPlot>` construction                                             | `registerBasic()` + `installCandidates()` (identity geoms/stats, every color/style kind, band-axis planner, host hit-testing) | `registerAll()` for specialty geoms/stats; `installTemporal()` for spec/`layers` temporal charts that have no Temporal child            |
+| `@ggsvelte/core/render` import                                      | same basic tier as `registerBasic()`                                                                                          | specialty families + Temporal                                                                                                           |
+| `@ggsvelte/core/temporal` import                                    | Temporal polyfill + guides                                                                                                    | the rest of the grammar                                                                                                                 |
+| CLI `ggsvelte-render`                                               | full grammar                                                                                                                  | nothing                                                                                                                                 |
+
+**Spec-driven Temporal:** ISO strings with no explicit temporal options keep
+the lean UTC path. Charts driven through `spec` or `layers` have no Temporal
+child. Call `installTemporal()` (from `@ggsvelte/svelte` or `@ggsvelte/core`)
+or `registerAll()` when those charts set `type: "time"`, a named parser,
+timezone, date interval, or full Temporal guide planning.
+
+**Lean headless** (`@ggsvelte/core/headless` + `@ggsvelte/core/headless/register`)
+is opt-in per family. One forgotten call fails at render:
+
+- Geoms: `registerBasicPoints()`, `registerBasicLines()`, `registerBasicAreas()`,
+  `registerBasicBars()`, `registerBasicRects()`, `registerBasicGlyphs()`,
+  `registerBasicSegments()`. Specialty geoms keep `registerSmooth()`,
+  `registerBoxplot()`, … (same names as `@ggsvelte/core`).
+- Color: `registerDefaultOrdinalColor()` for the built-in palette or an
+  explicit `range`. **Named** schemes (`observable10`, `viridis`, ColorBrewer,
+  Crameri, …) need `registerOrdinalColor()`. Other kinds:
+  `registerSequentialColor()`, `registerBinnedColor()`, `registerManualColor()`,
+  `registerIdentityColor()`.
+- Style: `registerNumericStyle()` (size / linewidth / alpha),
+  `registerFiniteStyle()` (shape / linetype).
+- Band axes: `registerBandGuide()` for categorical x/y.
+- Legends: `registerDiscreteLegend()` / `registerContinuousLegend()` (the
+  matching color register also pulls these).
+- Named themes: `@ggsvelte/core/headless` resolves only `default` and `void`.
+  `dark`, `minimal`, and the rest need `@ggsvelte/core` or
+  `@ggsvelte/core/render` — not a `register*()` call.
+
+`registerAll()` covers every stat frame, every geom batch, every color kind
+(with catalogs), every style kind, the band-axis planner, Temporal, and
+interaction candidates. `registerBasic()` covers identity charts only; it
+does not install Temporal or specialty geoms/stats.
 
 ## Mental model
 
@@ -204,7 +252,8 @@ Two rules worth keeping in working memory:
 - Temporal: ISO dates/date-times, four-digit-year strings, year-months, and
   year-quarters infer time automatically. Ambiguous ordered dates need
   `"parse": "dmy"` or `"mdy"`; force `{"type": "band"}` for year-like
-  identifiers; never preprocess dates into indexes.
+  identifiers; never preprocess dates into indexes. Spec-driven time scales
+  also need `installTemporal()` or `registerAll()` — see Registration.
 - Themes: 32 names (`default`, `light`, `dark`, `minimal`, `ggplot2`,
   `classic`, `bw`, `hrbr`, `few`, `clean`, `fivethirtyeight`, `economist`,
   `tufte`, `linedraw`, `void`, `stata`, `stata_s1color`, `solarized`,
@@ -356,3 +405,5 @@ or linked-view code.
   facets, guides, merge semantics),
   [interactions.md](references/interactions.md) (tooltips, selection, linking),
   [recipes.md](references/recipes.md) (long-tail chart recipes).
+  Registration calls live in this file (Registration); the references
+  restate the family that belongs to that page.

--- a/packages/skill/SKILL.md
+++ b/packages/skill/SKILL.md
@@ -51,14 +51,32 @@ timezone, date interval, or full Temporal guide planning.
 **Lean headless** (`@ggsvelte/core/headless` + `@ggsvelte/core/headless/register`)
 is opt-in per family. One forgotten call fails at render:
 
-- Geoms: `registerBasicPoints()`, `registerBasicLines()`, `registerBasicAreas()`,
-  `registerBasicBars()`, `registerBasicRects()`, `registerBasicGlyphs()`,
-  `registerBasicSegments()`. Specialty geoms keep `registerSmooth()`,
-  `registerBoxplot()`, … (same names as `@ggsvelte/core`).
+- Basic geoms: `registerBasicPoints()`, `registerBasicLines()`,
+  `registerBasicAreas()`, `registerBasicBars()`, `registerBasicRects()`,
+  `registerBasicGlyphs()`, `registerBasicSegments()`.
+- Specialty geoms/stats (same names from `@ggsvelte/core` /
+  `@ggsvelte/svelte`): `registerAbline()`, `registerAlign()`, `registerBin()`,
+  `registerBin2d()`, `registerBoxplot()`, `registerConnect()`,
+  `registerContour()`, `registerCrossbar()`, `registerCurve()`,
+  `registerDensity()`, `registerDensity2d()`, `registerDensity2dFilled()`,
+  `registerDotplot()`, `registerEcdf()`, `registerEllipse()`,
+  `registerErrorbar()`, `registerFunction()`, `registerHex()`,
+  `registerLinerange()`, `registerManual()`, `registerMap()`,
+  `registerPointrange()`, `registerPolygon()`, `registerQq()`,
+  `registerQqLine()`, `registerQuantile()`, `registerRaster()`,
+  `registerRug()`, `registerSf()`, `registerSfLabel()`, `registerSfText()`,
+  `registerSmooth()`, `registerSpoke()`, `registerSummary()`,
+  `registerSummaryBin()`, `registerSummaryRolling()`, `registerTile()`,
+  `registerUnique()`, `registerViolin()`.
 - Color: `registerDefaultOrdinalColor()` for the built-in palette or an
-  explicit `range`. **Named** schemes (`observable10`, `viridis`, ColorBrewer,
-  Crameri, …) need `registerOrdinalColor()`. Other kinds:
-  `registerSequentialColor()`, `registerBinnedColor()`, `registerManualColor()`,
+  explicit `range`. A named **categorical** scheme (`observable10`,
+  `colorblind`, `Dark2`, …) needs `registerOrdinalColor()`. A named
+  **sequential or diverging** scheme (`viridis`, `magma`, `Blues`, `RdBu`,
+  Crameri `batlow`, …) needs `registerSequentialColor()` — a sequential
+  name with no `type` infers sequential, so `registerOrdinalColor()` is
+  not enough. Explicit `type: "ordinal"` (including discrete sampling of
+  a sequential name) still needs `registerOrdinalColor()`. Other kinds:
+  `registerBinnedColor()`, `registerManualColor()`,
   `registerIdentityColor()`.
 - Style: `registerNumericStyle()` (size / linewidth / alpha),
   `registerFiniteStyle()` (shape / linetype).

--- a/packages/skill/references/geoms-and-stats.md
+++ b/packages/skill/references/geoms-and-stats.md
@@ -152,18 +152,21 @@ after-stat column, so usually map nothing at all.
 
 Non-default stats go on the layer; their params share the layer's `params` object.
 
-**Component-form registration:** a `<Geom*>` child self-registers only its
-DEFAULT stat. Any `stat="…"` override below needs the matching family
-register call once at app startup, imported from `@ggsvelte/svelte`:
+**Component-form registration:** a `<Geom*>` child self-registers only that
+geom and its DEFAULT stat. Spec-driven surfaces — JSON spec, `layers` prop,
+`runPipeline`, `renderToSVGString` — register nothing per layer: call
+`registerAll()` once instead (or the matching `register<Family>()`). Any
+`stat="…"` override below needs the matching family register call once at
+app startup, imported from `@ggsvelte/svelte`:
 `stat="summary"` → `registerSummary()`, `stat="summary_bin"` →
 `registerSummaryBin()`, `stat="summary_rolling"` → `registerSummaryRolling()`, `stat="ecdf"` → `registerEcdf()`, `stat="manual"` →
 `registerManual()`, `stat="unique"` → `registerUnique()`, `stat="connect"` →
 `registerConnect()`, `stat="align"` → `registerAlign()`, `stat="ellipse"` →
-`registerEllipse()`. (One `registerAll()` covers all of them.) Spec-driven
-surfaces — JSON spec, `layers` prop, `runPipeline`, `renderToSVGString` —
-register nothing per layer: call `registerAll()` once instead. Missing
+`registerEllipse()`. (One `registerAll()` covers all of them.) Missing
 registration fails loudly: 'Stat "…" is not registered in this build.',
-naming the fix.
+naming the fix. Lean headless geom families
+(`registerBasicPoints()`, `registerBasicLines()`, …) live on
+`@ggsvelte/core/headless/register`. Full inventory: SKILL.md Registration.
 
 ```json fragment
 {

--- a/packages/skill/references/scales-and-palettes.md
+++ b/packages/skill/references/scales-and-palettes.md
@@ -86,10 +86,13 @@ sequential name → sequential).
 **Headless color registration:** `@ggsvelte/core/render` and `registerBasic()`
 install every color kind. Lean `@ggsvelte/core/headless` does not. Call
 `registerDefaultOrdinalColor()` for the built-in palette or an explicit
-`range`; call `registerOrdinalColor()` when `scheme` names a catalog
-(`observable10`, `viridis`, ColorBrewer, Crameri). Other kinds:
-`registerSequentialColor()`, `registerBinnedColor()`, `registerManualColor()`,
-`registerIdentityColor()`. A named scheme on the default-only register throws
+`range`. A named categorical scheme (`observable10`, `Dark2`, …) needs
+`registerOrdinalColor()`. A named sequential or diverging scheme (`viridis`,
+`Blues`, Crameri `batlow`, …) needs `registerSequentialColor()` — a
+sequential name with no `type` infers sequential. Explicit
+`type: "ordinal"` still needs `registerOrdinalColor()`. Other kinds:
+`registerBinnedColor()`, `registerManualColor()`, `registerIdentityColor()`.
+A named scheme on the default-only register throws
 `not registered in this build`. Full inventory: SKILL.md Registration.
 
 ### Style scales

--- a/packages/skill/references/scales-and-palettes.md
+++ b/packages/skill/references/scales-and-palettes.md
@@ -83,7 +83,21 @@ single-entry manual guides need `force: true` to appear. When `type` is
 omitted, a named `scheme` selects its family (categorical → ordinal,
 sequential name → sequential).
 
+**Headless color registration:** `@ggsvelte/core/render` and `registerBasic()`
+install every color kind. Lean `@ggsvelte/core/headless` does not. Call
+`registerDefaultOrdinalColor()` for the built-in palette or an explicit
+`range`; call `registerOrdinalColor()` when `scheme` names a catalog
+(`observable10`, `viridis`, ColorBrewer, Crameri). Other kinds:
+`registerSequentialColor()`, `registerBinnedColor()`, `registerManualColor()`,
+`registerIdentityColor()`. A named scheme on the default-only register throws
+`not registered in this build`. Full inventory: SKILL.md Registration.
+
 ### Style scales
+
+**Headless style registration:** mapped size / linewidth / alpha need
+`registerNumericStyle()`; mapped shape / linetype need
+`registerFiniteStyle()`. `@ggsvelte/core/render` and `registerBasic()`
+install both. Categorical x/y axes also need `registerBandGuide()`.
 
 - **numeric-style** (size, linewidth, alpha): sequential, ordinal, binned,
   manual, identity — numeric output ranges instead of colors, identity
@@ -272,6 +286,13 @@ restarts the palette and emits the bounded `palette-exhausted` warning once;
 | circle-open      |               |
 
 ## Temporal scales
+
+**Registration:** Temporal scale children (`<ScaleXDate>`, `<ScaleYDatetime>`,
+`<ScaleColorDate>`, …) call `installTemporal()` on import. Spec-driven
+`spec` / `layers` charts have no child: call `installTemporal()` or
+`registerAll()` when they set `type: "time"`, a named parser, timezone, date
+interval, or full Temporal guides. ISO strings with no explicit temporal
+options keep the lean UTC path.
 
 **Auto-inference.** ISO dates and date-times, four-digit-year strings,
 year-months, month-years, and year-quarters infer a time scale after bounded

--- a/packages/skill/references/themes.md
+++ b/packages/skill/references/themes.md
@@ -49,6 +49,12 @@ optional `"name"` base plus role overrides, e.g.
 The internal `test` theme exists for snapshots only — not a product surface;
 do not document or recommend it.
 
+**Headless named themes:** `@ggsvelte/core/headless` resolves only `default`
+and `void`. A named catalog theme (`dark`, `minimal`, `economist`, …) on that
+entry throws. Use `@ggsvelte/core` or `@ggsvelte/core/render` (or pass the
+full editions table). This is not a `register*()` call. Full inventory:
+SKILL.md Registration.
+
 ## Svelte shells and overrides
 
 One named shell per product theme — `ThemeDefault`, `ThemeLight`,

--- a/scripts/skill-content.test.ts
+++ b/scripts/skill-content.test.ts
@@ -462,3 +462,90 @@ describe("skill teaches inspect mode selection and hit hygiene (#1530)", () => {
     expect(section!).toMatch(/Do not split/);
   });
 });
+
+/**
+ * Opt-in registration footguns. New register* / install* surfaces that
+ * fail at render when omitted must appear in SKILL.md Registration so
+ * agents do not ship "not registered in this build" charts.
+ */
+describe("skill teaches the opt-in registration contract", () => {
+  const skill = readFileSync(join(SKILL_DIR, "SKILL.md"), "utf8");
+  const section = skill.match(/## Registration \(call these\)[\s\S]*?(?=\n## )/)?.[0];
+  const scales = readFileSync(join(SKILL_DIR, "references", "scales-and-palettes.md"), "utf8");
+  const themes = readFileSync(join(SKILL_DIR, "references", "themes.md"), "utf8");
+  const geoms = readFileSync(join(SKILL_DIR, "references", "geoms-and-stats.md"), "utf8");
+
+  it("SKILL.md has a Registration section agents see without opening references", () => {
+    expect(section).toBeDefined();
+    expect(section!.length).toBeGreaterThan(400);
+  });
+
+  it("defaults spec-driven surfaces to registerAll() and names the loud failure", () => {
+    expect(section).toBeDefined();
+    expect(section!).toMatch(/registerAll\(\)/);
+    expect(section!).toMatch(/not registered in this build/);
+    expect(section!).toMatch(/ggsvelte-render/);
+    expect(section!).toMatch(/full grammar/);
+  });
+
+  it("names every current opt-in register / install agents can miss", () => {
+    expect(section).toBeDefined();
+    const required = [
+      "registerAll()",
+      "registerBasic()",
+      "registerSummary()",
+      "installTemporal()",
+      "registerDefaultOrdinalColor()",
+      "registerOrdinalColor()",
+      "registerSequentialColor()",
+      "registerBinnedColor()",
+      "registerManualColor()",
+      "registerIdentityColor()",
+      "registerNumericStyle()",
+      "registerFiniteStyle()",
+      "registerBandGuide()",
+      "registerDiscreteLegend()",
+      "registerContinuousLegend()",
+      "registerBasicPoints()",
+      "registerBasicLines()",
+      "registerBasicAreas()",
+      "registerBasicBars()",
+      "installCandidates()",
+      "@ggsvelte/core/headless/register",
+    ];
+    const missing = required.filter((name) => !section!.includes(name));
+    expect(missing).toEqual([]);
+  });
+
+  it("distinguishes default-palette color from named-scheme color", () => {
+    expect(section).toBeDefined();
+    expect(section!).toMatch(/registerDefaultOrdinalColor\(\)[\s\S]*named/i);
+    expect(section!).toMatch(/registerOrdinalColor\(\)/);
+  });
+
+  it("teaches spec-driven Temporal without a scale child", () => {
+    expect(section).toBeDefined();
+    expect(section!).toMatch(/installTemporal\(\)/);
+    expect(section!).toMatch(/no Temporal child|have no Temporal child/);
+    expect(section!).toMatch(/type: "time"/);
+  });
+
+  it("teaches that headless named themes are not a register call", () => {
+    expect(section).toBeDefined();
+    expect(section!).toMatch(/Named themes/);
+    expect(section!).toMatch(/`default` and `void`/);
+    expect(section!).toMatch(/@ggsvelte\/core\/headless/);
+  });
+
+  it("references restate the family that belongs on that page", () => {
+    expect(geoms).toMatch(/registerAll\(\)/);
+    expect(geoms).toMatch(/registerBasicPoints\(\)/);
+    expect(scales).toMatch(/registerDefaultOrdinalColor\(\)/);
+    expect(scales).toMatch(/registerOrdinalColor\(\)/);
+    expect(scales).toMatch(/registerNumericStyle\(\)/);
+    expect(scales).toMatch(/registerBandGuide\(\)/);
+    expect(scales).toMatch(/installTemporal\(\)/);
+    expect(themes).toMatch(/@ggsvelte\/core\/headless/);
+    expect(themes).toMatch(/`default`[\s\S]*`void`|only `default` and `void`/);
+  });
+});

--- a/scripts/skill-content.test.ts
+++ b/scripts/skill-content.test.ts
@@ -47,6 +47,10 @@ import {
   validate,
 } from "@ggsvelte/spec";
 import type { SpecInput } from "@ggsvelte/spec";
+import {
+  GEOM_REGISTER_HINTS,
+  STAT_REGISTER_HINTS,
+} from "../packages/core/src/pipeline/register-hints.ts";
 import { deprecatedGrammarPropPattern } from "../packages/svelte/src/lib/layers/grammar-families.ts";
 import { ggplotOpenAttrs, plotLevelInteractionOffenders } from "./ggplot-open-attrs.ts";
 import { codeBlocks } from "./guide-code-contract.ts";
@@ -488,39 +492,47 @@ describe("skill teaches the opt-in registration contract", () => {
     expect(section!).toMatch(/full grammar/);
   });
 
-  it("names every current opt-in register / install agents can miss", () => {
+  it("names every public geom/stat register family from the hint maps", () => {
     expect(section).toBeDefined();
-    const required = [
-      "registerAll()",
-      "registerBasic()",
-      "registerSummary()",
-      "installTemporal()",
-      "registerDefaultOrdinalColor()",
-      "registerOrdinalColor()",
-      "registerSequentialColor()",
-      "registerBinnedColor()",
-      "registerManualColor()",
-      "registerIdentityColor()",
-      "registerNumericStyle()",
-      "registerFiniteStyle()",
-      "registerBandGuide()",
-      "registerDiscreteLegend()",
-      "registerContinuousLegend()",
-      "registerBasicPoints()",
-      "registerBasicLines()",
-      "registerBasicAreas()",
-      "registerBasicBars()",
-      "installCandidates()",
-      "@ggsvelte/core/headless/register",
-    ];
-    const missing = required.filter((name) => !section!.includes(name));
+    const families = [
+      ...new Set([...Object.values(STAT_REGISTER_HINTS), ...Object.values(GEOM_REGISTER_HINTS)]),
+    ].toSorted();
+    const missing = families.filter((name) => !section!.includes(`${name}()`));
     expect(missing).toEqual([]);
   });
 
-  it("distinguishes default-palette color from named-scheme color", () => {
+  it("names every lean headless register export plus Temporal / umbrella calls", () => {
     expect(section).toBeDefined();
-    expect(section!).toMatch(/registerDefaultOrdinalColor\(\)[\s\S]*named/i);
-    expect(section!).toMatch(/registerOrdinalColor\(\)/);
+    const headless = readFileSync(
+      join(ROOT, "packages", "core", "src", "headless-register-entry.ts"),
+      "utf8",
+    );
+    const headlessRegisters = [...headless.matchAll(/export \{ (\w+) \}/g)]
+      .map((match) => match[1]!)
+      .filter(
+        (name) =>
+          name.startsWith("register") &&
+          name !== "registerGeomBatch" &&
+          name !== "registerStatFrame",
+      );
+    const extras = [
+      "registerAll",
+      "registerBasic",
+      "installTemporal",
+      "installCandidates",
+      ...headlessRegisters,
+    ];
+    const missing = extras.filter((name) => !section!.includes(`${name}()`));
+    expect(missing).toEqual([]);
+    expect(section!).toContain("@ggsvelte/core/headless/register");
+  });
+
+  it("splits categorical vs sequential named-scheme registration", () => {
+    expect(section).toBeDefined();
+    expect(section!).toMatch(/registerDefaultOrdinalColor\(\)/);
+    expect(section!).toMatch(/categorical[\s\S]*registerOrdinalColor\(\)/i);
+    expect(section!).toMatch(/sequential[\s\S]*registerSequentialColor\(\)/i);
+    expect(section!).toMatch(/infers sequential/);
   });
 
   it("teaches spec-driven Temporal without a scale child", () => {

--- a/scripts/skill-trigger.test.ts
+++ b/scripts/skill-trigger.test.ts
@@ -225,6 +225,9 @@ describe("skill body uses directives for the validation feedback loop", () => {
   });
 
   it("documents registerAll for headless / spec-driven surfaces", () => {
+    expect(skillMd).toMatch(/## Registration \(call these\)/);
     expect(skillMd).toMatch(/registerAll\(\)/);
+    expect(skillMd).toMatch(/installTemporal\(\)/);
+    expect(skillMd).toMatch(/registerDefaultOrdinalColor\(\)/);
   });
 });


### PR DESCRIPTION
## Summary

The agent skill now lists every opt-in register and install call that fails at render when omitted.

Version Packages #1648 and the lean-bundle PRs behind it (`installTemporal()`, `registerDefaultOrdinalColor()`) added more opt-in surfaces. The skill only taught `registerAll()` and stat overrides. Agents that followed the skill still shipped `not registered in this build` charts.

## What the skill now teaches

- Default: call `registerAll()` once for every spec-driven, `layers`, or `renderToSVGString` path.
- `<Geom*>` children self-register only the default stat; `stat="…"` still needs `register<Family>()`.
- Spec-driven Temporal charts need `installTemporal()` or `registerAll()` when there is no Temporal scale child.
- Lean headless color: default palette vs categorical scheme vs sequential/diverging scheme (a sequential name with no `type` infers sequential).
- Every geom/stat family from the public hint maps, plus band guides, style scales, legends, and named themes on `@ggsvelte/core/headless` (`default` and `void` only).
- `ggsvelte-render` already registers the full grammar.

Tests in `scripts/skill-content.test.ts` derive the required names from `STAT_REGISTER_HINTS`, `GEOM_REGISTER_HINTS`, and `@ggsvelte/core/headless/register` exports so a new family cannot land without a skill update.

## Review

Codex reviewed the first commit. Three P2 findings were fixed in the follow-up commit:

- sequential scheme names must use `registerSequentialColor()`
- list every specialty family, not an ellipsis
- derive the inventory test from public maps

## Test plan

- [x] `bun test scripts/skill-content.test.ts scripts/skill-trigger.test.ts`
- [x] Codex review (no Claude Code review)