### PR TITLE
refactor(svelte): enforce complexity limit

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -49,10 +49,10 @@
   },
   "overrides": [
     {
-      // Staged rollout inventory (2026-08-29): svelte 11, core 122.
+      // Staged rollout inventory (2026-08-29): core 122.
       // apps/docs, examples, scripts, tests, packages/spec, packages/cli,
       // packages/skill, and benchmarks pass and use the global rule.
-      "files": ["packages/svelte/**", "packages/core/**"],
+      "files": ["packages/core/**"],
       "rules": {
         "eslint/complexity": "off"
       }

--- a/packages/svelte/src/lib/codemod/migrate-plot-props.ts
+++ b/packages/svelte/src/lib/codemod/migrate-plot-props.ts
@@ -76,6 +76,89 @@ export interface MigrationResult {
  */
 const RULES: Readonly<Record<string, PropRule>> = grammarCodemodRules();
 
+type MigrationAccumulator = {
+  readonly edits: Edit[];
+  readonly changes: PropChange[];
+  readonly skipped: PropSkip[];
+  readonly needed: Set<string>;
+};
+
+function migrateElement(
+  source: string,
+  plotName: string,
+  element: Record<string, unknown>,
+  output: MigrationAccumulator,
+): void {
+  const attributes = Array.isArray(element["attributes"]) ? element["attributes"] : [];
+  const elementStart = (element as unknown as Node).start;
+  const elementEnd = (element as unknown as Node).end;
+  const children: string[] = [];
+  let previousEnd = elementStart + 1 + plotName.length;
+
+  for (const raw of attributes) {
+    if (!isRecord(raw) || !isNode(raw)) continue;
+    const attributeEnd = raw.end;
+    const attributeStart = raw.start;
+    const name = raw["name"];
+    if (raw["type"] !== "Attribute" || typeof name !== "string") {
+      previousEnd = attributeEnd;
+      continue;
+    }
+    const rule = Object.hasOwn(RULES, name) ? RULES[name] : undefined;
+    if (rule === undefined) {
+      previousEnd = attributeEnd;
+      continue;
+    }
+
+    const built = childFor(source, name, rule, raw);
+    if ("skip" in built) {
+      output.skipped.push({
+        prop: name,
+        line: lineOf(source, attributeStart),
+        reason: built.skip,
+        docUrl: rule.docUrl,
+      });
+      previousEnd = attributeEnd;
+      continue;
+    }
+
+    children.push(built.element);
+    output.needed.add(rule.component);
+    output.changes.push({
+      prop: name,
+      component: rule.component,
+      line: lineOf(source, attributeStart),
+    });
+    output.edits.push({ start: previousEnd, end: attributeEnd, text: "" });
+    previousEnd = attributeEnd;
+  }
+
+  if (children.length === 0) return;
+  const fragment = element["fragment"];
+  const fragmentNodes =
+    !Array.isArray(fragment) && isRecord(fragment) && Array.isArray(fragment["nodes"])
+      ? (fragment["nodes"] as unknown[])
+      : [];
+  const firstChild = fragmentNodes.find((node) => isNode(node));
+  const elementIndent = indentAt(source, elementStart);
+  const childIndent = `${elementIndent}  `;
+  const block = children.map((child) => `\n${childIndent}${child}`).join("");
+
+  if (firstChild === undefined) {
+    output.edits.push({
+      start: previousEnd,
+      end: elementEnd,
+      text: `>${block}\n${elementIndent}</${plotName}>`,
+    });
+  } else {
+    output.edits.push({
+      start: firstChild.start,
+      end: firstChild.start,
+      text: block,
+    });
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Transform
 // ---------------------------------------------------------------------------
@@ -109,82 +192,9 @@ export function migratePlotProps(source: string, options: MigrateOptions = {}): 
   const skipped: PropSkip[] = [];
   const needed = new Set<string>();
 
-  for (const element of collectComponents(ast.fragment, plotName)) {
-    const attributes = Array.isArray(element["attributes"]) ? element["attributes"] : [];
-    const elementStart = (element as unknown as Node).start;
-    const elementEnd = (element as unknown as Node).end;
-
-    const children: string[] = [];
-    let previousEnd = elementStart + 1 + plotName.length;
-
-    for (const raw of attributes) {
-      if (!isRecord(raw) || !isNode(raw)) continue;
-      const attributeEnd = raw.end;
-      const attributeStart = raw.start;
-      const name = raw["name"];
-      if (raw["type"] !== "Attribute" || typeof name !== "string") {
-        previousEnd = attributeEnd;
-        continue;
-      }
-      // Own keys only — plain RULES[name] walks Object.prototype and would
-      // treat constructor/toString/… as migratable (truthy functions), then
-      // emit <undefined …/> and an import of undefined under --write.
-      const rule = Object.hasOwn(RULES, name) ? RULES[name] : undefined;
-      if (rule === undefined) {
-        previousEnd = attributeEnd;
-        continue;
-      }
-
-      const built = childFor(source, name, rule, raw);
-      if ("skip" in built) {
-        skipped.push({
-          prop: name,
-          line: lineOf(source, attributeStart),
-          reason: built.skip,
-          docUrl: rule.docUrl,
-        });
-        previousEnd = attributeEnd;
-        continue;
-      }
-
-      children.push(built.element);
-      needed.add(rule.component);
-      changes.push({
-        prop: name,
-        component: rule.component,
-        line: lineOf(source, attributeStart),
-      });
-      // Swallow the whitespace that separated this attribute from the last
-      // surviving one, so removing a middle attribute does not leave a double
-      // space and removing the last does not leave a trailing one.
-      edits.push({ start: previousEnd, end: attributeEnd, text: "" });
-      previousEnd = attributeEnd;
-    }
-
-    if (children.length === 0) continue;
-
-    const fragmentNodes = Array.isArray(element["fragment"])
-      ? []
-      : isRecord(element["fragment"]) && Array.isArray(element["fragment"]["nodes"])
-        ? (element["fragment"]["nodes"] as unknown[])
-        : [];
-    const firstChild = fragmentNodes.find((node) => isNode(node));
-    const elementIndent = indentAt(source, elementStart);
-    const childIndent = `${elementIndent}  `;
-    const block = children.map((child) => `\n${childIndent}${child}`).join("");
-
-    if (firstChild === undefined) {
-      // Self-closing `<GGPlot … />`: grow a body. previousEnd is the end of the
-      // last attribute, so this also removes the ` /` before the `>`.
-      edits.push({
-        start: previousEnd,
-        end: elementEnd,
-        text: `>${block}\n${elementIndent}</${plotName}>`,
-      });
-    } else {
-      edits.push({ start: firstChild.start, end: firstChild.start, text: block });
-    }
-  }
+  const output = { edits, changes, skipped, needed };
+  for (const element of collectComponents(ast.fragment, plotName))
+    migrateElement(source, plotName, element, output);
 
   if (changes.length === 0) return { code: source, changes: [], skipped };
 

--- a/packages/svelte/src/lib/inspection/coordinator.ts
+++ b/packages/svelte/src/lib/inspection/coordinator.ts
@@ -315,6 +315,65 @@ export function createInspectionCoordinator<
     candidate.primitiveIndex === prior.seedPrimitiveIndex &&
     candidateBatchRole(model, candidate, roles) === prior.seedBatchRole;
 
+  const preferredPinnedSeed = (
+    model: RenderModel,
+    prior: Slot,
+    identityEpoch: PropertyKey,
+    roles: readonly string[],
+  ): CandidateFacts | null => {
+    if (prior.identityEpoch !== identityEpoch) return null;
+    const preferred = model.candidates.candidate(prior.seedId);
+    if (preferred === null) return null;
+    if (prior.seedKey === null)
+      return keylessPinMatch(model, prior, preferred, roles) ? preferred : null;
+    return keyedPinRoleMatch(model, prior, preferred, roles) ? preferred : null;
+  };
+
+  const uniqueKeylessPinnedSeed = (
+    model: RenderModel,
+    prior: Slot,
+    roles: readonly string[],
+  ): CandidateFacts | null => {
+    const matches: CandidateFacts[] = [];
+    for (let id = 0; id < model.candidates.size; id++) {
+      const candidate = model.candidates.candidate(id);
+      if (candidate !== null && keylessPinMatch(model, prior, candidate, roles))
+        matches.push(candidate);
+    }
+    return matches.length === 1 ? matches[0]! : null;
+  };
+
+  const uniqueKeyedPinnedSeed = (
+    model: RenderModel,
+    prior: Slot,
+    roles: readonly string[],
+  ): CandidateFacts | null => {
+    const matches: CandidateFacts[] = [];
+    for (let id = 0; id < model.candidates.size; id++) {
+      const candidate = model.candidates.candidate(id);
+      if (candidate !== null && keyedPinMatch(model, prior, candidate)) matches.push(candidate);
+    }
+    if (matches.length === 1) return matches[0]!;
+    if (matches.length < 2) return null;
+    const sourceRows = new Set(matches.map((candidate) => candidate.rowIndex));
+    if (sourceRows.size !== 1) return null;
+    const sameRole = matches.filter(
+      (candidate) =>
+        candidate.kind === prior.seedKind &&
+        candidateBatchRole(model, candidate, roles) === prior.seedBatchRole &&
+        candidate.primitiveIndex === prior.seedPrimitiveIndex,
+    );
+    return sameRole.length === 1 ? sameRole[0]! : null;
+  };
+
+  const clearPinned = (): void => {
+    pinned = null;
+    if (lastSlot !== "pinned") return;
+    lastSemanticFingerprint = null;
+    lastPresentationIdentity = null;
+    lastSlot = null;
+  };
+
   const reconcilePinned = (
     input: Readonly<{
       model: RenderModel;
@@ -326,70 +385,24 @@ export function createInspectionCoordinator<
   ): CoordinatedInspection<Row, Key> | null => {
     const prior = pinned;
     if (prior === null) return null;
-    let seed: CandidateFacts | null = null;
     const roles = rolesFor(input.model);
     // Same identityEpoch: O(1) seedId revalidation when id + role still match.
     // Keyed path requires kind/batch/primitive (not only layer+key) so geom
     // swaps that reuse seedId cannot pin the wrong primitive. Fall through to
     // full scan on miss. Identity-change keyed still full-scans for ambiguity;
     // keyless identity-change clears immediately below.
-    if (prior.identityEpoch === input.identityEpoch) {
-      const preferred = input.model.candidates.candidate(prior.seedId);
-      if (preferred !== null) {
-        if (prior.seedKey === null) {
-          if (keylessPinMatch(input.model, prior, preferred, roles)) seed = preferred;
-        } else if (keyedPinRoleMatch(input.model, prior, preferred, roles)) {
-          seed = preferred;
-        }
-      }
-    }
+    let seed = preferredPinnedSeed(input.model, prior, input.identityEpoch, roles);
     if (seed === null && prior.seedKey === null) {
       if (prior.identityEpoch !== input.identityEpoch) {
-        pinned = null;
-        if (lastSlot === "pinned") {
-          lastSemanticFingerprint = null;
-          lastPresentationIdentity = null;
-          lastSlot = null;
-        }
+        clearPinned();
         return null;
       }
-      const matches: CandidateFacts[] = [];
-      for (let id = 0; id < input.model.candidates.size; id++) {
-        const candidate = input.model.candidates.candidate(id);
-        if (candidate === null) continue;
-        if (!keylessPinMatch(input.model, prior, candidate, roles)) continue;
-        matches.push(candidate);
-      }
-      seed = matches.length === 1 ? matches[0]! : null;
-    } else if (seed === null) {
-      const matches: CandidateFacts[] = [];
-      for (let id = 0; id < input.model.candidates.size; id++) {
-        const candidate = input.model.candidates.candidate(id);
-        if (candidate === null) continue;
-        if (!keyedPinMatch(input.model, prior, candidate)) continue;
-        matches.push(candidate);
-      }
-      if (matches.length === 1) seed = matches[0]!;
-      else if (matches.length > 1) {
-        const sourceRows = new Set(matches.map((candidate) => candidate.rowIndex));
-        if (sourceRows.size === 1) {
-          const sameRole = matches.filter(
-            (candidate) =>
-              candidate.kind === prior.seedKind &&
-              candidateBatchRole(input.model, candidate, roles) === prior.seedBatchRole &&
-              candidate.primitiveIndex === prior.seedPrimitiveIndex,
-          );
-          seed = sameRole.length === 1 ? sameRole[0]! : null;
-        }
-      }
+      seed = uniqueKeylessPinnedSeed(input.model, prior, roles);
+    } else {
+      seed ??= uniqueKeyedPinnedSeed(input.model, prior, roles);
     }
     if (seed === null) {
-      pinned = null;
-      if (lastSlot === "pinned") {
-        lastSemanticFingerprint = null;
-        lastPresentationIdentity = null;
-        lastSlot = null;
-      }
+      clearPinned();
       return null;
     }
     return resolve({

--- a/packages/svelte/src/lib/interaction/normalize-interaction-config.ts
+++ b/packages/svelte/src/lib/interaction/normalize-interaction-config.ts
@@ -5,84 +5,118 @@
 import type {
   InteractionConfigInput,
   InteractionTool,
+  LegendFocusInput,
   ResolvedInteractionConfig,
+  SelectInput,
+  ZoomInput,
 } from "./interaction.js";
 import {
   INTERACTION_DIAGNOSTIC_CATALOG,
   type InteractionDiagnostic,
 } from "./interaction-diagnostics.js";
 
+type ResolvedInspect<Row, Key> = ResolvedInteractionConfig<Row, Key>["inspect"];
+type ResolvedSelect = ResolvedInteractionConfig["select"];
+
+function resolveInspect<Row, Key>(
+  input: InteractionConfigInput<Row, Key>["inspect"],
+  diagnostics: InteractionDiagnostic[],
+): ResolvedInspect<Row, Key> {
+  if (input === undefined || input === false) return null;
+  const value = input === true ? {} : input;
+  const maxDistance = value.maxDistance ?? 24;
+  if (!Number.isFinite(maxDistance) || maxDistance < 0) {
+    diagnostics.push({
+      ...INTERACTION_DIAGNOSTIC_CATALOG.INTERACTION_INVALID_MAX_DISTANCE,
+      actual: maxDistance,
+    });
+    return null;
+  }
+  return Object.freeze({
+    mode: value.mode ?? "auto",
+    pin: value.pin ?? true,
+    maxDistance,
+    contentMode: value.contentMode ?? "informational",
+    muteSiblings: value.muteSiblings ?? false,
+    ...(value.content !== undefined && { content: value.content }),
+  });
+}
+
+function resolveSelect(
+  input: SelectInput | undefined,
+  hasKey: boolean | undefined,
+  diagnostics: InteractionDiagnostic[],
+): ResolvedSelect {
+  if (input === undefined || input === false) return null;
+  const value = typeof input === "string" ? { type: input } : input;
+  const select = Object.freeze({
+    type: value.type,
+    mode: value.mode ?? "xy",
+    multiple: value.multiple ?? false,
+    persistent: value.persistent ?? true,
+    preset: value.preset ?? "independent",
+  });
+  if (value.type === "point" && hasKey === false) {
+    diagnostics.push({
+      ...INTERACTION_DIAGNOSTIC_CATALOG.INTERACTION_POINT_REQUIRES_KEY,
+    });
+  }
+  if (value.type === "interval" && select.preset !== "independent" && hasKey === false) {
+    diagnostics.push({
+      ...INTERACTION_DIAGNOSTIC_CATALOG.INTERACTION_INTERVAL_PRESET_REQUIRES_KEY,
+    });
+  }
+  return select;
+}
+
+function availableInteractionTools<Row, Key>(
+  inspect: ResolvedInspect<Row, Key>,
+  select: ResolvedSelect,
+  zoom: ResolvedInteractionConfig["zoom"],
+): InteractionTool[] {
+  const tools: InteractionTool[] = [];
+  if (inspect !== null || select?.type === "interval" || zoom !== null) tools.push("inspect");
+  if (select?.type === "point") tools.push("point");
+  if (select?.type === "interval") tools.push("select-area");
+  if (zoom !== null) tools.push("zoom-area");
+  return tools;
+}
+
+function resolveZoom(input: ZoomInput | undefined): ResolvedInteractionConfig["zoom"] {
+  if (input === undefined || input === false) return null;
+  const value = input === true ? {} : input;
+  return Object.freeze({
+    mode: value.mode ?? "xy",
+    trigger: value.trigger ?? "brush",
+  });
+}
+
+function resolveLegendFocus(
+  input: LegendFocusInput | undefined,
+  hasKey: boolean | undefined,
+  diagnostics: InteractionDiagnostic[],
+): ResolvedInteractionConfig["legendFocus"] {
+  if (input === undefined || input === false) return null;
+  if (hasKey === false) {
+    diagnostics.push({
+      ...INTERACTION_DIAGNOSTIC_CATALOG.INTERACTION_LEGEND_REQUIRES_KEY,
+    });
+    return null;
+  }
+  const value = input === true ? {} : input;
+  return Object.freeze({ preview: value.preview ?? true });
+}
+
 export function normalizeInteractionConfig<Row, Key>(
   input: InteractionConfigInput<Row, Key>,
   context: { faceted?: boolean; hasKey?: boolean } = {},
 ): ResolvedInteractionConfig<Row, Key> {
   const diagnostics: InteractionDiagnostic[] = [];
-  let inspect: ResolvedInteractionConfig<Row, Key>["inspect"] = null;
-  if (input.inspect !== undefined && input.inspect !== false) {
-    const value = input.inspect === true ? {} : input.inspect;
-    const maxDistance = value.maxDistance ?? 24;
-    if (!Number.isFinite(maxDistance) || maxDistance < 0) {
-      diagnostics.push({
-        ...INTERACTION_DIAGNOSTIC_CATALOG.INTERACTION_INVALID_MAX_DISTANCE,
-        actual: maxDistance,
-      });
-    } else {
-      inspect = Object.freeze({
-        mode: value.mode ?? "auto",
-        pin: value.pin ?? true,
-        maxDistance,
-        contentMode: value.contentMode ?? "informational",
-        muteSiblings: value.muteSiblings ?? false,
-        ...(value.content !== undefined && { content: value.content }),
-      });
-    }
-  }
+  const inspect = resolveInspect(input.inspect, diagnostics);
+  const select = resolveSelect(input.select, context.hasKey, diagnostics);
 
-  let select: ResolvedInteractionConfig["select"] = null;
-  if (input.select !== undefined && input.select !== false) {
-    const value = typeof input.select === "string" ? { type: input.select } : input.select;
-    select = Object.freeze({
-      type: value.type,
-      mode: value.mode ?? "xy",
-      multiple: value.multiple ?? false,
-      persistent: value.persistent ?? true,
-      preset: value.preset ?? "independent",
-    });
-    if (value.type === "point" && context.hasKey === false) {
-      diagnostics.push({
-        ...INTERACTION_DIAGNOSTIC_CATALOG.INTERACTION_POINT_REQUIRES_KEY,
-      });
-    }
-    if (value.type === "interval" && select.preset !== "independent" && context.hasKey === false) {
-      // Union combines stored record keys and cross-panel matches candidate
-      // semantic keys: with keyless rows both silently select nothing
-      // outside the origin rectangle.
-      diagnostics.push({
-        ...INTERACTION_DIAGNOSTIC_CATALOG.INTERACTION_INTERVAL_PRESET_REQUIRES_KEY,
-      });
-    }
-  }
-
-  let zoom: ResolvedInteractionConfig["zoom"] = null;
-  if (input.zoom !== undefined && input.zoom !== false) {
-    const value = input.zoom === true ? {} : input.zoom;
-    zoom = Object.freeze({
-      mode: value.mode ?? "xy",
-      trigger: value.trigger ?? "brush",
-    });
-  }
-
-  let legendFocus: ResolvedInteractionConfig["legendFocus"] = null;
-  if (input.legendFocus !== undefined && input.legendFocus !== false) {
-    if (context.hasKey === false) {
-      diagnostics.push({
-        ...INTERACTION_DIAGNOSTIC_CATALOG.INTERACTION_LEGEND_REQUIRES_KEY,
-      });
-    } else {
-      const value = input.legendFocus === true ? {} : input.legendFocus;
-      legendFocus = Object.freeze({ preview: value.preview ?? true });
-    }
-  }
+  let zoom = resolveZoom(input.zoom);
+  const legendFocus = resolveLegendFocus(input.legendFocus, context.hasKey, diagnostics);
 
   if (context.faceted === true && zoom !== null) {
     diagnostics.push({
@@ -91,12 +125,7 @@ export function normalizeInteractionConfig<Row, Key>(
     zoom = null;
   }
 
-  const availableTools: InteractionTool[] = [];
-  if (inspect !== null || select?.type === "interval" || zoom !== null)
-    availableTools.push("inspect");
-  if (select?.type === "point") availableTools.push("point");
-  if (select?.type === "interval") availableTools.push("select-area");
-  if (zoom !== null) availableTools.push("zoom-area");
+  const availableTools = availableInteractionTools(inspect, select, zoom);
   const fallbackTool = select?.type === "point" && inspect === null ? "point" : "inspect";
   const requestedTool = input.tool ?? fallbackTool;
   const initialTool = availableTools.includes(requestedTool) ? requestedTool : fallbackTool;

--- a/packages/svelte/src/lib/interval/bounds-editor.ts
+++ b/packages/svelte/src/lib/interval/bounds-editor.ts
@@ -190,28 +190,8 @@ export function validateBoundsDraft(
   upperDraft: string,
   inputSource: BoundsInputSource = "keyboard",
 ): BoundsDraftValidation {
-  if (input.scale === "band") {
-    const lowerIndex = Number(lowerDraft);
-    const upperIndex = Number(upperDraft);
-    const errors: { lower?: string; upper?: string } = {};
-    if (!Number.isInteger(lowerIndex) || input.categories[lowerIndex] === undefined) {
-      errors.lower = "Choose a valid lower category.";
-    }
-    if (!Number.isInteger(upperIndex) || input.categories[upperIndex] === undefined) {
-      errors.upper = "Choose a valid upper category.";
-    } else if (errors.lower === undefined && upperIndex < lowerIndex) {
-      errors.upper = "Upper category must be at or after the lower category.";
-    }
-    if (errors.lower !== undefined || errors.upper !== undefined) return { ok: false, errors };
-    return {
-      ok: true,
-      event: {
-        ...baseEvent(input, inputSource),
-        scale: "band",
-        bounds: [input.categories[lowerIndex]!.value, input.categories[upperIndex]!.value],
-      },
-    };
-  }
+  if (input.scale === "band")
+    return validateBandBoundsDraft(input, lowerDraft, upperDraft, inputSource);
 
   const lower =
     input.scale === "time"
@@ -221,28 +201,7 @@ export function validateBoundsDraft(
     input.scale === "time"
       ? parseTime(upperDraft, "Upper bound", input.temporalKind)
       : parseNumber(upperDraft, "Upper bound");
-  const errors: { lower?: string; upper?: string } = {};
-  if (typeof lower === "string") errors.lower = lower;
-  if (typeof upper === "string") errors.upper = upper;
-  if (input.scale === "linear" && input.transform === "log10") {
-    if (typeof lower === "number" && lower <= 0) {
-      errors.lower = "Lower bound must be greater than zero on a log scale.";
-    }
-    if (typeof upper === "number" && upper <= 0) {
-      errors.upper = "Upper bound must be greater than zero on a log scale.";
-    }
-  }
-  if (input.scale === "linear" && input.transform === "sqrt") {
-    if (typeof lower === "number" && lower < 0) {
-      errors.lower = "Lower bound must be zero or greater on a square-root scale.";
-    }
-    if (typeof upper === "number" && upper < 0) {
-      errors.upper = "Upper bound must be zero or greater on a square-root scale.";
-    }
-  }
-  if (typeof lower === "number" && typeof upper === "number" && upper <= lower) {
-    errors.upper = "Upper bound must be greater than the lower bound.";
-  }
+  const errors = continuousBoundsErrors(input, lower, upper);
   if (errors.lower !== undefined || errors.upper !== undefined) return { ok: false, errors };
 
   return {
@@ -261,4 +220,55 @@ export function validateBoundsDraft(
             bounds: [lower as number, upper as number],
           },
   };
+}
+
+function validateBandBoundsDraft(
+  input: BandBoundsEditorInput,
+  lowerDraft: string,
+  upperDraft: string,
+  inputSource: BoundsInputSource,
+): BoundsDraftValidation {
+  const lowerIndex = Number(lowerDraft);
+  const upperIndex = Number(upperDraft);
+  const errors: { lower?: string; upper?: string } = {};
+  if (!Number.isInteger(lowerIndex) || input.categories[lowerIndex] === undefined)
+    errors.lower = "Choose a valid lower category.";
+  if (!Number.isInteger(upperIndex) || input.categories[upperIndex] === undefined)
+    errors.upper = "Choose a valid upper category.";
+  else if (errors.lower === undefined && upperIndex < lowerIndex)
+    errors.upper = "Upper category must be at or after the lower category.";
+  if (errors.lower !== undefined || errors.upper !== undefined) return { ok: false, errors };
+  return {
+    ok: true,
+    event: {
+      ...baseEvent(input, inputSource),
+      scale: "band",
+      bounds: [input.categories[lowerIndex]!.value, input.categories[upperIndex]!.value],
+    },
+  };
+}
+
+function continuousBoundsErrors(
+  input: NumericBoundsEditorInput | TimeBoundsEditorInput,
+  lower: number | string,
+  upper: number | string,
+): BoundsDraftErrors {
+  const errors: { lower?: string; upper?: string } = {};
+  if (typeof lower === "string") errors.lower = lower;
+  if (typeof upper === "string") errors.upper = upper;
+  if (input.scale === "linear" && input.transform === "log10") {
+    if (typeof lower === "number" && lower <= 0)
+      errors.lower = "Lower bound must be greater than zero on a log scale.";
+    if (typeof upper === "number" && upper <= 0)
+      errors.upper = "Upper bound must be greater than zero on a log scale.";
+  }
+  if (input.scale === "linear" && input.transform === "sqrt") {
+    if (typeof lower === "number" && lower < 0)
+      errors.lower = "Lower bound must be zero or greater on a square-root scale.";
+    if (typeof upper === "number" && upper < 0)
+      errors.upper = "Upper bound must be zero or greater on a square-root scale.";
+  }
+  if (typeof lower === "number" && typeof upper === "number" && upper <= lower)
+    errors.upper = "Upper bound must be greater than the lower bound.";
+  return errors;
 }

--- a/packages/svelte/src/lib/interval/interval-bounds-state.svelte.ts
+++ b/packages/svelte/src/lib/interval/interval-bounds-state.svelte.ts
@@ -58,6 +58,71 @@ export type IntervalBoundsEditorState = {
   cancel(): void;
 };
 
+function temporalKindForAxis(model: RenderModel, axis: "x" | "y"): TemporalScaleKind | null {
+  for (const plan of model.guidePlans) {
+    if (plan.type === "axis" && plan.aesthetic === axis) return plan.temporalKind;
+  }
+  return null;
+}
+
+function zoomBoundsEditorInput(
+  deps: IntervalBoundsEditorDeps,
+  model: RenderModel,
+  editor: IntervalBoundsEditorRef,
+  temporalKind: TemporalScaleKind | null,
+): BoundsEditorInput | null {
+  const viewportPanel = model.viewport.panels[0];
+  if (viewportPanel === undefined) return null;
+  const scale = viewportPanel.axisEditModel(editor.axis);
+  if (scale.kind === "band") return null;
+  const bounds = deps.effectiveZoomDomains()?.[editor.axis] ?? scale.domain;
+  return boundsEditorInputForScale({
+    axis: editor.axis,
+    action: "zoom",
+    scale,
+    bounds,
+    temporalKind,
+  });
+}
+
+function selectionBoundsEditorInput(
+  deps: IntervalBoundsEditorDeps,
+  model: RenderModel,
+  editor: IntervalBoundsEditorRef,
+  temporalKind: TemporalScaleKind | null,
+): BoundsEditorInput | null {
+  const record = deps.currentIntervalRecord();
+  const targetPanelId = record?.panelId ?? editor.panelId;
+  if (targetPanelId === undefined) return null;
+  const viewportPanel = model.viewport.panel(targetPanelId);
+  if (viewportPanel === null) return null;
+  const scale = viewportPanel.axisEditModel(editor.axis);
+  const semantic = record?.domains[editor.axis];
+  const bounds =
+    semantic?.kind === "band"
+      ? ([semantic.values[0] ?? "", semantic.values.at(-1) ?? ""] as const)
+      : semantic?.domain;
+  return boundsEditorInputForScale({
+    axis: editor.axis,
+    action: "select",
+    scale,
+    temporalKind,
+    ...(bounds !== undefined && { bounds }),
+  });
+}
+
+function resolveBoundsEditorInput(
+  deps: IntervalBoundsEditorDeps,
+  editor: IntervalBoundsEditorRef | null,
+): BoundsEditorInput | null {
+  const model = deps.model();
+  if (editor === null || model === null) return null;
+  const temporalKind = temporalKindForAxis(model, editor.axis);
+  return editor.action === "zoom"
+    ? zoomBoundsEditorInput(deps, model, editor, temporalKind)
+    : selectionBoundsEditorInput(deps, model, editor, temporalKind);
+}
+
 // ---------------------------------------------------------------------------
 // Factory
 // ---------------------------------------------------------------------------
@@ -68,53 +133,7 @@ export function createIntervalBoundsEditor(
   let boundsEditor = $state<IntervalBoundsEditorRef | null>(null);
   let boundsReturnFocus = $state<HTMLElement | null>(null);
 
-  const boundsEditorInput = $derived.by((): BoundsEditorInput | null => {
-    const editor = boundsEditor;
-    const model = deps.model();
-    if (editor === null || model === null) return null;
-    // Axis guide plans carry temporalKind (including monthDay); the trained
-    // continuous scale does not. Use the first matching axis plan so the
-    // bounds editor can format drafts without the reference year.
-    let temporalKind: TemporalScaleKind | null = null;
-    for (const plan of model.guidePlans) {
-      if (plan.type === "axis" && plan.aesthetic === editor.axis) {
-        temporalKind = plan.temporalKind;
-        break;
-      }
-    }
-    if (editor.action === "zoom") {
-      const viewportPanel = model.viewport.panels[0];
-      if (viewportPanel === undefined) return null;
-      const scale = viewportPanel.axisEditModel(editor.axis);
-      if (scale.kind === "band") return null;
-      const bounds = deps.effectiveZoomDomains()?.[editor.axis] ?? scale.domain;
-      return boundsEditorInputForScale({
-        axis: editor.axis,
-        action: "zoom",
-        scale,
-        bounds,
-        temporalKind,
-      });
-    }
-    const record = deps.currentIntervalRecord();
-    const targetPanelId = record?.panelId ?? editor.panelId;
-    if (targetPanelId === undefined) return null;
-    const viewportPanel = model.viewport.panel(targetPanelId);
-    if (viewportPanel === null) return null;
-    const scale = viewportPanel.axisEditModel(editor.axis);
-    const semantic = record?.domains[editor.axis];
-    const bounds =
-      semantic?.kind === "band"
-        ? ([semantic.values[0] ?? "", semantic.values.at(-1) ?? ""] as const)
-        : semantic?.domain;
-    return boundsEditorInputForScale({
-      axis: editor.axis,
-      action: "select",
-      scale,
-      temporalKind,
-      ...(bounds !== undefined && { bounds }),
-    });
-  });
+  const boundsEditorInput = $derived.by(() => resolveBoundsEditorInput(deps, boundsEditor));
 
   $effect(() => {
     if (boundsEditor === null || boundsEditorInput !== null) return;

--- a/packages/svelte/src/lib/interval/interval-state.svelte.ts
+++ b/packages/svelte/src/lib/interval/interval-state.svelte.ts
@@ -359,19 +359,19 @@ export function createIntervalState(
     options.emitSelection(eventValue);
   }
 
-  function applyPreciseBounds(event: PreciseBoundsApplyEvent): void {
-    if (event.action === "zoom") {
-      if (event.scale === "band") return;
-      options.commitZoom(
-        frozenZoomDomains({
-          ...options.effectiveZoomDomains(),
-          [event.axis]: [...event.bounds],
-        }),
-        event.inputSource,
-      );
-      bounds.cancel();
-      return;
-    }
+  function applyPreciseZoomBounds(event: PreciseBoundsApplyEvent): void {
+    if (event.scale === "band") return;
+    options.commitZoom(
+      frozenZoomDomains({
+        ...options.effectiveZoomDomains(),
+        [event.axis]: [...event.bounds],
+      }),
+      event.inputSource,
+    );
+    bounds.cancel();
+  }
+
+  function applyPreciseSelectionBounds(event: PreciseBoundsApplyEvent): void {
     const prior = currentIntervalRecord;
     const targetPanelId = prior?.panelId ?? bounds.boundsEditor?.panelId;
     if (targetPanelId === null || targetPanelId === undefined || context.model() === null) return;
@@ -419,6 +419,11 @@ export function createIntervalState(
     committedInterval = persistentSelectionOrNull(context.selectConfig()?.persistent, eventValue);
     options.emitSelection(eventValue);
     bounds.cancel();
+  }
+
+  function applyPreciseBounds(event: PreciseBoundsApplyEvent): void {
+    if (event.action === "zoom") applyPreciseZoomBounds(event);
+    else applyPreciseSelectionBounds(event);
   }
 
   return {

--- a/packages/svelte/src/lib/runtime/semantic-data-identity.ts
+++ b/packages/svelte/src/lib/runtime/semantic-data-identity.ts
@@ -32,35 +32,38 @@ export function dataContentOrderToken(
 ): string {
   if (data === null || data === undefined) return "null";
   if (Array.isArray(data)) return rowRefOrderToken(data, sourceIdentity);
-  if (typeof data === "object") {
-    const record = data as Record<string, unknown>;
-    const fieldKeys = Object.keys(record);
-    // DataRef shapes only when single-key (matches packages/spec isDataRef).
-    // A bare column map may own a field named `values`/`columns` alongside
-    // other arrays and must not short-circuit (Codex P2).
-    if (fieldKeys.length === 1 && fieldKeys[0] === "values" && Array.isArray(record["values"])) {
-      return rowRefOrderToken(record["values"] as unknown[], sourceIdentity);
-    }
-    if (
-      fieldKeys.length === 1 &&
-      fieldKeys[0] === "columns" &&
-      record["columns"] !== null &&
-      typeof record["columns"] === "object" &&
-      !Array.isArray(record["columns"])
-    )
-      return `c:${columnMapOrderToken(record["columns"] as Record<string, unknown>, sourceIdentity)}`;
-    if (fieldKeys.length === 1 && fieldKeys[0] === "name" && typeof record["name"] === "string")
-      return `n:${record["name"]}`;
-    // Bare column-oriented object (gg() wraps as { columns }) — fingerprint
-    // each field's array identity so in-place column replacement bumps epoch.
-    if (fieldKeys.length > 0 && fieldKeys.every((key) => Array.isArray(record[key])))
-      return `c:${columnMapOrderToken(record, sourceIdentity)}`;
-    return `o:${sourceIdentity(data)}`;
-  }
+  if (typeof data === "object") return objectDataOrderToken(data, sourceIdentity);
   if (typeof data === "string" || typeof data === "number" || typeof data === "boolean")
     return `p:${String(data)}`;
   if (typeof data === "bigint") return `p:${data.toString()}`;
   return `p:${sourceIdentity(data)}`;
+}
+
+function objectDataOrderToken(data: object, sourceIdentity: (value: unknown) => string): string {
+  const record = data as Record<string, unknown>;
+  const fieldKeys = Object.keys(record);
+  // DataRef shapes only when single-key (matches packages/spec isDataRef).
+  // A bare column map may own a field named `values`/`columns` alongside
+  // other arrays and must not short-circuit (Codex P2).
+  if (fieldKeys.length === 1 && fieldKeys[0] === "values" && Array.isArray(record["values"])) {
+    return rowRefOrderToken(record["values"], sourceIdentity);
+  }
+  const columns = record["columns"];
+  if (
+    fieldKeys.length === 1 &&
+    fieldKeys[0] === "columns" &&
+    columns !== null &&
+    typeof columns === "object" &&
+    !Array.isArray(columns)
+  )
+    return `c:${columnMapOrderToken(columns as Record<string, unknown>, sourceIdentity)}`;
+  if (fieldKeys.length === 1 && fieldKeys[0] === "name" && typeof record["name"] === "string")
+    return `n:${record["name"]}`;
+  // Bare column-oriented object (gg() wraps as { columns }) — fingerprint
+  // each field's array identity so in-place column replacement bumps epoch.
+  if (fieldKeys.length > 0 && fieldKeys.every((key) => Array.isArray(record[key])))
+    return `c:${columnMapOrderToken(record, sourceIdentity)}`;
+  return `o:${sourceIdentity(data)}`;
 }
 
 /** O(fields) fingerprint: each column array's identity (+ length), not cells. */

--- a/packages/svelte/src/lib/runtime/semantic-keys-resolve.ts
+++ b/packages/svelte/src/lib/runtime/semantic-keys-resolve.ts
@@ -96,18 +96,10 @@ export function resolveSemanticKeysForPlot(input: {
   });
 }
 
-/**
- * Resolve durable semantic keys for interaction, emitting diagnostics in
- * encounter order: synthetic-rule missing lineage, per-candidate missing
- * lineage, then per-row invalid / unstable / duplicate key diagnostics.
- */
-export function resolveSemanticKeys(input: ResolveSemanticKeysInput): ResolveSemanticKeysResult {
-  const keys = new Map<number, PropertyKey | null>();
-  const diagnostics: InteractionDiagnostic[] = [];
-  const { model, datumKey, priorKeys, rowIdentity } = input;
-  if (datumKey === undefined) return { keys, diagnostics };
-
-  const owners = new Map<PropertyKey, number>();
+function sourceRowsForSemanticKeys(
+  model: SemanticKeyModelView,
+  diagnostics: InteractionDiagnostic[],
+): Set<number> {
   const sourceRows = new Set<number>();
   if (
     model.candidateCount === 0 &&
@@ -122,9 +114,6 @@ export function resolveSemanticKeys(input: ResolveSemanticKeysInput): ResolveSem
       actual: "synthetic rule has no source rows",
     });
 
-  // Expand each lineage id once. Smooth / aggregate eval-grid marks share one
-  // membership array across C marks (#1140) — re-spreading was O(C·L).
-  // Map value: true when the lineage has no source rows (empty-lineage diag).
   const lineageEmpty = new Map<number, boolean>();
   for (let id = 0; id < model.candidateCount; id++) {
     const candidate = model.candidate(id);
@@ -143,12 +132,27 @@ export function resolveSemanticKeys(input: ResolveSemanticKeysInput): ResolveSem
     if (candidate.rowIndex === null && empty)
       diagnostics.push({
         ...INTERACTION_DIAGNOSTIC_CATALOG.INTERACTION_MISSING_LINEAGE,
-        actual: {
-          layerIndex: candidate.layerIndex,
-          candidateId: candidate.id,
-        },
+        actual: { layerIndex: candidate.layerIndex, candidateId: candidate.id },
       });
   }
+  return sourceRows;
+}
+
+/**
+ * Resolve durable semantic keys for interaction, emitting diagnostics in
+ * encounter order: synthetic-rule missing lineage, per-candidate missing
+ * lineage, then per-row invalid / unstable / duplicate key diagnostics.
+ */
+export function resolveSemanticKeys(input: ResolveSemanticKeysInput): ResolveSemanticKeysResult {
+  const keys = new Map<number, PropertyKey | null>();
+  const diagnostics: InteractionDiagnostic[] = [];
+  const { model, datumKey, priorKeys, rowIdentity } = input;
+  if (datumKey === undefined) return { keys, diagnostics };
+
+  const owners = new Map<PropertyKey, number>();
+  // Expand each lineage id once. Smooth / aggregate eval-grid marks share one
+  // membership array across C marks (#1140) — re-spreading was O(C·L).
+  const sourceRows = sourceRowsForSemanticKeys(model, diagnostics);
 
   for (const rowIndex of sourceRows) {
     const row = model.row(rowIndex);

--- a/packages/svelte/src/lib/surface/keyboard.ts
+++ b/packages/svelte/src/lib/surface/keyboard.ts
@@ -95,6 +95,60 @@ type SurfaceKeyResolution = {
   readonly preventDefault: boolean;
 };
 
+function arrowDelta(key: string, step: number): PlotPoint {
+  const horizontal = key === "ArrowLeft" ? -step : key === "ArrowRight" ? step : 0;
+  const vertical = key === "ArrowUp" ? -step : key === "ArrowDown" ? step : 0;
+  return { x: horizontal, y: vertical };
+}
+
+function resolveAreaArrow(input: SurfaceKeyboardInput): SurfaceKeyResolution {
+  const panel = input.inspectionPanel ?? input.firstPanel;
+  if (panel === undefined || input.brushCorners === null) {
+    return { preventDefault: true, action: { type: "none" } };
+  }
+  const { x: dx, y: dy } = arrowDelta(input.key, input.shiftKey ? 10 : 1);
+  return {
+    preventDefault: true,
+    action: {
+      type: "nudge-brush",
+      corners: nudgeBrushEnd(input.brushCorners, dx, dy, panel),
+    },
+  };
+}
+
+function resolveAreaCommit(input: SurfaceKeyboardInput): SurfaceKeyResolution {
+  const action: SurfaceKeyAction =
+    input.brushCorners === null
+      ? {
+          type: "begin-area",
+          anchor: input.inspectionAnchor ?? panelCenterAnchor(input.firstPanel),
+        }
+      : {
+          type: "complete-area",
+          finish: resolveFinishBrushAction({
+            ended: { kind: "commit", rect: normalizedRect(input.brushCorners) },
+            activeTool: input.activeTool,
+          }),
+        };
+  return { preventDefault: true, action };
+}
+
+function resolveInspectionActivation(input: SurfaceKeyboardInput): SurfaceKeyResolution | null {
+  if (input.activeTool === "point" && input.hasInspection) {
+    return {
+      preventDefault: true,
+      action: {
+        type: "toggle-point-keys",
+        keys: input.focusKey === null ? input.sourceKeys : [input.focusKey],
+      },
+    };
+  }
+  if (input.hasInspection && input.pinEnabled) {
+    return { preventDefault: true, action: { type: "toggle-pin" } };
+  }
+  return null;
+}
+
 /**
  * Pure decision table for the plot capture-surface `keydown` handler.
  * Preserves existing priority: area draft arrows → area Enter/Space →
@@ -102,60 +156,16 @@ type SurfaceKeyResolution = {
  * Callers own side effects (brush mutation, inspection, tool changes).
  */
 export function resolveSurfaceKeyAction(input: SurfaceKeyboardInput): SurfaceKeyResolution {
-  const {
-    key,
-    shiftKey,
-    activeTool,
-    brushCorners,
-    hasInspection,
-    pinEnabled,
-    focusKey,
-    sourceKeys,
-    inspectionAnchor,
-    inspectionPanel,
-    firstPanel,
-  } = input;
+  const { key, activeTool, brushCorners } = input;
   const area = isAreaTool(activeTool);
   const hasDraft = brushCorners !== null;
 
   if (area && key.startsWith("Arrow") && hasDraft) {
-    const step = shiftKey ? 10 : 1;
-    const dx = key === "ArrowLeft" ? -step : key === "ArrowRight" ? step : 0;
-    const dy = key === "ArrowUp" ? -step : key === "ArrowDown" ? step : 0;
-    // Prefer inspection panel, else first panel (host previously inspectionPanel ?? panels[0]).
-    const panel = inspectionPanel ?? firstPanel;
-    if (panel === undefined) {
-      // Draft without a panel: swallow the key (preventDefault) without mutating.
-      return { preventDefault: true, action: { type: "none" } };
-    }
-    return {
-      preventDefault: true,
-      action: {
-        type: "nudge-brush",
-        corners: nudgeBrushEnd(brushCorners, dx, dy, panel),
-      },
-    };
+    return resolveAreaArrow(input);
   }
 
   if (area && (key === "Enter" || key === " ")) {
-    return {
-      preventDefault: true,
-      action:
-        brushCorners === null
-          ? {
-              type: "begin-area",
-              anchor: inspectionAnchor ?? panelCenterAnchor(firstPanel),
-            }
-          : {
-              type: "complete-area",
-              // Keyboard commits the live draft as-is (no free-corner update).
-              // Zero-size drafts still route as commit → select/zoom/end-area.
-              finish: resolveFinishBrushAction({
-                ended: { kind: "commit", rect: normalizedRect(brushCorners) },
-                activeTool,
-              }),
-            },
-    };
+    return resolveAreaCommit(input);
   }
 
   if (key === "]" || key === "[") {
@@ -169,28 +179,20 @@ export function resolveSurfaceKeyAction(input: SurfaceKeyboardInput): SurfaceKey
   }
 
   if (key.startsWith("Arrow")) {
+    const { x: dx, y: dy } = arrowDelta(key, 1);
     return {
       preventDefault: true,
       action: {
         type: "navigate-direction",
-        dx: key === "ArrowRight" ? 1 : key === "ArrowLeft" ? -1 : 0,
-        dy: key === "ArrowDown" ? 1 : key === "ArrowUp" ? -1 : 0,
+        dx,
+        dy,
       },
     };
   }
 
-  if ((key === "Enter" || key === " ") && activeTool === "point" && hasInspection) {
-    return {
-      preventDefault: true,
-      action: {
-        type: "toggle-point-keys",
-        keys: focusKey === null ? sourceKeys : [focusKey],
-      },
-    };
-  }
-
-  if ((key === "Enter" || key === " ") && hasInspection && pinEnabled) {
-    return { preventDefault: true, action: { type: "toggle-pin" } };
+  if (key === "Enter" || key === " ") {
+    const activation = resolveInspectionActivation(input);
+    if (activation !== null) return activation;
   }
 
   if (key === "Escape") {

--- a/packages/svelte/tests/geoms/geom-child-parity.test.ts
+++ b/packages/svelte/tests/geoms/geom-child-parity.test.ts
@@ -30,21 +30,29 @@ function componentName(geom: GeomName): string {
 }
 
 /** One representative value per param key family for the whitelist check. */
+const STRING_PARAM_VALUES: Readonly<Record<string, string>> = {
+  fun: "mean",
+  method: "loess",
+  shape: "circle",
+  curve: "linear",
+  connection: "linear",
+  direction: "hv",
+  stackdir: "up",
+  sides: "b",
+  outline: "full",
+  orientation: "x",
+  lineend: "butt",
+  linejoin: "round",
+  anchor: "middle",
+  closed: "right",
+  geometry: "geometry",
+  mapId: "id",
+  scale: "area",
+};
+
 function sampleValue(key: string): unknown {
-  if (key === "fun") return "mean";
-  if (key === "method") return "loess";
-  if (key === "shape") return "circle";
-  if (key === "curve") return "linear";
-  if (key === "connection") return "linear";
-  if (key === "direction") return "hv";
-  if (key === "stackdir") return "up";
-  if (key === "sides") return "b";
-  if (key === "outline") return "full";
-  if (key === "orientation") return "x";
-  if (key === "lineend") return "butt";
-  if (key === "linejoin") return "round";
-  if (key === "anchor") return "middle";
-  if (key === "closed") return "right";
+  const stringValue = STRING_PARAM_VALUES[key];
+  if (stringValue !== undefined) return stringValue;
   if (key === "drop") return true;
   if (key === "se") return true;
   if (key === "trim") return true;
@@ -54,10 +62,7 @@ function sampleValue(key: string): unknown {
   if (key === "breaks") return [0, 1];
   if (key === "quantiles") return [0.25, 0.5, 0.75];
   if (key === "args") return {};
-  if (key === "geometry") return "geometry";
-  if (key === "mapId") return "id";
-  if (key === "scale") return "area";
-  if (typeof key === "string" && (key.endsWith("Paint") || key === "glow")) {
+  if (key.endsWith("Paint") || key === "glow") {
     return key === "glow" ? 2 : "#ff0000";
   }
   if (key === "alpha" || key === "level" || key === "span" || key === "cut" || key === "adjust") {

--- a/packages/svelte/tests/scale/scale-child-parity.test.ts
+++ b/packages/svelte/tests/scale/scale-child-parity.test.ts
@@ -79,21 +79,8 @@ function representativeProps(helper: string): Record<string, unknown> {
     // size / linewidth
     return { values: [1, 2, 4] as const };
   }
-  if (helper === "scaleColorDiscrete" || helper === "scaleFillDiscrete") {
-    return { scheme: "colorblind" };
-  }
-  if (helper === "scaleColorContinuous" || helper === "scaleFillContinuous") {
-    return { scheme: "viridis" };
-  }
-  if (helper === "scaleXContinuous" || helper === "scaleYContinuous") {
-    return { domain: [0, 10] as const };
-  }
-  if (helper === "scaleSizeContinuous") {
-    return { range: [1, 6] as const };
-  }
-  if (helper === "scaleShapeDiscrete") {
-    return { range: ["circle", "triangle"] as const };
-  }
+  const common = representativeCommonProps(helper);
+  if (common !== undefined) return common;
   // gradientn requires ≥2 explicit stops (no defaults; #826).
   if (
     helper === "scaleColorGradientn" ||
@@ -111,6 +98,18 @@ function representativeProps(helper: string): Record<string, unknown> {
     return { colours: ["#000000", "#ffffff"] as const };
   }
   return {};
+}
+
+function representativeCommonProps(helper: string): Record<string, unknown> | undefined {
+  if (helper === "scaleColorDiscrete" || helper === "scaleFillDiscrete")
+    return { scheme: "colorblind" };
+  if (helper === "scaleColorContinuous" || helper === "scaleFillContinuous")
+    return { scheme: "viridis" };
+  if (helper === "scaleXContinuous" || helper === "scaleYContinuous")
+    return { domain: [0, 10] as const };
+  if (helper === "scaleSizeContinuous") return { range: [1, 6] as const };
+  if (helper === "scaleShapeDiscrete") return { range: ["circle", "triangle"] as const };
+  return undefined;
 }
 
 function callHelper(helper: string, props: Record<string, unknown>): Scales {


### PR DESCRIPTION
## Summary
- remove the staged cyclomatic-complexity exemption for `packages/svelte/**`
- split 11 high-complexity decisions into focused helpers without changing public behavior or diagnostic ordering
- keep only `packages/core/**` exempted for the final rollout stage

## Verification
- `bun run lint`
- `bun run lint:type-aware`
- `bun run fmt:check`
- `bun run check`
- `cd packages/svelte && bun run --bun check` (0 errors, 0 warnings)
- Svelte autofixer on both touched `.svelte.ts` modules (0 issues)
- `cd packages/svelte && bun run test:ssr` (132 passed)
- focused Chromium coverage for all changed paths (284 passed)
- `bun run test` (5,068 passed, 4 skipped)
- `pre-commit run --all-files` twice

## Benchmark gate
- captured the required 40-workload baseline before production edits
- the timing suite imports only `@ggsvelte/core` and `@ggsvelte/spec`, so none of these Svelte-module changes are on its runtime path; repeated samples showed bidirectional host-load swings rather than a coherent code regression
- ran the relevant retained-memory benchmark against contemporaneous main: grouped inspection two-slot retained memory improved from 2.27 MiB to 2.24 MiB; the control pipeline stayed flat at 9.29 vs 9.31 MiB

No coherent performance or memory regression was found.