### PR TITLE
deps-ci: bump changesets/action from 2.1.0 to 2.1.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,7 +191,7 @@ jobs:
       # Action v2 requires @changesets/cli v3, the version-script input name,
       # and github-token (env.GITHUB_TOKEN is ignored).
       - name: changesets — open/update Version Packages PR
-        uses: changesets/action@198f833dd7d863100ea6e28967bc9a9fdefadb0a # v2.1.0
+        uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1
         with:
           version-script: bun run version
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/release-wiring.test.ts
+++ b/scripts/release-wiring.test.ts
@@ -864,9 +864,9 @@ it("uses job-private Bun caches across CI workflows (issue #319)", () => {
 
 describe("release.yml concurrent-merge race recovery", () => {
   const release = () => read(".github/workflows/release.yml");
-  // Peeled v2.1.0 tag → commit (changesets/action@v2.1.0). Verified against
+  // Peeled v2.1.1 tag → commit (changesets/action@v2.1.1). Verified against
   // the annotated tag object, not copied from Dependabot #1655 alone.
-  const CHANGESETS_ACTION_V2 = "changesets/action@198f833dd7d863100ea6e28967bc9a9fdefadb0a";
+  const CHANGESETS_ACTION_V2 = "changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1";
 
   type ReleaseStep = {
     name?: string;


### PR DESCRIPTION
## Why

Dependabot opened #1673 to bump `changesets/action` from 2.1.0 to 2.1.1 (typo fix in renamed v2 inputs). CI failed because `scripts/release-wiring.test.ts` pins the peeled action SHA.

This replacement starts from current `main` and moves both the workflow pin and the test assertion to the peeled `v2.1.1` commit (`8488615`).

Verified: `git ls-remote` `refs/tags/v2.1.1^{}` = `8488615a623b1b9c987934bb89eae8af6a946ac1`. `bun test scripts/release-wiring.test.ts` is green.

Replaces #1673.

## Test plan

- [x] `bun test scripts/release-wiring.test.ts`
- [ ] CI unit + actions-security on this PR