### PR TITLE
docs(guards): mark the 500-LOC program complete in the ratchet header

### DIFF
--- a/scripts/guards/max-loc-exclusions.txt
+++ b/scripts/guards/max-loc-exclusions.txt
@@ -1,6 +1,13 @@
 # 500-LOC ratchet list — entries may only be REMOVED (or their LOC shrink).
 # Format: <path> <baseline-LOC> # reason. Generated files (DO NOT EDIT header)
 # are auto-exempt by the guard and must NOT be listed here.
+#
+# 2026-08: the 500-LOC program is complete. Every hand-written code file was
+# refactored under the limit across #1675-#1685 (core src/tests, spec
+# schema/routing/evals, svelte src/tests, scripts). The entries below are the
+# permanent waivers: pure data corpora with zero imports/logic — splitting
+# them is busywork. A guard run (--all) fails on any NEW oversize hand-written
+# file, so this list cannot grow.
 packages/svelte/src/lib/data/chocolate-bars.ts 20278 # pure data corpus, no logic — permanently exempt
 packages/svelte/src/lib/data/coffee-ratings.ts 16103 # pure data corpus, no logic — permanently exempt
 packages/svelte/src/lib/data/fastfood-menu.ts 4674 # pure data corpus, no logic — permanently exempt


### PR DESCRIPTION
## Summary
S8 closing audit of the 500-LOC program (enforcement #1674 + refactor slices #1675-#1685).

Final state, verified on this branch:
- `scripts/guards/max-loc.sh --all` — clean: every tracked .ts/.tsx/.js/.mjs/.cjs/.svelte file outside spikes/ is <= 500 LOC, except the 18 permanent pure-data waivers (zero imports/logic — listed with reasons in the ratchet file, header now documents program completion).
- All 53 hand-written violators from the original list were refactored across #1675 (core src), #1676 (core tests), #1677-#1678 (spec), #1679 (svelte src), #1680 (svelte tests), #1685 (scripts/evals/bench).
- Gates: bun run check (tsc -b + lifecycle + type-contracts), svelte-check 0/0, knip, lint:type-aware:run — all clean.