### PR TITLE
refactor(tests): enforce complexity limit

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -49,10 +49,10 @@
   },
   "overrides": [
     {
-      // Staged rollout inventory (2026-08-29): tests 8, spec 30, svelte 11,
-      // core 122. apps/docs, examples, scripts, packages/cli,
+      // Staged rollout inventory (2026-08-29): spec 30, svelte 11, core 122.
+      // apps/docs, examples, scripts, tests, packages/cli,
       // packages/skill, and benchmarks pass and use the global rule.
-      "files": ["tests/**", "packages/spec/**", "packages/svelte/**", "packages/core/**"],
+      "files": ["packages/spec/**", "packages/svelte/**", "packages/core/**"],
       "rules": {
         "eslint/complexity": "off"
       }

--- a/tests/evals/coverage.ts
+++ b/tests/evals/coverage.ts
@@ -1,0 +1,59 @@
+import type { EvalCase } from "./types.ts";
+
+function addLayerCoverage(
+  evalCase: EvalCase,
+  stats: Set<string>,
+  positions: Set<string>,
+  facts: Set<string>,
+): void {
+  if (evalCase.gold === null) return;
+  for (const layer of evalCase.gold.layers as Array<{
+    stat?: string;
+    position?: string;
+    params?: { method?: string };
+  }>) {
+    if (layer.stat !== undefined) stats.add(layer.stat);
+    if (layer.position !== undefined) positions.add(layer.position);
+    if (layer.params?.method !== undefined) facts.add(`smooth:${layer.params.method}`);
+  }
+}
+
+function addSpecCoverage(evalCase: EvalCase, facts: Set<string>): void {
+  if (evalCase.gold === null) return;
+  const gold = evalCase.gold as unknown as Record<string, unknown>;
+  const facet = gold["facet"] as Record<string, unknown> | undefined;
+  if (facet?.["wrap"] !== undefined) facts.add("facet:wrap");
+  if (facet?.["rows"] !== undefined || facet?.["cols"] !== undefined) facts.add("facet:grid");
+  if (facet?.["scales"] !== undefined && facet["scales"] !== "fixed") facts.add("facet:free");
+  const coord = gold["coord"] as Record<string, unknown> | undefined;
+  if (coord?.["type"] === "flip") facts.add("coord:flip");
+  addScaleCoverage(gold["scales"], facts);
+}
+
+function addScaleCoverage(scalesValue: unknown, facts: Set<string>): void {
+  const scales = scalesValue as Record<string, { type?: string; transform?: string }> | undefined;
+  for (const channel of ["x", "y", "color", "fill"]) {
+    const kind = channel === "color" || channel === "fill" ? "colorish" : "pos";
+    const type = scales?.[channel]?.type;
+    if (type !== undefined) facts.add(`scale:${kind}:${type}`);
+    const transform = scales?.[channel]?.transform;
+    if (transform !== undefined && transform !== "identity") {
+      facts.add(`scale:${kind}:${transform}`);
+    }
+  }
+}
+
+export function collectCoverage(cases: EvalCase[]): {
+  stats: Set<string>;
+  positions: Set<string>;
+  facts: Set<string>;
+} {
+  const stats = new Set<string>();
+  const positions = new Set<string>();
+  const facts = new Set<string>();
+  for (const evalCase of cases) {
+    addLayerCoverage(evalCase, stats, positions, facts);
+    addSpecCoverage(evalCase, facts);
+  }
+  return { stats, positions, facts };
+}

--- a/tests/evals/harness.test.ts
+++ b/tests/evals/harness.test.ts
@@ -13,6 +13,7 @@ import { describe, expect, test } from "bun:test";
 import type { PortableSpec, SpecInput } from "@ggsvelte/spec";
 import { KNOWN_GEOMS, normalize, validate } from "@ggsvelte/spec";
 
+import { collectCoverage } from "./coverage.ts";
 import { MockResponder } from "./model.ts";
 import {
   bindingSimilarity,
@@ -103,41 +104,7 @@ describe("case corpus", () => {
   });
 
   test("stat/position/facet/coord/scale coverage", () => {
-    const stats = new Set<string>();
-    const positions = new Set<string>();
-    const facts = new Set<string>();
-    for (const c of cases) {
-      if (c.gold === null) continue;
-      const g = c.gold as unknown as Record<string, unknown>;
-      for (const layer of c.gold.layers as Array<{
-        stat?: string;
-        position?: string;
-        params?: { method?: string };
-      }>) {
-        if (layer.stat !== undefined) stats.add(layer.stat);
-        if (layer.position !== undefined) positions.add(layer.position);
-        if (layer.params?.method !== undefined) facts.add(`smooth:${layer.params.method}`);
-      }
-      const facet = g["facet"] as Record<string, unknown> | undefined;
-      if (facet?.["wrap"] !== undefined) facts.add("facet:wrap");
-      if (facet?.["rows"] !== undefined || facet?.["cols"] !== undefined) facts.add("facet:grid");
-      if (facet?.["scales"] !== undefined && facet["scales"] !== "fixed") facts.add("facet:free");
-      const coord = g["coord"] as Record<string, unknown> | undefined;
-      if (coord?.["type"] === "flip") facts.add("coord:flip");
-      const scales = g["scales"] as
-        | Record<string, { type?: string; transform?: string }>
-        | undefined;
-      for (const channel of ["x", "y", "color", "fill"]) {
-        const kind = channel === "color" || channel === "fill" ? "colorish" : "pos";
-        const t = scales?.[channel]?.type;
-        if (t !== undefined) facts.add(`scale:${kind}:${t}`);
-        // Pre-stat position transform (log10/sqrt) is a canonical scale fact.
-        const transform = scales?.[channel]?.transform;
-        if (transform !== undefined && transform !== "identity") {
-          facts.add(`scale:${kind}:${transform}`);
-        }
-      }
-    }
+    const { stats, positions, facts } = collectCoverage(cases);
     for (const stat of ["count", "bin", "smooth", "boxplot", "density", "summary"]) {
       expect(stats.has(stat)).toBe(true);
     }
@@ -259,7 +226,10 @@ describe("MockResponder map refusal", () => {
       "",
       `Scatter of y by station and map region to color.\n${profileLine}`,
     );
-    const parsed = JSON.parse(reply) as { layers?: unknown[]; unsupported?: string };
+    const parsed = JSON.parse(reply) as {
+      layers?: unknown[];
+      unsupported?: string;
+    };
     expect(parsed.unsupported).toBeUndefined();
     expect(Array.isArray(parsed.layers)).toBe(true);
   });
@@ -320,7 +290,9 @@ describe("hard gate", () => {
     expect(ok.spec).not.toBeNull();
 
     const badField = gate(
-      { layers: [{ geom: "point", aes: { x: { field: "nope" }, y: { field: "b" } } }] },
+      {
+        layers: [{ geom: "point", aes: { x: { field: "nope" }, y: { field: "b" } } }],
+      },
       PROFILE,
     );
     expect(badField.ok).toBe(false);
@@ -342,7 +314,10 @@ describe("structural rubric", () => {
     expect(
       geomSimilarity(
         gold,
-        spec({ aes: { x: "a", y: "b" }, layers: [{ geom: "point" }, { geom: "smooth" }] }),
+        spec({
+          aes: { x: "a", y: "b" },
+          layers: [{ geom: "point" }, { geom: "smooth" }],
+        }),
       ),
     ).toBe(1);
     expect(
@@ -351,13 +326,19 @@ describe("structural rubric", () => {
     expect(
       geomSimilarity(
         gold,
-        spec({ aes: { x: "a", y: "b" }, layers: [{ geom: "line" }, { geom: "line" }] }),
+        spec({
+          aes: { x: "a", y: "b" },
+          layers: [{ geom: "line" }, { geom: "line" }],
+        }),
       ),
     ).toBe(0);
     // Duplicates count as a multiset, not a set.
     expect(
       geomSimilarity(
-        spec({ aes: { x: "a", y: "b" }, layers: [{ geom: "point" }, { geom: "point" }] }),
+        spec({
+          aes: { x: "a", y: "b" },
+          layers: [{ geom: "point" }, { geom: "point" }],
+        }),
         spec({ aes: { x: "a", y: "b" }, layers: [{ geom: "point" }] }),
       ),
     ).toBe(0.5);
@@ -402,7 +383,10 @@ describe("structural rubric", () => {
     });
     expect(extrasSimilarity(goldExtras, half)).toBe(0.5);
     // A gold with no non-default facts always scores 1.
-    const plain = spec({ aes: { x: "a", y: "b" }, layers: [{ geom: "point" }] });
+    const plain = spec({
+      aes: { x: "a", y: "b" },
+      layers: [{ geom: "point" }],
+    });
     expect(extrasSimilarity(plain, goldExtras)).toBe(1);
   });
 
@@ -414,7 +398,10 @@ describe("structural rubric", () => {
       layers: [{ geom: "point" }],
       scales: { y: { type: "log" } },
     });
-    const noFacts = spec({ aes: { x: "a", y: "b" }, layers: [{ geom: "point" }] });
+    const noFacts = spec({
+      aes: { x: "a", y: "b" },
+      layers: [{ geom: "point" }],
+    });
     const atBoundary = structuralScore(goldWithFacts, noFacts);
     expect(atBoundary.total).toBe(0.8);
     expect(atBoundary.total >= PASS_STRUCTURAL).toBe(true);

--- a/tests/evals/responders/mock/postprocess.ts
+++ b/tests/evals/responders/mock/postprocess.ts
@@ -6,7 +6,14 @@
 import type { MockContext } from "./types.ts";
 
 export function postprocess(ctx: MockContext): void {
-  const { prompt, pick, spec, scales } = ctx;
+  addRuleAnnotation(ctx);
+  applyFacets(ctx);
+  applyCoordinatesAndScales(ctx);
+  applyLegend(ctx);
+}
+
+function addRuleAnnotation(ctx: MockContext): void {
+  const { prompt, spec } = ctx;
 
   // --- rule annotation add-on (geom_hline / geom_vline sugar #818) ---------
   // Prefer explicit intercepts: "y = 10", "x = 2.5", or "at N" after
@@ -45,8 +52,11 @@ export function postprocess(ctx: MockContext): void {
       params: vertical ? { xintercept: value } : { yintercept: value },
     });
   }
+}
 
-  // --- facets ---------------------------------------------------------------
+function applyFacets(ctx: MockContext): void {
+  const { prompt, pick, spec } = ctx;
+
   if (prompt.includes("grid") && prompt.includes("rows")) {
     const rows = pick.mentionedCat();
     const cols = pick.mentionedCat();
@@ -63,6 +73,10 @@ export function postprocess(ctx: MockContext): void {
       spec.facet = facet;
     }
   }
+}
+
+function applyCoordinatesAndScales(ctx: MockContext): void {
+  const { prompt, spec, scales } = ctx;
 
   // --- coord / scales ---------------------------------------------------------
   const hasHorizontalRibbon = spec.layers.some(
@@ -102,6 +116,11 @@ export function postprocess(ctx: MockContext): void {
   const ordered = /\b(dmy|mdy|ymd|ydm|myd|dym)\b/.exec(prompt)?.[1];
   if (ordered !== undefined) scales["x"] = { type: "time", parse: ordered };
   if (Object.keys(scales).length > 0) spec.scales = scales;
+}
+
+function applyLegend(ctx: MockContext): void {
+  const { prompt, spec } = ctx;
+
   if (/legend[^.]*\b(?:below|bottom)\b|\b(?:below|bottom)[^.]*legend/.test(prompt)) {
     const aesthetic = spec.layers.some((layer) => layer.aes?.["color"] !== undefined)
       ? "color"

--- a/tests/evals/responders/mock/synthesize-basic.ts
+++ b/tests/evals/responders/mock/synthesize-basic.ts
@@ -9,34 +9,40 @@ import { fieldNamed } from "./profile.ts";
 import { colorFor, f, stylesFor } from "./style.ts";
 import type { MockAes, MockContext, MockLayer } from "./types.ts";
 
-export function synthesizeBasic(ctx: MockContext): MockLayer[] | undefined {
-  const { prompt, profile, pick, scales, repair } = ctx;
+type BasicHandler = (ctx: MockContext) => MockLayer[] | undefined;
+
+function synthesizeRibbon(ctx: MockContext): MockLayer[] | undefined {
+  const { prompt } = ctx;
 
   // Horizontal (y + xmin/xmax) vs vertical (x + ymin/ymax) ribbons.
   if (/\bribbon\b/.test(prompt) && !/without .*(?:band|ribbon)/.test(prompt)) {
     if (/\bhorizontal\b|map y to|xmin to|xmax to/.test(prompt) && !/ymin to|ymax to/.test(prompt)) {
-      const y = fieldNamed(profile, "station") ?? pick.quant() ?? "y";
-      const xmin =
-        fieldNamed(profile, "min_depth") ?? fieldNamed(profile, "xmin") ?? pick.quant() ?? "xmin";
-      const xmax =
-        fieldNamed(profile, "max_depth") ?? fieldNamed(profile, "xmax") ?? pick.quant() ?? "xmax";
-      return [
-        {
-          geom: "ribbon",
-          aes: { y: f(y), xmin: f(xmin), xmax: f(xmax) },
-        },
-      ];
+      return horizontalRibbon(ctx);
     }
-    const x = fieldNamed(profile, "week") ?? pick.temporal() ?? pick.quant() ?? "x";
-    const ymin = fieldNamed(profile, "lo") ?? fieldNamed(profile, "ymin") ?? pick.quant() ?? "ymin";
-    const ymax = fieldNamed(profile, "hi") ?? fieldNamed(profile, "ymax") ?? pick.quant() ?? "ymax";
-    return [
-      {
-        geom: "ribbon",
-        aes: { x: f(x), ymin: f(ymin), ymax: f(ymax) },
-      },
-    ];
+    return verticalRibbon(ctx);
   }
+
+  return undefined;
+}
+
+function horizontalRibbon({ profile, pick }: MockContext): MockLayer[] {
+  const y = fieldNamed(profile, "station") ?? pick.quant() ?? "y";
+  const xmin =
+    fieldNamed(profile, "min_depth") ?? fieldNamed(profile, "xmin") ?? pick.quant() ?? "xmin";
+  const xmax =
+    fieldNamed(profile, "max_depth") ?? fieldNamed(profile, "xmax") ?? pick.quant() ?? "xmax";
+  return [{ geom: "ribbon", aes: { y: f(y), xmin: f(xmin), xmax: f(xmax) } }];
+}
+
+function verticalRibbon({ profile, pick }: MockContext): MockLayer[] {
+  const x = fieldNamed(profile, "week") ?? pick.temporal() ?? pick.quant() ?? "x";
+  const ymin = fieldNamed(profile, "lo") ?? fieldNamed(profile, "ymin") ?? pick.quant() ?? "ymin";
+  const ymax = fieldNamed(profile, "hi") ?? fieldNamed(profile, "ymax") ?? pick.quant() ?? "ymax";
+  return [{ geom: "ribbon", aes: { x: f(x), ymin: f(ymin), ymax: f(ymax) } }];
+}
+
+function synthesizeDistribution(ctx: MockContext): MockLayer[] | undefined {
+  const { prompt, pick, scales, repair } = ctx;
 
   // Intentionally-invalid first attempt (unknown geom) to exercise the
   // repair round; the repair call returns the fixed valid spec.
@@ -68,6 +74,12 @@ export function synthesizeBasic(ctx: MockContext): MockLayer[] | undefined {
     colorFor(ctx, "color", aes);
     return [{ geom: "density", aes }];
   }
+
+  return undefined;
+}
+
+function synthesizeInterval(ctx: MockContext): MockLayer[] | undefined {
+  const { prompt, pick } = ctx;
 
   if (/box ?plot|compare (?:the )?teams?/.test(prompt)) {
     const x = pick.cat() ?? "x";
@@ -106,6 +118,12 @@ export function synthesizeBasic(ctx: MockContext): MockLayer[] | undefined {
     return layers;
   }
 
+  return undefined;
+}
+
+function synthesizeTrend(ctx: MockContext): MockLayer[] | undefined {
+  const { prompt, pick, scales } = ctx;
+
   if (/smooth|trend line|regression|best[- ]fit|loess/.test(prompt)) {
     const first = pick.quant() ?? "x";
     const second = pick.quant() ?? "y";
@@ -131,6 +149,12 @@ export function synthesizeBasic(ctx: MockContext): MockLayer[] | undefined {
     if (pick.typeOf(x) === "temporal") scales["x"] = { type: "time" };
     return [{ geom: "area", aes }];
   }
+
+  return undefined;
+}
+
+function synthesizeScatter(ctx: MockContext): MockLayer[] | undefined {
+  const { prompt, pick } = ctx;
 
   if (/scatter|\b(?:versus|vs\.?|against)\b|relationship|correlat/.test(prompt)) {
     const first = pick.quant() ?? "x";
@@ -163,6 +187,12 @@ export function synthesizeBasic(ctx: MockContext): MockLayer[] | undefined {
     return layers;
   }
 
+  return undefined;
+}
+
+function synthesizeLineAndCount(ctx: MockContext): MockLayer[] | undefined {
+  const { prompt, pick, scales } = ctx;
+
   if (
     /line chart|connected line|over time|time series|per (?:day|week|month|hour)|trend/.test(prompt)
   ) {
@@ -186,6 +216,12 @@ export function synthesizeBasic(ctx: MockContext): MockLayer[] | undefined {
     return [layer];
   }
 
+  return undefined;
+}
+
+function synthesizeJitterAndRule(ctx: MockContext): MockLayer[] | undefined {
+  const { prompt, pick } = ctx;
+
   if (/\bjitter/.test(prompt)) {
     const x = pick.cat() ?? "x";
     const y = pick.quant() ?? "y";
@@ -208,6 +244,12 @@ export function synthesizeBasic(ctx: MockContext): MockLayer[] | undefined {
     return [{ geom: "rule", aes: { x: f(x) } }];
   }
 
+  return undefined;
+}
+
+function synthesizeBar(ctx: MockContext): MockLayer[] | undefined {
+  const { prompt, pick } = ctx;
+
   if (/bar|column/.test(prompt)) {
     const x = pick.cat() ?? "x";
     const y = pick.mentionedQuant();
@@ -229,6 +271,12 @@ export function synthesizeBasic(ctx: MockContext): MockLayer[] | undefined {
     return layers;
   }
 
+  return undefined;
+}
+
+function synthesizeFallback(ctx: MockContext): MockLayer[] {
+  const { pick, scales } = ctx;
+
   // Fallback: temporal+quant → line; two quants → point; else bar count.
   const t = pick.temporal();
   const q1 = pick.quant();
@@ -242,4 +290,23 @@ export function synthesizeBasic(ctx: MockContext): MockLayer[] | undefined {
   }
   const x = pick.cat() ?? q1 ?? "x";
   return [{ geom: "bar", aes: { x: f(x) } }];
+}
+
+const BASIC_HANDLERS: BasicHandler[] = [
+  synthesizeRibbon,
+  synthesizeDistribution,
+  synthesizeInterval,
+  synthesizeTrend,
+  synthesizeScatter,
+  synthesizeLineAndCount,
+  synthesizeJitterAndRule,
+  synthesizeBar,
+];
+
+export function synthesizeBasic(ctx: MockContext): MockLayer[] {
+  for (const handler of BASIC_HANDLERS) {
+    const layers = handler(ctx);
+    if (layers !== undefined) return layers;
+  }
+  return synthesizeFallback(ctx);
 }

--- a/tests/evals/responders/mock/synthesize-bins.ts
+++ b/tests/evals/responders/mock/synthesize-bins.ts
@@ -7,7 +7,9 @@ import { fieldNamed } from "./profile.ts";
 import { colorFor, f } from "./style.ts";
 import type { MockAes, MockContext, MockLayer } from "./types.ts";
 
-export function synthesizeBins(ctx: MockContext): MockLayer[] | undefined {
+type BinHandler = (ctx: MockContext) => MockLayer[] | undefined;
+
+function synthesizeRaster(ctx: MockContext): MockLayer[] | undefined {
   const { prompt, profile, pick } = ctx;
 
   if (/\braster\b/.test(prompt)) {
@@ -22,6 +24,12 @@ export function synthesizeBins(ctx: MockContext): MockLayer[] | undefined {
     const aes: MockAes = { x: f(x), y: f(y), fill: f(fill) };
     return [{ geom: "raster", aes }];
   }
+
+  return undefined;
+}
+
+function synthesizeHex(ctx: MockContext): MockLayer[] | undefined {
+  const { prompt, profile, pick } = ctx;
 
   // geom_hex / hexagonal bin heatmap — must win over bare "heatmap" → tile (#800).
   if (/\bhex(?:agon(?:al)?)?(?:\s+bin)?\b|\bgeom[_\s]?hex\b|\bbin_hex\b/.test(prompt)) {
@@ -54,6 +62,12 @@ export function synthesizeBins(ctx: MockContext): MockLayer[] | undefined {
     return [layer];
   }
 
+  return undefined;
+}
+
+function synthesizeBin2d(ctx: MockContext): MockLayer[] | undefined {
+  const { prompt, profile, pick } = ctx;
+
   if (
     /\bgeom[_\s]?bin[_ ]?2d\b|\bbin[_ ]?2d\b|\b2d bin(?:ned)? heatmap\b|\b2d rectangular bins?\b|\brectangular bins?\b.*\bheatmap\b|\bheatmap\b.*\brectangular bins?\b|\bbin heatmap\b/.test(
       prompt,
@@ -85,6 +99,12 @@ export function synthesizeBins(ctx: MockContext): MockLayer[] | undefined {
     return [layer];
   }
 
+  return undefined;
+}
+
+function synthesizeTile(ctx: MockContext): MockLayer[] | undefined {
+  const { prompt, profile, pick } = ctx;
+
   if (/\b(?:geom )?tiles?\b|heatmap/.test(prompt)) {
     const cats = profile.fields.filter(
       (field) => field.type === "nominal" || field.type === "ordinal",
@@ -111,6 +131,12 @@ export function synthesizeBins(ctx: MockContext): MockLayer[] | undefined {
     return [{ geom: "tile", aes }];
   }
 
+  return undefined;
+}
+
+function synthesizeRect(ctx: MockContext): MockLayer[] | undefined {
+  const { prompt, profile, pick } = ctx;
+
   if (/\brectangles?\b|\bgeom rect\b|\brect\b.*xmin|\bxmin\/xmax\b/.test(prompt)) {
     const xmin =
       fieldNamed(profile, "xmin") ?? fieldNamed(profile, "start") ?? pick.quant() ?? "xmin";
@@ -131,6 +157,12 @@ export function synthesizeBins(ctx: MockContext): MockLayer[] | undefined {
     return [layer];
   }
 
+  return undefined;
+}
+
+function synthesizeSegment(ctx: MockContext): MockLayer[] | undefined {
+  const { prompt, profile, pick } = ctx;
+
   if (/\bsegment\b|leader line|xend|yend/.test(prompt)) {
     const x = fieldNamed(profile, "x") ?? pick.quant() ?? "x";
     const y = fieldNamed(profile, "y") ?? pick.quant() ?? "y";
@@ -145,6 +177,12 @@ export function synthesizeBins(ctx: MockContext): MockLayer[] | undefined {
     colorFor(ctx, "color", aes);
     return [{ geom: "segment", aes }];
   }
+
+  return undefined;
+}
+
+function synthesizeMap(ctx: MockContext): MockLayer[] | undefined {
+  const { prompt, profile, pick } = ctx;
 
   // geom_map (#808): join value map_id to an inline fortified triangle set.
   if (/\bgeom map\b|\bfortified\b/.test(prompt)) {
@@ -176,5 +214,23 @@ export function synthesizeBins(ctx: MockContext): MockLayer[] | undefined {
     return [{ geom: "map", aes, params }];
   }
 
+  return undefined;
+}
+
+const BIN_HANDLERS: BinHandler[] = [
+  synthesizeRaster,
+  synthesizeHex,
+  synthesizeBin2d,
+  synthesizeTile,
+  synthesizeRect,
+  synthesizeSegment,
+  synthesizeMap,
+];
+
+export function synthesizeBins(ctx: MockContext): MockLayer[] | undefined {
+  for (const handler of BIN_HANDLERS) {
+    const layers = handler(ctx);
+    if (layers !== undefined) return layers;
+  }
   return undefined;
 }

--- a/tests/evals/responders/mock/synthesize-specialty.ts
+++ b/tests/evals/responders/mock/synthesize-specialty.ts
@@ -8,7 +8,9 @@ import { fieldNamed } from "./profile.ts";
 import { colorFor, f } from "./style.ts";
 import type { MockAes, MockContext, MockLayer } from "./types.ts";
 
-export function synthesizeSpecialty(ctx: MockContext): MockLayer[] | undefined {
+type SpecialtyHandler = (ctx: MockContext) => MockLayer[] | undefined;
+
+function synthesizeFunction(ctx: MockContext): MockLayer[] | undefined {
   const { prompt, profile, pick } = ctx;
 
   // geom_function / stat_function: portable named registry curve (#797).
@@ -60,6 +62,12 @@ export function synthesizeSpecialty(ctx: MockContext): MockLayer[] | undefined {
     return layers;
   }
 
+  return undefined;
+}
+
+function synthesizeInterval(ctx: MockContext): MockLayer[] | undefined {
+  const { prompt, profile, pick } = ctx;
+
   // Interval family beyond errorbar (#793). Multi-geom prompts emit all
   // named forms so corpus golds with three layers stay mock-reachable.
   if (/\bgeom[_\s]?linerange\b|\bgeom[_\s]?pointrange\b|\bgeom[_\s]?crossbar\b/.test(prompt)) {
@@ -92,6 +100,12 @@ export function synthesizeSpecialty(ctx: MockContext): MockLayer[] | undefined {
     return layers;
   }
 
+  return undefined;
+}
+
+function synthesizeQq(ctx: MockContext): MockLayer[] | undefined {
+  const { prompt, profile, pick } = ctx;
+
   // geom_qq + geom_qq_line: sample channel (ggplot2 aes.sample) (#804).
   if (
     /\bq-?q\b/.test(prompt) ||
@@ -115,6 +129,12 @@ export function synthesizeSpecialty(ctx: MockContext): MockLayer[] | undefined {
     return layers;
   }
 
+  return undefined;
+}
+
+function synthesizeStep(ctx: MockContext): MockLayer[] | undefined {
+  const { prompt, pick } = ctx;
+
   // geom_step: hv/vh staircase polylines (#789). Not the intentional
   // "stepped" unknown-geom repair fixture handled in the basic families.
   if (
@@ -134,6 +154,12 @@ export function synthesizeSpecialty(ctx: MockContext): MockLayer[] | undefined {
     return [layer];
   }
 
+  return undefined;
+}
+
+function synthesizeCount(ctx: MockContext): MockLayer[] | undefined {
+  const { prompt, profile, pick } = ctx;
+
   // geom_count: stat sum at unique (x, y); size defaults to after_stat n (#795).
   if (/\bgeom[_\s]?count\b|\boverplotting\b/.test(prompt)) {
     const x = fieldNamed(profile, "x") ?? pick.quant() ?? "x";
@@ -142,6 +168,12 @@ export function synthesizeSpecialty(ctx: MockContext): MockLayer[] | undefined {
     colorFor(ctx, "color", aes);
     return [{ geom: "count", aes }];
   }
+
+  return undefined;
+}
+
+function synthesizeViolin(ctx: MockContext): MockLayer[] | undefined {
+  const { prompt, pick } = ctx;
 
   // geom_violin: mirrored ydensity polygons per discrete x (#798).
   if (/\bgeom[_\s]?violin\b|\bviolin plots?\b|\bviolin\b/.test(prompt)) {
@@ -156,6 +188,12 @@ export function synthesizeSpecialty(ctx: MockContext): MockLayer[] | undefined {
     }
     return [layer];
   }
+
+  return undefined;
+}
+
+function synthesizeLabel(ctx: MockContext): MockLayer[] | undefined {
+  const { prompt, pick } = ctx;
 
   // geom_label alone: boxed text marks, no companion point layer (#792).
   if (
@@ -173,6 +211,12 @@ export function synthesizeSpecialty(ctx: MockContext): MockLayer[] | undefined {
     return [layer];
   }
 
+  return undefined;
+}
+
+function synthesizePolygon(ctx: MockContext): MockLayer[] | undefined {
+  const { prompt, profile, pick } = ctx;
+
   // geom_polygon: closed filled rings in data order, one per group (#807).
   // Vertex fields are positional, not prompt-ordered — prefer literal x/y.
   if (
@@ -186,6 +230,12 @@ export function synthesizeSpecialty(ctx: MockContext): MockLayer[] | undefined {
     colorFor(ctx, "fill", layer.aes);
     return [layer];
   }
+
+  return undefined;
+}
+
+function synthesizeSpoke(ctx: MockContext): MockLayer[] | undefined {
+  const { prompt, profile, pick } = ctx;
 
   // geom_spoke: origin + angle (radians) + radius → segment (#810).
   if (
@@ -212,6 +262,12 @@ export function synthesizeSpecialty(ctx: MockContext): MockLayer[] | undefined {
     }
     return [layer];
   }
+
+  return undefined;
+}
+
+function synthesizeBlank(ctx: MockContext): MockLayer[] | undefined {
+  const { prompt, profile, pick } = ctx;
 
   // geom_blank: scale training without marks (#791).
   if (
@@ -242,5 +298,26 @@ export function synthesizeSpecialty(ctx: MockContext): MockLayer[] | undefined {
     return layers;
   }
 
+  return undefined;
+}
+
+const SPECIALTY_HANDLERS: SpecialtyHandler[] = [
+  synthesizeFunction,
+  synthesizeInterval,
+  synthesizeQq,
+  synthesizeStep,
+  synthesizeCount,
+  synthesizeViolin,
+  synthesizeLabel,
+  synthesizePolygon,
+  synthesizeSpoke,
+  synthesizeBlank,
+];
+
+export function synthesizeSpecialty(ctx: MockContext): MockLayer[] | undefined {
+  for (const handler of SPECIALTY_HANDLERS) {
+    const layers = handler(ctx);
+    if (layers !== undefined) return layers;
+  }
   return undefined;
 }

--- a/tests/evals/responders/mock/synthesize-surfaces.ts
+++ b/tests/evals/responders/mock/synthesize-surfaces.ts
@@ -8,8 +8,10 @@ import { fieldNamed } from "./profile.ts";
 import { f } from "./style.ts";
 import type { MockAes, MockContext, MockLayer } from "./types.ts";
 
-export function synthesizeSurfaces(ctx: MockContext): MockLayer[] | undefined {
-  const { prompt, profile, pick, scales } = ctx;
+type SurfaceHandler = (ctx: MockContext) => MockLayer[] | undefined;
+
+function synthesizeSfLabel(ctx: MockContext): MockLayer[] | undefined {
+  const { prompt, profile, pick } = ctx;
 
   // geom_sf_label: boxed labels at representative SF points (#809 phase 3).
   if (
@@ -30,6 +32,12 @@ export function synthesizeSurfaces(ctx: MockContext): MockLayer[] | undefined {
     if (label !== undefined) aes.label = f(label);
     return [{ geom: "sf_label", aes }];
   }
+
+  return undefined;
+}
+
+function synthesizeSfText(ctx: MockContext): MockLayer[] | undefined {
+  const { prompt, profile, pick } = ctx;
 
   // geom_sf_text: labels at representative SF points (#809 phase 2).
   if (
@@ -55,6 +63,12 @@ export function synthesizeSurfaces(ctx: MockContext): MockLayer[] | undefined {
     return [{ geom: "sf_text", aes }];
   }
 
+  return undefined;
+}
+
+function synthesizeSf(ctx: MockContext): MockLayer[] | undefined {
+  const { prompt, profile, pick } = ctx;
+
   // geom_sf: GeoJSON Geometry JSON strings in a column (#809).
   if (
     /\bgeom[_\s]?sf\b|\bgeojson\b|\bsimple features?\b|\bsf (?:point|polygon|layer|choropleth)\b/.test(
@@ -70,6 +84,12 @@ export function synthesizeSurfaces(ctx: MockContext): MockLayer[] | undefined {
     if (fill !== undefined) aes.fill = f(fill);
     return [{ geom: "sf", aes }];
   }
+
+  return undefined;
+}
+
+function synthesizeThreeLayers(ctx: MockContext): MockLayer[] | undefined {
+  const { prompt, pick, scales } = ctx;
 
   if (
     prompt.includes("three layers") &&
@@ -94,6 +114,12 @@ export function synthesizeSurfaces(ctx: MockContext): MockLayer[] | undefined {
       { geom: "density", aes: { x: f(x) } },
     ];
   }
+
+  return undefined;
+}
+
+function synthesizeFilledDensity(ctx: MockContext): MockLayer[] | undefined {
+  const { prompt, profile, pick } = ctx;
 
   // geom_density_2d_filled closed KDE rings (#802 phase 2).
   if (
@@ -125,6 +151,12 @@ export function synthesizeSurfaces(ctx: MockContext): MockLayer[] | undefined {
     return layers;
   }
 
+  return undefined;
+}
+
+function synthesizeEllipse(ctx: MockContext): MockLayer[] | undefined {
+  const { prompt, profile, pick } = ctx;
+
   // stat_ellipse bivariate normal rings on path (#812).
   if (/\bellipse\b|\bconfidence (?:ellipse|ring)/.test(prompt)) {
     const x = fieldNamed(profile, "x") ?? pick.mentionedQuant() ?? pick.quant() ?? "x";
@@ -153,6 +185,12 @@ export function synthesizeSurfaces(ctx: MockContext): MockLayer[] | undefined {
     return layers;
   }
 
+  return undefined;
+}
+
+function synthesizeDotplot(ctx: MockContext): MockLayer[] | undefined {
+  const { prompt, profile, pick } = ctx;
+
   // geom_dotplot / stat_bindot histodot stacks (#803).
   if (/\bdotplot\b|\bhistodot\b|\bbindot\b/.test(prompt)) {
     const x =
@@ -174,6 +212,12 @@ export function synthesizeSurfaces(ctx: MockContext): MockLayer[] | undefined {
     if (Object.keys(params).length > 0) layer.params = params;
     return [layer];
   }
+
+  return undefined;
+}
+
+function synthesizeDensity2d(ctx: MockContext): MockLayer[] | undefined {
+  const { prompt, profile, pick } = ctx;
 
   // geom_density_2d / stat_density_2d product Gaussian isolines (#802).
   if (/\bdensity[_ ]?2d\b|\bbivariate kde\b|\bkde isolines?\b/.test(prompt)) {
@@ -207,6 +251,12 @@ export function synthesizeSurfaces(ctx: MockContext): MockLayer[] | undefined {
     return layers;
   }
 
+  return undefined;
+}
+
+function synthesizeContour(ctx: MockContext): MockLayer[] | undefined {
+  const { prompt, profile, pick } = ctx;
+
   // geom_contour + stat_contour over a regular x/y/z grid (#801).
   if (/\bcontour\b|isolines?\b/.test(prompt)) {
     const x = fieldNamed(profile, "x") ?? pick.quant() ?? "x";
@@ -231,5 +281,25 @@ export function synthesizeSurfaces(ctx: MockContext): MockLayer[] | undefined {
     return [layer];
   }
 
+  return undefined;
+}
+
+const SURFACE_HANDLERS: SurfaceHandler[] = [
+  synthesizeSfLabel,
+  synthesizeSfText,
+  synthesizeSf,
+  synthesizeThreeLayers,
+  synthesizeFilledDensity,
+  synthesizeEllipse,
+  synthesizeDotplot,
+  synthesizeDensity2d,
+  synthesizeContour,
+];
+
+export function synthesizeSurfaces(ctx: MockContext): MockLayer[] | undefined {
+  for (const handler of SURFACE_HANDLERS) {
+    const layers = handler(ctx);
+    if (layers !== undefined) return layers;
+  }
   return undefined;
 }

--- a/tests/evals/run.ts
+++ b/tests/evals/run.ts
@@ -255,31 +255,38 @@ function renderReport(board: Scoreboard, casesById: Map<string, EvalCase>): stri
   return lines.join("\n") + "\n";
 }
 
-export async function runEvals(options: RunEvalsOptions = {}): Promise<Scoreboard> {
+function resolveResponder(options: RunEvalsOptions): Responder {
   const dryRun = options.dryRun ?? false;
-  const repairEnabled = options.repair ?? true;
   const apiKey = process.env["OPENROUTER_API_KEY"];
-
-  let responder: Responder;
   if (options.responder !== undefined) {
-    responder = options.responder;
-  } else if (!dryRun && apiKey !== undefined && apiKey !== "") {
-    responder = new OpenRouterResponder(apiKey, options.model);
-  } else {
-    if (!dryRun && !(options.quiet ?? false)) {
-      console.log("NOTICE: OPENROUTER_API_KEY is not set — falling back to the MockResponder.");
-    }
-    responder = new MockResponder();
+    return options.responder;
   }
-  const live = responder instanceof OpenRouterResponder;
+  if (!dryRun && apiKey !== undefined && apiKey !== "") {
+    return new OpenRouterResponder(apiKey, options.model);
+  }
+  if (!dryRun && !(options.quiet ?? false)) {
+    console.log("NOTICE: OPENROUTER_API_KEY is not set — falling back to the MockResponder.");
+  }
+  return new MockResponder();
+}
 
+function selectCases(options: RunEvalsOptions): EvalCase[] {
   let cases = loadCases();
   if (options.cases !== undefined && options.cases.length > 0) {
     const wanted = new Set(options.cases);
     cases = cases.filter((c) => wanted.has(c.id));
   }
   if (options.max !== undefined) cases = cases.slice(0, options.max);
+  return cases;
+}
 
+async function scoreCases(
+  cases: EvalCase[],
+  responder: Responder,
+  options: RunEvalsOptions,
+): Promise<CaseScore[]> {
+  const live = responder instanceof OpenRouterResponder;
+  const repairEnabled = options.repair ?? true;
   const scores: CaseScore[] = [];
   for (const evalCase of cases) {
     if (scores.length > 0 && live) await sleep(INTER_CALL_DELAY_MS);
@@ -294,23 +301,36 @@ export async function runEvals(options: RunEvalsOptions = {}): Promise<Scoreboar
       );
     }
   }
+  return scores;
+}
 
-  const board: Scoreboard = {
+function buildScoreboard(responder: Responder, scores: CaseScore[]): Scoreboard {
+  return {
     meta: {
       timestamp: new Date().toISOString(),
       model: responder.name,
-      dryRun: !live,
+      dryRun: !(responder instanceof OpenRouterResponder),
       caseCount: scores.length,
     },
     totals: computeTotals(scores),
     cases: scores,
   };
+}
 
+function writeOutputs(board: Scoreboard, cases: EvalCase[]): void {
+  mkdirSync(OUT_DIR, { recursive: true });
+  writeFileSync(join(OUT_DIR, "scoreboard.json"), JSON.stringify(board, null, 2) + "\n");
+  const casesById = new Map(cases.map((c) => [c.id, c]));
+  writeFileSync(join(OUT_DIR, "report.md"), renderReport(board, casesById));
+}
+
+export async function runEvals(options: RunEvalsOptions = {}): Promise<Scoreboard> {
+  const responder = resolveResponder(options);
+  const cases = selectCases(options);
+  const scores = await scoreCases(cases, responder, options);
+  const board = buildScoreboard(responder, scores);
   if (options.writeOutputs ?? true) {
-    mkdirSync(OUT_DIR, { recursive: true });
-    writeFileSync(join(OUT_DIR, "scoreboard.json"), JSON.stringify(board, null, 2) + "\n");
-    const casesById = new Map(cases.map((c) => [c.id, c]));
-    writeFileSync(join(OUT_DIR, "report.md"), renderReport(board, casesById));
+    writeOutputs(board, cases);
   }
   if (!(options.quiet ?? false)) {
     console.log(JSON.stringify(board.totals));

--- a/tests/evals/score.ts
+++ b/tests/evals/score.ts
@@ -222,7 +222,17 @@ export function nonDefaultFacts(spec: PortableSpec): string[] {
   const facts: string[] = [];
   const s = spec as unknown as Record<string, unknown>;
 
-  const facet = s["facet"];
+  addFacetFacts(s["facet"], facts);
+
+  const coord = s["coord"];
+  if (isRecord(coord) && coord["type"] === "flip") facts.push("coord=flip");
+
+  addScaleFacts(s["scales"], facts);
+  addPositionFacts(spec, facts);
+  return facts;
+}
+
+function addFacetFacts(facet: unknown, facts: string[]): void {
   if (isRecord(facet)) {
     for (const form of ["wrap", "rows", "cols"] as const) {
       const ref = facet[form];
@@ -234,11 +244,9 @@ export function nonDefaultFacts(spec: PortableSpec): string[] {
       facts.push(`facet.scales=${facet["scales"]}`);
     }
   }
+}
 
-  const coord = s["coord"];
-  if (isRecord(coord) && coord["type"] === "flip") facts.push("coord=flip");
-
-  const scales = s["scales"];
+function addScaleFacts(scales: unknown, facts: string[]): void {
   if (isRecord(scales)) {
     for (const channel of ["x", "y", "color", "fill"] as const) {
       const config = scales[channel];
@@ -247,7 +255,9 @@ export function nonDefaultFacts(spec: PortableSpec): string[] {
       }
     }
   }
+}
 
+function addPositionFacts(spec: PortableSpec, facts: string[]): void {
   const seen = new Map<string, number>();
   for (const layer of layersOf(spec)) {
     const defaults = GEOM_DEFAULTS[layer.geom as keyof typeof GEOM_DEFAULTS];
@@ -259,7 +269,6 @@ export function nonDefaultFacts(spec: PortableSpec): string[] {
       facts.push(n === 0 ? key : `${key}#${n}`); // multiset-safe within a set
     }
   }
-  return facts;
 }
 
 /** Fraction of gold's non-default facts reproduced by the candidate. */
@@ -358,6 +367,9 @@ export function renderCheck(spec: PortableSpec, evalCase: EvalCase): RenderResul
     });
     return svg.length > 0 ? { ok: true } : { ok: false, error: "empty SVG output" };
   } catch (error) {
-    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
   }
 }


### PR DESCRIPTION
## Summary
- split eval mock synthesis and postprocessing into focused handlers
- extract eval coverage and scoring helpers
- remove the temporary `tests/**` cyclomatic-complexity exemption

## Verification
- `bun run lint`
- `bun run check`
- `pre-commit run --all-files`
- `bun test tests/evals scripts/max-loc.test.ts` (41 pass)
- `bun run test` (5067 pass, 4 skip; one unrelated timing assertion failed under full-suite load, then passed in isolation: 11 pass)
- benchmark checkpoint vs clean `origin/main`: no coherent regression; repeat 1 was 18 faster / 22 slower, repeat 2 was 32 faster / 8 slower, with changing outliers; this PR changes test/eval code only