### PR TITLE
fix(core): keep stroke keys when linetype is mapped separately

### DIFF
--- a/.changeset/mapped-linetype-colour-stroke-keys.md
+++ b/.changeset/mapped-linetype-colour-stroke-keys.md
@@ -1,0 +1,7 @@
+---
+"@ggsvelte/core": patch
+---
+
+Discrete colour legends on line-only plots keep stroke keys when linetype is mapped on a hidden or separate guide.
+
+Migration: none — internal colour-legend key style when linetype is mapped

--- a/packages/core/src/pipeline/guide-config.ts
+++ b/packages/core/src/pipeline/guide-config.ts
@@ -208,6 +208,12 @@ function mergeDiscrete(group: readonly DiscreteLegendInput[]): DiscreteLegendInp
     keyOf(value: unknown): LegendKeyStyle {
       const key: LegendKeyStyle = {};
       for (const input of group) Object.assign(key, input.keyOf?.(value));
+      // Paint enrichment may stamp a solid linetype fallback on colour keys.
+      // Dedicated style scales must win regardless of input order.
+      for (const input of group) {
+        if (input.scale === "color" || input.scale === "fill") continue;
+        Object.assign(key, input.keyOf?.(value));
+      }
       // Paint enrichment may stamp shape:"circle" onto colour keys. When the
       // same domain also carries linetype (line+point dual layers), keep the
       // dash pattern unless a shape scale is in the merge group — otherwise

--- a/packages/core/src/pipeline/guide-paint-keys.ts
+++ b/packages/core/src/pipeline/guide-paint-keys.ts
@@ -10,10 +10,14 @@
  * Line-family colour keys get the same treatment: a constant or default
  * `linetype` so renderers draw a stroke segment instead of a square.
  *
- * When shape or linetype is a mapped aesthetic, leave that field alone so the
- * scale-merge path in prepareLegendInputs can supply it. Area/bar/col fill
- * keys stay squares. Do not stamp linetype onto a key that already carries
- * an agreed point shape — mergeDiscrete drops shape when both exist.
+ * When shape or linetype is a mapped aesthetic, leave the agreed-constant
+ * map empty so the scale-merge path in prepareLegendInputs can supply the
+ * scaled value. Colour keys on line-only plots still get a solid stroke
+ * fallback when merge does not set linetype (hidden or separate linetype
+ * guide). Area/bar/col fill keys stay squares. Do not stamp linetype onto
+ * a key that already carries an agreed point shape — mergeDiscrete drops
+ * shape when both exist. Two constant linetypes that conflict also get the
+ * solid fallback so the colour key stays a stroke.
  */
 import { LINETYPE_NAMES, POINT_SHAPE_NAMES } from "@ggsvelte/spec";
 
@@ -166,9 +170,41 @@ function agreedMarkStyle<T>(
 }
 
 /**
+ * Domain values whose colour keys should draw a stroke even when no
+ * constant linetype agreed. Only when every contributing layer is a
+ * line-family geom. A point or text layer on the same colour scale
+ * suppresses the fallback. Fill-only geoms clear aes.color, so they
+ * never join this set.
+ */
+function lineStrokeFallbackKeys(
+  relevant: readonly LayerBinding[],
+  aesthetic: "color" | "fill",
+  domain: readonly unknown[],
+): Set<string> {
+  const keys = new Set<string>();
+  for (const value of domain) {
+    let sawLine = false;
+    let sawOther = false;
+    for (const binding of relevant) {
+      if (!layerContributesPaintValue(binding, aesthetic, value)) continue;
+      if (LINE_MARK_GEOMS.has(binding.layer.geom)) sawLine = true;
+      else sawOther = true;
+    }
+    if (!sawLine || sawOther) continue;
+    try {
+      keys.add(encodeKey(value));
+    } catch {
+      // Non-encodable domain values cannot key a legend entry.
+    }
+  }
+  return keys;
+}
+
+/**
  * Enrich a discrete paint legend so each domain value carries the constant
  * point shape and/or stroke pattern of the layer(s) that paint it. No-op
- * when no mark-style layer maps the aesthetic, or when styles conflict.
+ * when no mark-style layer maps the aesthetic, or when styles conflict
+ * and no line-only stroke fallback applies.
  */
 export function enrichPaintLegendKeys(
   input: DiscreteLegendInput,
@@ -184,7 +220,13 @@ export function enrichPaintLegendKeys(
     aesthetic === "color"
       ? agreedMarkStyle(relevant, aesthetic, input.domain, layerConstantLinetype)
       : new Map<string, Linetype>();
-  if (shapeByKey.size === 0 && linetypeByKey.size === 0) return input;
+  const strokeFallback =
+    aesthetic === "color"
+      ? lineStrokeFallbackKeys(relevant, aesthetic, input.domain)
+      : new Set<string>();
+  if (shapeByKey.size === 0 && linetypeByKey.size === 0 && strokeFallback.size === 0) {
+    return input;
+  }
 
   // Capture as a free function so oxlint unbound-method does not flag the
   // method reference when we call it from the enriched keyOf.
@@ -201,9 +243,11 @@ export function enrichPaintLegendKeys(
         }
         // mergeDiscrete deletes shape when both fields exist and no shape
         // scale is merged. Skip linetype if this key already has a shape.
-        if (key.shape === undefined && key.linetype === undefined) {
-          const linetype = linetypeByKey.get(encoded);
-          if (linetype !== undefined) key.linetype = linetype;
+        // Colour-key linetype only when every contributing layer is a
+        // line-family geom. Otherwise a lone line's default solid would
+        // paint stroke keys on mixed text/point colour legends.
+        if (key.shape === undefined && key.linetype === undefined && strokeFallback.has(encoded)) {
+          key.linetype = linetypeByKey.get(encoded) ?? "solid";
         }
       } catch {
         // leave key without mark style

--- a/packages/core/tests/pipeline-responsive-guides.test.ts
+++ b/packages/core/tests/pipeline-responsive-guides.test.ts
@@ -188,6 +188,108 @@ describe("responsive guide planning", () => {
     expect(svg).not.toContain('<line class="gg-legend-key"');
   });
 
+  it("keeps scaled linetype on a merged colour+linetype legend", () => {
+    const spec = gg(rows, aes({ x: "x", y: "y", color: "region", linetype: "region" }))
+      .geomLine()
+      .labs({ color: "Region", linetype: "Region" });
+    const legends = discrete(720, spec);
+    expect(legends).toHaveLength(1);
+    expect(legends[0]?.aesthetics).toEqual(["color", "linetype"]);
+    const patterns = legends[0]!.entries.map((entry) => entry.linetype);
+    expect(patterns.every((pattern) => pattern !== undefined)).toBe(true);
+    expect(new Set(patterns).size).toBeGreaterThan(1);
+    const svg = renderToSVGString(spec.spec(), { width: 720, height: 360 });
+    expect(svg).toContain('<line class="gg-legend-key"');
+    expect(svg).not.toContain("gg-legend-swatch");
+  });
+
+  it("puts a solid stroke on colour keys when the linetype guide is hidden", () => {
+    const styled = [
+      { x: 1, y: 2, region: "North", style: "A" },
+      { x: 2, y: 4, region: "South", style: "B" },
+      { x: 3, y: 3, region: "North", style: "A" },
+    ];
+    const spec = gg(styled, aes({ x: "x", y: "y", color: "region", linetype: "style" }))
+      .geomLine()
+      .guides({ linetype: guideNone() });
+    const legends = discrete(720, spec);
+    expect(legends).toHaveLength(1);
+    expect(legends[0]?.aesthetics).toEqual(["color"]);
+    expect(legends[0]?.entries.map((entry) => entry.linetype)).toEqual(["solid", "solid"]);
+    const svg = renderToSVGString(spec.spec(), { width: 720, height: 360 });
+    expect(svg).toContain('<line class="gg-legend-key"');
+    expect(svg).not.toContain("gg-legend-swatch");
+  });
+
+  it("puts a solid stroke on colour keys when linetype has its own guide", () => {
+    const styled = [
+      { x: 1, y: 2, region: "North", style: "A" },
+      { x: 2, y: 4, region: "South", style: "B" },
+      { x: 3, y: 3, region: "North", style: "A" },
+    ];
+    const spec = gg(styled, aes({ x: "x", y: "y", color: "region", linetype: "style" })).geomLine();
+    const legends = discrete(720, spec);
+    expect(legends.map((legend) => legend.aesthetics)).toEqual([["color"], ["linetype"]]);
+    const colorLegend = legends.find((legend) => legend.aesthetics.includes("color"));
+    expect(colorLegend?.entries.map((entry) => entry.linetype)).toEqual(["solid", "solid"]);
+    const svg = renderToSVGString(spec.spec(), { width: 720, height: 360 });
+    const colorStart = svg.indexOf("gg-legend-color");
+    const linetypeStart = svg.indexOf("gg-legend-linetype");
+    expect(colorStart).toBeGreaterThan(-1);
+    expect(linetypeStart).toBeGreaterThan(-1);
+    const colorChunk =
+      colorStart < linetypeStart ? svg.slice(colorStart, linetypeStart) : svg.slice(colorStart);
+    expect(colorChunk).toContain('<line class="gg-legend-key"');
+    expect(colorChunk).not.toContain("gg-legend-swatch");
+  });
+
+  it("falls back to a solid stroke when constant linetypes conflict", () => {
+    const spec = gg(rows, aes({ x: "x", y: "y", color: "region" }))
+      .geomLine({ aes: aes({ linetype: { value: "dashed" } }) })
+      .geomLine({ aes: aes({ linetype: { value: "dotted" } }) });
+    const legends = discrete(720, spec);
+    expect(legends).toHaveLength(1);
+    expect(legends[0]?.entries.map((entry) => entry.linetype)).toEqual(["solid", "solid"]);
+  });
+
+  it("does not put a stroke fallback on colour keys when a point layer also maps colour", () => {
+    const styled = [
+      { x: 1, y: 2, region: "North", style: "A" },
+      { x: 2, y: 4, region: "South", style: "B" },
+      { x: 3, y: 3, region: "North", style: "A" },
+    ];
+    const spec = gg(styled, aes({ x: "x", y: "y", color: "region" }))
+      .geomPoint({ aes: aes({ shape: "style" }) })
+      .geomLine({ aes: aes({ linetype: "style" }) });
+    const colorLegend = discrete(720, spec).find((legend) => legend.aesthetics.includes("color"));
+    expect(colorLegend).toBeDefined();
+    expect(colorLegend!.entries.every((entry) => entry.linetype === undefined)).toBe(true);
+  });
+
+  it("puts a solid stroke on colour keys when linetype is a hidden scaled constant", () => {
+    const spec = gg(rows, aes({ x: "x", y: "y", color: "region" }))
+      .geomLine({
+        aes: aes({ linetype: { value: "dashed", scale: true } }),
+      })
+      .guides({ linetype: guideNone() });
+    const legends = discrete(720, spec);
+    expect(legends).toHaveLength(1);
+    expect(legends[0]?.aesthetics).toEqual(["color"]);
+    expect(legends[0]?.entries.map((entry) => entry.linetype)).toEqual(["solid", "solid"]);
+  });
+
+  it("keeps colour keys as squares when a non-line layer shares the colour scale", () => {
+    // col/bar/area clear aes.color (fill-only geoms). text maps colour and is
+    // not a LINE_MARK_GEOM, so it must suppress the stroke fallback.
+    const spec = gg(rows, aes({ x: "x", y: "y", color: "region", label: "region" }))
+      .geomText()
+      .geomLine();
+    const colorLegend = discrete(720, spec).find((legend) => legend.aesthetics.includes("color"));
+    expect(colorLegend).toBeDefined();
+    expect(colorLegend!.entries.every((entry) => entry.linetype === undefined)).toBe(true);
+    expect(colorLegend!.entries.every((entry) => entry.shape === undefined)).toBe(true);
+  });
+
   it("keeps swapped per-layer aesthetic sources in separate guides", () => {
     const swappedRows = [
       { x: 1, y: 1, a: "North", b: "North" },


### PR DESCRIPTION
## Summary

Colour legends on line-only plots now keep stroke keys when `linetype` is a mapped field on a hidden or separate guide.

PR #1656 already drew stroke keys for a constant or default linetype. This change covers the leftover case from #1658: mapped linetype that does not merge into the colour guide.

A dedicated linetype scale still wins on a merged colour+linetype legend. Mixed point or text colour scales stay squares.

## Tests

- Hidden linetype guide: colour keys are solid strokes
- Separate colour and linetype guides: colour block uses `gg-legend-key`, not swatches
- Merged same-field colour+linetype: scale patterns stay on the composite key
- Conflicting constant linetypes fall back to a solid stroke
- Point or text on the same colour scale suppresses the fallback

`bun test packages/core` — 2449 pass.

Closes #1658.