### PR TITLE
refactor(spec): enforce complexity limit

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -49,10 +49,10 @@
   },
   "overrides": [
     {
-      // Staged rollout inventory (2026-08-29): spec 30, svelte 11, core 122.
-      // apps/docs, examples, scripts, tests, packages/cli,
+      // Staged rollout inventory (2026-08-29): svelte 11, core 122.
+      // apps/docs, examples, scripts, tests, packages/spec, packages/cli,
       // packages/skill, and benchmarks pass and use the global rule.
-      "files": ["packages/spec/**", "packages/svelte/**", "packages/core/**"],
+      "files": ["packages/svelte/**", "packages/core/**"],
       "rules": {
         "eslint/complexity": "off"
       }

--- a/packages/spec/src/coord-reference-build.ts
+++ b/packages/spec/src/coord-reference-build.ts
@@ -170,32 +170,36 @@ function typeSummaryOf(node: unknown, depth = 0): string {
     return JSON.stringify(node["const"]);
   }
   const anyOf = node["anyOf"];
-  if (Array.isArray(anyOf)) {
-    const parts = anyOf.map((branch) => typeSummaryOf(branch, depth + 1));
-    if (parts.every((p) => p.startsWith('"') || p.startsWith("'") || /^-?\d/.test(p))) {
-      return [...new Set(parts)].join(" | ");
-    }
-    return parts.join(" | ");
-  }
+  if (Array.isArray(anyOf)) return unionSummary(anyOf, depth);
   const type = node["type"];
   if (type === "number" || type === "integer") return type === "integer" ? "integer" : "number";
   if (type === "string") return "string";
   if (type === "boolean") return "boolean";
   if (type === "object") return "object";
-  if (type === "array") {
-    const items = node["items"];
-    const itemSummary = items === undefined ? "unknown" : typeSummaryOf(items, depth + 1);
-    const min = node["minItems"];
-    const max = node["maxItems"];
-    if (typeof min === "number" && typeof max === "number" && min === max) {
-      return `[${Array.from({ length: min }, () => itemSummary).join(", ")}]`;
-    }
-    return `${itemSummary}[]`;
-  }
+  if (type === "array") return arraySummary(node, depth);
   if (Array.isArray(type)) {
     return type.filter((t) => t !== "null").join(" | ") || "unknown";
   }
   return "unknown";
+}
+
+function unionSummary(anyOf: unknown[], depth: number): string {
+  const parts = anyOf.map((branch) => typeSummaryOf(branch, depth + 1));
+  if (parts.every((part) => part.startsWith('"') || part.startsWith("'") || /^-?\d/.test(part))) {
+    return [...new Set(parts)].join(" | ");
+  }
+  return parts.join(" | ");
+}
+
+function arraySummary(node: Record<string, unknown>, depth: number): string {
+  const items = node["items"];
+  const itemSummary = items === undefined ? "unknown" : typeSummaryOf(items, depth + 1);
+  const min = node["minItems"];
+  const max = node["maxItems"];
+  if (typeof min === "number" && typeof max === "number" && min === max) {
+    return `[${Array.from({ length: min }, () => itemSummary).join(", ")}]`;
+  }
+  return `${itemSummary}[]`;
 }
 
 function descriptionOf(node: unknown, name: string): string {

--- a/packages/spec/src/lint-layer-rules.ts
+++ b/packages/spec/src/lint-layer-rules.ts
@@ -57,104 +57,119 @@ export function collectLayerLintAdvisories(input: {
       typeof layer["position"] === "string"
         ? layer["position"]
         : (defaults?.position ?? "identity");
-
-    // --- line-over-nominal-x ------------------------------------------------
-    if (geom === "line" || geom === "step") {
-      const x = fieldOf(layerAes, "x");
-      if (x !== null && x.info.type === "nominal") {
-        advisories.push({
-          code: "line-over-nominal-x",
-          path: `/layers/${i}/aes/x`,
-          message: `This ${geom} layer connects points across "${x.field}", a nominal (unordered) field — the line's slopes carry no meaning.`,
-          suggestion: {
-            description:
-              'Use geom "col" (or "bar" with the count stat) for per-category values; keep "line"/"step" only for ordered x (numbers, dates, or a genuinely ordinal field).',
-            example: { geom: "col" },
-          },
-        });
-      }
-    }
-
-    // --- discrete-discrete-scatter -------------------------------------------
-    if (geom === "point" && position !== "jitter") {
-      const x = fieldOf(layerAes, "x");
-      const y = fieldOf(layerAes, "y");
-      if (
-        x !== null &&
-        y !== null &&
-        x.info.type !== null &&
-        y.info.type !== null &&
-        DISCRETE.has(x.info.type) &&
-        DISCRETE.has(y.info.type)
-      ) {
-        advisories.push({
-          code: "discrete-discrete-scatter",
-          path: `/layers/${i}`,
-          message: `This point layer maps discrete fields on both axes ("${x.field}" × "${y.field}") — identical combinations overplot invisibly.`,
-          suggestion: {
-            description:
-              'Add position: "jitter" to spread the points, or count the combinations and encode the count (e.g. point size).',
-            example: { geom: "point", position: "jitter" },
-          },
-        });
-      }
-    }
-
-    // --- stacked-area-negative -----------------------------------------------
-    if (geom === "area" && (position === "stack" || position === "fill")) {
-      const y = fieldOf(layerAes, "y");
-      const values = y?.info.values;
-      if (y !== null && values !== null && values !== undefined) {
-        let hasNegative = hasNegativeByField.get(y.field);
-        if (hasNegative === undefined) {
-          hasNegative = values.some((v) => typeof v === "number" && v < 0);
-          hasNegativeByField.set(y.field, hasNegative);
-        }
-        if (hasNegative) {
-          advisories.push({
-            code: "stacked-area-negative",
-            path: `/layers/${i}/aes/y`,
-            message: `This stacked area layer's y field "${y.field}" contains negative values — stacked bands will cross and misread as parts of a whole.`,
-            suggestion: {
-              description:
-                'Draw one line per series instead, or set position: "identity" to overlap the areas.',
-              example: { geom: "area", position: "identity" },
-            },
-          });
-        }
-      }
-    }
-
-    // --- many-discrete-colors -------------------------------------------------
-    for (const channel of ["color", "fill"] as const) {
-      const c = fieldOf(layerAes, channel);
-      const values = c?.info.values;
-      if (
-        c !== null &&
-        values !== null &&
-        values !== undefined &&
-        c.info.type !== null &&
-        DISCRETE.has(c.info.type)
-      ) {
-        let distinct = distinctNonNullByField.get(c.field);
-        if (distinct === undefined) {
-          distinct = countDistinctNonNull(values);
-          distinctNonNullByField.set(c.field, distinct);
-        }
-        if (distinct > 10) {
-          advisories.push({
-            code: "many-discrete-colors",
-            path: `/layers/${i}/aes/${channel}`,
-            message: `Field "${c.field}" maps ${distinct} distinct values to ${channel} — beyond ~10, hues stop being distinguishable and the default palette cycles.`,
-            suggestion: {
-              description: `Facet by "${c.field}", aggregate it to fewer categories, or pin scales.${channel}.domain (+ a range) to the values that matter.`,
-              example: { facet: { wrap: { field: c.field } } },
-            },
-          });
-        }
-      }
-    }
+    addLineAdvisory({ advisories, fieldOf, geom, layerAes, index: i });
+    addScatterAdvisory({ advisories, fieldOf, geom, layerAes, position, index: i });
+    addAreaAdvisory({
+      advisories,
+      fieldOf,
+      geom,
+      layerAes,
+      position,
+      index: i,
+      hasNegativeByField,
+    });
+    addColorAdvisories({
+      advisories,
+      fieldOf,
+      layerAes,
+      index: i,
+      distinctNonNullByField,
+    });
   }
 
   return advisories;
+}
+
+interface LayerLintContext {
+  advisories: SpecAdvisory[];
+  fieldOf: LintFieldOf;
+  geom: string;
+  layerAes: Aes | undefined;
+  index: number;
+}
+
+function addLineAdvisory(ctx: LayerLintContext): void {
+  if (ctx.geom !== "line" && ctx.geom !== "step") return;
+  const x = ctx.fieldOf(ctx.layerAes, "x");
+  if (x === null || x.info.type !== "nominal") return;
+  ctx.advisories.push({
+    code: "line-over-nominal-x",
+    path: `/layers/${ctx.index}/aes/x`,
+    message: `This ${ctx.geom} layer connects points across "${x.field}", a nominal (unordered) field — the line's slopes carry no meaning.`,
+    suggestion: {
+      description:
+        'Use geom "col" (or "bar" with the count stat) for per-category values; keep "line"/"step" only for ordered x (numbers, dates, or a genuinely ordinal field).',
+      example: { geom: "col" },
+    },
+  });
+}
+
+function addScatterAdvisory(ctx: LayerLintContext & { position: string }): void {
+  if (ctx.geom !== "point" || ctx.position === "jitter") return;
+  const x = ctx.fieldOf(ctx.layerAes, "x");
+  const y = ctx.fieldOf(ctx.layerAes, "y");
+  if (x === null || y === null || x.info.type === null || y.info.type === null) return;
+  if (!DISCRETE.has(x.info.type) || !DISCRETE.has(y.info.type)) return;
+  ctx.advisories.push({
+    code: "discrete-discrete-scatter",
+    path: `/layers/${ctx.index}`,
+    message: `This point layer maps discrete fields on both axes ("${x.field}" × "${y.field}") — identical combinations overplot invisibly.`,
+    suggestion: {
+      description:
+        'Add position: "jitter" to spread the points, or count the combinations and encode the count (e.g. point size).',
+      example: { geom: "point", position: "jitter" },
+    },
+  });
+}
+
+function addAreaAdvisory(
+  ctx: LayerLintContext & { position: string; hasNegativeByField: Map<string, boolean> },
+): void {
+  if (ctx.geom !== "area" || (ctx.position !== "stack" && ctx.position !== "fill")) return;
+  const y = ctx.fieldOf(ctx.layerAes, "y");
+  const values = y?.info.values;
+  if (y === null || values === null || values === undefined) return;
+  let hasNegative = ctx.hasNegativeByField.get(y.field);
+  if (hasNegative === undefined) {
+    hasNegative = values.some((value) => typeof value === "number" && value < 0);
+    ctx.hasNegativeByField.set(y.field, hasNegative);
+  }
+  if (!hasNegative) return;
+  ctx.advisories.push({
+    code: "stacked-area-negative",
+    path: `/layers/${ctx.index}/aes/y`,
+    message: `This stacked area layer's y field "${y.field}" contains negative values — stacked bands will cross and misread as parts of a whole.`,
+    suggestion: {
+      description:
+        'Draw one line per series instead, or set position: "identity" to overlap the areas.',
+      example: { geom: "area", position: "identity" },
+    },
+  });
+}
+
+function addColorAdvisories(
+  ctx: Omit<LayerLintContext, "geom"> & { distinctNonNullByField: Map<string, number> },
+): void {
+  for (const channel of ["color", "fill"] as const) {
+    const color = ctx.fieldOf(ctx.layerAes, channel);
+    const values = color?.info.values;
+    if (color === null || values === null || values === undefined || color.info.type === null)
+      continue;
+    if (!DISCRETE.has(color.info.type)) continue;
+    let distinct = ctx.distinctNonNullByField.get(color.field);
+    if (distinct === undefined) {
+      distinct = countDistinctNonNull(values);
+      ctx.distinctNonNullByField.set(color.field, distinct);
+    }
+    if (distinct <= 10) continue;
+    ctx.advisories.push({
+      code: "many-discrete-colors",
+      path: `/layers/${ctx.index}/aes/${channel}`,
+      message: `Field "${color.field}" maps ${distinct} distinct values to ${channel} — beyond ~10, hues stop being distinguishable and the default palette cycles.`,
+      suggestion: {
+        description: `Facet by "${color.field}", aggregate it to fewer categories, or pin scales.${channel}.domain (+ a range) to the values that matter.`,
+        example: { facet: { wrap: { field: color.field } } },
+      },
+    });
+  }
 }

--- a/packages/spec/src/lint-scale-rules.ts
+++ b/packages/spec/src/lint-scale-rules.ts
@@ -59,6 +59,20 @@ function looksLikeFractionalCalendarYears(values: readonly CellValue[]): boolean
   if (yearLike.length < MIN_YEAR_LIKE_SAMPLES) return false;
   if (yearLike.length / finiteCount < MIN_YEAR_LIKE_DOMINANCE) return false;
 
+  const stats = fractionalYearStats(yearLike);
+  if (stats.fractional < MIN_FRACTIONAL_SAMPLES) return false;
+  if (stats.fractional / yearLike.length < MIN_FRACTIONAL_RATE) return false;
+  if (stats.monthGridHits / yearLike.length < MIN_MONTH_GRID_HIT_RATE) return false;
+  if (stats.monthIndices.size < MIN_DISTINCT_MONTHS) return false;
+  return stats.nonQuarterFractional >= 1;
+}
+
+function fractionalYearStats(yearLike: readonly number[]): {
+  fractional: number;
+  monthGridHits: number;
+  monthIndices: Set<number>;
+  nonQuarterFractional: number;
+} {
   let fractional = 0;
   let monthGridHits = 0;
   const monthIndices = new Set<number>();
@@ -81,14 +95,7 @@ function looksLikeFractionalCalendarYears(values: readonly CellValue[]): boolean
       if (isFractional && !QUARTER_MONTH_INDEX.has(k)) nonQuarterFractional++;
     }
   }
-
-  if (fractional < MIN_FRACTIONAL_SAMPLES) return false;
-  if (fractional / yearLike.length < MIN_FRACTIONAL_RATE) return false;
-  if (monthGridHits / yearLike.length < MIN_MONTH_GRID_HIT_RATE) return false;
-  // Reject quarter/half-only grids (e.g. 1000.5, 2500.25, 3000.75).
-  if (monthIndices.size < MIN_DISTINCT_MONTHS) return false;
-  if (nonQuarterFractional < 1) return false;
-  return true;
+  return { fractional, monthGridHits, monthIndices, nonQuarterFractional };
 }
 
 /** First year-like fractional sample for advisory copy, or null. */
@@ -151,7 +158,7 @@ function countTransformDomain(
 }
 
 /** Scale-scoped advisories for one lintSpec pass. */
-export function collectScaleLintAdvisories(input: {
+function collectTransformAdvisories(input: {
   layers: unknown[];
   scales: Record<string, unknown> | undefined;
   fieldOf: LintFieldOf;
@@ -203,6 +210,17 @@ export function collectScaleLintAdvisories(input: {
       }
     }
   }
+
+  return advisories;
+}
+
+function collectFractionalYearAdvisories(input: {
+  layers: unknown[];
+  scales: Record<string, unknown> | undefined;
+  fieldOf: LintFieldOf;
+}): SpecAdvisory[] {
+  const { layers, scales, fieldOf } = input;
+  const advisories: SpecAdvisory[] = [];
 
   // --- fractional-calendar-years (x only, once) ------------------------------
   // Monthly series re-encoded as year + month/12 and plotted on a default or
@@ -256,4 +274,12 @@ export function collectScaleLintAdvisories(input: {
   }
 
   return advisories;
+}
+
+export function collectScaleLintAdvisories(input: {
+  layers: unknown[];
+  scales: Record<string, unknown> | undefined;
+  fieldOf: LintFieldOf;
+}): SpecAdvisory[] {
+  return [...collectTransformAdvisories(input), ...collectFractionalYearAdvisories(input)];
 }

--- a/packages/spec/src/normalize-coord.ts
+++ b/packages/spec/src/normalize-coord.ts
@@ -69,31 +69,39 @@ export function normalizeCoord(coord: CoordSpec | undefined): CoordSpec | undefi
       : undefined;
   if (record["type"] === "flip") return { ...record } as CoordSpec;
   if (record["type"] === "fixed" || record["type"] === "sf") {
-    const fixed = { ...record } as unknown as { type: "fixed" | "sf"; ratio?: unknown };
-    if (fixed.ratio === 1 || fixed.ratio === undefined) delete fixed.ratio;
-    return fixed as CoordSpec;
+    return normalizeFixedCoord(record);
   }
   if (record["type"] === "radial") {
-    const radial = { ...record } as unknown as CoordRadialSpec & Record<string, unknown>;
-    if (radial.theta === "x" || radial.theta === undefined) delete radial.theta;
-    if (radial.start === 0 || radial.start === undefined) delete radial.start;
-    if (radial.innerRadius === 0 || radial.innerRadius === undefined) delete radial.innerRadius;
-    if (radial.expand === true || radial.expand === undefined) delete radial.expand;
-    // Radial default clip is off (false); only keep explicit true (or malformed).
-    if (radial.clip === false || radial.clip === undefined) delete radial.clip;
-    if (radial.reverse === "none" || radial.reverse === undefined) delete radial.reverse;
-    // Shallow-copy valid-shaped limit tuples; leave malformed arrays intact so
-    // schema validation can reject wrong lengths (same as transform axes).
-    if (Array.isArray(radial.thetaLimits) && radial.thetaLimits.length === 2) {
-      radial.thetaLimits = [radial.thetaLimits[0]!, radial.thetaLimits[1]!];
-    }
-    if (Array.isArray(radial.rLimits) && radial.rLimits.length === 2) {
-      radial.rLimits = [radial.rLimits[0]!, radial.rLimits[1]!];
-    }
-    return radial;
+    return normalizeRadialCoord(record);
   }
   if (record["type"] !== "transform") return { ...record } as CoordSpec;
-  const transformed = coord as CoordTransformSpec;
+  return normalizeTransformCoord(coord as CoordTransformSpec);
+}
+
+function normalizeFixedCoord(record: Record<string, unknown>): CoordSpec {
+  const fixed = { ...record } as unknown as { type: "fixed" | "sf"; ratio?: unknown };
+  if (fixed.ratio === 1 || fixed.ratio === undefined) delete fixed.ratio;
+  return fixed as CoordSpec;
+}
+
+function normalizeRadialCoord(record: Record<string, unknown>): CoordSpec {
+  const radial = { ...record } as unknown as CoordRadialSpec & Record<string, unknown>;
+  if (radial.theta === "x" || radial.theta === undefined) delete radial.theta;
+  if (radial.start === 0 || radial.start === undefined) delete radial.start;
+  if (radial.innerRadius === 0 || radial.innerRadius === undefined) delete radial.innerRadius;
+  if (radial.expand === true || radial.expand === undefined) delete radial.expand;
+  if (radial.clip === false || radial.clip === undefined) delete radial.clip;
+  if (radial.reverse === "none" || radial.reverse === undefined) delete radial.reverse;
+  if (Array.isArray(radial.thetaLimits) && radial.thetaLimits.length === 2) {
+    radial.thetaLimits = [radial.thetaLimits[0]!, radial.thetaLimits[1]!];
+  }
+  if (Array.isArray(radial.rLimits) && radial.rLimits.length === 2) {
+    radial.rLimits = [radial.rLimits[0]!, radial.rLimits[1]!];
+  }
+  return radial;
+}
+
+function normalizeTransformCoord(transformed: CoordTransformSpec): CoordSpec | undefined {
   const x = normalizeCoordAxis(transformed.x);
   const y = normalizeCoordAxis(transformed.y);
   const hasUnknownKey = Object.keys(transformed).some(

--- a/packages/spec/src/normalize.ts
+++ b/packages/spec/src/normalize.ts
@@ -193,12 +193,7 @@ function canonicalGeom(geom: LayerInput["geom"]): NormalizedGeomName {
 function normalizeLayer(layer: LayerInput, plotAes: Aes | undefined): NormalizedLayerSpec {
   // Data-driven hline/vline are one-axis rules: drop the orthogonal position
   // channel from inheritance so plot-level x+y does not trigger rule-both-axes.
-  let layerAesInput = layer.aes;
-  if (layer.geom === "hline" && !isAnnotationRule(layer)) {
-    layerAesInput = { ...layerAesInput, x: null };
-  } else if (layer.geom === "vline" && !isAnnotationRule(layer)) {
-    layerAesInput = { ...layerAesInput, y: null };
-  }
+  const layerAesInput = normalizeRuleAesInput(layer);
 
   const inherited = isAnnotationRule(layer) || isAnnotationAbline(layer) ? undefined : plotAes;
   let aes = resolveLayerAes(inherited, normalizeAes(layerAesInput));
@@ -217,40 +212,7 @@ function normalizeLayer(layer: LayerInput, plotAes: Aes | undefined): Normalized
   // Stat default mappings (ggplot2's `after_stat()` default aes): the count
   // and bin stats map y to their count column; the density stat maps y to
   // its density column.
-  if ((stat === "count" || stat === "bin") && aes?.y === undefined) {
-    aes = { ...aes, y: { stat: "count" } };
-  }
-  if (stat === "density" && aes?.y === undefined) {
-    aes = { ...aes, y: { stat: "density" } };
-  }
-  // geom_count / stat_sum: size defaults to after_stat(n) when unset.
-  if (stat === "sum" && aes?.size === undefined) {
-    aes = { ...aes, size: { stat: "n" } };
-  }
-  if (stat === "function" && aes?.y === undefined) {
-    aes = { ...aes, y: { stat: "y" } };
-  }
-  // bin_hex maps fill to after_stat count (ggplot2 geom_hex default aes).
-  if (stat === "bin_hex" && aes?.fill === undefined) {
-    aes = { ...aes, fill: { stat: "count" } };
-  }
-  if (stat === "ecdf" && aes?.y === undefined) {
-    aes = { ...aes, y: { stat: "ecdf" } };
-  }
-  // density_2d_filled defaults fill to after_stat(level) like ggplot2.
-  if (
-    (stat === "density_2d_filled" || layer.geom === "density_2d_filled") &&
-    aes?.fill === undefined
-  ) {
-    aes = { ...aes, fill: { stat: "level" } };
-  }
-  if (stat === "bindot" && aes?.y === undefined) {
-    aes = { ...aes, y: { stat: "stackpos" } };
-  }
-  // bin_2d maps fill to after_stat count (ggplot2 geom_bin2d default aes).
-  if (stat === "bin_2d" && aes?.fill === undefined) {
-    aes = { ...aes, fill: { stat: "count" } };
-  }
+  aes = normalizeStatAes(aes, stat, layer.geom);
   const geom = canonicalGeom(layer.geom);
   const positionParams =
     "positionParams" in layer && layer.positionParams !== undefined
@@ -262,12 +224,7 @@ function normalizeLayer(layer: LayerInput, plotAes: Aes | undefined): Normalized
   // canonicalizes away (same rule as coord "cartesian" / a11y "auto").
   const render = layer.render === "auto" ? undefined : layer.render;
   // Jitter alias has no position field on the input type; always use defaults.
-  const position =
-    layer.geom === "jitter"
-      ? defaults.position
-      : "position" in layer && layer.position !== undefined
-        ? layer.position
-        : defaults.position;
+  const position = normalizeLayerPosition(layer, defaults.position);
   const out = {
     geom,
     stat,
@@ -285,6 +242,55 @@ function normalizeLayer(layer: LayerInput, plotAes: Aes | undefined): Normalized
     ...(params !== undefined && { params }),
   };
   return out as NormalizedLayerSpec;
+}
+
+function normalizeRuleAesInput(layer: LayerInput): LayerInput["aes"] {
+  if (layer.geom === "hline" && !isAnnotationRule(layer)) return { ...layer.aes, x: null };
+  if (layer.geom === "vline" && !isAnnotationRule(layer)) return { ...layer.aes, y: null };
+  return layer.aes;
+}
+
+function normalizeStatAes(
+  aes: Aes | undefined,
+  stat: string,
+  geom: LayerInput["geom"],
+): Aes | undefined {
+  let normalized = normalizeStatPositionAes(aes, stat);
+  normalized = normalizeStatStyleAes(normalized, stat, geom);
+  return normalized;
+}
+
+function normalizeStatPositionAes(aes: Aes | undefined, stat: string): Aes | undefined {
+  if ((stat === "count" || stat === "bin") && aes?.y === undefined) {
+    return { ...aes, y: { stat: "count" } };
+  }
+  if (stat === "density" && aes?.y === undefined) return { ...aes, y: { stat: "density" } };
+  if (stat === "function" && aes?.y === undefined) return { ...aes, y: { stat: "y" } };
+  if (stat === "ecdf" && aes?.y === undefined) return { ...aes, y: { stat: "ecdf" } };
+  if (stat === "bindot" && aes?.y === undefined) return { ...aes, y: { stat: "stackpos" } };
+  return aes;
+}
+
+function normalizeStatStyleAes(
+  aes: Aes | undefined,
+  stat: string,
+  geom: LayerInput["geom"],
+): Aes | undefined {
+  if (stat === "sum" && aes?.size === undefined) return { ...aes, size: { stat: "n" } };
+  if (stat === "bin_hex" && aes?.fill === undefined) return { ...aes, fill: { stat: "count" } };
+  if ((stat === "density_2d_filled" || geom === "density_2d_filled") && aes?.fill === undefined) {
+    return { ...aes, fill: { stat: "level" } };
+  }
+  if (stat === "bin_2d" && aes?.fill === undefined) return { ...aes, fill: { stat: "count" } };
+  return aes;
+}
+
+function normalizeLayerPosition(
+  layer: LayerInput,
+  defaultPosition: NormalizedLayerSpec["position"],
+): NormalizedLayerSpec["position"] {
+  if (layer.geom === "jitter") return defaultPosition;
+  return "position" in layer && layer.position !== undefined ? layer.position : defaultPosition;
 }
 
 /** Canonicalize one facet field: bare string -> { field }; clone levels/labels. */

--- a/packages/spec/src/scale-color-helpers.ts
+++ b/packages/spec/src/scale-color-helpers.ts
@@ -14,24 +14,26 @@ const SEQUENTIAL_SCHEMES = new Set<string>(SEQUENTIAL_SCHEME_NAMES);
 export function configuredColorScaleType(
   config: ColorScaleSpec | undefined,
 ): ColorScaleSpec["type"] | undefined {
-  if (config?.type !== undefined) return config.type;
-  if (config?.scheme !== undefined && config.range === undefined) {
+  if (config === undefined) return undefined;
+  if (config.type !== undefined) return config.type;
+  if (config.scheme !== undefined && config.range === undefined) {
     return SEQUENTIAL_SCHEMES.has(config.scheme) ? "sequential" : "ordinal";
   }
-  if (
-    config?.transform !== undefined ||
-    config?.temporalKind !== undefined ||
-    config?.parse !== undefined ||
-    config?.parseFailure !== undefined ||
-    config?.timezone !== undefined ||
-    config?.disambiguation !== undefined ||
-    config?.breaks !== undefined ||
-    config?.oob !== undefined ||
-    config?.labels !== undefined
-  ) {
+  const sequentialOptions = [
+    config.transform,
+    config.temporalKind,
+    config.parse,
+    config.parseFailure,
+    config.timezone,
+    config.disambiguation,
+    config.breaks,
+    config.oob,
+    config.labels,
+  ];
+  if (sequentialOptions.some((value) => value !== undefined)) {
     return "sequential";
   }
-  if (config?.domainMode !== undefined || config?.onExhaust !== undefined) return "ordinal";
+  if (config.domainMode !== undefined || config.onExhaust !== undefined) return "ordinal";
   return undefined;
 }
 

--- a/packages/spec/src/scale-reference-classify-color.ts
+++ b/packages/spec/src/scale-reference-classify-color.ts
@@ -86,214 +86,249 @@ type ColorFillFamily = "color-fill";
 
 const colorParams = (keys: readonly string[]) => paramDocsFromSchema("ColorScaleSpec", keys);
 
-export function classifyColorFillHelper(helper: string, family: ColorFillFamily): HelperMeta {
+type ColorHandler = (helper: string) => HelperMeta | undefined;
+
+function classifyPalette(helper: string): HelperMeta | undefined {
   const aes = aestheticFromHelper(helper);
+
+  if (helper.includes("Viridis")) {
+    const kind = helper.endsWith("D") ? "ordinal" : helper.endsWith("B") ? "binned" : "sequential";
+    const label =
+      kind === "ordinal"
+        ? "discrete (viridis_d)"
+        : kind === "binned"
+          ? "binned (viridis_b)"
+          : "continuous (viridis_c)";
+    return {
+      optionsType: "ViridisScaleOptions",
+      scaleType: kind,
+      params: withViridisOption(colorParams(COLOR_SEQUENTIAL_KEYS.filter((k) => k !== "scheme"))),
+      guide: guideFor(aes, kind),
+      summary: `Viridis-family ${aes} scale — ${label}.`,
+    };
+  }
+  if (helper.includes("Brewer")) {
+    return {
+      optionsType: "ColorBrewerScaleOptions",
+      scaleType: "ordinal",
+      params: withPaletteDirection(colorParams(COLOR_DISCRETE_KEYS)),
+      guide: guideFor(aes, "ordinal"),
+      summary: `ColorBrewer qualitative ${aes} scale (discrete categories).`,
+    };
+  }
+  if (helper.includes("Distiller")) {
+    return {
+      optionsType: "ColorDistillerScaleOptions",
+      scaleType: "sequential",
+      params: withPaletteDirection(colorParams(COLOR_SEQUENTIAL_KEYS)),
+      guide: guideFor(aes, "sequential"),
+      summary: `ColorBrewer sequential/diverging ${aes} ramp (distiller).`,
+    };
+  }
+  if (helper.includes("Fermenter")) {
+    return {
+      optionsType: "ColorFermenterScaleOptions",
+      scaleType: "binned",
+      params: withPaletteDirection(colorParams(COLOR_SEQUENTIAL_KEYS)),
+      guide: guideFor(aes, "binned"),
+      summary: `ColorBrewer binned ${aes} steps (fermenter).`,
+    };
+  }
+  return undefined;
+}
+
+function classifyGradient2(helper: string): HelperMeta | undefined {
+  const aes = aestheticFromHelper(helper);
+
+  if (helper.includes("Gradient2") || helper.includes("Steps2")) {
+    const binned = helper.includes("Steps");
+    return {
+      optionsType: binned ? "Steps2ScaleOptions" : "Gradient2ScaleOptions",
+      scaleType: binned ? "binned" : "sequential",
+      params: withGradientStops(colorParams(COLOR_SEQUENTIAL_KEYS), binned ? "steps2" : "2"),
+      guide: guideFor(aes, binned ? "binned" : "sequential"),
+      summary: binned
+        ? `Three-stop diverging binned ${aes} steps (low/mid/high).`
+        : `Three-stop diverging continuous ${aes} gradient (low/mid/high).`,
+    };
+  }
+  return undefined;
+}
+
+function classifyGradient(helper: string): HelperMeta | undefined {
+  const aes = aestheticFromHelper(helper);
+
+  if (helper.includes("Gradientn") || helper.includes("Stepsn")) {
+    const binned = helper.includes("Steps");
+    return {
+      optionsType: binned ? "StepsnScaleOptions" : "GradientnScaleOptions",
+      scaleType: binned ? "binned" : "sequential",
+      params: withGradientStops(colorParams(COLOR_SEQUENTIAL_KEYS), binned ? "stepsn" : "n"),
+      guide: guideFor(aes, binned ? "binned" : "sequential"),
+      summary: binned
+        ? `N-stop binned ${aes} steps from an ordered color list.`
+        : `N-stop continuous ${aes} gradient from an ordered color list.`,
+    };
+  }
+  if (helper.includes("Gradient") || helper.endsWith("Steps")) {
+    const binned = helper.endsWith("Steps");
+    return {
+      optionsType: binned ? "StepsScaleOptions" : "GradientScaleOptions",
+      scaleType: binned ? "binned" : "sequential",
+      params: withGradientStops(colorParams(COLOR_SEQUENTIAL_KEYS), binned ? "steps" : "steps"),
+      guide: guideFor(aes, binned ? "binned" : "sequential"),
+      summary: binned
+        ? `Two-stop binned ${aes} steps (low/high).`
+        : `Two-stop continuous ${aes} gradient (low/high).`,
+    };
+  }
+  return undefined;
+}
+
+function classifyNamedPalette(helper: string): HelperMeta | undefined {
+  const aes = aestheticFromHelper(helper);
+
+  if (helper.includes("Hue")) {
+    return {
+      optionsType: "HueScaleOptions",
+      scaleType: "ordinal",
+      params: withHueGrey(colorParams(COLOR_DISCRETE_KEYS), "hue"),
+      guide: guideFor(aes, "ordinal"),
+      summary: `Evenly spaced hue ${aes} palette for discrete categories.`,
+    };
+  }
+  if (helper.includes("Grey") || helper.includes("Gray")) {
+    return {
+      optionsType: "GreyScaleOptions",
+      scaleType: "ordinal",
+      params: withHueGrey(colorParams(COLOR_DISCRETE_KEYS), "grey"),
+      guide: guideFor(aes, "ordinal"),
+      summary: `Grey ramp ${aes} palette for discrete categories.`,
+    };
+  }
+  if (helper.includes("Ordinal")) {
+    return {
+      optionsType: "OrdinalColorScaleOptions",
+      scaleType: "ordinal",
+      params: colorParams(COLOR_DISCRETE_KEYS),
+      guide: guideFor(aes, "ordinal"),
+      summary: `Explicit ordinal ${aes} scale (categories → colors).`,
+    };
+  }
+  return undefined;
+}
+
+function classifyBaseColor(helper: string): HelperMeta | undefined {
+  const aes = aestheticFromHelper(helper);
+
+  if (helper.includes("Log10")) {
+    return {
+      optionsType: "TransformedColorScaleOptions",
+      scaleType: "sequential",
+      transform: "log10",
+      params: colorParams(COLOR_TRANSFORMED_KEYS),
+      guide: guideFor(aes, "sequential"),
+      summary: `Sequential ${aes} scale with log10 pre-training transform.`,
+    };
+  }
+  if (helper.includes("Sqrt")) {
+    return {
+      optionsType: "TransformedColorScaleOptions",
+      scaleType: "sequential",
+      transform: "sqrt",
+      params: colorParams(COLOR_TRANSFORMED_KEYS),
+      guide: guideFor(aes, "sequential"),
+      summary: `Sequential ${aes} scale with sqrt pre-training transform.`,
+    };
+  }
+  if (helper.includes("Datetime")) {
+    return {
+      optionsType: "TemporalColorScaleOptions",
+      scaleType: "sequential",
+      temporalKind: "datetime",
+      params: colorParams(COLOR_TEMPORAL_KEYS),
+      guide: guideFor(aes, "sequential"),
+      summary: `Sequential ${aes} scale trained on datetime values.`,
+    };
+  }
+  if (helper.includes("Date")) {
+    return {
+      optionsType: "TemporalColorScaleOptions",
+      scaleType: "sequential",
+      temporalKind: "date",
+      params: colorParams(COLOR_TEMPORAL_KEYS),
+      guide: guideFor(aes, "sequential"),
+      summary: `Sequential ${aes} scale trained on calendar dates.`,
+    };
+  }
+  if (helper.includes("Manual")) {
+    return {
+      optionsType: "ManualColorScaleOptions",
+      scaleType: "manual",
+      params: withValues(
+        colorParams(COLOR_MANUAL_KEYS),
+        "string[]",
+        "Colors paired positionally with the explicit or trained domain (required).",
+      ),
+      guide: guideFor(aes, "manual"),
+      summary: `Manual ${aes} mapping: domain values paired with explicit colors.`,
+    };
+  }
+  if (helper.includes("Identity")) {
+    return {
+      optionsType: "IdentityColorScaleOptions",
+      scaleType: "identity",
+      params: colorParams(COLOR_IDENTITY_KEYS),
+      guide: guideFor(aes, "identity"),
+      summary: `Identity ${aes} scale: source values are validated #rgb/#rrggbb colors used as-is.`,
+    };
+  }
+  if (helper.includes("Binned")) {
+    return {
+      optionsType: "BinnedColorScaleOptions",
+      scaleType: "binned",
+      params: colorParams(COLOR_SEQUENTIAL_KEYS),
+      guide: guideFor(aes, "binned"),
+      summary: `Binned ${aes} scale: continuous values → ordered color steps.`,
+    };
+  }
+  if (helper.includes("Discrete")) {
+    return {
+      optionsType: "DiscreteColorScaleOptions",
+      scaleType: "ordinal",
+      params: colorParams(COLOR_DISCRETE_KEYS),
+      guide: guideFor(aes, "ordinal"),
+      summary: `Discrete ${aes} scale for categorical data (default ordinal family).`,
+    };
+  }
+  if (helper.includes("Continuous")) {
+    return {
+      optionsType: "SequentialColorScaleOptions",
+      scaleType: "sequential",
+      params: colorParams(COLOR_SEQUENTIAL_KEYS),
+      guide: guideFor(aes, "sequential"),
+      summary: `Continuous sequential ${aes} scale (default continuous color family).`,
+    };
+  }
+  return undefined;
+}
+
+const COLOR_HANDLERS: ColorHandler[] = [
+  classifyPalette,
+  classifyGradient2,
+  classifyGradient,
+  classifyNamedPalette,
+  classifyBaseColor,
+];
+
+export function classifyColorFillHelper(helper: string, _family: ColorFillFamily): HelperMeta {
+  for (const handler of COLOR_HANDLERS) {
+    const meta = handler(helper);
+    if (meta !== undefined) return meta;
+  }
   const stem = helper.replace(
     /^scale(Colour|Color|Fill|X|Y|Size|Linewidth|Alpha|Shape|Linetype|Radius)/,
     "",
   );
-
-  // --- color / fill -------------------------------------------------------
-  if (family === "color-fill") {
-    if (helper.includes("Viridis")) {
-      const kind = helper.endsWith("D")
-        ? "ordinal"
-        : helper.endsWith("B")
-          ? "binned"
-          : "sequential";
-      const label =
-        kind === "ordinal"
-          ? "discrete (viridis_d)"
-          : kind === "binned"
-            ? "binned (viridis_b)"
-            : "continuous (viridis_c)";
-      return {
-        optionsType: "ViridisScaleOptions",
-        scaleType: kind,
-        params: withViridisOption(colorParams(COLOR_SEQUENTIAL_KEYS.filter((k) => k !== "scheme"))),
-        guide: guideFor(aes, kind),
-        summary: `Viridis-family ${aes} scale — ${label}.`,
-      };
-    }
-    if (helper.includes("Brewer")) {
-      return {
-        optionsType: "ColorBrewerScaleOptions",
-        scaleType: "ordinal",
-        params: withPaletteDirection(colorParams(COLOR_DISCRETE_KEYS)),
-        guide: guideFor(aes, "ordinal"),
-        summary: `ColorBrewer qualitative ${aes} scale (discrete categories).`,
-      };
-    }
-    if (helper.includes("Distiller")) {
-      return {
-        optionsType: "ColorDistillerScaleOptions",
-        scaleType: "sequential",
-        params: withPaletteDirection(colorParams(COLOR_SEQUENTIAL_KEYS)),
-        guide: guideFor(aes, "sequential"),
-        summary: `ColorBrewer sequential/diverging ${aes} ramp (distiller).`,
-      };
-    }
-    if (helper.includes("Fermenter")) {
-      return {
-        optionsType: "ColorFermenterScaleOptions",
-        scaleType: "binned",
-        params: withPaletteDirection(colorParams(COLOR_SEQUENTIAL_KEYS)),
-        guide: guideFor(aes, "binned"),
-        summary: `ColorBrewer binned ${aes} steps (fermenter).`,
-      };
-    }
-    if (helper.includes("Gradient2") || helper.includes("Steps2")) {
-      const binned = helper.includes("Steps");
-      return {
-        optionsType: binned ? "Steps2ScaleOptions" : "Gradient2ScaleOptions",
-        scaleType: binned ? "binned" : "sequential",
-        params: withGradientStops(colorParams(COLOR_SEQUENTIAL_KEYS), binned ? "steps2" : "2"),
-        guide: guideFor(aes, binned ? "binned" : "sequential"),
-        summary: binned
-          ? `Three-stop diverging binned ${aes} steps (low/mid/high).`
-          : `Three-stop diverging continuous ${aes} gradient (low/mid/high).`,
-      };
-    }
-    if (helper.includes("Gradientn") || helper.includes("Stepsn")) {
-      const binned = helper.includes("Steps");
-      return {
-        optionsType: binned ? "StepsnScaleOptions" : "GradientnScaleOptions",
-        scaleType: binned ? "binned" : "sequential",
-        params: withGradientStops(colorParams(COLOR_SEQUENTIAL_KEYS), binned ? "stepsn" : "n"),
-        guide: guideFor(aes, binned ? "binned" : "sequential"),
-        summary: binned
-          ? `N-stop binned ${aes} steps from an ordered color list.`
-          : `N-stop continuous ${aes} gradient from an ordered color list.`,
-      };
-    }
-    if (helper.includes("Gradient") || helper.endsWith("Steps")) {
-      const binned = helper.endsWith("Steps");
-      return {
-        optionsType: binned ? "StepsScaleOptions" : "GradientScaleOptions",
-        scaleType: binned ? "binned" : "sequential",
-        params: withGradientStops(colorParams(COLOR_SEQUENTIAL_KEYS), binned ? "steps" : "steps"),
-        guide: guideFor(aes, binned ? "binned" : "sequential"),
-        summary: binned
-          ? `Two-stop binned ${aes} steps (low/high).`
-          : `Two-stop continuous ${aes} gradient (low/high).`,
-      };
-    }
-    if (helper.includes("Hue")) {
-      return {
-        optionsType: "HueScaleOptions",
-        scaleType: "ordinal",
-        params: withHueGrey(colorParams(COLOR_DISCRETE_KEYS), "hue"),
-        guide: guideFor(aes, "ordinal"),
-        summary: `Evenly spaced hue ${aes} palette for discrete categories.`,
-      };
-    }
-    if (helper.includes("Grey") || helper.includes("Gray")) {
-      return {
-        optionsType: "GreyScaleOptions",
-        scaleType: "ordinal",
-        params: withHueGrey(colorParams(COLOR_DISCRETE_KEYS), "grey"),
-        guide: guideFor(aes, "ordinal"),
-        summary: `Grey ramp ${aes} palette for discrete categories.`,
-      };
-    }
-    if (helper.includes("Ordinal")) {
-      return {
-        optionsType: "OrdinalColorScaleOptions",
-        scaleType: "ordinal",
-        params: colorParams(COLOR_DISCRETE_KEYS),
-        guide: guideFor(aes, "ordinal"),
-        summary: `Explicit ordinal ${aes} scale (categories → colors).`,
-      };
-    }
-    if (helper.includes("Log10")) {
-      return {
-        optionsType: "TransformedColorScaleOptions",
-        scaleType: "sequential",
-        transform: "log10",
-        params: colorParams(COLOR_TRANSFORMED_KEYS),
-        guide: guideFor(aes, "sequential"),
-        summary: `Sequential ${aes} scale with log10 pre-training transform.`,
-      };
-    }
-    if (helper.includes("Sqrt")) {
-      return {
-        optionsType: "TransformedColorScaleOptions",
-        scaleType: "sequential",
-        transform: "sqrt",
-        params: colorParams(COLOR_TRANSFORMED_KEYS),
-        guide: guideFor(aes, "sequential"),
-        summary: `Sequential ${aes} scale with sqrt pre-training transform.`,
-      };
-    }
-    if (helper.includes("Datetime")) {
-      return {
-        optionsType: "TemporalColorScaleOptions",
-        scaleType: "sequential",
-        temporalKind: "datetime",
-        params: colorParams(COLOR_TEMPORAL_KEYS),
-        guide: guideFor(aes, "sequential"),
-        summary: `Sequential ${aes} scale trained on datetime values.`,
-      };
-    }
-    if (helper.includes("Date")) {
-      return {
-        optionsType: "TemporalColorScaleOptions",
-        scaleType: "sequential",
-        temporalKind: "date",
-        params: colorParams(COLOR_TEMPORAL_KEYS),
-        guide: guideFor(aes, "sequential"),
-        summary: `Sequential ${aes} scale trained on calendar dates.`,
-      };
-    }
-    if (helper.includes("Manual")) {
-      return {
-        optionsType: "ManualColorScaleOptions",
-        scaleType: "manual",
-        params: withValues(
-          colorParams(COLOR_MANUAL_KEYS),
-          "string[]",
-          "Colors paired positionally with the explicit or trained domain (required).",
-        ),
-        guide: guideFor(aes, "manual"),
-        summary: `Manual ${aes} mapping: domain values paired with explicit colors.`,
-      };
-    }
-    if (helper.includes("Identity")) {
-      return {
-        optionsType: "IdentityColorScaleOptions",
-        scaleType: "identity",
-        params: colorParams(COLOR_IDENTITY_KEYS),
-        guide: guideFor(aes, "identity"),
-        summary: `Identity ${aes} scale: source values are validated #rgb/#rrggbb colors used as-is.`,
-      };
-    }
-    if (helper.includes("Binned")) {
-      return {
-        optionsType: "BinnedColorScaleOptions",
-        scaleType: "binned",
-        params: colorParams(COLOR_SEQUENTIAL_KEYS),
-        guide: guideFor(aes, "binned"),
-        summary: `Binned ${aes} scale: continuous values → ordered color steps.`,
-      };
-    }
-    if (helper.includes("Discrete")) {
-      return {
-        optionsType: "DiscreteColorScaleOptions",
-        scaleType: "ordinal",
-        params: colorParams(COLOR_DISCRETE_KEYS),
-        guide: guideFor(aes, "ordinal"),
-        summary: `Discrete ${aes} scale for categorical data (default ordinal family).`,
-      };
-    }
-    if (helper.includes("Continuous")) {
-      return {
-        optionsType: "SequentialColorScaleOptions",
-        scaleType: "sequential",
-        params: colorParams(COLOR_SEQUENTIAL_KEYS),
-        guide: guideFor(aes, "sequential"),
-        summary: `Continuous sequential ${aes} scale (default continuous color family).`,
-      };
-    }
-  }
   throw new Error(`SCALE_REFERENCE: unhandled color/fill helper "${helper}" (stem ${stem})`);
 }

--- a/packages/spec/src/scale-reference-classify-style.ts
+++ b/packages/spec/src/scale-reference-classify-style.ts
@@ -72,112 +72,116 @@ const FINITE_BINNED_KEYS = [
 type StyleFamily = "numeric-style" | "finite-style";
 
 export function classifyStyleHelper(helper: string, family: StyleFamily): HelperMeta {
+  return family === "numeric-style"
+    ? classifyNumericStyleHelper(helper)
+    : classifyFiniteStyleHelper(helper);
+}
+
+function classifyNumericStyleHelper(helper: string): HelperMeta {
   const aes = aestheticFromHelper(helper);
-
-  // --- numeric style ------------------------------------------------------
-  if (family === "numeric-style") {
-    const decl = styleSchemaFor(aes);
-    if (helper === "scaleSizeArea" || helper === "scaleSizeBinnedArea") {
-      const binned = helper.includes("Binned");
-      return {
-        optionsType: "SizeAreaScaleOptions",
-        scaleType: binned ? "binned" : "sequential",
-        params: [
-          ...paramDocsFromSchema(decl, STYLE_SEQUENTIAL_KEYS),
-          sugarParam(
-            "maxSize",
-            "number",
-            "Maximum area-mapped size (ggplot2 scale_size_area max_size).",
-          ),
-        ],
-        guide: guideFor(aes, binned ? "binned" : "sequential"),
-        summary: binned
-          ? "Binned size scale with area mapping (zero maps to zero area)."
-          : "Continuous size scale with area mapping (zero maps to zero area).",
-      };
-    }
-    if (helper === "scaleRadius") {
-      return {
-        optionsType: "SequentialStyleScaleOptions",
-        scaleType: "sequential",
-        params: paramDocsFromSchema(decl, STYLE_SEQUENTIAL_KEYS),
-        guide: guideFor("size", "sequential"),
-        summary: "Continuous size scale with radius (linear) mapping instead of area.",
-      };
-    }
-    if (helper.includes("Discrete") || helper.includes("Ordinal")) {
-      return {
-        optionsType: "DiscreteNumericStyleScaleOptions",
-        scaleType: "ordinal",
-        params: paramDocsFromSchema(decl, STYLE_DISCRETE_KEYS),
-        guide: guideFor(aes, "ordinal"),
-        summary: `Discrete ${aes} scale for categories (ordinal).`,
-      };
-    }
-    if (helper.includes("Manual")) {
-      return {
-        optionsType: "ManualNumericStyleScaleOptions",
-        scaleType: "manual",
-        params: withValues(
-          paramDocsFromSchema(decl, STYLE_MANUAL_KEYS),
-          "number[]",
-          "Numeric range values paired with domain (required).",
+  const decl = styleSchemaFor(aes);
+  if (helper === "scaleSizeArea" || helper === "scaleSizeBinnedArea") {
+    const binned = helper.includes("Binned");
+    return {
+      optionsType: "SizeAreaScaleOptions",
+      scaleType: binned ? "binned" : "sequential",
+      params: [
+        ...paramDocsFromSchema(decl, STYLE_SEQUENTIAL_KEYS),
+        sugarParam(
+          "maxSize",
+          "number",
+          "Maximum area-mapped size (ggplot2 scale_size_area max_size).",
         ),
-        guide: guideFor(aes, "manual"),
-        summary: `Manual ${aes} mapping: domain values paired with explicit numbers.`,
-      };
-    }
-    if (helper.includes("Identity")) {
-      return {
-        optionsType: "IdentityNumericStyleScaleOptions",
-        scaleType: "identity",
-        params: paramDocsFromSchema(decl, STYLE_IDENTITY_KEYS),
-        guide: guideFor(aes, "identity"),
-        summary: `Identity ${aes} scale: source numbers used as mapped style values.`,
-      };
-    }
-    if (helper.includes("Datetime")) {
-      return {
-        optionsType: "TemporalNumericStyleScaleOptions",
-        scaleType: "sequential",
-        temporalKind: "datetime",
-        params: paramDocsFromSchema(decl, STYLE_SEQUENTIAL_KEYS),
-        guide: guideFor(aes, "sequential"),
-        summary: `Sequential ${aes} scale trained on datetime values.`,
-      };
-    }
-    if (helper.includes("Date")) {
-      return {
-        optionsType: "TemporalNumericStyleScaleOptions",
-        scaleType: "sequential",
-        temporalKind: "date",
-        params: paramDocsFromSchema(decl, STYLE_SEQUENTIAL_KEYS),
-        guide: guideFor(aes, "sequential"),
-        summary: `Sequential ${aes} scale trained on calendar dates.`,
-      };
-    }
-    if (helper.includes("Binned")) {
-      return {
-        optionsType: "SequentialStyleScaleOptions",
-        scaleType: "binned",
-        params: paramDocsFromSchema(decl, STYLE_SEQUENTIAL_KEYS),
-        guide: guideFor(aes, "binned"),
-        summary: `Binned ${aes} scale: continuous values → stepped numeric style.`,
-      };
-    }
-    if (helper.includes("Continuous")) {
-      return {
-        optionsType: "SequentialStyleScaleOptions",
-        scaleType: "sequential",
-        params: paramDocsFromSchema(decl, STYLE_SEQUENTIAL_KEYS),
-        guide: guideFor(aes, "sequential"),
-        summary: `Continuous sequential ${aes} scale.`,
-      };
-    }
-    throw new Error(`SCALE_REFERENCE: unhandled numeric-style helper "${helper}"`);
+      ],
+      guide: guideFor(aes, binned ? "binned" : "sequential"),
+      summary: binned
+        ? "Binned size scale with area mapping (zero maps to zero area)."
+        : "Continuous size scale with area mapping (zero maps to zero area).",
+    };
   }
+  if (helper === "scaleRadius") {
+    return {
+      optionsType: "SequentialStyleScaleOptions",
+      scaleType: "sequential",
+      params: paramDocsFromSchema(decl, STYLE_SEQUENTIAL_KEYS),
+      guide: guideFor("size", "sequential"),
+      summary: "Continuous size scale with radius (linear) mapping instead of area.",
+    };
+  }
+  if (helper.includes("Discrete") || helper.includes("Ordinal")) {
+    return {
+      optionsType: "DiscreteNumericStyleScaleOptions",
+      scaleType: "ordinal",
+      params: paramDocsFromSchema(decl, STYLE_DISCRETE_KEYS),
+      guide: guideFor(aes, "ordinal"),
+      summary: `Discrete ${aes} scale for categories (ordinal).`,
+    };
+  }
+  if (helper.includes("Manual")) {
+    return {
+      optionsType: "ManualNumericStyleScaleOptions",
+      scaleType: "manual",
+      params: withValues(
+        paramDocsFromSchema(decl, STYLE_MANUAL_KEYS),
+        "number[]",
+        "Numeric range values paired with domain (required).",
+      ),
+      guide: guideFor(aes, "manual"),
+      summary: `Manual ${aes} mapping: domain values paired with explicit numbers.`,
+    };
+  }
+  if (helper.includes("Identity")) {
+    return {
+      optionsType: "IdentityNumericStyleScaleOptions",
+      scaleType: "identity",
+      params: paramDocsFromSchema(decl, STYLE_IDENTITY_KEYS),
+      guide: guideFor(aes, "identity"),
+      summary: `Identity ${aes} scale: source numbers used as mapped style values.`,
+    };
+  }
+  if (helper.includes("Datetime")) {
+    return {
+      optionsType: "TemporalNumericStyleScaleOptions",
+      scaleType: "sequential",
+      temporalKind: "datetime",
+      params: paramDocsFromSchema(decl, STYLE_SEQUENTIAL_KEYS),
+      guide: guideFor(aes, "sequential"),
+      summary: `Sequential ${aes} scale trained on datetime values.`,
+    };
+  }
+  if (helper.includes("Date")) {
+    return {
+      optionsType: "TemporalNumericStyleScaleOptions",
+      scaleType: "sequential",
+      temporalKind: "date",
+      params: paramDocsFromSchema(decl, STYLE_SEQUENTIAL_KEYS),
+      guide: guideFor(aes, "sequential"),
+      summary: `Sequential ${aes} scale trained on calendar dates.`,
+    };
+  }
+  if (helper.includes("Binned")) {
+    return {
+      optionsType: "SequentialStyleScaleOptions",
+      scaleType: "binned",
+      params: paramDocsFromSchema(decl, STYLE_SEQUENTIAL_KEYS),
+      guide: guideFor(aes, "binned"),
+      summary: `Binned ${aes} scale: continuous values → stepped numeric style.`,
+    };
+  }
+  if (helper.includes("Continuous")) {
+    return {
+      optionsType: "SequentialStyleScaleOptions",
+      scaleType: "sequential",
+      params: paramDocsFromSchema(decl, STYLE_SEQUENTIAL_KEYS),
+      guide: guideFor(aes, "sequential"),
+      summary: `Continuous sequential ${aes} scale.`,
+    };
+  }
+  throw new Error(`SCALE_REFERENCE: unhandled numeric-style helper "${helper}"`);
+}
 
-  // --- finite style -------------------------------------------------------
+function classifyFiniteStyleHelper(helper: string): HelperMeta {
+  const aes = aestheticFromHelper(helper);
   const decl = styleSchemaFor(aes);
   const output =
     aes === "shape" ? "PointShapeName" : aes === "linetype" ? "LinetypeName" : "string";

--- a/packages/spec/src/temporal-column.ts
+++ b/packages/spec/src/temporal-column.ts
@@ -188,6 +188,43 @@ function inferTemporalColumnInternal(
   if (candidates.length > 1) return nominalDecision("ambiguous", values, candidates, analyzed);
 
   const parser = allDates ? null : candidates[0]!;
+  const scan = scanTemporalValues(values, parser, options, onSuccess);
+  const failedCount = nonNullCount - scan.validatedCount;
+  if (failedCount > 0) {
+    return {
+      ...nominalDecision("invalid", values, parser === null ? ["native-date"] : [parser], analyzed),
+      parser,
+      parserKey: `auto:${parser ?? "native-date"}:invalid`,
+      validatedCount: scan.validatedCount,
+      failedCount,
+      failures: scan.failures,
+    };
+  }
+  return {
+    status: "temporal",
+    parser: parser ?? "native-date",
+    parserKey: `auto:${parser ?? "native-date"}`,
+    kind: scan.kind ?? "datetime",
+    precision: scan.precision ?? "millisecond",
+    evidence: sample.slice(0, 8).map((value) => evidenceValue(value)),
+    nonNullCount,
+    validatedCount: scan.validatedCount,
+    failedCount: 0,
+    candidates: parser === null ? ["native-date"] : [parser],
+  };
+}
+
+function scanTemporalValues(
+  values: readonly unknown[],
+  parser: TemporalParserName | null,
+  options: TemporalParseOptions,
+  onSuccess?: (index: number, epochMs: number) => void,
+): {
+  validatedCount: number;
+  failures: TemporalFailure[];
+  kind: TemporalKind | null;
+  precision: TemporalPrecision | null;
+} {
   let validatedCount = 0;
   const failures: TemporalFailure[] = [];
   let kind: TemporalKind | null = null;
@@ -211,29 +248,7 @@ function inferTemporalColumnInternal(
     kind = kind === "datetime" || parsed.kind === "datetime" ? "datetime" : "date";
     precision = finestPrecision(precision, parsed.precision);
   }
-  const failedCount = nonNullCount - validatedCount;
-  if (failedCount > 0) {
-    return {
-      ...nominalDecision("invalid", values, parser === null ? ["native-date"] : [parser], analyzed),
-      parser,
-      parserKey: `auto:${parser ?? "native-date"}:invalid`,
-      validatedCount,
-      failedCount,
-      failures,
-    };
-  }
-  return {
-    status: "temporal",
-    parser: parser ?? "native-date",
-    parserKey: `auto:${parser ?? "native-date"}`,
-    kind: kind ?? "datetime",
-    precision: precision ?? "millisecond",
-    evidence: sample.slice(0, 8).map((value) => evidenceValue(value)),
-    nonNullCount,
-    validatedCount,
-    failedCount: 0,
-    candidates: parser === null ? ["native-date"] : [parser],
-  };
+  return { validatedCount, failures, kind, precision };
 }
 
 export function inferTemporalColumn(

--- a/packages/spec/src/temporal-parse-core.ts
+++ b/packages/spec/src/temporal-parse-core.ts
@@ -158,29 +158,33 @@ function daysInMonth(year: number, month: number): number {
 }
 
 function validateParts(parts: DateParts): string | null {
-  if (!Number.isInteger(parts.year) || parts.year < 0 || parts.year > 9999) {
+  if (!integerInRange(parts.year, 0, 9999)) {
     return "year must be an integer from 0000 through 9999";
   }
-  if (!Number.isInteger(parts.month) || parts.month < 1 || parts.month > 12) {
+  if (!integerInRange(parts.month, 1, 12)) {
     return "month must be from 1 through 12";
   }
   const maxDay = daysInMonth(parts.year, parts.month);
-  if (!Number.isInteger(parts.day) || parts.day < 1 || parts.day > maxDay) {
+  if (!integerInRange(parts.day, 1, maxDay)) {
     return `day must be from 1 through ${maxDay} for this month`;
   }
-  if (!Number.isInteger(parts.hour) || parts.hour < 0 || parts.hour > 23) {
+  if (!integerInRange(parts.hour, 0, 23)) {
     return "hour must be from 0 through 23";
   }
-  if (!Number.isInteger(parts.minute) || parts.minute < 0 || parts.minute > 59) {
+  if (!integerInRange(parts.minute, 0, 59)) {
     return "minute must be from 0 through 59";
   }
-  if (!Number.isInteger(parts.second) || parts.second < 0 || parts.second > 59) {
+  if (!integerInRange(parts.second, 0, 59)) {
     return "second must be from 0 through 59";
   }
-  if (!Number.isInteger(parts.millisecond) || parts.millisecond < 0 || parts.millisecond > 999) {
+  if (!integerInRange(parts.millisecond, 0, 999)) {
     return "millisecond must be from 0 through 999";
   }
   return null;
+}
+
+function integerInRange(value: number, min: number, max: number): boolean {
+  return Number.isInteger(value) && value >= min && value <= max;
 }
 
 function utcEpoch(parts: DateParts): number {

--- a/packages/spec/src/temporal-parse-format.ts
+++ b/packages/spec/src/temporal-parse-format.ts
@@ -122,20 +122,12 @@ export function parseExactFormat(
   if (!compiled.ok) return temporalParseFailure(compiled.reason);
   const match = compiled.regex.exec(value);
   if (match === null) return temporalParseFailure("value does not match the exact format");
-  const values: Record<string, string> = {};
-  for (let index = 0; index < compiled.tokens.length; index++) {
-    values[compiled.tokens[index]!] = match[index + 1]!;
-  }
-  if (values["Y"] === undefined) return temporalParseFailure("exact formats require %Y");
-  if (values["m"] !== undefined && values["q"] !== undefined)
-    return temporalParseFailure("exact formats cannot contain both %m and %q");
-  const hasClockTime =
-    values["H"] !== undefined ||
-    values["M"] !== undefined ||
-    values["S"] !== undefined ||
-    values["L"] !== undefined;
-  if (hasClockTime && (values["H"] === undefined || values["M"] === undefined))
-    return temporalParseFailure("time formats require both %H and %M");
+  const values = exactFormatValues(compiled.tokens, match);
+  const validationError = validateExactFormatValues(values);
+  if (validationError !== null) return temporalParseFailure(validationError);
+  const hasClockTime = [values["H"], values["M"], values["S"], values["L"]].some(
+    (part) => part !== undefined,
+  );
   const parts: DateParts = {
     year: Number(values["Y"]),
     month: values["q"] === undefined ? Number(values["m"] ?? 1) : (Number(values["q"]) - 1) * 3 + 1,
@@ -145,6 +137,40 @@ export function parseExactFormat(
     second: Number(values["S"] ?? 0),
     millisecond: Number((values["L"] ?? "0").padEnd(3, "0")),
   };
+  const precision = exactFormatPrecision(values, hasClockTime);
+  const kind: TemporalKind = hasClockTime || values["z"] !== undefined ? "datetime" : "date";
+  return withMetadata(partsToEpoch(parts, options, values["z"], kind), kind, precision);
+}
+
+function exactFormatValues(
+  tokens: readonly string[],
+  match: RegExpExecArray,
+): Record<string, string> {
+  const values: Record<string, string> = {};
+  for (let index = 0; index < tokens.length; index++) {
+    values[tokens[index]!] = match[index + 1]!;
+  }
+  return values;
+}
+
+function validateExactFormatValues(values: Record<string, string>): string | null {
+  if (values["Y"] === undefined) return "exact formats require %Y";
+  if (values["m"] !== undefined && values["q"] !== undefined) {
+    return "exact formats cannot contain both %m and %q";
+  }
+  const hasClockTime = [values["H"], values["M"], values["S"], values["L"]].some(
+    (part) => part !== undefined,
+  );
+  if (hasClockTime && (values["H"] === undefined || values["M"] === undefined)) {
+    return "time formats require both %H and %M";
+  }
+  return null;
+}
+
+function exactFormatPrecision(
+  values: Record<string, string>,
+  hasClockTime: boolean,
+): TemporalPrecision {
   let precision: TemporalPrecision = "year";
   if (values["m"] !== undefined) precision = "month";
   if (values["q"] !== undefined) precision = "quarter";
@@ -152,8 +178,7 @@ export function parseExactFormat(
   if (hasClockTime) precision = "minute";
   if (values["S"] !== undefined) precision = "second";
   if (values["L"] !== undefined) precision = "millisecond";
-  const kind: TemporalKind = hasClockTime || values["z"] !== undefined ? "datetime" : "date";
-  return withMetadata(partsToEpoch(parts, options, values["z"], kind), kind, precision);
+  return precision;
 }
 
 const FORMAT_SAMPLE_VALUES: Readonly<Record<string, string>> = {

--- a/packages/spec/src/temporal-parse.ts
+++ b/packages/spec/src/temporal-parse.ts
@@ -213,19 +213,7 @@ export function parseTemporal(
       : temporalParseFailure("invalid Date value");
   }
   if (typeof parser === "object" && "epoch" in parser) {
-    if (
-      (typeof value !== "number" && typeof value !== "string") ||
-      (typeof value === "string" && value.trim() === "")
-    ) {
-      return temporalParseFailure(`expected epoch ${parser.epoch}`);
-    }
-    const numeric = typeof value === "number" ? value : Number(value);
-    if (!Number.isFinite(numeric))
-      return temporalParseFailure(`expected finite epoch ${parser.epoch}`);
-    const epochMs = parser.epoch === "seconds" ? numeric * 1000 : numeric;
-    return Number.isFinite(new Date(epochMs).getTime())
-      ? { ok: true, epochMs, kind: "datetime", precision: "millisecond" }
-      : temporalParseFailure("instant is outside the supported range");
+    return parseEpoch(value, parser.epoch);
   }
   if (typeof value !== "string" || value.trim() !== value)
     return temporalParseFailure("expected an exact temporal string");
@@ -236,6 +224,21 @@ export function parseTemporal(
     return parsePeriod(value, parser, options);
   }
   return parseOrdered(value, parser, options);
+}
+
+function parseEpoch(value: unknown, unit: "seconds" | "milliseconds"): TemporalParseResult {
+  if (
+    (typeof value !== "number" && typeof value !== "string") ||
+    (typeof value === "string" && value.trim() === "")
+  ) {
+    return temporalParseFailure(`expected epoch ${unit}`);
+  }
+  const numeric = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(numeric)) return temporalParseFailure(`expected finite epoch ${unit}`);
+  const epochMs = unit === "seconds" ? numeric * 1000 : numeric;
+  return Number.isFinite(new Date(epochMs).getTime())
+    ? { ok: true, epochMs, kind: "datetime", precision: "millisecond" }
+    : temporalParseFailure("instant is outside the supported range");
 }
 
 function fnv1a(value: string): string {

--- a/packages/spec/src/temporal-ticks.ts
+++ b/packages/spec/src/temporal-ticks.ts
@@ -158,7 +158,17 @@ export function temporalIntervalTicks(
   if (timezone === "UTC" || timezone === "Etc/UTC" || timezone === "Z") {
     return utcCalendarTicks(min, max, interval, weekStart, limit);
   }
+  return zonedCalendarTicks(min, max, interval, timezone, weekStart, limit);
+}
 
+function zonedCalendarTicks(
+  min: number,
+  max: number,
+  interval: TemporalInterval,
+  timezone: string,
+  weekStart: number,
+  limit: number,
+): number[] {
   const Temporal = temporalImplementation();
   const current = Temporal.Instant.fromEpochMilliseconds(min).toZonedDateTimeISO(timezone);
   const parts = {

--- a/packages/spec/src/validate-data-checks-color-temporal.ts
+++ b/packages/spec/src/validate-data-checks-color-temporal.ts
@@ -15,6 +15,21 @@ import {
   type TemporalDecisionCache,
 } from "./validate-data-checks-temporal.js";
 
+type ParsedBound = { epochMs: number; kind: string | undefined };
+type ParseBound = (value: unknown) => ParsedBound | null;
+type TrainingFieldResult = {
+  trainingFields: ReadonlySet<string>;
+  kindConflicts: boolean;
+  conflictingKind: string | null;
+};
+type TemporalRecoverySetup = {
+  temporalInputsUsable: boolean;
+  requestsTemporal: boolean;
+  parser: Parameters<typeof temporalDecisionForField>[3];
+  temporalOptions: Parameters<typeof temporalDecisionForField>[4];
+  parseBound: ParseBound;
+};
+
 /**
  * Recovery sources for `parseFailure: "censor"` on temporal color/fill scales.
  * Mirrors runtime `collectColorChannelValues` + sequential/binned train:
@@ -48,149 +63,173 @@ export function colorTemporalCensorRecovery(input: {
 } {
   const { config, colorFields, colorScaledConstants, temporalDecisionCache, typeOf, evidenceOf } =
     input;
-  const parseUsable = temporalParserUsable(config?.parse);
-  const temporalOptionsUsable =
+  const setup = temporalRecoverySetup(config);
+  const { hasExplicitDomain, domainBlocksRecovery } = temporalDomainRecovery(
+    config,
+    setup.parseBound,
+  );
+
+  // Do not drop null breaks: runtime maps every authored break and throws
+  // color-binned-breaks when any maps to undefined.
+  const hasBinnedBreaks = temporalBinnedBreaksTrain(config, setup.parseBound);
+  const fieldResult = temporalTrainingFields({
+    config,
+    colorFields,
+    temporalDecisionCache,
+    typeOf,
+    evidenceOf,
+    parser: setup.parser,
+    temporalOptions: setup.temporalOptions,
+    enabled: setup.temporalInputsUsable && setup.requestsTemporal,
+  });
+
+  const kindOk = (kind: string | undefined): boolean =>
+    config?.temporalKind === undefined || kind === undefined || kind === config.temporalKind;
+  const constantResult = temporalTrainingConstants(colorScaledConstants, setup.parseBound, kindOk);
+  return {
+    hasExplicitDomain,
+    hasBinnedBreaks,
+    domainBlocksRecovery,
+    trainingFields: fieldResult.trainingFields,
+    constantTrains: constantResult.constantTrains,
+    kindConflicts: fieldResult.kindConflicts || constantResult.kindConflicts,
+    conflictingKind: constantResult.conflictingKind ?? fieldResult.conflictingKind,
+  };
+}
+
+function temporalRecoverySetup(config: ColorScaleSpec | undefined): TemporalRecoverySetup {
+  const temporalInputsUsable =
+    temporalParserUsable(config?.parse) &&
     (config?.timezone === undefined || typeof config.timezone === "string") &&
     (config?.disambiguation === undefined || typeof config.disambiguation === "string");
-  const temporalInputsUsable = parseUsable && temporalOptionsUsable;
   const temporalOptions = {
-    ...(config?.timezone !== undefined &&
-      typeof config.timezone === "string" && { timezone: config.timezone }),
-    ...(config?.disambiguation !== undefined &&
-      typeof config.disambiguation === "string" && {
-        disambiguation: config.disambiguation,
-      }),
+    ...(typeof config?.timezone === "string" && { timezone: config.timezone }),
+    ...(typeof config?.disambiguation === "string" && { disambiguation: config.disambiguation }),
   };
-  // Runtime uses config?.parse ?? "auto" in resolveColorValueView — kind-conflict
-  // detection must do the same (not only when parse is explicit). parseTemporal does
-  // not accept "auto", so column parsing is the shared path for both cases.
   const parser: Parameters<typeof temporalDecisionForField>[3] = config?.parse ?? "auto";
-  const parseBound = (value: unknown): { epochMs: number; kind: string | undefined } | null => {
-    if (!temporalInputsUsable) return null;
-    if (value === null || value === undefined) return null;
-    if (!(value instanceof Date) && typeof value !== "string" && typeof value !== "number") {
+  const requestsTemporal = [
+    config?.temporalKind,
+    config?.parse,
+    config?.timezone,
+    config?.disambiguation,
+  ].some((value) => value !== undefined);
+  return {
+    temporalInputsUsable,
+    requestsTemporal,
+    parser,
+    temporalOptions,
+    parseBound: temporalBoundParser(temporalInputsUsable, parser, temporalOptions),
+  };
+}
+
+function temporalDomainRecovery(
+  config: ColorScaleSpec | undefined,
+  parseBound: ParseBound,
+): { hasExplicitDomain: boolean; domainBlocksRecovery: boolean } {
+  const domainValues = Array.isArray(config?.domain)
+    ? config.domain.filter((value) => value !== null)
+    : [];
+  const hasExplicitDomain =
+    domainValues.length === 2 && domainValues.every((value) => parseBound(value) !== null);
+  return {
+    hasExplicitDomain,
+    domainBlocksRecovery: Array.isArray(config?.domain) && !hasExplicitDomain,
+  };
+}
+
+function temporalBoundParser(
+  usable: boolean,
+  parser: Parameters<typeof parseTemporalColumn>[1],
+  options: Parameters<typeof parseTemporalColumn>[2],
+): ParseBound {
+  return (value) => {
+    if (!usable || value === null || value === undefined) return null;
+    if (!(value instanceof Date) && typeof value !== "string" && typeof value !== "number")
       return null;
-    }
     const column = parseTemporalColumn(
       [value] as Parameters<typeof parseTemporalColumn>[0],
       parser,
-      temporalOptions,
+      options,
     );
     if (column.valid[0] !== 1) return null;
     const epochMs = column.semantic[0];
     if (epochMs === undefined || !Number.isFinite(epochMs)) return null;
     return { epochMs, kind: column.decision.kind ?? undefined };
   };
+}
 
-  const domainValues = Array.isArray(config?.domain)
-    ? config.domain.filter((value) => value !== null)
-    : [];
-  const hasExplicitDomain =
-    domainValues.length === 2 && domainValues.every((value) => parseBound(value) !== null);
-  // Runtime throws color-domain-invalid / color-binned-domain whenever domain is
-  // authored but not exactly two parseable endpoints — before siblings/breaks train.
-  const domainBlocksRecovery = Array.isArray(config?.domain) && !hasExplicitDomain;
-
-  // Do not drop null breaks: runtime maps every authored break and throws
-  // color-binned-breaks when any maps to undefined.
-  const authoredBreaks =
-    config?.type === "binned" && Array.isArray(config.breaks) ? config.breaks : [];
-  const parsedBreakEpochs: number[] = [];
-  let hasBinnedBreaks = false;
-  if (authoredBreaks.length >= 2) {
-    let allParseable = true;
-    for (const value of authoredBreaks) {
-      if (value === null) {
-        allParseable = false;
-        break;
-      }
-      const parsed = parseBound(value);
-      if (parsed === null) {
-        allParseable = false;
-        break;
-      }
-      parsedBreakEpochs.push(parsed.epochMs);
-    }
-    if (allParseable && parsedBreakEpochs.length >= 2) {
-      hasBinnedBreaks = true;
-      for (let index = 1; index < parsedBreakEpochs.length; index++) {
-        const prev = parsedBreakEpochs[index - 1];
-        const current = parsedBreakEpochs[index];
-        if (prev === undefined || current === undefined || current <= prev) {
-          hasBinnedBreaks = false;
-          break;
-        }
-      }
-    }
+function temporalBinnedBreaksTrain(
+  config: ColorScaleSpec | undefined,
+  parseBound: ParseBound,
+): boolean {
+  const breaks = config?.type === "binned" && Array.isArray(config.breaks) ? config.breaks : [];
+  if (breaks.length < 2) return false;
+  const epochs: number[] = [];
+  for (const value of breaks) {
+    if (value === null) return false;
+    const parsed = parseBound(value);
+    if (parsed === null) return false;
+    epochs.push(parsed.epochMs);
   }
+  return epochs.every((epoch, index) => index === 0 || epoch > (epochs[index - 1] ?? epoch));
+}
 
+function temporalTrainingFields(input: {
+  config: ColorScaleSpec | undefined;
+  colorFields: readonly ChannelFieldUse[];
+  temporalDecisionCache: TemporalDecisionCache;
+  typeOf: (use: ChannelFieldUse) => string | null;
+  evidenceOf: (use: ChannelFieldUse) => FieldEvidenceEntry | undefined;
+  parser: Parameters<typeof temporalDecisionForField>[3];
+  temporalOptions: Parameters<typeof temporalDecisionForField>[4];
+  enabled: boolean;
+}): TrainingFieldResult {
   const trainingFields = new Set<string>();
-  let kindConflicts = false;
   let conflictingKind: string | null = null;
-  const requestsTemporal =
-    config?.temporalKind !== undefined ||
-    config?.parse !== undefined ||
-    config?.timezone !== undefined ||
-    config?.disambiguation !== undefined;
-  if (temporalInputsUsable && requestsTemporal) {
-    for (const use of colorFields) {
-      const type = typeOf(use);
-      // Always reparse under the configured parser — type:"temporal" from default
-      // evidence does not mean the value trains when parse is an explicit override.
-      if (
-        type !== "temporal" &&
-        type !== "quantitative" &&
-        type !== "nominal" &&
-        type !== "ordinal"
-      ) {
-        continue;
-      }
-      const decision = temporalDecisionForField(
-        temporalDecisionCache,
-        use.field,
-        evidenceOf(use),
-        parser,
-        temporalOptions,
-      );
-      if (decision === null || decision === undefined) continue;
-      const trains = decision.status === "temporal" || (decision.validatedCount ?? 0) > 0;
-      if (!trains) continue;
-      if (
-        typeof config?.temporalKind === "string" &&
-        decision.kind !== null &&
-        decision.kind !== undefined &&
-        decision.kind !== config.temporalKind
-      ) {
-        kindConflicts = true;
-        conflictingKind = decision.kind;
-        continue;
-      }
-      trainingFields.add(use.field);
+  if (!input.enabled) return { trainingFields, kindConflicts: false, conflictingKind };
+  for (const use of input.colorFields) {
+    if (!fieldCanTrainTemporal(input.typeOf(use))) continue;
+    const decision = temporalDecisionForField(
+      input.temporalDecisionCache,
+      use.field,
+      input.evidenceOf(use),
+      input.parser,
+      input.temporalOptions,
+    );
+    if (decision === null || decision === undefined) continue;
+    if (decision.status !== "temporal" && (decision.validatedCount ?? 0) === 0) continue;
+    if (
+      typeof input.config?.temporalKind === "string" &&
+      decision.kind !== null &&
+      decision.kind !== undefined &&
+      decision.kind !== input.config.temporalKind
+    ) {
+      conflictingKind = decision.kind;
+      continue;
     }
+    trainingFields.add(use.field);
   }
+  return { trainingFields, kindConflicts: conflictingKind !== null, conflictingKind };
+}
 
-  const kindOk = (kind: string | undefined): boolean =>
-    config?.temporalKind === undefined || kind === undefined || kind === config.temporalKind;
+function fieldCanTrainTemporal(type: string | null): boolean {
+  return type === "temporal" || type === "quantitative" || type === "nominal" || type === "ordinal";
+}
+
+function temporalTrainingConstants(
+  values: readonly unknown[],
+  parseBound: ParseBound,
+  kindOk: (kind: string | undefined) => boolean,
+): { constantTrains: boolean; kindConflicts: boolean; conflictingKind: string | null } {
   let constantTrains = false;
-  for (const value of colorScaledConstants) {
+  let conflictingKind: string | null = null;
+  for (const value of values) {
     const parsed = parseBound(value);
     if (parsed === null) continue;
-    if (kindOk(parsed.kind)) {
-      constantTrains = true;
-    } else {
-      kindConflicts = true;
-      conflictingKind = parsed.kind ?? null;
-    }
+    if (kindOk(parsed.kind)) constantTrains = true;
+    else conflictingKind = parsed.kind ?? null;
   }
-  return {
-    hasExplicitDomain,
-    hasBinnedBreaks,
-    domainBlocksRecovery,
-    trainingFields,
-    constantTrains,
-    kindConflicts,
-    conflictingKind,
-  };
+  return { constantTrains, kindConflicts: conflictingKind !== null, conflictingKind };
 }
 
 export function censoredTemporalColorRecovers(input: {

--- a/packages/spec/src/validate-data-checks-color.ts
+++ b/packages/spec/src/validate-data-checks-color.ts
@@ -88,6 +88,209 @@ function expectedManualDomainLength(
   return { kind: unknownFieldValues ? "min" : "exact", size: seen.size };
 }
 
+function manualColorRangeErrors(input: {
+  channel: "color" | "fill";
+  config: ColorScaleSpec | undefined;
+  effectiveType: string | undefined;
+  uses: readonly ChannelFieldUse[];
+  constants: readonly unknown[];
+  evidenceOf: (use: ChannelFieldUse) => FieldEvidenceEntry | undefined;
+}): SpecError[] {
+  const { channel, config, effectiveType, uses, constants, evidenceOf } = input;
+  if (effectiveType !== "manual" && config?.type !== "manual") return [];
+  if (!Array.isArray(config?.range)) return [];
+  const expected = expectedManualDomainLength(
+    config.domain,
+    uses.map((use) => evidenceOf(use)?.values),
+    constants,
+  );
+  if (expected === null) return [];
+  const mismatch =
+    expected.kind === "exact"
+      ? config.range.length !== expected.size
+      : config.range.length < expected.size;
+  if (!mismatch) return [];
+  return [
+    {
+      code: "color-manual-domain-range",
+      path: `/scales/${channel}`,
+      message:
+        expected.kind === "exact"
+          ? `The manual ${channel} scale needs one range color per domain value (${String(expected.size)} values, ${String(config.range.length)} colors).`
+          : `The manual ${channel} scale has at least ${String(expected.size)} known domain values (scaled constants and/or observed categories) but only ${String(config.range.length)} range colors.`,
+      fix: {
+        description: `Provide at least ${String(expected.size)} range colors, or set scales.${channel}.domain explicitly to match the range length.`,
+      },
+    },
+  ];
+}
+
+type ColorFieldInput = {
+  channel: "color" | "fill";
+  config: ColorScaleSpec | undefined;
+  effectiveType: string | undefined;
+  inferredFromSequentialScheme: boolean;
+  requestsTemporal: boolean;
+  recovery: ReturnType<typeof colorTemporalCensorRecovery>;
+  use: ChannelFieldUse;
+  evidenceOf: (use: ChannelFieldUse) => FieldEvidenceEntry | undefined;
+  typeOf: (use: ChannelFieldUse) => string | null;
+  temporalDecisionCache: TemporalDecisionCache;
+};
+
+function colorFieldErrors(input: ColorFieldInput): SpecError[] {
+  const type = input.typeOf(input.use);
+  const transformError = temporalColorTransformError(input, type);
+  if (transformError !== null) return [transformError];
+  if (type === "quantitative" && input.requestsTemporal) {
+    return quantitativeTemporalColorErrors(input);
+  }
+  if (type !== "nominal" && type !== "ordinal") return [];
+  if (input.requestsTemporal && !temporalParserUsable(input.config?.parse)) return [];
+  return input.requestsTemporal
+    ? discreteTemporalColorErrors(input, type)
+    : [discreteSequentialColorError(input, type)];
+}
+
+function temporalColorTransformError(
+  input: ColorFieldInput,
+  type: string | null,
+): SpecError | null {
+  const transform = input.config?.transform;
+  if (type !== "temporal" || transform === undefined || transform === "identity") return null;
+  return {
+    code: "scale-type-mismatch",
+    path: input.use.path,
+    message: `scales.${input.channel}.transform is "${transform}" but field "${input.use.field}" is temporal; temporal color scales permit only the identity transform.`,
+    fix: {
+      description: `Remove scales.${input.channel}.transform to keep temporal inference, or map a non-temporal quantitative field.`,
+    },
+  };
+}
+
+function colorTemporalDecision(input: ColorFieldInput) {
+  return temporalDecisionForField(
+    input.temporalDecisionCache,
+    input.use.field,
+    input.evidenceOf(input.use),
+    input.config?.parse ?? "auto",
+    {
+      ...(input.config?.timezone !== undefined && { timezone: input.config.timezone }),
+      ...(input.config?.disambiguation !== undefined && {
+        disambiguation: input.config.disambiguation,
+      }),
+    },
+  );
+}
+
+function quantitativeTemporalColorErrors(input: ColorFieldInput): SpecError[] {
+  if (!temporalParserUsable(input.config?.parse)) return [];
+  const decision = colorTemporalDecision(input);
+  const recovers = censoredTemporalColorRecovers({
+    config: input.config,
+    decision,
+    field: input.use.field,
+    recovery: input.recovery,
+  });
+  if (decision?.status !== "temporal" && !recovers) {
+    return [
+      {
+        code: "scale-type-mismatch",
+        path: input.use.path,
+        message: `scales.${input.channel} requests temporal colors but field "${input.use.field}" is quantitative (numbers are not treated as temporal without a successful epoch parse).`,
+        fix: {
+          description: `Map a temporal field, use a working parse: { epoch: "ms" | "s" }, or remove temporal color options.`,
+        },
+      },
+    ];
+  }
+  const kindError = temporalColorKindError(input, decision?.kind);
+  return kindError === null ? [] : [kindError];
+}
+
+function temporalColorKindError(
+  input: ColorFieldInput,
+  actualKind: string | null | undefined,
+): SpecError | null {
+  const expectedKind = input.config?.temporalKind;
+  if (
+    expectedKind === undefined ||
+    actualKind === null ||
+    actualKind === undefined ||
+    actualKind === expectedKind
+  )
+    return null;
+  return {
+    code: "scale-type-mismatch",
+    path: input.use.path,
+    message: `scales.${input.channel} requests temporal kind "${expectedKind}" but field "${input.use.field}" parses as "${actualKind}".`,
+    fix: {
+      description: `Use the ${actualKind} color helper or correct the source precision.`,
+    },
+  };
+}
+
+function discreteSequentialColorError(
+  input: ColorFieldInput,
+  type: "nominal" | "ordinal",
+): SpecError {
+  const { channel, config, effectiveType, inferredFromSequentialScheme, use } = input;
+  return {
+    code: "scale-type-mismatch",
+    path: use.path,
+    message: inferredFromSequentialScheme
+      ? `scales.${channel}.scheme is "${config?.scheme}" and selects a sequential scale, but field "${use.field}" is ${type}; sequential color ramps need quantitative values.`
+      : `scales.${channel}.type is "${effectiveType}" but field "${use.field}" is ${type}; quantitative color scales need quantitative or temporal values.`,
+    fix: inferredFromSequentialScheme
+      ? {
+          description: `Set scales.${channel}.scheme to a categorical scheme, remove it to infer an ordinal scale from "${use.field}", or map a quantitative field.`,
+          example: { scheme: "observable10" },
+        }
+      : { description: `Set scales.${channel}.type to "ordinal".` },
+  };
+}
+
+function discreteTemporalColorErrors(
+  input: ColorFieldInput,
+  type: "nominal" | "ordinal",
+): SpecError[] {
+  const decision = colorTemporalDecision(input);
+  const recovers = censoredTemporalColorRecovers({
+    config: input.config,
+    decision,
+    field: input.use.field,
+    recovery: input.recovery,
+  });
+  if (decision?.status === "temporal" || recovers) {
+    const kindError = temporalColorKindError(input, decision?.kind);
+    return kindError === null ? [] : [kindError];
+  }
+  const detail = colorTemporalDecisionDetail(decision);
+  return [
+    {
+      code: "scale-type-mismatch",
+      path: input.use.path,
+      message: `scales.${input.channel} requests temporal colors but field "${input.use.field}" is ${type}.${detail}`,
+      fix: {
+        description:
+          input.config?.parse === undefined
+            ? `Set scales.${input.channel}.parse to the exact temporal order, or use type: "ordinal".`
+            : `Correct the rejected values, choose the matching parser, or set parseFailure: "censor" explicitly.`,
+      },
+    },
+  ];
+}
+
+function colorTemporalDecisionDetail(decision: ReturnType<typeof colorTemporalDecision>): string {
+  if (decision?.status === "ambiguous") {
+    return ` Automatic temporal inference was ambiguous between: ${decision.candidates.join(", ")}.`;
+  }
+  if (decision?.status === "invalid") {
+    return ` Temporal parsing rejected ${String(decision.failedCount)} value(s).`;
+  }
+  return "";
+}
+
 /** Post-layer color/fill scale type compatibility against collected field uses. */
 export function checkColorScaleDataCompatibility(input: {
   scales: Record<string, unknown> | undefined;
@@ -113,31 +316,16 @@ export function checkColorScaleDataCompatibility(input: {
     const config = scales?.[channel] as ColorScaleSpec | undefined;
     const effectiveType = configuredColorScaleType(config);
 
-    // Manual range length vs domain / inferred unique values (union across layers).
-    if ((effectiveType === "manual" || config?.type === "manual") && Array.isArray(config?.range)) {
-      const range = config.range;
-      const expected = expectedManualDomainLength(
-        config.domain,
-        colorFields[channel].map((use) => evidenceOf(use)?.values),
-        colorScaledConstants[channel],
-      );
-      const rangeMismatch =
-        expected !== null &&
-        (expected.kind === "exact" ? range.length !== expected.size : range.length < expected.size);
-      if (rangeMismatch && expected !== null) {
-        errors.push({
-          code: "color-manual-domain-range",
-          path: `/scales/${channel}`,
-          message:
-            expected.kind === "exact"
-              ? `The manual ${channel} scale needs one range color per domain value (${String(expected.size)} values, ${String(range.length)} colors).`
-              : `The manual ${channel} scale has at least ${String(expected.size)} known domain values (scaled constants and/or observed categories) but only ${String(range.length)} range colors.`,
-          fix: {
-            description: `Provide at least ${String(expected.size)} range colors, or set scales.${channel}.domain explicitly to match the range length.`,
-          },
-        });
-      }
-    }
+    errors.push(
+      ...manualColorRangeErrors({
+        channel,
+        config,
+        effectiveType,
+        uses: colorFields[channel],
+        constants: colorScaledConstants[channel],
+        evidenceOf,
+      }),
+    );
 
     const inferredFromSequentialScheme =
       config?.type === undefined &&
@@ -146,11 +334,12 @@ export function checkColorScaleDataCompatibility(input: {
       SEQUENTIAL_SCHEMES.has(config.scheme);
     if (effectiveType !== "sequential" && effectiveType !== "binned") continue;
 
-    const requestsTemporal =
-      config?.temporalKind !== undefined ||
-      config?.parse !== undefined ||
-      config?.timezone !== undefined ||
-      config?.disambiguation !== undefined;
+    const requestsTemporal = [
+      config?.temporalKind,
+      config?.parse,
+      config?.timezone,
+      config?.disambiguation,
+    ].some((value) => value !== undefined);
     const recovery = colorTemporalCensorRecovery({
       config,
       colorFields: colorFields[channel],
@@ -161,176 +350,46 @@ export function checkColorScaleDataCompatibility(input: {
     });
     // Runtime collects all channel values into one temporal column; a kind
     // conflict (sibling field or scaled constant) throws color-temporal-kind.
-    if (
-      recovery.kindConflicts &&
-      typeof config?.temporalKind === "string" &&
-      recovery.conflictingKind !== null
-    ) {
-      errors.push({
-        code: "scale-type-mismatch",
-        path: `/scales/${channel}`,
-        message: `scales.${channel} requests temporal kind "${config.temporalKind}" but a channel value parses as "${recovery.conflictingKind}".`,
-        fix: {
-          description: `Use ${config.temporalKind} values for every color mapping and scaled constant, or set temporalKind to "${recovery.conflictingKind}".`,
-        },
-      });
-    }
+    const conflictError = colorChannelKindConflictError(channel, config, recovery);
+    if (conflictError !== null) errors.push(conflictError);
 
     for (const use of colorFields[channel]) {
-      const type = typeOf(use);
-      if (
-        type === "temporal" &&
-        config?.transform !== undefined &&
-        config.transform !== "identity"
-      ) {
-        errors.push({
-          code: "scale-type-mismatch",
-          path: use.path,
-          message: `scales.${channel}.transform is "${config.transform}" but field "${use.field}" is temporal; temporal color scales permit only the identity transform.`,
-          fix: {
-            description: `Remove scales.${channel}.transform to keep temporal inference, or map a non-temporal quantitative field.`,
-          },
-        });
-        continue;
-      }
-
-      // Quantitative fields with temporal-only options fail at resolve time unless
-      // parseFailure: "censor" recovers via this field, a sibling, a scaled constant,
-      // or a parseable domain / binned breaks (pipeline only throws color-transform-empty
-      // when every channel value fails and no authored bound trains the scale).
-      if (type === "quantitative" && requestsTemporal) {
-        // A schema-invalid parser reaches tier-2 (schema errors don't short-circuit
-        // it); handing it to temporalDecisionForField would throw instead of
-        // yielding the schema diagnostic. Defer to that diagnostic.
-        if (!temporalParserUsable(config?.parse)) continue;
-        const info = evidenceOf(use);
-        const decision = temporalDecisionForField(
-          temporalDecisionCache,
-          use.field,
-          info,
-          config?.parse ?? "auto",
-          {
-            ...(config?.timezone !== undefined && { timezone: config.timezone }),
-            ...(config?.disambiguation !== undefined && {
-              disambiguation: config.disambiguation,
-            }),
-          },
-        );
-        const censoredInvalid = censoredTemporalColorRecovers({
+      errors.push(
+        ...colorFieldErrors({
+          channel,
           config,
-          decision,
-          field: use.field,
+          effectiveType,
+          inferredFromSequentialScheme,
+          requestsTemporal,
           recovery,
-        });
-        if (decision?.status !== "temporal" && !censoredInvalid) {
-          errors.push({
-            code: "scale-type-mismatch",
-            path: use.path,
-            message: `scales.${channel} requests temporal colors but field "${use.field}" is quantitative (numbers are not treated as temporal without a successful epoch parse).`,
-            fix: {
-              description: `Map a temporal field, use a working parse: { epoch: "ms" | "s" }, or remove temporal color options.`,
-            },
-          });
-          continue;
-        }
-        if (
-          config?.temporalKind !== undefined &&
-          decision?.kind !== null &&
-          decision?.kind !== undefined &&
-          decision.kind !== config.temporalKind
-        ) {
-          errors.push({
-            code: "scale-type-mismatch",
-            path: use.path,
-            message: `scales.${channel} requests temporal kind "${config.temporalKind}" but field "${use.field}" parses as "${decision.kind}".`,
-            fix: {
-              description: `Use the ${decision.kind ?? "matching"} color helper or correct the source precision.`,
-            },
-          });
-          continue;
-        }
-      }
-
-      if (type !== "nominal" && type !== "ordinal") continue;
-
-      // Same schema-invalid-parser guard as the quantitative branch above: a
-      // malformed parser would throw in temporalDecisionForField below.
-      if (requestsTemporal && !temporalParserUsable(config?.parse)) continue;
-
-      if (!requestsTemporal) {
-        errors.push({
-          code: "scale-type-mismatch",
-          path: use.path,
-          message: inferredFromSequentialScheme
-            ? `scales.${channel}.scheme is "${config.scheme}" and selects a sequential scale, but field "${use.field}" is ${type}; sequential color ramps need quantitative values.`
-            : `scales.${channel}.type is "${effectiveType}" but field "${use.field}" is ${type}; quantitative color scales need quantitative or temporal values.`,
-          fix: inferredFromSequentialScheme
-            ? {
-                description: `Set scales.${channel}.scheme to a categorical scheme, remove it to infer an ordinal scale from "${use.field}", or map a quantitative field.`,
-                example: { scheme: "observable10" },
-              }
-            : { description: `Set scales.${channel}.type to "ordinal".` },
-        });
-        continue;
-      }
-
-      const info = evidenceOf(use);
-      const decision = temporalDecisionForField(
-        temporalDecisionCache,
-        use.field,
-        info,
-        config?.parse ?? "auto",
-        {
-          ...(config?.timezone !== undefined && { timezone: config.timezone }),
-          ...(config?.disambiguation !== undefined && {
-            disambiguation: config.disambiguation,
-          }),
-        },
+          use,
+          evidenceOf,
+          typeOf,
+          temporalDecisionCache,
+        }),
       );
-      const censoredInvalid = censoredTemporalColorRecovers({
-        config,
-        decision,
-        field: use.field,
-        recovery,
-      });
-      if (decision?.status === "temporal" || censoredInvalid) {
-        // Mirror runtime: compare recovered kind even when status is invalid+censored.
-        if (
-          config?.temporalKind !== undefined &&
-          decision?.kind !== null &&
-          decision?.kind !== undefined &&
-          decision.kind !== config.temporalKind
-        ) {
-          errors.push({
-            code: "scale-type-mismatch",
-            path: use.path,
-            message: `scales.${channel} requests temporal kind "${config.temporalKind}" but field "${use.field}" parses as "${decision.kind}".`,
-            fix: {
-              description: `Use the ${decision.kind ?? "matching"} color helper or correct the source precision.`,
-            },
-          });
-        }
-        continue;
-      }
-
-      const detail =
-        decision?.status === "ambiguous"
-          ? ` Automatic temporal inference was ambiguous between: ${decision.candidates.join(", ")}.`
-          : decision?.status === "invalid"
-            ? ` Temporal parsing rejected ${String(decision.failedCount)} value(s).`
-            : "";
-      errors.push({
-        code: "scale-type-mismatch",
-        path: use.path,
-        message: `scales.${channel} requests temporal colors but field "${use.field}" is ${type}.${detail}`,
-        fix: {
-          description:
-            config?.parse === undefined
-              ? `Set scales.${channel}.parse to the exact temporal order, or use type: "ordinal".`
-              : `Correct the rejected values, choose the matching parser, or set parseFailure: "censor" explicitly.`,
-        },
-      });
     }
   }
   return errors;
+}
+
+function colorChannelKindConflictError(
+  channel: "color" | "fill",
+  config: ColorScaleSpec | undefined,
+  recovery: ReturnType<typeof colorTemporalCensorRecovery>,
+): SpecError | null {
+  if (
+    !recovery.kindConflicts ||
+    typeof config?.temporalKind !== "string" ||
+    recovery.conflictingKind === null
+  )
+    return null;
+  return {
+    code: "scale-type-mismatch",
+    path: `/scales/${channel}`,
+    message: `scales.${channel} requests temporal kind "${config.temporalKind}" but a channel value parses as "${recovery.conflictingKind}".`,
+    fix: {
+      description: `Use ${config.temporalKind} values for every color mapping and scaled constant, or set temporalKind to "${recovery.conflictingKind}".`,
+    },
+  };
 }

--- a/packages/spec/src/validate-data-checks-layer.ts
+++ b/packages/spec/src/validate-data-checks-layer.ts
@@ -110,275 +110,383 @@ export function collectLayerDataChecks(input: {
   layerMaps: readonly (FieldEvidenceMap | null)[] | null;
   scaleRequestsTime: (channel: ChannelName) => boolean;
 }): LayerWalkCollections {
-  const { layers, plotAes, plotFields, layerMaps, scaleRequestsTime } = input;
+  const collections = emptyLayerWalkCollections();
+  for (let index = 0; index < input.layers.length; index++) {
+    collectLayerDataChecksForLayer(input, index, collections);
+  }
+  return collections;
+}
+
+type LayerWalkInput = Parameters<typeof collectLayerDataChecks>[0];
+type FieldTypeOf = (channel: ChannelName) => [string, ProfileFieldType] | null;
+type LayerTypeContext = {
+  geom: string;
+  stat: string;
+  index: number;
+  fieldTypeOf: FieldTypeOf;
+  scaleRequestsTime: (channel: ChannelName) => boolean;
+};
+
+function emptyLayerWalkCollections(): LayerWalkCollections {
+  return {
+    errors: [],
+    axisFields: { x: [], y: [] },
+    colorFields: { color: [], fill: [] },
+    colorScaledConstants: { color: [], fill: [] },
+    finiteStyleFields: { shape: [], linetype: [] },
+    numericStyleFields: { size: [], linewidth: [], alpha: [] },
+    numericStyleScaledConstants: { size: [], linewidth: [], alpha: [] },
+  };
+}
+
+function collectLayerDataChecksForLayer(
+  input: LayerWalkInput,
+  index: number,
+  collections: LayerWalkCollections,
+): void {
+  const layer = input.layers[index];
+  if (!isRecord(layer)) return;
+  const geom = typeof layer["geom"] === "string" ? layer["geom"] : "";
+  const layerAes = isRecord(layer["aes"]) ? (layer["aes"] as Aes) : undefined;
+  const defaultStat = GEOM_DEFAULTS[geom as keyof typeof GEOM_DEFAULTS]?.stat ?? "identity";
+  const stat = typeof layer["stat"] === "string" ? layer["stat"] : defaultStat;
+  const fields =
+    input.layerMaps === null ? input.plotFields : (input.layerMaps[index] ?? input.plotFields);
+  if (fields === null) return;
+  const fieldTypeOf = layerFieldTypeLookup(
+    input.plotAes,
+    layerAes,
+    fields,
+    input.scaleRequestsTime,
+  );
+  collections.errors.push(
+    ...geomFieldTypeErrors({
+      geom,
+      stat,
+      index,
+      fieldTypeOf,
+      scaleRequestsTime: input.scaleRequestsTime,
+    }),
+  );
+  collectLayerChannels({
+    plotAes: input.plotAes,
+    layerAes,
+    fields,
+    stat,
+    index,
+    collections,
+  });
+}
+
+function layerFieldTypeLookup(
+  plotAes: Aes | undefined,
+  layerAes: Aes | undefined,
+  fields: FieldEvidenceMap,
+  scaleRequestsTime: (channel: ChannelName) => boolean,
+): FieldTypeOf {
+  return (channel) => {
+    const mapped = effectiveChannel(plotAes, layerAes, channel);
+    if (mapped === undefined || !("field" in mapped)) return null;
+    const type = fields.get(mapped.field)?.type;
+    if (type === undefined || type === null) return null;
+    return [mapped.field, scaleRequestsTime(channel) ? "temporal" : type];
+  };
+}
+
+function geomFieldTypeErrors(context: LayerTypeContext): SpecError[] {
+  return [
+    ...smoothTypeErrors(context),
+    ...boxplotTypeErrors(context),
+    ...continuousStatTypeErrors(context),
+    ...intervalTypeErrors(context),
+    ...rectTypeErrors(context),
+    ...rasterTypeErrors(context),
+    ...tileTypeErrors(context),
+  ];
+}
+
+function channelTypeError(
+  index: number,
+  channel: ChannelName,
+  message: string,
+  description: string,
+): SpecError {
+  return {
+    code: "channel-type-mismatch",
+    path: `/layers/${index}/aes/${channel}`,
+    message,
+    fix: { description },
+  };
+}
+
+function isDiscreteType(type: ProfileFieldType): boolean {
+  return type === "nominal" || type === "ordinal";
+}
+
+function smoothTypeErrors(context: LayerTypeContext): SpecError[] {
+  if (context.geom !== "smooth") return [];
   const errors: SpecError[] = [];
-  const axisFields: Record<"x" | "y", ChannelFieldUse[]> = { x: [], y: [] };
-  const colorFields: Record<"color" | "fill", ChannelFieldUse[]> = { color: [], fill: [] };
-  const colorScaledConstants: Record<"color" | "fill", unknown[]> = { color: [], fill: [] };
-  const finiteStyleFields: Record<"shape" | "linetype", ChannelFieldUse[]> = {
-    shape: [],
-    linetype: [],
-  };
-  const numericStyleFields: Record<"size" | "linewidth" | "alpha", ChannelFieldUse[]> = {
-    size: [],
-    linewidth: [],
-    alpha: [],
-  };
-  const numericStyleScaledConstants: Record<"size" | "linewidth" | "alpha", unknown[]> = {
-    size: [],
-    linewidth: [],
-    alpha: [],
-  };
+  for (const channel of ["x", "y"] as const) {
+    const info = context.fieldTypeOf(channel);
+    if (info === null || !isDiscreteType(info[1])) continue;
+    errors.push(
+      channelTypeError(
+        context.index,
+        channel,
+        `The smooth stat needs quantitative x and y, but field "${info[0]}" (${channel}) is ${info[1]}.`,
+        "Map the channel to a numeric field, or use a boxplot for discrete x.",
+      ),
+    );
+  }
+  return errors;
+}
 
-  for (let i = 0; i < layers.length; i++) {
-    const layer = layers[i];
-    if (!isRecord(layer)) continue;
-    const geom = typeof layer["geom"] === "string" ? layer["geom"] : "";
-    const layerAes = isRecord(layer["aes"]) ? (layer["aes"] as Aes) : undefined;
-    const defaultStat = GEOM_DEFAULTS[geom as keyof typeof GEOM_DEFAULTS]?.stat ?? "identity";
-    const stat = typeof layer["stat"] === "string" ? layer["stat"] : defaultStat;
+function boxplotTypeErrors(context: LayerTypeContext): SpecError[] {
+  if (context.geom !== "boxplot") return [];
+  const errors: SpecError[] = [];
+  const x = context.fieldTypeOf("x");
+  if (x !== null && (x[1] === "quantitative" || x[1] === "temporal")) {
+    errors.push(
+      channelTypeError(
+        context.index,
+        "x",
+        `The boxplot geom needs a DISCRETE x this milestone, but field "${x[0]}" is ${x[1]}.`,
+        "Map x to a categorical field (strings), or bin the values into labeled categories first.",
+      ),
+    );
+  }
+  const y = context.fieldTypeOf("y");
+  if (y !== null && isDiscreteType(y[1])) {
+    errors.push(
+      channelTypeError(
+        context.index,
+        "y",
+        `The boxplot stat needs a quantitative y, but field "${y[0]}" is ${y[1]}.`,
+        "Map y to a numeric field.",
+      ),
+    );
+  }
+  return errors;
+}
 
-    const fields: FieldEvidenceMap | null =
-      layerMaps === null ? plotFields : (layerMaps[i] ?? plotFields);
-    if (fields === null) continue; // runtime-only named data: skip field checks
-    const available = [...fields.keys()];
+function continuousStatTypeErrors(context: LayerTypeContext): SpecError[] {
+  const { geom, stat } = context;
+  const continuous =
+    ["histogram", "freqpoly", "density"].includes(geom) ||
+    ((geom === "bar" || geom === "line") && stat === "bin");
+  if (!continuous) return [];
+  const x = context.fieldTypeOf("x");
+  if (x === null || !isDiscreteType(x[1])) return [];
+  return [
+    channelTypeError(
+      context.index,
+      "x",
+      `The ${geom === "density" ? "density" : "bin"} stat needs a continuous x, but field "${x[0]}" is ${x[1]}.`,
+      'Use geom "bar" (the count stat) to count categories instead.',
+    ),
+  ];
+}
 
-    // --- geom/stat field-type rules (M2 statistical layer) -----------------
-    const fieldTypeOf = (channel: ChannelName): [string, ProfileFieldType] | null => {
-      const m = effectiveChannel(plotAes, layerAes, channel);
-      if (m === undefined || !("field" in m)) return null;
-      const t = fields.get(m.field)?.type;
-      if (t === undefined || t === null) return null;
-      // Geom/stat contracts see position values after configured temporal parsing.
-      // Parse failures and configuration errors are owned by scale validation below.
-      return [m.field, scaleRequestsTime(channel) ? "temporal" : t];
-    };
-    const typeError = (channel: ChannelName, message: string, fixDesc: string) => {
-      errors.push({
-        code: "channel-type-mismatch",
-        path: `/layers/${i}/aes/${channel}`,
-        message,
-        fix: { description: fixDesc },
-      });
-    };
-    if (geom === "smooth") {
-      for (const channel of ["x", "y"] as const) {
-        const info = fieldTypeOf(channel);
-        if (info !== null && (info[1] === "nominal" || info[1] === "ordinal")) {
-          typeError(
-            channel,
-            `The smooth stat needs quantitative x and y, but field "${info[0]}" (${channel}) is ${info[1]}.`,
-            "Map the channel to a numeric field, or use a boxplot for discrete x.",
-          );
-        }
-      }
-    }
-    if (geom === "boxplot") {
-      const x = fieldTypeOf("x");
-      if (x !== null && (x[1] === "quantitative" || x[1] === "temporal")) {
-        typeError(
-          "x",
-          `The boxplot geom needs a DISCRETE x this milestone, but field "${x[0]}" is ${x[1]}.`,
-          "Map x to a categorical field (strings), or bin the values into labeled categories first.",
-        );
-      }
-      const y = fieldTypeOf("y");
-      if (y !== null && (y[1] === "nominal" || y[1] === "ordinal")) {
-        typeError(
-          "y",
-          `The boxplot stat needs a quantitative y, but field "${y[0]}" is ${y[1]}.`,
-          "Map y to a numeric field.",
-        );
-      }
-    }
-    if (
-      geom === "histogram" ||
-      geom === "freqpoly" ||
-      geom === "density" ||
-      (geom === "bar" && stat === "bin") ||
-      (geom === "line" && stat === "bin")
-    ) {
-      const x = fieldTypeOf("x");
-      if (x !== null && (x[1] === "nominal" || x[1] === "ordinal")) {
-        typeError(
-          "x",
-          `The ${geom === "density" ? "density" : "bin"} stat needs a continuous x, but field "${x[0]}" is ${x[1]}.`,
-          'Use geom "bar" (the count stat) to count categories instead.',
-        );
-      }
-    }
-    if (
-      geom === "errorbar" ||
-      geom === "linerange" ||
-      geom === "pointrange" ||
-      geom === "crossbar"
-    ) {
-      for (const channel of ["ymin", "ymax"] as const) {
-        const info = fieldTypeOf(channel);
-        if (
-          info !== null &&
-          (info[1] === "nominal" || info[1] === "ordinal") &&
-          !scaleRequestsTime("y")
-        ) {
-          typeError(
-            channel,
-            `The ${geom} geom needs quantitative bounds, but field "${info[0]}" (${channel}) is ${info[1]}.`,
-            "Map the channel to a numeric field.",
-          );
-        }
-      }
-    }
-    if (geom === "rect") {
-      for (const channel of ["xmin", "xmax"] as const) {
-        const info = fieldTypeOf(channel);
-        if (
-          info !== null &&
-          (info[1] === "nominal" || info[1] === "ordinal") &&
-          !scaleRequestsTime("x")
-        ) {
-          typeError(
-            channel,
-            `The rect geom needs quantitative edges, but field "${info[0]}" (${channel}) is ${info[1]}.`,
-            "Map the channel to a numeric field.",
-          );
-        }
-      }
-      for (const channel of ["ymin", "ymax"] as const) {
-        const info = fieldTypeOf(channel);
-        if (
-          info !== null &&
-          (info[1] === "nominal" || info[1] === "ordinal") &&
-          !scaleRequestsTime("y")
-        ) {
-          typeError(
-            channel,
-            `The rect geom needs quantitative edges, but field "${info[0]}" (${channel}) is ${info[1]}.`,
-            "Map the channel to a numeric field.",
-          );
-        }
-      }
-    }
-    if (geom === "raster") {
-      for (const channel of ["x", "y"] as const) {
-        const info = fieldTypeOf(channel);
-        if (info !== null && (info[1] === "nominal" || info[1] === "ordinal")) {
-          typeError(
-            channel,
-            `The raster geom needs continuous ${channel}, but field "${info[0]}" is ${info[1]}.`,
-            'Use geom "tile" for discrete axes.',
-          );
-        }
-      }
-    }
-    if (geom === "tile") {
-      for (const channel of ["width", "height"] as const) {
-        const info = fieldTypeOf(channel);
-        if (info !== null && info[1] !== "quantitative") {
-          typeError(
-            channel,
-            `The tile geom needs quantitative ${channel}, but field "${info[0]}" is ${info[1]}.`,
-            `Map ${channel} to a positive numeric field, or use params.${channel}.`,
-          );
-        }
-      }
-    }
+function intervalTypeErrors(context: LayerTypeContext): SpecError[] {
+  if (!["errorbar", "linerange", "pointrange", "crossbar"].includes(context.geom)) return [];
+  if (context.scaleRequestsTime("y")) return [];
+  const errors: SpecError[] = [];
+  for (const channel of ["ymin", "ymax"] as const) {
+    const info = context.fieldTypeOf(channel);
+    if (info === null || !isDiscreteType(info[1])) continue;
+    errors.push(
+      channelTypeError(
+        context.index,
+        channel,
+        `The ${context.geom} geom needs quantitative bounds, but field "${info[0]}" (${channel}) is ${info[1]}.`,
+        "Map the channel to a numeric field.",
+      ),
+    );
+  }
+  return errors;
+}
 
-    for (const channel of CHANNELS) {
-      const mapped = effectiveChannel(plotAes, layerAes, channel);
-      if (mapped === undefined) continue;
-      const path = `/layers/${i}/aes/${channel}`;
+function rectTypeErrors(context: LayerTypeContext): SpecError[] {
+  if (context.geom !== "rect") return [];
+  return [
+    ...rectAxisTypeErrors(context, "x", ["xmin", "xmax"]),
+    ...rectAxisTypeErrors(context, "y", ["ymin", "ymax"]),
+  ];
+}
 
-      if ("stat" in mapped) {
-        const generated =
-          (channel === "y" ? STAT_Y_CHANNEL_COLUMNS[stat] : STAT_COLUMNS[stat]) ?? [];
-        if (!generated.includes(mapped.stat)) {
-          errors.push({
-            code: "unknown-stat-column",
-            path,
-            message:
-              generated.length === 0
-                ? `Channel "${channel}" maps stat column "${mapped.stat}", but this layer's stat ("${stat}") generates no columns.`
-                : `Channel "${channel}" maps stat column "${mapped.stat}", but this layer's stat ("${stat}") generates: ${generated.join(", ")}.`,
-            ...(generated.length > 0 && { allowed: [...generated] }),
-          });
-        }
-        continue;
-      }
-      if ("value" in mapped) {
-        // Runtime trains manual/ordinal color domains on scaled constants too.
-        if (
-          (channel === "color" || channel === "fill") &&
-          mapped.scale === true &&
-          mapped.value !== null
-        ) {
-          colorScaledConstants[channel].push(mapped.value);
-        }
-        // The runtime trains numeric style scales on scaled constants as well, so
-        // a scaled string constant on a sequential/binned size/linewidth/alpha
-        // scale must face the same scale-family check as a mapped field below.
-        if (
-          (channel === "size" || channel === "linewidth" || channel === "alpha") &&
-          mapped.scale === true &&
-          mapped.value !== null
-        ) {
-          numericStyleScaledConstants[channel].push(mapped.value);
-        }
-        continue;
-      }
-      if (!("field" in mapped)) continue;
+function rectAxisTypeErrors(
+  context: LayerTypeContext,
+  axis: "x" | "y",
+  channels: readonly ChannelName[],
+): SpecError[] {
+  if (context.scaleRequestsTime(axis)) return [];
+  const errors: SpecError[] = [];
+  for (const channel of channels) {
+    const info = context.fieldTypeOf(channel);
+    if (info === null || !isDiscreteType(info[1])) continue;
+    errors.push(
+      channelTypeError(
+        context.index,
+        channel,
+        `The rect geom needs quantitative edges, but field "${info[0]}" (${channel}) is ${info[1]}.`,
+        "Map the channel to a numeric field.",
+      ),
+    );
+  }
+  return errors;
+}
 
-      const info = fields.get(mapped.field);
-      if (info === undefined) {
-        const suggestion = didYouMean(mapped.field, available);
-        errors.push({
-          code: "unknown-field",
-          path,
-          message:
-            `Unknown field "${mapped.field}" (available: ${available.join(", ") || "none"}).` +
-            (suggestion === undefined ? "" : ` Did you mean "${suggestion}"?`),
-          allowed: available,
-          ...(suggestion !== undefined && {
-            fix: {
-              description: `Map "${channel}" to "${suggestion}".`,
-              example: { field: suggestion },
-            },
-          }),
-        });
-        continue;
-      }
-      if (info.allNull) {
-        errors.push({
-          code: "all-null-column",
-          path,
-          message: `Field "${mapped.field}" contains only null values; the "${channel}" channel cannot be drawn from it.`,
-        });
-        continue;
-      }
-      if (channel === "x" || channel === "xmin" || channel === "xmax" || channel === "xend") {
-        axisFields.x.push({ field: mapped.field, path });
-      }
-      if (channel === "y" || channel === "ymin" || channel === "ymax" || channel === "yend") {
-        axisFields.y.push({ field: mapped.field, path });
-      }
-      if (channel === "color" || channel === "fill") {
-        colorFields[channel].push({ field: mapped.field, path });
-      }
-      if (channel === "shape" || channel === "linetype") {
-        finiteStyleFields[channel].push({ field: mapped.field, path });
-      }
-      if (channel === "size" || channel === "linewidth" || channel === "alpha") {
-        numericStyleFields[channel].push({ field: mapped.field, path });
-      }
+function rasterTypeErrors(context: LayerTypeContext): SpecError[] {
+  if (context.geom !== "raster") return [];
+  const errors: SpecError[] = [];
+  for (const channel of ["x", "y"] as const) {
+    const info = context.fieldTypeOf(channel);
+    if (info === null || !isDiscreteType(info[1])) continue;
+    errors.push(
+      channelTypeError(
+        context.index,
+        channel,
+        `The raster geom needs continuous ${channel}, but field "${info[0]}" is ${info[1]}.`,
+        'Use geom "tile" for discrete axes.',
+      ),
+    );
+  }
+  return errors;
+}
+
+function tileTypeErrors(context: LayerTypeContext): SpecError[] {
+  if (context.geom !== "tile") return [];
+  const errors: SpecError[] = [];
+  for (const channel of ["width", "height"] as const) {
+    const info = context.fieldTypeOf(channel);
+    if (info === null || info[1] === "quantitative") continue;
+    errors.push(
+      channelTypeError(
+        context.index,
+        channel,
+        `The tile geom needs quantitative ${channel}, but field "${info[0]}" is ${info[1]}.`,
+        `Map ${channel} to a positive numeric field, or use params.${channel}.`,
+      ),
+    );
+  }
+  return errors;
+}
+
+function collectLayerChannels(input: {
+  plotAes: Aes | undefined;
+  layerAes: Aes | undefined;
+  fields: FieldEvidenceMap;
+  stat: string;
+  index: number;
+  collections: LayerWalkCollections;
+}): void {
+  const available = [...input.fields.keys()];
+  for (const channel of CHANNELS) {
+    const mapped = effectiveChannel(input.plotAes, input.layerAes, channel);
+    if (mapped === undefined) continue;
+    const path = `/layers/${input.index}/aes/${channel}`;
+    if ("stat" in mapped) {
+      const error = statColumnError(channel, mapped.stat, input.stat, path);
+      if (error !== null) input.collections.errors.push(error);
+    } else if ("value" in mapped) {
+      collectScaledConstant(input.collections, channel, mapped);
+    } else if ("field" in mapped) {
+      collectFieldChannel(input.collections, channel, mapped.field, path, input.fields, available);
     }
   }
+}
 
+function statColumnError(
+  channel: ChannelName,
+  statColumn: string,
+  stat: string,
+  path: string,
+): SpecError | null {
+  const generated = (channel === "y" ? STAT_Y_CHANNEL_COLUMNS[stat] : STAT_COLUMNS[stat]) ?? [];
+  if (generated.includes(statColumn)) return null;
   return {
-    errors,
-    axisFields,
-    colorFields,
-    colorScaledConstants,
-    finiteStyleFields,
-    numericStyleFields,
-    numericStyleScaledConstants,
+    code: "unknown-stat-column",
+    path,
+    message:
+      generated.length === 0
+        ? `Channel "${channel}" maps stat column "${statColumn}", but this layer's stat ("${stat}") generates no columns.`
+        : `Channel "${channel}" maps stat column "${statColumn}", but this layer's stat ("${stat}") generates: ${generated.join(", ")}.`,
+    ...(generated.length > 0 && { allowed: [...generated] }),
   };
+}
+
+function collectScaledConstant(
+  collections: LayerWalkCollections,
+  channel: ChannelName,
+  mapped: { value: unknown; scale?: boolean },
+): void {
+  if (mapped.scale !== true || mapped.value === null) return;
+  if (channel === "color" || channel === "fill") {
+    collections.colorScaledConstants[channel].push(mapped.value);
+  }
+  if (channel === "size" || channel === "linewidth" || channel === "alpha") {
+    collections.numericStyleScaledConstants[channel].push(mapped.value);
+  }
+}
+
+function collectFieldChannel(
+  collections: LayerWalkCollections,
+  channel: ChannelName,
+  field: string,
+  path: string,
+  fields: FieldEvidenceMap,
+  available: string[],
+): void {
+  const info = fields.get(field);
+  if (info === undefined) {
+    collections.errors.push(unknownFieldError(channel, field, path, available));
+    return;
+  }
+  if (info.allNull) {
+    collections.errors.push({
+      code: "all-null-column",
+      path,
+      message: `Field "${field}" contains only null values; the "${channel}" channel cannot be drawn from it.`,
+    });
+    return;
+  }
+  collectFieldUse(collections, channel, { field, path });
+}
+
+function unknownFieldError(
+  channel: ChannelName,
+  field: string,
+  path: string,
+  available: string[],
+): SpecError {
+  const suggestion = didYouMean(field, available);
+  return {
+    code: "unknown-field",
+    path,
+    message:
+      `Unknown field "${field}" (available: ${available.join(", ") || "none"}).` +
+      (suggestion === undefined ? "" : ` Did you mean "${suggestion}"?`),
+    allowed: available,
+    ...(suggestion !== undefined && {
+      fix: {
+        description: `Map "${channel}" to "${suggestion}".`,
+        example: { field: suggestion },
+      },
+    }),
+  };
+}
+
+function collectFieldUse(
+  collections: LayerWalkCollections,
+  channel: ChannelName,
+  use: ChannelFieldUse,
+): void {
+  if (["x", "xmin", "xmax", "xend"].includes(channel)) collections.axisFields.x.push(use);
+  if (["y", "ymin", "ymax", "yend"].includes(channel)) collections.axisFields.y.push(use);
+  if (channel === "color" || channel === "fill") collections.colorFields[channel].push(use);
+  if (channel === "shape" || channel === "linetype")
+    collections.finiteStyleFields[channel].push(use);
+  if (channel === "size" || channel === "linewidth" || channel === "alpha") {
+    collections.numericStyleFields[channel].push(use);
+  }
 }

--- a/packages/spec/src/validate-data-checks-position.ts
+++ b/packages/spec/src/validate-data-checks-position.ts
@@ -67,20 +67,49 @@ export function scaleRequestsTime(
   axis: "x" | "y",
 ): boolean {
   const config = scales?.[axis] as PositionScaleSpec | undefined;
-  return (
-    config?.type !== "band" &&
-    (config?.type === "time" ||
-      config?.parse !== undefined ||
-      config?.temporalKind !== undefined ||
-      config?.timezone !== undefined ||
-      config?.disambiguation !== undefined ||
-      config?.parseFailure !== undefined ||
-      config?.dateBreaks !== undefined ||
-      config?.dateMinorBreaks !== undefined ||
-      config?.dateLabels !== undefined ||
-      config?.locale !== undefined ||
-      config?.weekStart !== undefined)
-  );
+  if (config?.type === "band") return false;
+  if (config?.type === "time") return true;
+  return [
+    config?.parse,
+    config?.temporalKind,
+    config?.timezone,
+    config?.disambiguation,
+    config?.parseFailure,
+    config?.dateBreaks,
+    config?.dateMinorBreaks,
+    config?.dateLabels,
+    config?.locale,
+    config?.weekStart,
+  ].some((value) => value !== undefined);
+}
+
+function temporalAxisConfigurationError(config: PositionScaleSpec | undefined): string | null {
+  const effectiveParser = config?.parse ?? (config?.temporalKind === "monthDay" ? "md" : "auto");
+  const parserError = temporalParserConfigurationError(effectiveParser, {
+    ...(config?.timezone !== undefined && { timezone: config.timezone }),
+    ...(config?.disambiguation !== undefined && { disambiguation: config.disambiguation }),
+  });
+  if (parserError !== null) return parserError;
+  const intervalError = temporalIntervalConfigurationError(config);
+  if (intervalError !== null) return intervalError;
+  const labelError =
+    config?.dateLabels === undefined
+      ? null
+      : temporalLabelConfigurationError(config.dateLabels, config.temporalKind);
+  if (labelError !== null) return labelError;
+  return config?.locale === undefined ? null : temporalLocaleConfigurationError(config.locale);
+}
+
+function temporalIntervalConfigurationError(config: PositionScaleSpec | undefined): string | null {
+  for (const interval of [config?.dateBreaks, config?.dateMinorBreaks]) {
+    if (interval === undefined) continue;
+    try {
+      parseTemporalInterval(interval);
+    } catch (error) {
+      return error instanceof Error ? error.message : "invalid temporal interval";
+    }
+  }
+  return null;
 }
 
 /**
@@ -103,31 +132,7 @@ export function validateTemporalAxisConfiguration(scales: Record<string, unknown
       continue;
     }
     if (config?.type === "band" || !scaleRequestsTime(scales, axis)) continue;
-    // Mirror the runtime effective parser (temporal-position.ts): unset parse
-    // on monthDay means `md`, not `auto`. Same expression as
-    // checkPositionScaleDataCompatibility below.
-    const effectiveParser = config?.parse ?? (config?.temporalKind === "monthDay" ? "md" : "auto");
-    let configurationError = temporalParserConfigurationError(effectiveParser, {
-      ...(config?.timezone !== undefined && { timezone: config.timezone }),
-      ...(config?.disambiguation !== undefined && { disambiguation: config.disambiguation }),
-    });
-    if (configurationError === null) {
-      for (const interval of [config?.dateBreaks, config?.dateMinorBreaks]) {
-        if (interval === undefined) continue;
-        try {
-          parseTemporalInterval(interval);
-        } catch (error) {
-          configurationError = error instanceof Error ? error.message : "invalid temporal interval";
-          break;
-        }
-      }
-    }
-    if (configurationError === null && config?.dateLabels !== undefined) {
-      configurationError = temporalLabelConfigurationError(config.dateLabels, config.temporalKind);
-    }
-    if (configurationError === null && config?.locale !== undefined) {
-      configurationError = temporalLocaleConfigurationError(config.locale);
-    }
+    const configurationError = temporalAxisConfigurationError(config);
     if (configurationError === null) continue;
     invalidTemporalAxes.add(axis);
     errors.push({
@@ -167,73 +172,104 @@ export function checkPositionScaleDataCompatibility(input: {
     if (declared === undefined || declared === "band" || invalidTemporalAxes.has(axis)) continue;
     for (const use of axisFields[axis]) {
       const info = evidenceOf(use);
-      const type = info?.type ?? null;
-      if (type === null) continue;
+      if (info === undefined || info.type === null) continue;
+      const type = info.type;
       if (declared === "time") {
-        // Same effective parser as validateTemporalAxisConfiguration above.
-        const effectiveParser =
-          config?.parse ?? (config?.temporalKind === "monthDay" ? "md" : "auto");
-        const decision = temporalDecisionForField(
-          temporalDecisionCache,
-          use.field,
-          info,
-          effectiveParser,
-          {
-            ...(config?.timezone !== undefined && { timezone: config.timezone }),
-            ...(config?.disambiguation !== undefined && {
-              disambiguation: config.disambiguation,
-            }),
-          },
-        );
-        const censoredInvalid =
-          config?.parse !== undefined &&
-          config.parseFailure === "censor" &&
-          decision?.status === "invalid";
-        const profileTemporal = info?.values === null && type === "temporal";
-        if (decision?.status === "temporal" || censoredInvalid || profileTemporal) {
-          appendTemporalKindMismatch(errors, {
-            axis,
-            path: use.path,
-            field: use.field,
-            expected: config?.temporalKind,
-            actual: decision?.kind ?? null,
-          });
-          continue;
-        }
-        const firstFailure = decision?.failures?.[0];
-        const detail =
-          firstFailure === undefined
-            ? decision?.status === "ambiguous"
-              ? ` Automatic temporal inference was ambiguous between: ${decision.candidates.join(", ")}.`
-              : decision?.status === "invalid"
-                ? ` Automatic temporal inference failed whole-column validation for ${decision.failedCount} value(s).`
-                : ""
-            : ` Parser ${JSON.stringify(effectiveParser)} rejected ${decision?.failedCount ?? 0} value(s), including row ${firstFailure.index}: ${JSON.stringify(firstFailure.value)}.`;
-        errors.push({
-          code: "scale-type-mismatch",
-          path: use.path,
-          message: `scales.${axis} requests time but field "${use.field}" is ${type}.${detail}`,
-          fix: {
-            description:
-              config?.parse === undefined
-                ? `Set scales.${axis}.parse to an explicit temporal order, or set scales.${axis}.type to "band" to keep categories.`
-                : `Correct the rejected values, choose the matching scales.${axis}.parse value, or use parseFailure: "censor" explicitly.`,
-          },
-        });
-        continue;
-      }
-      if (
+        errors.push(...timePositionErrors(axis, use, info, config, temporalDecisionCache));
+      } else if (
         (declared === "log" || declared === "linear") &&
         (type === "nominal" || type === "ordinal")
       ) {
-        errors.push({
-          code: "scale-type-mismatch",
-          path: use.path,
-          message: `scales.${axis}.type is "${declared}" but field "${use.field}" is ${type}; use a band scale (or a quantitative field).`,
-          fix: { description: `Set scales.${axis}.type to "band".` },
-        });
+        errors.push(linearPositionError(axis, declared, use, type));
       }
     }
   }
   return errors;
+}
+
+function timePositionErrors(
+  axis: "x" | "y",
+  use: ChannelFieldUse,
+  info: FieldEvidenceEntry,
+  config: PositionScaleSpec | undefined,
+  cache: TemporalDecisionCache,
+): SpecError[] {
+  const effectiveParser = config?.parse ?? (config?.temporalKind === "monthDay" ? "md" : "auto");
+  const options = temporalPositionOptions(config);
+  const decision = temporalDecisionForField(cache, use.field, info, effectiveParser, options);
+  const profileTemporal = info.values === null && info.type === "temporal";
+  if (timePositionResolves(config, decision, profileTemporal)) {
+    const errors: SpecError[] = [];
+    appendTemporalKindMismatch(errors, {
+      axis,
+      path: use.path,
+      field: use.field,
+      expected: config?.temporalKind,
+      actual: decision?.kind ?? null,
+    });
+    return errors;
+  }
+  const firstFailure = decision?.failures?.[0];
+  const detail =
+    firstFailure === undefined
+      ? temporalDecisionDetail(decision)
+      : ` Parser ${JSON.stringify(effectiveParser)} rejected ${decision?.failedCount ?? 0} value(s), including row ${firstFailure.index}: ${JSON.stringify(firstFailure.value)}.`;
+  return [
+    {
+      code: "scale-type-mismatch",
+      path: use.path,
+      message: `scales.${axis} requests time but field "${use.field}" is ${info.type}.${detail}`,
+      fix: {
+        description:
+          config?.parse === undefined
+            ? `Set scales.${axis}.parse to an explicit temporal order, or set scales.${axis}.type to "band" to keep categories.`
+            : `Correct the rejected values, choose the matching scales.${axis}.parse value, or use parseFailure: "censor" explicitly.`,
+      },
+    },
+  ];
+}
+
+function temporalPositionOptions(config: PositionScaleSpec | undefined) {
+  return {
+    ...(config?.timezone !== undefined && { timezone: config.timezone }),
+    ...(config?.disambiguation !== undefined && { disambiguation: config.disambiguation }),
+  };
+}
+
+function timePositionResolves(
+  config: PositionScaleSpec | undefined,
+  decision: ReturnType<typeof temporalDecisionForField>,
+  profileTemporal: boolean,
+): boolean {
+  return (
+    decision?.status === "temporal" ||
+    profileTemporal ||
+    (config?.parse !== undefined &&
+      config.parseFailure === "censor" &&
+      decision?.status === "invalid")
+  );
+}
+
+function temporalDecisionDetail(decision: ReturnType<typeof temporalDecisionForField>): string {
+  if (decision?.status === "ambiguous") {
+    return ` Automatic temporal inference was ambiguous between: ${decision.candidates.join(", ")}.`;
+  }
+  if (decision?.status === "invalid") {
+    return ` Automatic temporal inference failed whole-column validation for ${decision.failedCount} value(s).`;
+  }
+  return "";
+}
+
+function linearPositionError(
+  axis: "x" | "y",
+  declared: "log" | "linear",
+  use: ChannelFieldUse,
+  type: "nominal" | "ordinal",
+): SpecError {
+  return {
+    code: "scale-type-mismatch",
+    path: use.path,
+    message: `scales.${axis}.type is "${declared}" but field "${use.field}" is ${type}; use a band scale (or a quantitative field).`,
+    fix: { description: `Set scales.${axis}.type to "band".` },
+  };
 }

--- a/packages/spec/src/validate-data-checks-style-numeric.ts
+++ b/packages/spec/src/validate-data-checks-style-numeric.ts
@@ -13,6 +13,27 @@ import {
   type TemporalDecisionCache,
 } from "./validate-data-checks-temporal.js";
 
+type NumericStyleConfig = {
+  type?: string;
+  temporalKind?: unknown;
+  parse?: unknown;
+  timezone?: unknown;
+  disambiguation?: unknown;
+  domain?: unknown;
+  parseFailure?: unknown;
+  breaks?: unknown;
+};
+
+type NumericStyleFacts = {
+  requestsTemporal: boolean;
+  temporalInputsUsable: boolean;
+  parser: Parameters<typeof parseTemporalColumn>[1];
+  temporalOptions: Parameters<typeof parseTemporalColumn>[2];
+  hasEpochParser: boolean;
+  hasExplicitDomain: boolean;
+  hasBinnedBreaks: boolean;
+};
+
 /** True when a scaled constant is what the core `cellToNumber()` coerces to a
  *  finite number, mirroring the non-temporal numeric-style path
  *  (scale-style-values.ts). Booleans, numeric strings and ISO date strings all
@@ -87,22 +108,13 @@ function quantitativeTemporalFieldError(input: {
   const censorRecovers =
     parseFailure === "censor" && (hasExplicitDomain || hasBinnedBreaks || channelTrains);
   if (decision === null || decision === undefined) {
-    // Profile-backed: no samples. An epoch parser makes numbers temporal, but always as
-    // `datetime`, so it can never satisfy a requested `date` kind — the runtime throws
-    // style-temporal-kind. Reject that combination outright.
-    if (hasEpochParser && typeof temporalKind === "string" && temporalKind !== "datetime") {
-      return {
-        code: "scale-type-mismatch",
-        path: `/scales/${aesthetic}`,
-        message: `scales.${aesthetic} requests temporal kind "${temporalKind}" but an epoch parser yields "datetime".`,
-        fix: {
-          description: `Set scales.${aesthetic}.temporalKind to "datetime", or use a parser that yields ${temporalKind} values.`,
-        },
-      };
-    }
-    // Otherwise defer only when the scale renders regardless of the eventual data — a
-    // (kind-compatible) epoch parser, or censor recovery trained from parseable bounds.
-    return hasEpochParser || censorRecovers ? null : mismatch;
+    return profileQuantitativeTemporalError({
+      aesthetic,
+      temporalKind,
+      hasEpochParser,
+      censorRecovers,
+      mismatch,
+    });
   }
   const censoredInvalid =
     parse !== undefined &&
@@ -128,6 +140,27 @@ function quantitativeTemporalFieldError(input: {
     };
   }
   return null;
+}
+
+function profileQuantitativeTemporalError(input: {
+  aesthetic: "size" | "linewidth" | "alpha";
+  temporalKind: unknown;
+  hasEpochParser: boolean;
+  censorRecovers: boolean;
+  mismatch: SpecError;
+}): SpecError | null {
+  const { aesthetic, temporalKind, hasEpochParser, censorRecovers, mismatch } = input;
+  if (hasEpochParser && typeof temporalKind === "string" && temporalKind !== "datetime") {
+    return {
+      code: "scale-type-mismatch",
+      path: `/scales/${aesthetic}`,
+      message: `scales.${aesthetic} requests temporal kind "${temporalKind}" but an epoch parser yields "datetime".`,
+      fix: {
+        description: `Set scales.${aesthetic}.temporalKind to "datetime", or use a parser that yields ${temporalKind} values.`,
+      },
+    };
+  }
+  return hasEpochParser || censorRecovers ? null : mismatch;
 }
 
 /** A scaled numeric-style constant is checked against the same resolution path the
@@ -244,106 +277,20 @@ export function checkNumericStyleScaleDataCompatibility(input: {
   // same "use ordinal" guidance color scales give. Fields without an explicit
   // sequential/binned type default to an ordinal numeric style and are fine.
   for (const aesthetic of ["size", "linewidth", "alpha"] as const) {
-    const config = scales?.[aesthetic] as
-      | {
-          type?: string;
-          temporalKind?: unknown;
-          parse?: unknown;
-          timezone?: unknown;
-          disambiguation?: unknown;
-          domain?: unknown;
-          parseFailure?: unknown;
-          breaks?: unknown;
-        }
-      | undefined;
+    const config = scales?.[aesthetic] as NumericStyleConfig | undefined;
     if (config?.type !== "sequential" && config?.type !== "binned") continue;
-    const requestsTemporal =
-      config.temporalKind !== undefined ||
-      config.parse !== undefined ||
-      config.timezone !== undefined ||
-      config.disambiguation !== undefined;
-    // Config-level temporal facts, shared by the field checks and the scaled-constant
-    // checks below (both mirror the runtime resolveNumericStyleValueView path).
-    // A schema-invalid parser or option (e.g. a Symbol timezone) reaches tier-2 (schema
-    // errors don't short-circuit it); handing it to the temporal helpers throws in their
-    // cache-key/evidence formatting instead of yielding the schema diagnostic, so gate
-    // every temporal call on the inputs being usable and defer otherwise.
-    const parseUsable = temporalParserUsable(config.parse);
-    const temporalOptionsUsable =
-      (config.timezone === undefined || typeof config.timezone === "string") &&
-      (config.disambiguation === undefined || typeof config.disambiguation === "string");
-    const temporalInputsUsable = parseUsable && temporalOptionsUsable;
-    const parser = (config.parse ?? "auto") as Parameters<typeof parseTemporalColumn>[1];
-    const temporalOptions = {
-      ...(config.timezone !== undefined && { timezone: config.timezone }),
-      ...(config.disambiguation !== undefined && { disambiguation: config.disambiguation }),
-    } as Parameters<typeof parseTemporalColumn>[2];
-    // Only an epoch parser turns quantitative (numeric) values temporal at runtime.
-    const hasEpochParser =
-      typeof config.parse === "object" && config.parse !== null && "epoch" in config.parse;
-    // A censor-recovery bound (explicit domain / binned breaks) only rescues an
-    // otherwise-invalid temporal column if a usable, explicit parser can actually parse
-    // it. Without a parser the runtime infers a non-temporal auto parser and throws
-    // style-domain-invalid / style-binned-breaks, so require parseability before
-    // treating either as a recovery bound (matches numericSequentialResolution).
-    const parseableBound = (value: unknown): boolean =>
-      temporalInputsUsable &&
-      config.parse !== undefined &&
-      parseTemporal(value, config.parse as Parameters<typeof parseTemporal>[1], temporalOptions).ok;
-    const domainValues = Array.isArray(config.domain)
-      ? config.domain.filter((value) => value !== null)
-      : [];
-    const hasExplicitDomain =
-      domainValues.length === 2 && domainValues.every((value) => parseableBound(value));
-    const binnedBreaks =
-      config.type === "binned" && Array.isArray(config.breaks)
-        ? config.breaks.filter((value) => value !== null)
-        : [];
-    const hasBinnedBreaks =
-      binnedBreaks.length >= 2 && binnedBreaks.every((value) => parseableBound(value));
+    const facts = numericStyleFacts(config);
     // Pass 1: channel-wide training sources (sibling fields + scaled constants).
     // Runtime trains sequential/binned style scales from the full channel value
     // list, so an all-invalid field/constant is censored when any sibling trains.
-    let fieldTrainsScale = false;
-    for (const use of numericStyleFields[aesthetic]) {
-      const type = typeOf(use);
-      if (type === "temporal") {
-        fieldTrainsScale = true;
-        continue;
-      }
-      if (type !== "quantitative" || !requestsTemporal || !temporalInputsUsable) continue;
-      const decision = temporalDecisionForField(
-        temporalDecisionCache,
-        use.field,
-        evidenceOf(use),
-        parser as Parameters<typeof temporalDecisionForField>[3],
-        temporalOptions as Parameters<typeof temporalDecisionForField>[4],
-      );
-      fieldTrainsScale ||=
-        decision !== null &&
-        decision !== undefined &&
-        (decision.status === "temporal" || (decision.validatedCount ?? 0) > 0);
-    }
-    let constantTrainsScale = false;
-    if (requestsTemporal && temporalInputsUsable) {
-      for (const value of numericStyleScaledConstants[aesthetic]) {
-        if (value instanceof Date) {
-          constantTrainsScale = true;
-          break;
-        }
-        if (typeof value !== "string" && typeof value !== "number") continue;
-        const decision = parseTemporalColumn(
-          [value] as Parameters<typeof parseTemporalColumn>[0],
-          parser,
-          temporalOptions,
-        ).decision;
-        if (decision.status === "temporal" || (decision.validatedCount ?? 0) > 0) {
-          constantTrainsScale = true;
-          break;
-        }
-      }
-    }
-    const channelTrains = fieldTrainsScale || constantTrainsScale;
+    const channelTrains = numericStyleChannelTrains({
+      uses: numericStyleFields[aesthetic],
+      constants: numericStyleScaledConstants[aesthetic],
+      evidenceOf,
+      typeOf,
+      cache: temporalDecisionCache,
+      facts,
+    });
 
     // Pass 2: field diagnostics (use channel-wide censor recovery).
     for (const use of numericStyleFields[aesthetic]) {
@@ -351,15 +298,15 @@ export function checkNumericStyleScaleDataCompatibility(input: {
       // A quantitative field carrying temporal options fails at resolve time
       // unless a working parser (or censor recovery) yields temporal values —
       // mirror the color checker rather than deferring unconditionally.
-      if (type === "quantitative" && requestsTemporal) {
+      if (type === "quantitative" && facts.requestsTemporal) {
         // Defer to the schema diagnostic when the parser/options are schema-invalid.
-        if (!temporalInputsUsable) continue;
+        if (!facts.temporalInputsUsable) continue;
         const decision = temporalDecisionForField(
           temporalDecisionCache,
           use.field,
           evidenceOf(use),
-          parser as Parameters<typeof temporalDecisionForField>[3],
-          temporalOptions as Parameters<typeof temporalDecisionForField>[4],
+          facts.parser as Parameters<typeof temporalDecisionForField>[3],
+          facts.temporalOptions as Parameters<typeof temporalDecisionForField>[4],
         );
         const error = quantitativeTemporalFieldError({
           decision,
@@ -368,9 +315,9 @@ export function checkNumericStyleScaleDataCompatibility(input: {
           temporalKind: config.temporalKind,
           parse: config.parse,
           parseFailure: config.parseFailure,
-          hasEpochParser,
-          hasExplicitDomain,
-          hasBinnedBreaks,
+          hasEpochParser: facts.hasEpochParser,
+          hasExplicitDomain: facts.hasExplicitDomain,
+          hasBinnedBreaks: facts.hasBinnedBreaks,
           channelTrains,
         });
         if (error !== null) errors.push(error);
@@ -380,7 +327,7 @@ export function checkNumericStyleScaleDataCompatibility(input: {
       // scales give. A nominal field carrying temporal options may still resolve
       // to temporal at runtime, so defer (mirror the color checker).
       if (type !== "nominal" && type !== "ordinal") continue;
-      if (requestsTemporal) continue;
+      if (facts.requestsTemporal) continue;
       errors.push({
         code: "scale-type-mismatch",
         path: `/scales/${aesthetic}`,
@@ -395,21 +342,114 @@ export function checkNumericStyleScaleDataCompatibility(input: {
     // resolve throws at runtime (style-domain-empty / style-temporal-parse). Reject
     // it here too, mirroring the field checks above for both resolution paths.
     const censorRecovers =
-      config.parseFailure === "censor" && (hasExplicitDomain || hasBinnedBreaks || channelTrains);
+      config.parseFailure === "censor" &&
+      (facts.hasExplicitDomain || facts.hasBinnedBreaks || channelTrains);
     for (const value of numericStyleScaledConstants[aesthetic]) {
       const error = numericStyleConstantError({
         value,
         aesthetic,
         configType: config.type,
-        requestsTemporal,
+        requestsTemporal: facts.requestsTemporal,
         temporalKind: config.temporalKind,
-        parseUsable: temporalInputsUsable,
-        parser,
-        options: temporalOptions,
+        parseUsable: facts.temporalInputsUsable,
+        parser: facts.parser,
+        options: facts.temporalOptions,
         censorRecovers,
       });
       if (error !== null) errors.push(error);
     }
   }
   return errors;
+}
+
+function numericStyleFacts(config: NumericStyleConfig): NumericStyleFacts {
+  const requestsTemporal = [
+    config.temporalKind,
+    config.parse,
+    config.timezone,
+    config.disambiguation,
+  ].some((value) => value !== undefined);
+  const temporalInputsUsable =
+    temporalParserUsable(config.parse) &&
+    (config.timezone === undefined || typeof config.timezone === "string") &&
+    (config.disambiguation === undefined || typeof config.disambiguation === "string");
+  const parser = (config.parse ?? "auto") as Parameters<typeof parseTemporalColumn>[1];
+  const temporalOptions = {
+    ...(config.timezone !== undefined && { timezone: config.timezone }),
+    ...(config.disambiguation !== undefined && { disambiguation: config.disambiguation }),
+  } as Parameters<typeof parseTemporalColumn>[2];
+  const parseableBound = (value: unknown): boolean =>
+    temporalInputsUsable &&
+    config.parse !== undefined &&
+    parseTemporal(value, config.parse as Parameters<typeof parseTemporal>[1], temporalOptions).ok;
+  const domainValues = Array.isArray(config.domain) ? config.domain.filter(nonNull) : [];
+  const binnedBreaks =
+    config.type === "binned" && Array.isArray(config.breaks) ? config.breaks.filter(nonNull) : [];
+  return {
+    requestsTemporal,
+    temporalInputsUsable,
+    parser,
+    temporalOptions,
+    hasEpochParser:
+      typeof config.parse === "object" && config.parse !== null && "epoch" in config.parse,
+    hasExplicitDomain:
+      domainValues.length === 2 && domainValues.every((value) => parseableBound(value)),
+    hasBinnedBreaks:
+      binnedBreaks.length >= 2 && binnedBreaks.every((value) => parseableBound(value)),
+  };
+}
+
+function nonNull(value: unknown): boolean {
+  return value !== null;
+}
+
+function numericStyleChannelTrains(input: {
+  uses: ChannelFieldUse[];
+  constants: unknown[];
+  evidenceOf: (use: ChannelFieldUse) => FieldEvidenceEntry | undefined;
+  typeOf: (use: ChannelFieldUse) => FieldEvidenceEntry["type"] | null;
+  cache: TemporalDecisionCache;
+  facts: NumericStyleFacts;
+}): boolean {
+  const { uses, constants, evidenceOf, typeOf, cache, facts } = input;
+  if (uses.some((use) => fieldTrainsNumericStyle(use, evidenceOf, typeOf, cache, facts)))
+    return true;
+  if (!facts.requestsTemporal || !facts.temporalInputsUsable) return false;
+  return constants.some((value) => constantTrainsNumericStyle(value, facts));
+}
+
+function fieldTrainsNumericStyle(
+  use: ChannelFieldUse,
+  evidenceOf: (use: ChannelFieldUse) => FieldEvidenceEntry | undefined,
+  typeOf: (use: ChannelFieldUse) => FieldEvidenceEntry["type"] | null,
+  cache: TemporalDecisionCache,
+  facts: NumericStyleFacts,
+): boolean {
+  const type = typeOf(use);
+  if (type === "temporal") return true;
+  if (type !== "quantitative" || !facts.requestsTemporal || !facts.temporalInputsUsable)
+    return false;
+  const decision = temporalDecisionForField(
+    cache,
+    use.field,
+    evidenceOf(use),
+    facts.parser as Parameters<typeof temporalDecisionForField>[3],
+    facts.temporalOptions as Parameters<typeof temporalDecisionForField>[4],
+  );
+  return (
+    decision !== null &&
+    decision !== undefined &&
+    (decision.status === "temporal" || (decision.validatedCount ?? 0) > 0)
+  );
+}
+
+function constantTrainsNumericStyle(value: unknown, facts: NumericStyleFacts): boolean {
+  if (value instanceof Date) return true;
+  if (typeof value !== "string" && typeof value !== "number") return false;
+  const decision = parseTemporalColumn(
+    [value] as Parameters<typeof parseTemporalColumn>[0],
+    facts.parser,
+    facts.temporalOptions,
+  ).decision;
+  return decision.status === "temporal" || (decision.validatedCount ?? 0) > 0;
 }

--- a/packages/spec/src/validate-data-evidence.ts
+++ b/packages/spec/src/validate-data-evidence.ts
@@ -197,14 +197,7 @@ export function resolveLayerFieldEvidence(
   limits: ValidateLimits,
 ): ResolveLayerFieldEvidenceResult {
   if (options.profile !== undefined) {
-    const bad = profileErrors(options.profile);
-    if (bad.length > 0) return { status: "errors", errors: bad };
-    const fields: FieldEvidenceMap = new Map();
-    for (const f of options.profile.fields) {
-      fields.set(f.name, { type: f.type, allNull: false, values: null, temporal: null });
-    }
-    const layers = Array.isArray(spec["layers"]) ? (spec["layers"] as unknown[]) : [];
-    return { status: "ok", plot: fields, layers: layers.map(() => fields) };
+    return evidenceFromProfile(options.profile, spec);
   }
 
   const datasets = spec["datasets"];
@@ -232,9 +225,6 @@ export function resolveLayerFieldEvidence(
   }
 
   const layers = Array.isArray(spec["layers"]) ? (spec["layers"] as unknown[]) : [];
-  const layerColumns: Array<Record<string, readonly CellValue[]> | null | "runtime"> = [];
-  /** Layer index → dataset name, for the layers that reference one. */
-  const layerNames: Array<string | null> = [];
   // Several layers commonly name one dataset. Pivoting {values} rows into
   // columns is O(rows x columns), so resolve each name once rather than once
   // per reference. Inline data keeps its own table: equal content is not the
@@ -246,34 +236,12 @@ export function resolveLayerFieldEvidence(
   // The plot's own table seeds it, so a layer naming the plot's dataset reuses
   // that pivot instead of building a second one.
   if (plotColumns !== null && plotName !== null) columnsByName.set(plotName, plotColumns);
-  for (const layer of layers) {
-    if (!isRecord(layer) || layer["data"] === undefined) {
-      layerColumns.push(null); // inherit plot
-      layerNames.push(null);
-      continue;
-    }
-    const data = layer["data"];
-    const name = isRecord(data) && typeof data["name"] === "string" ? data["name"] : null;
-    let cols = name === null ? undefined : columnsByName.get(name);
-    if (cols === undefined) {
-      const resolved = columnsFromDataRef(data, datasets);
-      if (resolved === null) {
-        // Named ref not in datasets (or malformed) — runtime-only / skip.
-        // Left unmemoized: a miss is cheap and re-resolving keeps the
-        // runtime marker distinct from a resolved table.
-        layerColumns.push("runtime");
-        layerNames.push(null);
-        continue;
-      }
-      cols = resolved;
-      if (name !== null) columnsByName.set(name, cols);
-    }
-    // Deduplicate limit accounting for shared named datasets.
-    const key = name === null ? `inline:${layerColumns.length}` : `name:${name}`;
-    countTable(key, cols);
-    layerColumns.push(cols);
-    layerNames.push(name);
-  }
+  const { layerColumns, layerNames } = resolveLayerColumns(
+    layers,
+    datasets,
+    columnsByName,
+    countTable,
+  );
 
   if (plotColumns === null && layerColumns.every((c) => c === null || c === "runtime")) {
     return { status: "none" };
@@ -322,6 +290,58 @@ export function resolveLayerFieldEvidence(
     return built;
   });
   return { status: "ok", plot, layers: layerMaps };
+}
+
+function evidenceFromProfile(
+  profile: NonNullable<ValidateOptions["profile"]>,
+  spec: Record<string, unknown>,
+): ResolveLayerFieldEvidenceResult {
+  const bad = profileErrors(profile);
+  if (bad.length > 0) return { status: "errors", errors: bad };
+  const fields: FieldEvidenceMap = new Map();
+  for (const field of profile.fields) {
+    fields.set(field.name, { type: field.type, allNull: false, values: null, temporal: null });
+  }
+  const layers = Array.isArray(spec["layers"]) ? (spec["layers"] as unknown[]) : [];
+  return { status: "ok", plot: fields, layers: layers.map(() => fields) };
+}
+
+function resolveLayerColumns(
+  layers: unknown[],
+  datasets: unknown,
+  columnsByName: Map<string, Record<string, readonly CellValue[]>>,
+  countTable: (key: string, columns: Record<string, readonly CellValue[]>) => void,
+): {
+  layerColumns: Array<Record<string, readonly CellValue[]> | null | "runtime">;
+  layerNames: Array<string | null>;
+} {
+  const layerColumns: Array<Record<string, readonly CellValue[]> | null | "runtime"> = [];
+  const layerNames: Array<string | null> = [];
+  for (const layer of layers) {
+    if (!isRecord(layer) || layer["data"] === undefined) {
+      layerColumns.push(null);
+      layerNames.push(null);
+      continue;
+    }
+    const data = layer["data"];
+    const name = isRecord(data) && typeof data["name"] === "string" ? data["name"] : null;
+    let columns = name === null ? undefined : columnsByName.get(name);
+    if (columns === undefined) {
+      const resolved = columnsFromDataRef(data, datasets);
+      if (resolved === null) {
+        layerColumns.push("runtime");
+        layerNames.push(null);
+        continue;
+      }
+      columns = resolved;
+      if (name !== null) columnsByName.set(name, columns);
+    }
+    const key = name === null ? `inline:${layerColumns.length}` : `name:${name}`;
+    countTable(key, columns);
+    layerColumns.push(columns);
+    layerNames.push(name);
+  }
+  return { layerColumns, layerNames };
 }
 
 function estimateBytes(columns: Record<string, readonly CellValue[]>, rowCount: number): number {

--- a/packages/spec/src/validate-map-path-unions.ts
+++ b/packages/spec/src/validate-map-path-unions.ts
@@ -82,56 +82,7 @@ export function mapUnionPathGroup(
     isChannelPath(path);
 
   if (isChannel && !members.allConst) {
-    // Near-canonical channel object:
-    // - mixed forms (field+value) → invalid-channel-value
-    // - form-illegal keys (field+scale) / typos → fall through to addl
-    // - nested type failures only (value: {}) → suppress union catalog
-    if (
-      isRecord(valueAtPath) &&
-      looksLikeChannelForm(valueAtPath) &&
-      typeof valueAtPath !== "string"
-    ) {
-      const discs = channelDiscriminatorKeys(valueAtPath);
-      if (discs.length > 1) {
-        return {
-          status: "done",
-          errors: [
-            {
-              code: "invalid-channel-value",
-              path,
-              message: `Channel "${key}" mixes forms (${discs.map((d) => `"${d}"`).join(" and ")}); use exactly one of {"field": ...}, {"value": ...}, or {"stat": ...}.`,
-              fix: {
-                description: `Pick a single channel form for "${key}".`,
-                example: CHANNEL_FIX_EXAMPLE,
-              },
-            },
-          ],
-        };
-      }
-      const formKeys = allowedKeysForPresentChannelForm(valueAtPath);
-      if (formKeys !== null && hasActionableAddlNoise(group, formKeys)) {
-        return { status: "continue", activeFormKeys: formKeys };
-      }
-      // Nested path owns the diagnostic — empty done, not fall-through.
-      return { status: "done", errors: [] };
-    }
-    const bareString = typeof valueAtPath === "string";
-    return {
-      status: "done",
-      errors: [
-        {
-          code: "invalid-channel-value",
-          path,
-          message: bareString
-            ? `Channel "${key}" is the bare string ${JSON.stringify(valueAtPath)}; portable specs require the canonical form {"field": ${JSON.stringify(valueAtPath)}}.`
-            : `Channel "${key}" must be {"field": ...}, {"value": ...}, {"stat": ...}, or null.`,
-          fix: {
-            description: `Use a canonical channel form, e.g. {"field": "column_name"} to map "${key}" to a data column.`,
-            example: bareString ? { field: valueAtPath } : CHANNEL_FIX_EXAMPLE,
-          },
-        },
-      ],
-    };
+    return mapChannelUnion(group, path, key, valueAtPath);
   }
 
   const isDataUnion =
@@ -140,69 +91,21 @@ export function mapUnionPathGroup(
     (isDataUnionPath(path) && anyOfErr !== undefined);
 
   if (isDataUnion) {
-    const allowedDataDiscriminators = dataDiscriminatorsForUnion(members, path);
-    const allowedDataForms = allowedDataDiscriminators.map((discriminator) =>
-      discriminator === "values"
-        ? '{"values": [...rows]}'
-        : discriminator === "columns"
-          ? '{"columns": {...arrays}}'
-          : '{"name": "dataset"}',
-    );
-    const allowedDataFormsMessage =
-      allowedDataForms.length === 2
-        ? `${allowedDataForms[0]} or ${allowedDataForms[1]}`
-        : `${allowedDataForms.slice(0, -1).join(", ")}, or ${allowedDataForms.at(-1)}`;
-    // Already wrapped as an allowed data form:
-    // - mixed allowed forms (values+name on DataRef) → invalid-data
-    // - illegal discriminators / extra siblings → fall through for unexpected-property
-    // - nested cell failures only → suppress invalid-data re-wrap
-    if (isRecord(valueAtPath) && looksLikeDataContainer(valueAtPath)) {
-      const discs = dataDiscriminatorKeys(valueAtPath, allowedDataDiscriminators);
-      if (discs.length > 1) {
-        return {
-          status: "done",
-          errors: [
-            {
-              code: "invalid-data",
-              path,
-              message: `Data mixes forms (${discs.map((d) => `"${d}"`).join(" and ")}); use exactly one of ${allowedDataFormsMessage}.`,
-              allowed: [...allowedDataDiscriminators],
-              fix: {
-                description: "Pick a single data form.",
-                example: { values: [{ x: 1, y: 2 }] },
-              },
-            },
-          ],
-        };
-      }
-      const presentFormKeys = allowedKeysForPresentDataForm(valueAtPath, allowedDataDiscriminators);
-      const formKeys = presentFormKeys ?? new Set(allowedDataDiscriminators);
-      if (hasActionableAddlNoise(group, formKeys)) {
-        return { status: "continue", activeFormKeys: formKeys };
-      }
-      // Nested path owns the diagnostic — empty done, not fall-through.
-      return { status: "done", errors: [] };
-    }
-    return {
-      status: "done",
-      errors: [
-        {
-          code: "invalid-data",
-          path,
-          message: `Data must be one of ${allowedDataFormsMessage}.`,
-          allowed: [...allowedDataDiscriminators],
-          fix: {
-            description: 'Wrap inline rows as {"values": [...]}.',
-            example: { values: [{ x: 1, y: 2 }] },
-          },
-        },
-      ],
-    };
+    return mapDataUnion(group, members, path, valueAtPath);
   }
 
-  // Prefer allowed values from the actual const errors TypeBox emitted —
-  // schemaPath resolution against Cyclic $defs can land on the wrong
-  // sibling union (e.g. scale type vs coord type both use `properties/type`).
+  return mapEnumUnion(anyOfErr, constErrs, members, hasObjectBranchNoise, valueAtPath, path, key);
+}
+
+function mapEnumUnion(
+  anyOfErr: TLocalizedValidationError | undefined,
+  constErrs: readonly TLocalizedValidationError[],
+  members: ReturnType<typeof unionMembers>,
+  hasObjectBranchNoise: boolean,
+  valueAtPath: unknown,
+  path: string,
+  key: string,
+): UnionPathResult {
   let allowed: string[] = [];
   if (constErrs.length > 0) {
     allowed = constErrs
@@ -266,7 +169,113 @@ export function mapUnionPathGroup(
       ],
     };
   }
-  // Mixed union with object-branch property noise: fall through to
-  // additionalProperties / required handlers below.
   return { status: "continue", activeFormKeys: null };
+}
+
+function mapChannelUnion(
+  group: readonly TLocalizedValidationError[],
+  path: string,
+  key: string,
+  valueAtPath: unknown,
+): UnionPathResult {
+  if (isRecord(valueAtPath) && looksLikeChannelForm(valueAtPath)) {
+    const discs = channelDiscriminatorKeys(valueAtPath);
+    if (discs.length > 1) {
+      return {
+        status: "done",
+        errors: [
+          {
+            code: "invalid-channel-value",
+            path,
+            message: `Channel "${key}" mixes forms (${discs.map((disc) => `"${disc}"`).join(" and ")}); use exactly one of {"field": ...}, {"value": ...}, or {"stat": ...}.`,
+            fix: {
+              description: `Pick a single channel form for "${key}".`,
+              example: CHANNEL_FIX_EXAMPLE,
+            },
+          },
+        ],
+      };
+    }
+    const formKeys = allowedKeysForPresentChannelForm(valueAtPath);
+    if (formKeys !== null && hasActionableAddlNoise(group, formKeys)) {
+      return { status: "continue", activeFormKeys: formKeys };
+    }
+    return { status: "done", errors: [] };
+  }
+  const bareString = typeof valueAtPath === "string";
+  return {
+    status: "done",
+    errors: [
+      {
+        code: "invalid-channel-value",
+        path,
+        message: bareString
+          ? `Channel "${key}" is the bare string ${JSON.stringify(valueAtPath)}; portable specs require the canonical form {"field": ${JSON.stringify(valueAtPath)}}.`
+          : `Channel "${key}" must be {"field": ...}, {"value": ...}, {"stat": ...}, or null.`,
+        fix: {
+          description: `Use a canonical channel form, e.g. {"field": "column_name"} to map "${key}" to a data column.`,
+          example: bareString ? { field: valueAtPath } : CHANNEL_FIX_EXAMPLE,
+        },
+      },
+    ],
+  };
+}
+
+function mapDataUnion(
+  group: readonly TLocalizedValidationError[],
+  members: ReturnType<typeof unionMembers>,
+  path: string,
+  valueAtPath: unknown,
+): UnionPathResult {
+  const allowed = dataDiscriminatorsForUnion(members, path);
+  const forms = allowed.map((discriminator) => {
+    if (discriminator === "values") return '{"values": [...rows]}';
+    if (discriminator === "columns") return '{"columns": {...arrays}}';
+    return '{"name": "dataset"}';
+  });
+  const formsMessage =
+    forms.length === 2
+      ? `${forms[0]} or ${forms[1]}`
+      : `${forms.slice(0, -1).join(", ")}, or ${forms.at(-1)}`;
+  if (isRecord(valueAtPath) && looksLikeDataContainer(valueAtPath)) {
+    const discs = dataDiscriminatorKeys(valueAtPath, allowed);
+    if (discs.length > 1) {
+      return {
+        status: "done",
+        errors: [
+          {
+            code: "invalid-data",
+            path,
+            message: `Data mixes forms (${discs.map((disc) => `"${disc}"`).join(" and ")}); use exactly one of ${formsMessage}.`,
+            allowed: [...allowed],
+            fix: {
+              description: "Pick a single data form.",
+              example: { values: [{ x: 1, y: 2 }] },
+            },
+          },
+        ],
+      };
+    }
+    const presentFormKeys = allowedKeysForPresentDataForm(valueAtPath, allowed);
+    const formKeys = presentFormKeys ?? new Set(allowed);
+    if (hasActionableAddlNoise(group, formKeys)) {
+      return { status: "continue", activeFormKeys: formKeys };
+    }
+    return { status: "done", errors: [] };
+  }
+  return {
+    status: "done",
+    errors: [
+      {
+        code: "invalid-data",
+        path,
+        message: `Data must be one of ${formsMessage}.`,
+        allowed: [...allowed],
+        fix: {
+          description: 'Wrap inline rows as {"values": [...]}.',
+          example: { values: [{ x: 1, y: 2 }] },
+        },
+      },
+    ],
+  };
 }

--- a/packages/spec/src/validate-structure-layer-ribbon.ts
+++ b/packages/spec/src/validate-structure-layer-ribbon.ts
@@ -37,19 +37,15 @@ export function ribbonStructuralErrors(
   const orientation: "x" | "y" | null =
     pinned === "x" || pinned === "y" ? pinned : xContract ? "x" : yContract ? "y" : null;
 
-  const needed: ChannelName[] =
+  const usesYContract =
     orientation === "y" ||
     (orientation === null &&
-      (mapped("y") !== undefined || mapped("xmin") !== undefined || mapped("xmax") !== undefined))
-      ? ["y", "xmin", "xmax"]
-      : orientation === "x" || orientation === null
-        ? ["x", "ymin", "ymax"]
-        : ["x", "ymin", "ymax"];
+      [mapped("y"), mapped("xmin"), mapped("xmax")].some((value) => value !== undefined));
+  const needed: ChannelName[] = usesYContract ? ["y", "xmin", "xmax"] : ["x", "ymin", "ymax"];
 
   for (const channel of needed) {
     if (mapped(channel) !== undefined) continue;
-    const suffix =
-      orientation === null ? "for its interval contract" : `with orientation "${orientation}"`;
+    const suffix = ribbonContractSuffix(orientation);
     pushMissingChannel(
       errors,
       layerPath,
@@ -58,4 +54,8 @@ export function ribbonStructuralErrors(
     );
   }
   return errors;
+}
+
+function ribbonContractSuffix(orientation: "x" | "y" | null): string {
+  return orientation === null ? "for its interval contract" : `with orientation "${orientation}"`;
 }

--- a/packages/spec/src/validate-structure-layer-rule.ts
+++ b/packages/spec/src/validate-structure-layer-rule.ts
@@ -39,13 +39,7 @@ export function ruleFamilyStructuralErrors(
   // Pre-normalize data-driven aliases: orthogonal axis is not part of the form.
   if (!intercepts && geom === "hline") x = undefined;
   if (!intercepts && geom === "vline") y = undefined;
-  const interceptHint =
-    geom === "hline"
-      ? "params.yintercept"
-      : geom === "vline"
-        ? "params.xintercept"
-        : "params.xintercept/yintercept";
-  const dataHint = geom === "hline" ? "aes.y" : geom === "vline" ? "aes.x" : "aes.x/aes.y";
+  const { interceptHint, dataHint } = ruleHints(geom);
   if (intercepts && (x !== undefined || y !== undefined)) {
     errors.push({
       code: "rule-form-ambiguous",
@@ -54,10 +48,7 @@ export function ruleFamilyStructuralErrors(
       fix: {
         description:
           "Remove the intercept params (data-driven form), or unset the position aes with null (annotation form).",
-        example:
-          geom === "vline"
-            ? { geom: "vline", params: { xintercept: 0 } }
-            : { geom: geom === "hline" ? "hline" : "rule", params: { yintercept: 0 } },
+        example: ruleExample(geom),
       },
     });
   } else if (!intercepts && x === undefined && y === undefined) {
@@ -66,16 +57,8 @@ export function ruleFamilyStructuralErrors(
       path: layerPath,
       message: `This ${geom} layer has neither fixed intercepts (${interceptHint}) nor a mapped ${dataHint} — nothing to draw.`,
       fix: {
-        description:
-          geom === "hline"
-            ? "Set params.yintercept for an annotation, or map aes.y for data-driven rules."
-            : geom === "vline"
-              ? "Set params.xintercept for an annotation, or map aes.x for data-driven rules."
-              : "Set params.yintercept (or xintercept) for an annotation, or map aes.x/aes.y to a field for data-driven rules.",
-        example:
-          geom === "vline"
-            ? { geom: "vline", params: { xintercept: 0 } }
-            : { geom: geom === "hline" ? "hline" : "rule", params: { yintercept: 0 } },
+        description: missingRuleDescription(geom),
+        example: ruleExample(geom),
       },
     });
   } else if (!intercepts && x !== undefined && y !== undefined) {
@@ -91,4 +74,25 @@ export function ruleFamilyStructuralErrors(
     });
   }
   return errors;
+}
+
+function ruleHints(geom: string): { interceptHint: string; dataHint: string } {
+  if (geom === "hline") return { interceptHint: "params.yintercept", dataHint: "aes.y" };
+  if (geom === "vline") return { interceptHint: "params.xintercept", dataHint: "aes.x" };
+  return { interceptHint: "params.xintercept/yintercept", dataHint: "aes.x/aes.y" };
+}
+
+function ruleExample(geom: string) {
+  if (geom === "vline") return { geom: "vline", params: { xintercept: 0 } };
+  return { geom: geom === "hline" ? "hline" : "rule", params: { yintercept: 0 } };
+}
+
+function missingRuleDescription(geom: string): string {
+  if (geom === "hline") {
+    return "Set params.yintercept for an annotation, or map aes.y for data-driven rules.";
+  }
+  if (geom === "vline") {
+    return "Set params.xintercept for an annotation, or map aes.x for data-driven rules.";
+  }
+  return "Set params.yintercept (or xintercept) for an annotation, or map aes.x/aes.y to a field for data-driven rules.";
 }

--- a/packages/spec/src/validate-structure-layers.ts
+++ b/packages/spec/src/validate-structure-layers.ts
@@ -20,6 +20,8 @@ import {
   pushMissingChannel,
 } from "./validate-structure-layer-shared.js";
 
+type MappedChannel = (channel: ChannelName) => ReturnType<typeof effectiveChannel>;
+
 /**
  * Channels every geom needs mapped (after plot-aes inheritance).
  * Total over GeomName — a missing geom is a type error, not a silent `?? []`
@@ -95,20 +97,7 @@ export function layerStructuralErrors(
   const isRuleFamily = geom === "rule" || geom === "hline" || geom === "vline";
   const annotationRule = isRuleFamily && hasGeomIntercepts(geom, layer);
 
-  for (const aesthetic of Object.keys(STYLE_AESTHETIC_GEOMS) as StyleAesthetic[]) {
-    const value = annotationRule ? (layerAes?.[aesthetic] ?? undefined) : mapped(aesthetic);
-    if (value === undefined) continue;
-    const compatible = STYLE_AESTHETIC_GEOMS[aesthetic] as readonly string[];
-    if (compatible.includes(geom)) continue;
-    errors.push({
-      code: "unsupported-geom-aesthetic",
-      path: `${layerPath}/aes/${aesthetic}`,
-      message: `The ${geom} geom does not consume aes.${aesthetic}; supported geoms: ${compatible.join(", ")}.`,
-      fix: {
-        description: `Remove aes.${aesthetic} or move it to a compatible ${compatible[0]} layer.`,
-      },
-    });
-  }
+  errors.push(...styleAestheticErrors(layerAes, geom, annotationRule, mapped, layerPath));
 
   if (isRuleFamily) {
     // Keep unsupported-geom-aesthetic errors already pushed above; rule form
@@ -124,215 +113,246 @@ export function layerStructuralErrors(
 
   errors.push(...computedYMappedErrors(geom, stat, layerPath, mapped));
 
-  if (
-    geom === "bar" ||
-    geom === "histogram" ||
-    geom === "freqpoly" ||
-    geom === "dotplot" ||
+  errors.push(
+    ...binAlignmentErrors(layer, geom, stat, layerPath),
+    ...intervalChannelErrors(geom, stat, layerPath, mapped),
+    ...(geom === "ribbon" ? ribbonStructuralErrors(layer, layerPath, mapped) : []),
+    ...statParameterErrors(layer, stat, layerPath),
+    ...spokeStructuralErrors(layer, geom, layerPath, mapped),
+    ...rugStructuralErrors(layer, geom, layerPath, mapped),
+    ...paintStructuralErrors(layer, layerPath, plotAes),
+    ...requiredChannelErrors(geom, stat, layerPath, mapped),
+  );
+  return errors;
+}
+
+function binAlignmentErrors(
+  layer: Record<string, unknown>,
+  geom: string,
+  stat: string,
+  layerPath: string,
+): SpecError[] {
+  const binnedGeom = ["bar", "histogram", "freqpoly", "dotplot"].includes(geom);
+  const binnedLayer =
+    binnedGeom ||
     (geom === "line" && (stat === "bin" || stat === "summary_bin")) ||
-    (geom === "point" && stat === "summary_bin") ||
-    (geom === "errorbar" && stat === "summary_bin") ||
+    ((geom === "point" || geom === "errorbar") && stat === "summary_bin") ||
     stat === "summary_bin" ||
-    stat === "bindot"
+    stat === "bindot";
+  if (!binnedLayer) return [];
+  const params = isRecord(layer["params"]) ? layer["params"] : {};
+  const binStat =
+    ["histogram", "freqpoly", "dotplot"].includes(geom) ||
+    ["bin", "summary_bin", "bindot"].includes(stat);
+  if (!binStat || params["center"] === undefined || params["boundary"] === undefined) return [];
+  return [
+    {
+      code: "bin-center-and-boundary",
+      path: `${layerPath}/params`,
+      message: `The ${stat === "summary_bin" ? "summary_bin" : "bin"} stat accepts params.center OR params.boundary (both align the bin grid), never both.`,
+      fix: {
+        description: "Keep one alignment parameter and remove the other.",
+        example: { params: { binwidth: 1, boundary: 0 } },
+      },
+    },
+  ];
+}
+
+function intervalChannelErrors(
+  geom: string,
+  stat: string,
+  layerPath: string,
+  mapped: MappedChannel,
+): SpecError[] {
+  if (!["errorbar", "linerange", "pointrange", "crossbar"].includes(geom)) return [];
+  const needed: ChannelName[] =
+    stat === "summary" || stat === "summary_bin"
+      ? ["y"]
+      : geom === "pointrange" || geom === "crossbar"
+        ? ["y", "ymin", "ymax"]
+        : ["ymin", "ymax"];
+  return needed.flatMap((channel) =>
+    mapped(channel) === undefined
+      ? [
+          {
+            code: "missing-required-channel" as const,
+            path: `${layerPath}/aes/${channel}`,
+            message: `The ${geom} geom with the ${stat} stat requires a "${channel}" channel; map it in the layer's aes or the plot-level aes.`,
+            fix: {
+              description: `Map "${channel}" to a data field.`,
+              example: { [channel]: CHANNEL_FIX_EXAMPLE },
+            },
+          },
+        ]
+      : [],
+  );
+}
+
+function statParameterErrors(
+  layer: Record<string, unknown>,
+  stat: string,
+  layerPath: string,
+): SpecError[] {
+  const errors: SpecError[] = [];
+  const params = isRecord(layer["params"]) ? layer["params"] : {};
+  const fun = params["fun"];
+  if (
+    ["summary", "summary_bin", "summary_rolling"].includes(stat) &&
+    (fun === "first" || fun === "last")
   ) {
-    const params = isRecord(layer["params"]) ? layer["params"] : {};
-    const binStat =
-      geom === "histogram" ||
-      geom === "freqpoly" ||
-      geom === "dotplot" ||
-      stat === "bin" ||
-      stat === "summary_bin" ||
-      stat === "bindot";
-    if (binStat && params["center"] !== undefined && params["boundary"] !== undefined) {
-      errors.push({
-        code: "bin-center-and-boundary",
-        path: `${layerPath}/params`,
-        message: `The ${stat === "summary_bin" ? "summary_bin" : "bin"} stat accepts params.center OR params.boundary (both align the bin grid), never both.`,
-        fix: {
-          description: "Keep one alignment parameter and remove the other.",
-          example: { params: { binwidth: 1, boundary: 0 } },
-        },
-      });
+    errors.push({
+      code: "summary-fun-unsupported",
+      path: `${layerPath}/params/fun`,
+      message: `The ${stat} stat summarizes with the registry funs mean|median|sum|min|max; params.fun "${fun}" is a manual-stat keep transform and has no meaning here.`,
+      fix: {
+        description:
+          "Use mean, median, or sum for the center summary (min/max via funMin/funMax where supported).",
+        example: { params: { fun: "median" } },
+      },
+    });
+  }
+  const window = params["window"];
+  if (stat === "summary_rolling" && (window === undefined || window === null || window === "")) {
+    errors.push({
+      code: "summary-rolling-window-required",
+      path: `${layerPath}/params/window`,
+      message:
+        "The summary_rolling stat requires params.window (rolling-window width in x data units, greater than 0). There is no silent default width.",
+      fix: {
+        description:
+          "Set params.window to the window width in x units (e.g. 30 for a 30-year running summary).",
+        example: { params: { window: 30 } },
+      },
+    });
+  }
+  if (stat === "manual" && (fun === undefined || fun === null || fun === "")) {
+    errors.push({
+      code: "manual-fun-required",
+      path: `${layerPath}/params/fun`,
+      message:
+        "The manual stat requires params.fun (one of first|last|mean|median|min|max|sum). There is no silent identity default (ggplot2 divergence; #814).",
+      fix: {
+        description: "Set params.fun to a registered portable transform name.",
+        example: { params: { fun: "mean" } },
+      },
+    });
+  }
+  return errors;
+}
+
+function spokeStructuralErrors(
+  layer: Record<string, unknown>,
+  geom: string,
+  layerPath: string,
+  mapped: MappedChannel,
+): SpecError[] {
+  if (geom !== "spoke") return [];
+  const errors: SpecError[] = [];
+  const params = isRecord(layer["params"]) ? layer["params"] : {};
+  for (const channel of ["angle", "radius"] as const) {
+    const fromAes = mapped(channel);
+    const fromParams = params[channel];
+    if (fromAes === undefined && fromParams === undefined) {
+      errors.push(spokeChannelError(channel, layerPath, false));
+    }
+    if (fromAes !== undefined && !("field" in fromAes) && fromParams === undefined) {
+      errors.push(spokeChannelError(channel, layerPath, true));
     }
   }
+  return errors;
+}
 
-  if (geom === "errorbar" || geom === "linerange" || geom === "pointrange" || geom === "crossbar") {
-    const needed: ChannelName[] =
-      stat === "summary" || stat === "summary_bin"
-        ? ["y"]
-        : geom === "pointrange" || geom === "crossbar"
-          ? ["y", "ymin", "ymax"]
-          : ["ymin", "ymax"];
-    for (const channel of needed) {
-      if (mapped(channel) === undefined) {
-        errors.push({
-          code: "missing-required-channel",
-          path: `${layerPath}/aes/${channel}`,
-          message: `The ${geom} geom with the ${stat} stat requires a "${channel}" channel; map it in the layer's aes or the plot-level aes.`,
-          fix: {
-            description: `Map "${channel}" to a data field.`,
-            example: { [channel]: CHANNEL_FIX_EXAMPLE },
-          },
-        });
-      }
-    }
+function spokeChannelError(
+  channel: "angle" | "radius",
+  layerPath: string,
+  invalidAesConstant: boolean,
+): SpecError {
+  const message = invalidAesConstant
+    ? `The spoke geom requires aes.${channel} to map a data field (not a constant or stat). Use params.${channel} for a fixed value.`
+    : `The spoke geom requires "${channel}" via aes.${channel} or params.${channel}.`;
+  return {
+    code: "missing-required-channel",
+    path: `${layerPath}/aes/${channel}`,
+    message,
+    fix: {
+      description: `Map aes.${channel} to a field, or set params.${channel} to a constant.`,
+      example:
+        channel === "angle"
+          ? { geom: "spoke", params: { angle: 0, radius: 1 } }
+          : { geom: "spoke", params: { radius: 1, angle: 0 } },
+    },
+  };
+}
+
+function rugStructuralErrors(
+  layer: Record<string, unknown>,
+  geom: string,
+  layerPath: string,
+  mapped: MappedChannel,
+): SpecError[] {
+  if (geom !== "rug") return [];
+  const errors: SpecError[] = [];
+  const params = isRecord(layer["params"]) ? layer["params"] : {};
+  const sides = typeof params["sides"] === "string" ? params["sides"] : "bl";
+  if (/[bt]/.test(sides) && mapped("x") === undefined) {
+    pushMissingChannel(
+      errors,
+      layerPath,
+      "x",
+      `The rug geom with sides "${sides}" requires an "x" channel for bottom/top ticks; map aes.x or narrow params.sides.`,
+    );
   }
-
-  if (geom === "ribbon") {
-    errors.push(...ribbonStructuralErrors(layer, layerPath, mapped));
+  if (/[lr]/.test(sides) && mapped("y") === undefined) {
+    pushMissingChannel(
+      errors,
+      layerPath,
+      "y",
+      `The rug geom with sides "${sides}" requires a "y" channel for left/right ticks; map aes.y or narrow params.sides.`,
+    );
   }
+  return errors;
+}
 
-  if (stat === "summary" || stat === "summary_bin" || stat === "summary_rolling") {
-    const params = isRecord(layer["params"]) ? layer["params"] : {};
-    const fun = params["fun"];
-    // first|last are stat manual's row-keep transforms. The point/line params
-    // union admits them for every stat, and core's summary registry does not
-    // implement them — they must fail here, not silently summarize as max.
-    if (fun === "first" || fun === "last") {
-      errors.push({
-        code: "summary-fun-unsupported",
-        path: `${layerPath}/params/fun`,
-        message: `The ${stat} stat summarizes with the registry funs mean|median|sum|min|max; params.fun "${fun}" is a manual-stat keep transform and has no meaning here.`,
-        fix: {
-          description:
-            "Use mean, median, or sum for the center summary (min/max via funMin/funMax where supported).",
-          example: { params: { fun: "median" } },
-        },
-      });
-    }
+function styleAestheticErrors(
+  layerAes: Aes | undefined,
+  geom: string,
+  annotationRule: boolean,
+  mapped: MappedChannel,
+  layerPath: string,
+): SpecError[] {
+  const errors: SpecError[] = [];
+  for (const aesthetic of Object.keys(STYLE_AESTHETIC_GEOMS) as StyleAesthetic[]) {
+    const value = annotationRule ? (layerAes?.[aesthetic] ?? undefined) : mapped(aesthetic);
+    if (value === undefined) continue;
+    const compatible = STYLE_AESTHETIC_GEOMS[aesthetic] as readonly string[];
+    if (compatible.includes(geom)) continue;
+    errors.push({
+      code: "unsupported-geom-aesthetic",
+      path: `${layerPath}/aes/${aesthetic}`,
+      message: `The ${geom} geom does not consume aes.${aesthetic}; supported geoms: ${compatible.join(", ")}.`,
+      fix: {
+        description: `Remove aes.${aesthetic} or move it to a compatible ${compatible[0]} layer.`,
+      },
+    });
   }
+  return errors;
+}
 
-  if (stat === "summary_rolling") {
-    const params = isRecord(layer["params"]) ? layer["params"] : {};
-    const window = params["window"];
-    // Non-number / non-positive windows are rejected by the schema type.
-    if (window === undefined || window === null || window === "") {
-      errors.push({
-        code: "summary-rolling-window-required",
-        path: `${layerPath}/params/window`,
-        message:
-          "The summary_rolling stat requires params.window (rolling-window width in x data units, greater than 0). There is no silent default width.",
-        fix: {
-          description:
-            "Set params.window to the window width in x units (e.g. 30 for a 30-year running summary).",
-          example: { params: { window: 30 } },
-        },
-      });
-    }
-  }
-
-  if (stat === "manual") {
-    const params = isRecord(layer["params"]) ? layer["params"] : {};
-    const fun = params["fun"];
-    // Unknown names are rejected by the schema enum as invalid-enum-value.
-    if (fun === undefined || fun === null || fun === "") {
-      errors.push({
-        code: "manual-fun-required",
-        path: `${layerPath}/params/fun`,
-        message:
-          "The manual stat requires params.fun (one of first|last|mean|median|min|max|sum). There is no silent identity default (ggplot2 divergence; #814).",
-        fix: {
-          description: "Set params.fun to a registered portable transform name.",
-          example: { params: { fun: "mean" } },
-        },
-      });
-    }
-  }
-
-  if (geom === "spoke") {
-    const params = isRecord(layer["params"]) ? layer["params"] : {};
-    for (const channel of ["angle", "radius"] as const) {
-      const fromAes = mapped(channel);
-      const fromParams = params[channel];
-      if (fromAes === undefined && fromParams === undefined) {
-        errors.push({
-          code: "missing-required-channel",
-          path: `${layerPath}/aes/${channel}`,
-          message: `The spoke geom requires "${channel}" via aes.${channel} or params.${channel}.`,
-          fix: {
-            description: `Map aes.${channel} to a field, or set params.${channel} to a constant.`,
-            example:
-              channel === "angle"
-                ? { geom: "spoke", params: { angle: 0, radius: 1 } }
-                : { geom: "spoke", params: { radius: 1, angle: 0 } },
-          },
-        });
-      }
-      // Runtime only materializes field angle/radius (checkField); aes constants
-      // would pass validation then throw in requireField — reject early. Prefer
-      // params.angle / params.radius for constants (ggplot2-compatible).
-      if (fromAes !== undefined && !("field" in fromAes) && fromParams === undefined) {
-        errors.push({
-          code: "missing-required-channel",
-          path: `${layerPath}/aes/${channel}`,
-          message: `The spoke geom requires aes.${channel} to map a data field (not a constant or stat). Use params.${channel} for a fixed value.`,
-          fix: {
-            description: `Map aes.${channel} to a field, or set params.${channel} to a constant.`,
-            example:
-              channel === "angle"
-                ? { geom: "spoke", params: { angle: 0, radius: 1 } }
-                : { geom: "spoke", params: { radius: 1, angle: 0 } },
-          },
-        });
-      }
-    }
-  }
-
-  if (geom === "rug") {
-    const params = isRecord(layer["params"]) ? layer["params"] : {};
-    const sides = typeof params["sides"] === "string" ? params["sides"] : "bl";
-    if (/[bt]/.test(sides) && mapped("x") === undefined) {
-      pushMissingChannel(
-        errors,
-        layerPath,
-        "x",
-        `The rug geom with sides "${sides}" requires an "x" channel for bottom/top ticks; map aes.x or narrow params.sides.`,
-      );
-    }
-    if (/[lr]/.test(sides) && mapped("y") === undefined) {
-      pushMissingChannel(
-        errors,
-        layerPath,
-        "y",
-        `The rug geom with sides "${sides}" requires a "y" channel for left/right ticks; map aes.y or narrow params.sides.`,
-      );
-    }
-  }
-
-  errors.push(...paintStructuralErrors(layer, layerPath, plotAes));
-
+function requiredChannelErrors(
+  geom: string,
+  stat: string,
+  layerPath: string,
+  mapped: MappedChannel,
+): SpecError[] {
+  const errors: SpecError[] = [];
   for (const channel of REQUIRED_CHANNELS[geom as GeomName]) {
-    if (
-      (geom === "bar" ||
-        geom === "histogram" ||
-        geom === "freqpoly" ||
-        geom === "density" ||
-        geom === "dotplot" ||
-        (geom === "line" && stat === "bin")) &&
-      channel !== "x"
-    ) {
-      continue;
-    }
+    if (computedPositionChannel(geom, stat, channel)) continue;
     const value = mapped(channel);
     if (value === undefined) {
-      errors.push({
-        code: "missing-required-channel",
-        path: `${layerPath}/aes/${channel}`,
-        message: `The ${geom} geom requires a "${channel}" channel; map it in the layer's aes or the plot-level aes.`,
-        fix: {
-          description: `Map "${channel}" to a data field.`,
-          example: { [channel]: CHANNEL_FIX_EXAMPLE },
-        },
-      });
+      errors.push(missingChannelError(geom, layerPath, channel));
       continue;
     }
-    // Segment/curve runtime only materializes field endpoints (checkField);
-    // constants/stat mappings would pass validation then throw in requireField.
-    if (
-      (geom === "segment" || geom === "curve") &&
-      (channel === "x" || channel === "y" || channel === "xend" || channel === "yend") &&
-      !("field" in value)
-    ) {
+    if (requiresFieldMapping(geom, channel) && !("field" in value)) {
       errors.push({
         code: "missing-required-channel",
         path: `${layerPath}/aes/${channel}`,
@@ -343,18 +363,34 @@ export function layerStructuralErrors(
         },
       });
     }
-    // Spoke origin x/y are field-only in the pipeline (same requireField path).
-    if (geom === "spoke" && (channel === "x" || channel === "y") && !("field" in value)) {
-      errors.push({
-        code: "missing-required-channel",
-        path: `${layerPath}/aes/${channel}`,
-        message: `The spoke geom requires aes.${channel} to map a data field (not a constant or stat).`,
-        fix: {
-          description: `Map "${channel}" to a data field.`,
-          example: { [channel]: CHANNEL_FIX_EXAMPLE },
-        },
-      });
-    }
   }
   return errors;
+}
+
+function computedPositionChannel(geom: string, stat: string, channel: ChannelName): boolean {
+  if (channel === "x") return false;
+  return (
+    ["bar", "histogram", "freqpoly", "density", "dotplot"].includes(geom) ||
+    (geom === "line" && stat === "bin")
+  );
+}
+
+function requiresFieldMapping(geom: string, channel: ChannelName): boolean {
+  const endpoint = channel === "x" || channel === "y" || channel === "xend" || channel === "yend";
+  return (
+    ((geom === "segment" || geom === "curve") && endpoint) ||
+    (geom === "spoke" && (channel === "x" || channel === "y"))
+  );
+}
+
+function missingChannelError(geom: string, layerPath: string, channel: ChannelName): SpecError {
+  return {
+    code: "missing-required-channel",
+    path: `${layerPath}/aes/${channel}`,
+    message: `The ${geom} geom requires a "${channel}" channel; map it in the layer's aes or the plot-level aes.`,
+    fix: {
+      description: `Map "${channel}" to a data field.`,
+      example: { [channel]: CHANNEL_FIX_EXAMPLE },
+    },
+  };
 }

--- a/packages/spec/src/validate-structure-layers.ts
+++ b/packages/spec/src/validate-structure-layers.ts
@@ -111,9 +111,8 @@ export function layerStructuralErrors(
       ? layer["stat"]
       : (GEOM_DEFAULTS[geom as keyof typeof GEOM_DEFAULTS]?.stat ?? "identity");
 
-  errors.push(...computedYMappedErrors(geom, stat, layerPath, mapped));
-
   errors.push(
+    ...computedYMappedErrors(geom, stat, layerPath, mapped),
     ...binAlignmentErrors(layer, geom, stat, layerPath),
     ...intervalChannelErrors(geom, stat, layerPath, mapped),
     ...(geom === "ribbon" ? ribbonStructuralErrors(layer, layerPath, mapped) : []),

--- a/packages/spec/src/validate-structure-scales.ts
+++ b/packages/spec/src/validate-structure-scales.ts
@@ -40,27 +40,15 @@ export function guideStructuralErrors(
     if (!isRecord(guide) || typeof guide["type"] !== "string") return;
     const type = guide["type"];
     if (type === "none") return;
-    const positional = aesthetic === "x" || aesthetic === "y";
     const scale = isRecord(scales?.[aesthetic]) ? scales?.[aesthetic] : undefined;
     const scaleType = scale?.["type"];
-    const valid = positional
-      ? type === "axis"
-      : aesthetic === "color" || aesthetic === "fill"
-        ? (type === "legend" && scaleType !== "sequential" && scaleType !== "binned") ||
-          (type === "colorbar" && (scaleType === undefined || scaleType === "sequential")) ||
-          (type === "colorsteps" && scaleType === "binned")
-        : type === "legend";
-    if (valid) return;
+    if (guideIsValid(aesthetic, type, scaleType)) return;
     errors.push({
       code: "guide-aesthetic-incompatible",
       path,
       message: `The ${type} guide is incompatible with the ${aesthetic} aesthetic${typeof scaleType === "string" ? ` using a ${scaleType} scale` : ""}.`,
       fix: {
-        description: positional
-          ? 'Use { type: "axis" } or { type: "none" } for positional aesthetics.'
-          : aesthetic === "color" || aesthetic === "fill"
-            ? "Use legend for discrete colors, colorbar for sequential colors, colorsteps for binned colors, or none."
-            : 'Use { type: "legend" } or { type: "none" } for mapped style aesthetics.',
+        description: guideFixDescription(aesthetic),
       },
     });
   };
@@ -74,6 +62,24 @@ export function guideStructuralErrors(
   return errors;
 }
 
+function guideIsValid(aesthetic: string, type: string, scaleType: unknown): boolean {
+  if (aesthetic === "x" || aesthetic === "y") return type === "axis";
+  if (aesthetic !== "color" && aesthetic !== "fill") return type === "legend";
+  if (type === "legend") return scaleType !== "sequential" && scaleType !== "binned";
+  if (type === "colorbar") return scaleType === undefined || scaleType === "sequential";
+  return type === "colorsteps" && scaleType === "binned";
+}
+
+function guideFixDescription(aesthetic: string): string {
+  if (aesthetic === "x" || aesthetic === "y") {
+    return 'Use { type: "axis" } or { type: "none" } for positional aesthetics.';
+  }
+  if (aesthetic === "color" || aesthetic === "fill") {
+    return "Use legend for discrete colors, colorbar for sequential colors, colorsteps for binned colors, or none.";
+  }
+  return 'Use { type: "legend" } or { type: "none" } for mapped style aesthetics.';
+}
+
 /** Named color schemes must match the configured color scale family. */
 export function colorScaleStructuralErrors(scales: Record<string, unknown>): SpecError[] {
   const errors: SpecError[] = [];
@@ -82,92 +88,9 @@ export function colorScaleStructuralErrors(scales: Record<string, unknown>): Spe
     if (!isRecord(scale)) continue;
     const type = scale["type"];
     const scheme = scale["scheme"];
-    // range must be an array when present (schema shape; kept TypeBox-free for render).
-    if ("range" in scale && scale["range"] !== undefined && !Array.isArray(scale["range"])) {
-      errors.push({
-        code: "invalid-type",
-        path: `/scales/${channel}/range`,
-        message: `scales.${channel}.range must be an array of colors (got ${typeof scale["range"]}).`,
-        fix: {
-          description: "Provide range as a JSON array of #rgb/#rrggbb colors.",
-          example: ["#f00", "#0f0", "#00f"],
-        },
-      });
-    }
-    if (type === "binned" && scale["oob"] === "wrap") {
-      errors.push({
-        code: "scale-scheme-oob",
-        path: `/scales/${channel}/oob`,
-        message: `The binned ${channel} scale cannot use wrap out-of-bounds.`,
-        fix: {
-          description: 'Use "censor" or "squish" on binned color scales.',
-          example: "censor",
-        },
-      });
-    }
+    addBasicColorScaleErrors(errors, scale, channel, type);
 
-    if (typeof scheme === "string" && CYCLIC_SCHEMES.has(scheme)) {
-      if (type !== undefined && type !== "sequential") {
-        const typeLabel = typeof type === "string" ? type : "this";
-        errors.push({
-          code: "scale-scheme-type",
-          path: `/scales/${channel}/scheme`,
-          message: `The cyclic scheme "${scheme}" cannot be used with a ${typeLabel} color scale.`,
-          fix: {
-            description: 'Use type "sequential" with an explicit domain period and oob "wrap".',
-            example: "sequential",
-          },
-        });
-      }
-      if (scale["oob"] === "censor" || scale["oob"] === "squish") {
-        errors.push({
-          code: "scale-scheme-oob",
-          path: `/scales/${channel}/oob`,
-          message: `The cyclic scheme "${scheme}" requires wrap out-of-bounds.`,
-          fix: {
-            description: 'Set oob to "wrap", or omit it (cyclic schemes default to wrap).',
-            example: "wrap",
-          },
-        });
-      }
-      if (!Array.isArray(scale["domain"]) || scale["domain"].length !== 2) {
-        errors.push({
-          code: "scale-cyclic-domain",
-          path: `/scales/${channel}/domain`,
-          message: `The cyclic scheme "${scheme}" requires an explicit two-value domain period.`,
-          fix: {
-            description: "Set domain to one period, for example [0, 360] for degrees.",
-            example: [0, 360],
-          },
-        });
-      }
-      if (scale["range"] !== undefined) {
-        errors.push({
-          code: "scale-scheme-type",
-          path: `/scales/${channel}/range`,
-          message: `The cyclic scheme "${scheme}" cannot be combined with an explicit range.`,
-          fix: {
-            description: "Remove range and keep the named cyclic scheme, or drop the scheme.",
-          },
-        });
-      }
-      const cyclicTransform = scale["transform"];
-      const cyclicTemporal = scale["temporalKind"] !== undefined || scale["parse"] !== undefined;
-      if (
-        (typeof cyclicTransform === "string" && cyclicTransform !== "identity") ||
-        cyclicTemporal
-      ) {
-        errors.push({
-          code: "scale-type-transform-conflict",
-          path: `/scales/${channel}/transform`,
-          message: `The cyclic scheme "${scheme}" cannot apply a transform or temporal parser.`,
-          fix: {
-            description: "Remove transform and temporal options. Wrap in semantic space only.",
-            example: "identity",
-          },
-        });
-      }
-    }
+    addCyclicScaleErrors(errors, scale, channel, type, scheme);
 
     if (
       (type === "sequential" || type === "binned") &&
@@ -217,38 +140,139 @@ export function colorScaleStructuralErrors(scales: Record<string, unknown>): Spe
       });
     }
 
-    const range = scale["range"];
-    const domain = scale["domain"];
-    if (
-      type === "manual" &&
-      Array.isArray(domain) &&
-      Array.isArray(range) &&
-      domain.length !== range.length
-    ) {
-      errors.push({
-        code: "color-manual-domain-range",
-        path: `/scales/${channel}`,
-        message: `The manual ${channel} scale has ${String(domain.length)} domain values but ${String(range.length)} range colors.`,
-        fix: {
-          description: "Provide exactly one range color for each explicit domain value.",
-        },
-      });
-    }
-
-    if (!Array.isArray(range)) continue;
-    for (let index = 0; index < range.length; index++) {
-      const color: unknown = range[index];
-      if (typeof color !== "string" || /^#(?:[0-9a-f]{3}|[0-9a-f]{6})$/i.test(color)) continue;
-      errors.push({
-        code: "scale-range-color",
-        path: `/scales/${channel}/range/${index}`,
-        message: `The color stop "${color}" is not a supported hex color.`,
-        fix: {
-          description: "Use #rgb or #rrggbb syntax for custom color ranges.",
-          example: "#ff0000",
-        },
-      });
-    }
+    addColorRangeErrors(errors, scale, channel, type);
   }
   return errors;
+}
+
+function addBasicColorScaleErrors(
+  errors: SpecError[],
+  scale: Record<string, unknown>,
+  channel: "color" | "fill",
+  type: unknown,
+): void {
+  if ("range" in scale && scale["range"] !== undefined && !Array.isArray(scale["range"])) {
+    errors.push({
+      code: "invalid-type",
+      path: `/scales/${channel}/range`,
+      message: `scales.${channel}.range must be an array of colors (got ${typeof scale["range"]}).`,
+      fix: {
+        description: "Provide range as a JSON array of #rgb/#rrggbb colors.",
+        example: ["#f00", "#0f0", "#00f"],
+      },
+    });
+  }
+  if (type === "binned" && scale["oob"] === "wrap") {
+    errors.push({
+      code: "scale-scheme-oob",
+      path: `/scales/${channel}/oob`,
+      message: `The binned ${channel} scale cannot use wrap out-of-bounds.`,
+      fix: {
+        description: 'Use "censor" or "squish" on binned color scales.',
+        example: "censor",
+      },
+    });
+  }
+}
+
+function addCyclicScaleErrors(
+  errors: SpecError[],
+  scale: Record<string, unknown>,
+  channel: "color" | "fill",
+  type: unknown,
+  scheme: unknown,
+): void {
+  if (typeof scheme !== "string" || !CYCLIC_SCHEMES.has(scheme)) return;
+  if (type !== undefined && type !== "sequential") {
+    const typeLabel = typeof type === "string" ? type : "this";
+    errors.push({
+      code: "scale-scheme-type",
+      path: `/scales/${channel}/scheme`,
+      message: `The cyclic scheme "${scheme}" cannot be used with a ${typeLabel} color scale.`,
+      fix: {
+        description: 'Use type "sequential" with an explicit domain period and oob "wrap".',
+        example: "sequential",
+      },
+    });
+  }
+  if (scale["oob"] === "censor" || scale["oob"] === "squish") {
+    errors.push({
+      code: "scale-scheme-oob",
+      path: `/scales/${channel}/oob`,
+      message: `The cyclic scheme "${scheme}" requires wrap out-of-bounds.`,
+      fix: {
+        description: 'Set oob to "wrap", or omit it (cyclic schemes default to wrap).',
+        example: "wrap",
+      },
+    });
+  }
+  if (!Array.isArray(scale["domain"]) || scale["domain"].length !== 2) {
+    errors.push({
+      code: "scale-cyclic-domain",
+      path: `/scales/${channel}/domain`,
+      message: `The cyclic scheme "${scheme}" requires an explicit two-value domain period.`,
+      fix: {
+        description: "Set domain to one period, for example [0, 360] for degrees.",
+        example: [0, 360],
+      },
+    });
+  }
+  if (scale["range"] !== undefined) {
+    errors.push({
+      code: "scale-scheme-type",
+      path: `/scales/${channel}/range`,
+      message: `The cyclic scheme "${scheme}" cannot be combined with an explicit range.`,
+      fix: { description: "Remove range and keep the named cyclic scheme, or drop the scheme." },
+    });
+  }
+  const transform = scale["transform"];
+  const temporal = scale["temporalKind"] !== undefined || scale["parse"] !== undefined;
+  if ((typeof transform === "string" && transform !== "identity") || temporal) {
+    errors.push({
+      code: "scale-type-transform-conflict",
+      path: `/scales/${channel}/transform`,
+      message: `The cyclic scheme "${scheme}" cannot apply a transform or temporal parser.`,
+      fix: {
+        description: "Remove transform and temporal options. Wrap in semantic space only.",
+        example: "identity",
+      },
+    });
+  }
+}
+
+function addColorRangeErrors(
+  errors: SpecError[],
+  scale: Record<string, unknown>,
+  channel: "color" | "fill",
+  type: unknown,
+): void {
+  const range = scale["range"];
+  const domain = scale["domain"];
+  if (
+    type === "manual" &&
+    Array.isArray(domain) &&
+    Array.isArray(range) &&
+    domain.length !== range.length
+  ) {
+    errors.push({
+      code: "color-manual-domain-range",
+      path: `/scales/${channel}`,
+      message: `The manual ${channel} scale has ${String(domain.length)} domain values but ${String(range.length)} range colors.`,
+      fix: { description: "Provide exactly one range color for each explicit domain value." },
+    });
+  }
+  if (!Array.isArray(range)) return;
+  for (let index = 0; index < range.length; index++) {
+    const color: unknown = range[index];
+    if (typeof color !== "string" || /^#(?:[0-9a-f]{3}|[0-9a-f]{6})$/i.test(color)) continue;
+    errors.push({
+      code: "scale-range-color",
+      path: `/scales/${channel}/range/${index}`,
+      message: `The color stop "${color}" is not a supported hex color.`,
+      fix: {
+        description: "Use #rgb or #rrggbb syntax for custom color ranges.",
+        example: "#ff0000",
+      },
+    });
+  }
 }

--- a/packages/spec/src/validate.ts
+++ b/packages/spec/src/validate.ts
@@ -135,11 +135,12 @@ export function validate(input: unknown, options?: ValidateOptions): ValidateRes
     // specs remain composable.
     // Eligibility: record layers with a known geom whose branch is valid
     // (see branchOkLayers above). Uses shared GEOM_BRANCHES for known-geom keys.
-    errors.push(...collectLayerGrammarErrors(input, options, branchOkLayers));
-
     // --- tier 2 (opt-in): facet form rules --------------------------------------
     // Runs for any record-valued facet, even when the facet is schema-invalid.
-    errors.push(...collectFacetGrammarErrors(input, options));
+    errors.push(
+      ...collectLayerGrammarErrors(input, options, branchOkLayers),
+      ...collectFacetGrammarErrors(input, options),
+    );
 
     // --- tier 2 (opt-in): data-aware checks + optional lint --------------------
     // One resolveLayerFieldEvidence pass for plot + layer tables; dataChecks and

--- a/packages/spec/src/validate.ts
+++ b/packages/spec/src/validate.ts
@@ -135,40 +135,17 @@ export function validate(input: unknown, options?: ValidateOptions): ValidateRes
     // specs remain composable.
     // Eligibility: record layers with a known geom whose branch is valid
     // (see branchOkLayers above). Uses shared GEOM_BRANCHES for known-geom keys.
-    if (options !== undefined && isRecord(input) && Array.isArray(input["layers"])) {
-      const plotAes = isRecord(input["aes"]) ? (input["aes"] as Aes) : undefined;
-      const layers = input["layers"] as unknown[];
-      for (let i = 0; i < layers.length; i++) {
-        const layer = layers[i];
-        if (!isRecord(layer)) continue;
-        const geom = layer["geom"];
-        // Own-key check, as in validate-schema-shape: `in` walks the prototype
-        // chain, so a geom named "constructor" would look like a known key.
-        if (typeof geom !== "string" || !Object.hasOwn(GEOM_BRANCHES, geom)) continue;
-        if (branchOkLayers !== "all" && !branchOkLayers.has(i)) continue;
-        errors.push(...layerStructuralErrors(layer, geom, i, plotAes));
-      }
-    }
+    errors.push(...collectLayerGrammarErrors(input, options, branchOkLayers));
 
     // --- tier 2 (opt-in): facet form rules --------------------------------------
     // Runs for any record-valued facet, even when the facet is schema-invalid.
-    if (options !== undefined && isRecord(input) && isRecord(input["facet"])) {
-      errors.push(...facetStructuralErrors(input["facet"]));
-    }
+    errors.push(...collectFacetGrammarErrors(input, options));
 
     // --- tier 2 (opt-in): data-aware checks + optional lint --------------------
     // One resolveLayerFieldEvidence pass for plot + layer tables; dataChecks and
     // lintSpec share it. On limit/profile errors, lint gets no shared map so it
     // does not re-scan data that data-aware validation already refused.
-    let advisories: SpecAdvisory[] | undefined;
-    if (options !== undefined && isRecord(input)) {
-      const layerResolved = resolveLayerFieldEvidence(input, options, limits);
-      errors.push(...dataChecks(input, options, limits, layerResolved));
-      if (options.lint === true) {
-        const shared = layerResolved.status === "ok" ? layerResolved.plot : null;
-        advisories = lintSpec(input, options, shared);
-      }
-    }
+    const advisories = collectDataValidation(input, options, limits, errors);
     const withAdvisories = advisories !== undefined && advisories.length > 0 ? { advisories } : {};
 
     if (errors.length > limits.maxDiagnostics) {
@@ -189,4 +166,46 @@ export function validate(input: unknown, options?: ValidateOptions): ValidateRes
       exactOptionalPropertyTypes: previousExactOptional,
     });
   }
+}
+
+function collectLayerGrammarErrors(
+  input: unknown,
+  options: ValidateOptions | undefined,
+  branchOkLayers: ReadonlySet<number> | "all",
+): SpecError[] {
+  if (options === undefined || !isRecord(input) || !Array.isArray(input["layers"])) return [];
+  const errors: SpecError[] = [];
+  const plotAes = isRecord(input["aes"]) ? (input["aes"] as Aes) : undefined;
+  const layers = input["layers"] as unknown[];
+  for (let index = 0; index < layers.length; index++) {
+    const layer = layers[index];
+    if (!isRecord(layer)) continue;
+    const geom = layer["geom"];
+    if (typeof geom !== "string" || !Object.hasOwn(GEOM_BRANCHES, geom)) continue;
+    if (branchOkLayers !== "all" && !branchOkLayers.has(index)) continue;
+    errors.push(...layerStructuralErrors(layer, geom, index, plotAes));
+  }
+  return errors;
+}
+
+function collectFacetGrammarErrors(
+  input: unknown,
+  options: ValidateOptions | undefined,
+): SpecError[] {
+  if (options === undefined || !isRecord(input) || !isRecord(input["facet"])) return [];
+  return facetStructuralErrors(input["facet"]);
+}
+
+function collectDataValidation(
+  input: unknown,
+  options: ValidateOptions | undefined,
+  limits: typeof DEFAULT_VALIDATE_LIMITS,
+  errors: SpecError[],
+): SpecAdvisory[] | undefined {
+  if (options === undefined || !isRecord(input)) return undefined;
+  const layerResolved = resolveLayerFieldEvidence(input, options, limits);
+  errors.push(...dataChecks(input, options, limits, layerResolved));
+  if (options.lint !== true) return undefined;
+  const shared = layerResolved.status === "ok" ? layerResolved.plot : null;
+  return lintSpec(input, options, shared);
 }


### PR DESCRIPTION
## Summary
- refactor spec normalization, temporal parsing, reference classification, and validation into focused helpers
- preserve diagnostic ordering and validation behavior while bringing every spec function under cyclomatic complexity 20
- remove the `packages/spec/**` Oxlint complexity exemption

## Verification
- `bun run lint`
- `bun run check`
- `bun test ./packages/spec/tests` (771 pass)
- `bun run test` (5068 pass, 4 skip)
- `pre-commit run --all-files` (twice)
- Oxlint spec complexity inventory: 0

## Performance gate
- ran two post-change 40-workload benchmark samples
- investigated a stale-baseline slowdown with a contemporaneous detached-main A/B
- contemporaneous result split evenly: 20 workloads faster, 20 slower, with large bidirectional host-noise outliers; no coherent regression