### PR TITLE
deps: bump svelte from 5.56.9 to 5.56.10

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -26,7 +26,7 @@
     "@testing-library/svelte-core": "^1.1.3",
     "@vitest/browser-playwright": "^4.1.11",
     "playwright": "1.61.1",
-    "svelte": "^5.56.9",
+    "svelte": "^5.56.10",
     "svelte-check": "^4.7.4",
     "typescript": "^6.0.3",
     "vite": "^8.2.0",

--- a/benchmarks/competitive/package.json
+++ b/benchmarks/competitive/package.json
@@ -30,7 +30,7 @@
     "layercake": "^10.0.3",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
-    "svelte": "^5.56.9",
+    "svelte": "^5.56.10",
     "svelteplot": "^0.14.2",
     "uplot": "^1.6.32"
   },

--- a/bun.lock
+++ b/bun.lock
@@ -47,7 +47,7 @@
         "@testing-library/svelte-core": "^1.1.3",
         "@vitest/browser-playwright": "^4.1.11",
         "playwright": "1.61.1",
-        "svelte": "^5.56.9",
+        "svelte": "^5.56.10",
         "svelte-check": "^4.7.4",
         "typescript": "^6.0.3",
         "vite": "^8.2.0",
@@ -84,7 +84,7 @@
         "layercake": "^10.0.3",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
-        "svelte": "^5.56.9",
+        "svelte": "^5.56.10",
         "svelteplot": "^0.14.2",
         "uplot": "^1.6.32",
       },
@@ -105,7 +105,7 @@
         "@ggsvelte/svelte": "workspace:*",
       },
       "devDependencies": {
-        "svelte": "^5.56.9",
+        "svelte": "^5.56.10",
         "typescript": "^6.0.3",
       },
     },
@@ -163,7 +163,7 @@
         "@vitest/coverage-v8": "^4.1.11",
         "axe-core": "^4.13.0",
         "playwright": "1.61.1",
-        "svelte": "^5.56.9",
+        "svelte": "^5.56.10",
         "svelte-check": "^4.7.4",
         "typescript": "^6.0.3",
         "vite": "^8.2.0",
@@ -181,7 +181,7 @@
         "@testing-library/svelte-core": "^1.1.3",
         "@vitest/browser-playwright": "^4.1.11",
         "playwright": "1.61.1",
-        "svelte": "^5.56.9",
+        "svelte": "^5.56.10",
         "typescript": "^6.0.3",
         "vite": "^8.2.0",
         "vitest": "^4.1.11",
@@ -1560,7 +1560,7 @@
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
-    "svelte": ["svelte@5.56.9", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.10", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.8.1", "esm-env": "^1.2.1", "esrap": "^2.2.12", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-VT8kSnlEg8069w7AiCcAk3Yf5xvMnrGTagVOmU/OpOLHaHnNqXhWZCH/4EVga/bT/HtWhvE6/fHrXLErx7OnJA=="],
+    "svelte": ["svelte@5.56.10", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.10", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.8.1", "esm-env": "^1.2.1", "esrap": "^2.2.12", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-Lcxbj8I/KAbpY+VjtY4ENQBV0dDCipfGAhqb51XQZ67CIQqXgsv/8dPkbILaj4Fb6/b6JAEM/PIVbILXgDQy2g=="],
 
     "svelte-check": ["svelte-check@4.7.4", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.25", "@sveltejs/load-config": "^0.2.1", "chokidar": "^4.0.1", "fdir": "^6.2.0", "picocolors": "^1.0.0", "sade": "^1.7.4" }, "peerDependencies": { "svelte": "^4.0.0 || ^5.0.0-next.0", "typescript": "^5.0.0 || ^6.0.0" }, "bin": { "svelte-check": "bin/svelte-check" } }, "sha512-IW9ot9YqAoyv8FvyN+eb4ZTe8zgcKZrJLNYU6dzSKkGwEBsSPc4K7lmQ8bKn8W2YMXM6WDfZSSVOaGtekyUfOQ=="],
 
@@ -1702,6 +1702,8 @@
 
     "@types/d3-sankey/@types/d3-shape": ["@types/d3-shape@1.3.12", "", { "dependencies": { "@types/d3-path": "^1" } }, "sha512-8oMzcd4+poSLGgV0R1Q1rOlx/xdmozS4Xab7np0eamFFUYq71AU9pOCJEFnkXW2aI/oXdVYJzw6pssbSut7Z9Q=="],
 
+    "@unovis/svelte/svelte": ["svelte@5.56.9", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.10", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.8.1", "esm-env": "^1.2.1", "esrap": "^2.2.12", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-VT8kSnlEg8069w7AiCcAk3Yf5xvMnrGTagVOmU/OpOLHaHnNqXhWZCH/4EVga/bT/HtWhvE6/fHrXLErx7OnJA=="],
+
     "@vitest/browser/magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "@vitest/mocker/magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
@@ -1761,6 +1763,8 @@
     "@sveltejs/package/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
     "@types/d3-sankey/@types/d3-shape/@types/d3-path": ["@types/d3-path@1.0.11", "", {}, "sha512-4pQMp8ldf7UaB/gR8Fvvy69psNHkTpD/pVw3vmEi8iZAB9EPMBruB1JvHO4BIq9QkUUd2lV1F5YXpMNj7JPBpw=="],
+
+    "@unovis/svelte/svelte/magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "d3-sankey/d3-array/internmap": ["internmap@1.0.1", "", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
 

--- a/examples/package.json
+++ b/examples/package.json
@@ -9,7 +9,7 @@
     "@ggsvelte/svelte": "workspace:*"
   },
   "devDependencies": {
-    "svelte": "^5.56.9",
+    "svelte": "^5.56.10",
     "typescript": "^6.0.3"
   }
 }

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -67,7 +67,7 @@
     "@vitest/coverage-v8": "^4.1.11",
     "axe-core": "^4.13.0",
     "playwright": "1.61.1",
-    "svelte": "^5.56.9",
+    "svelte": "^5.56.10",
     "svelte-check": "^4.7.4",
     "typescript": "^6.0.3",
     "vite": "^8.2.0",

--- a/spikes/browser/package.json
+++ b/spikes/browser/package.json
@@ -13,7 +13,7 @@
     "@testing-library/svelte-core": "^1.1.3",
     "@vitest/browser-playwright": "^4.1.11",
     "playwright": "1.61.1",
-    "svelte": "^5.56.9",
+    "svelte": "^5.56.10",
     "typescript": "^6.0.3",
     "vite": "^8.2.0",
     "vitest": "^4.1.11",


### PR DESCRIPTION
## Why

Dependabot #1667 bumped `svelte` 5.56.9 → 5.56.10 (patch). CI failed with `lockfile had changes, but lockfile is frozen` — Dependabot's `bun.lock` was incomplete.

This replacement starts from current `main` and regenerates `bun.lock` with `bun install`. `bun install --frozen-lockfile` is green locally.

Replaces #1667.

## Test plan

- [x] `bun install --frozen-lockfile`
- [ ] CI on this PR