### PR TITLE
lint: add cyclomatic complexity ratchet

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -42,9 +42,29 @@
     // Pipeline stages and the validator walk are cohesive units; splitting
     // them to satisfy a line count harms readability.
     "eslint/max-lines": "off",
-    "eslint/max-lines-per-function": "off"
+    "eslint/max-lines-per-function": "off",
+    // Keep branching readable and testable. The rollout override below is a
+    // temporary ratchet: remove one scope after its violations are refactored.
+    "eslint/complexity": ["error", { "max": 20 }]
   },
   "overrides": [
+    {
+      // Staged rollout inventory (2026-08-29): docs 1, examples 1, scripts 13,
+      // tests 8, spec 30, svelte 11, core 122. packages/cli, packages/skill,
+      // and benchmarks already pass and are enforced by the global rule.
+      "files": [
+        "apps/docs/**",
+        "examples/**",
+        "scripts/**",
+        "tests/**",
+        "packages/spec/**",
+        "packages/svelte/**",
+        "packages/core/**"
+      ],
+      "rules": {
+        "eslint/complexity": "off"
+      }
+    },
     {
       // Tests + benchmarks: fixture literals are cast deliberately (invalid
       // specs, RuntimeSpec shapes) and test files run long by design.


### PR DESCRIPTION
## Summary

- enable Oxlint cyclomatic complexity enforcement at the official default maximum of 20
- enforce it through the existing staged Oxlint pre-commit hook and CI pre-commit parity job
- add a temporary scoped rollout override for the directories with existing violations

## Rollout inventory

- already enforced: `packages/cli`, `packages/skill` (no lintable source), and `benchmarks`
- temporarily excluded: docs (1), examples (1), scripts (13), tests (8), spec (30), svelte (11), core (122)

Each follow-up PR will remove one scope from the override after its violations are cleared. Non-doc package fixes will include before/after benchmark evidence.

## Verification

- `bun run lint`
- `pre-commit run --all-files --show-diff-on-failure`
- `bun test packages/spec packages/core packages/cli benchmarks scripts tests/evals` (5,068 pass, 4 skip, 0 fail)

No complexity-driven production refactor is included, so this infrastructure PR does not require a benchmark comparison.
