### PR TITLE
refactor(core): enforce complexity in stats

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -49,12 +49,18 @@
   },
   "overrides": [
     {
-      // Staged rollout inventory (2026-08-29): core 122.
-      // apps/docs, examples, scripts, tests, packages/spec, packages/cli,
-      // packages/skill, and benchmarks pass and use the global rule.
+      // Final staged rollout inventory (2026-08-29): packages/core 122.
+      // Later overrides re-enable the rule for each completed core scope;
+      // remove this exemption after the last scope reaches zero.
       "files": ["packages/core/**"],
       "rules": {
         "eslint/complexity": "off"
+      }
+    },
+    {
+      "files": ["packages/core/src/stats/**"],
+      "rules": {
+        "eslint/complexity": ["error", { "max": 20 }]
       }
     },
     {

--- a/packages/core/src/stats/bin-2d.ts
+++ b/packages/core/src/stats/bin-2d.ts
@@ -63,8 +63,168 @@ function finiteRange(values: Float64Array): [number, number] | null {
   return [min, max];
 }
 
+type BinBreaks = ReturnType<typeof binBreaksBins>;
+
+function indexGroups(input: Bin2dStatInput, rowCount: number) {
+  const order: number[] = [];
+  const slots = new Map<number, number>();
+  const sampleRows: number[] = [];
+  for (let i = 0; i < rowCount; i++) {
+    const group = input.groups[i]!;
+    if (slots.has(group)) continue;
+    slots.set(group, order.length);
+    order.push(group);
+    sampleRows.push(i);
+  }
+  return { order, slots, sampleRows };
+}
+
+function countCells(
+  input: Bin2dStatInput,
+  rowCount: number,
+  xBreaks: BinBreaks,
+  yBreaks: BinBreaks,
+  groupSlots: Map<number, number>,
+) {
+  const nx = xBreaks.breaks.length - 1;
+  const cellCount = nx * (yBreaks.breaks.length - 1);
+  const counts = new Float64Array(groupSlots.size * cellCount);
+  let dropped = 0;
+  for (let i = 0; i < rowCount; i++) {
+    const x = input.x[i]!;
+    const y = input.y[i]!;
+    if (!Number.isFinite(x) || !Number.isFinite(y)) {
+      dropped++;
+      continue;
+    }
+    const ix = binIndexOf(x, xBreaks.fuzzy, xBreaks.rightClosed);
+    const iy = binIndexOf(y, yBreaks.fuzzy, yBreaks.rightClosed);
+    if (ix === -1 || iy === -1) {
+      dropped++;
+      continue;
+    }
+    const rawWeight = input.weights?.[i];
+    const weight = rawWeight === undefined ? 1 : Number.isFinite(rawWeight) ? rawWeight : 0;
+    const slot = groupSlots.get(input.groups[i]!)! * cellCount + iy * nx + ix;
+    counts[slot] = counts[slot]! + weight;
+  }
+  return { counts, dropped };
+}
+
+function outputRowCount(
+  counts: Float64Array,
+  groupCount: number,
+  cellCount: number,
+  drop: boolean,
+) {
+  let result = 0;
+  for (let group = 0; group < groupCount; group++) {
+    for (let cell = 0; cell < cellCount; cell++) {
+      if (!drop || counts[group * cellCount + cell] !== 0) result++;
+    }
+  }
+  return result;
+}
+
+function density(count: number, area: number, total: number): number {
+  return total > 0 && area > 0 ? count / area / total : 0;
+}
+
+function normalized(value: number, max: number): number {
+  return max > 0 ? value / max : 0;
+}
+
+function emitCells(
+  input: Bin2dStatInput,
+  counts: Float64Array,
+  xBreaks: BinBreaks,
+  yBreaks: BinBreaks,
+  groupOrder: number[],
+  sampleRows: number[],
+  carriedNames: string[],
+  drop: boolean,
+  rowCount: number,
+) {
+  const x = new Float64Array(rowCount);
+  const y = new Float64Array(rowCount);
+  const xmin = new Float64Array(rowCount);
+  const xmax = new Float64Array(rowCount);
+  const ymin = new Float64Array(rowCount);
+  const ymax = new Float64Array(rowCount);
+  const count = new Float64Array(rowCount);
+  const densities = new Float64Array(rowCount);
+  const ncount = new Float64Array(rowCount);
+  const ndensity = new Float64Array(rowCount);
+  const groups: number[] = [];
+  const carried: Record<string, CellValue[]> = {};
+  for (const name of carriedNames) carried[name] = [];
+
+  const nx = xBreaks.breaks.length - 1;
+  const ny = yBreaks.breaks.length - 1;
+  const cellCount = nx * ny;
+  let row = 0;
+  for (let group = 0; group < groupOrder.length; group++) {
+    let total = 0;
+    let maxCount = 0;
+    for (let cell = 0; cell < cellCount; cell++) {
+      const value = counts[group * cellCount + cell]!;
+      total += Math.abs(value);
+      if (Math.abs(value) > maxCount) maxCount = Math.abs(value);
+    }
+    let maxDensity = 0;
+    for (let iy = 0; iy < ny; iy++) {
+      const height = yBreaks.breaks[iy + 1]! - yBreaks.breaks[iy]!;
+      for (let ix = 0; ix < nx; ix++) {
+        const width = xBreaks.breaks[ix + 1]! - xBreaks.breaks[ix]!;
+        const value = density(counts[group * cellCount + iy * nx + ix]!, width * height, total);
+        if (value > maxDensity) maxDensity = value;
+      }
+    }
+    for (let iy = 0; iy < ny; iy++) {
+      const yLo = yBreaks.breaks[iy]!;
+      const yHi = yBreaks.breaks[iy + 1]!;
+      for (let ix = 0; ix < nx; ix++) {
+        const xLo = xBreaks.breaks[ix]!;
+        const xHi = xBreaks.breaks[ix + 1]!;
+        const value = counts[group * cellCount + iy * nx + ix]!;
+        if (drop && value === 0) continue;
+        const cellDensity = density(value, (xHi - xLo) * (yHi - yLo), total);
+        x[row] = (xLo + xHi) / 2;
+        y[row] = (yLo + yHi) / 2;
+        xmin[row] = xLo;
+        xmax[row] = xHi;
+        ymin[row] = yLo;
+        ymax[row] = yHi;
+        count[row] = value;
+        densities[row] = cellDensity;
+        ncount[row] = normalized(value, maxCount);
+        ndensity[row] = normalized(cellDensity, maxDensity);
+        groups.push(groupOrder[group]!);
+        for (const name of carriedNames) {
+          carried[name]!.push(input.carried![name]![sampleRows[group]!]!);
+        }
+        row++;
+      }
+    }
+  }
+  return {
+    x,
+    y,
+    xmin,
+    xmax,
+    ymin,
+    ymax,
+    count,
+    densities,
+    ncount,
+    ndensity,
+    groups,
+    carried,
+  };
+}
+
 export function statBin2d(input: Bin2dStatInput): Bin2dStatResult {
-  const { x, y, groups, weights } = input;
+  const { x, y } = input;
   const params = input.params ?? {};
   const drop = params.drop !== false;
   const carriedNames = Object.keys(input.carried ?? {});
@@ -108,134 +268,40 @@ export function statBin2d(input: Bin2dStatInput): Bin2dStatResult {
   const ny = yBreaks.breaks.length - 1;
   if (nx <= 0 || ny <= 0) return empty(nIn);
 
-  const groupOrder: number[] = [];
-  const groupSlot = new Map<number, number>();
-  const sampleRow: number[] = [];
-  for (let i = 0; i < nIn; i++) {
-    const g = groups[i]!;
-    if (!groupSlot.has(g)) {
-      groupSlot.set(g, groupOrder.length);
-      groupOrder.push(g);
-      sampleRow.push(i);
-    }
-  }
+  const { order: groupOrder, slots: groupSlot, sampleRows: sampleRow } = indexGroups(input, nIn);
   const gCount = groupOrder.length;
   const cellCount = nx * ny;
-  const counts = new Float64Array(gCount * cellCount);
-  let dropped = 0;
-  for (let i = 0; i < nIn; i++) {
-    const xv = x[i]!;
-    const yv = y[i]!;
-    if (!Number.isFinite(xv) || !Number.isFinite(yv)) {
-      dropped++;
-      continue;
-    }
-    const ix = binIndexOf(xv, xBreaks.fuzzy, xBreaks.rightClosed);
-    const iy = binIndexOf(yv, yBreaks.fuzzy, yBreaks.rightClosed);
-    if (ix === -1 || iy === -1) {
-      dropped++;
-      continue;
-    }
-    let w = 1;
-    if (weights !== null && weights !== undefined) {
-      w = Number.isFinite(weights[i]!) ? weights[i]! : 0;
-    }
-    const slot = groupSlot.get(groups[i]!)! * cellCount + iy * nx + ix;
-    counts[slot] = counts[slot]! + w;
-  }
+  const { counts, dropped } = countCells(input, nIn, xBreaks, yBreaks, groupSlot);
 
   // First pass: how many output rows?
-  let nOut = 0;
-  for (let s = 0; s < gCount; s++) {
-    for (let c = 0; c < cellCount; c++) {
-      const cnt = counts[s * cellCount + c]!;
-      if (!drop || cnt !== 0) nOut++;
-    }
-  }
+  const nOut = outputRowCount(counts, gCount, cellCount, drop);
   if (nOut === 0) return empty(dropped);
 
-  const outX = new Float64Array(nOut);
-  const outY = new Float64Array(nOut);
-  const outXmin = new Float64Array(nOut);
-  const outXmax = new Float64Array(nOut);
-  const outYmin = new Float64Array(nOut);
-  const outYmax = new Float64Array(nOut);
-  const outCount = new Float64Array(nOut);
-  const outDensity = new Float64Array(nOut);
-  const outNcount = new Float64Array(nOut);
-  const outNdensity = new Float64Array(nOut);
-  const outGroups: number[] = [];
-  const carried: Record<string, CellValue[]> = {};
-  for (const name of carriedNames) carried[name] = [];
-
-  let row = 0;
-  for (let s = 0; s < gCount; s++) {
-    let total = 0;
-    let maxCount = 0;
-    for (let c = 0; c < cellCount; c++) {
-      const cnt = counts[s * cellCount + c]!;
-      total += Math.abs(cnt);
-      if (Math.abs(cnt) > maxCount) maxCount = Math.abs(cnt);
-    }
-    let maxDensity = 0;
-    for (let iy = 0; iy < ny; iy++) {
-      const yLo = yBreaks.breaks[iy]!;
-      const yHi = yBreaks.breaks[iy + 1]!;
-      const wy = yHi - yLo;
-      for (let ix = 0; ix < nx; ix++) {
-        const xLo = xBreaks.breaks[ix]!;
-        const xHi = xBreaks.breaks[ix + 1]!;
-        const wx = xHi - xLo;
-        const area = wx * wy;
-        const cnt = counts[s * cellCount + iy * nx + ix]!;
-        const d = total > 0 && area > 0 ? cnt / area / total : 0;
-        if (d > maxDensity) maxDensity = d;
-      }
-    }
-    for (let iy = 0; iy < ny; iy++) {
-      const yLo = yBreaks.breaks[iy]!;
-      const yHi = yBreaks.breaks[iy + 1]!;
-      const wy = yHi - yLo;
-      for (let ix = 0; ix < nx; ix++) {
-        const xLo = xBreaks.breaks[ix]!;
-        const xHi = xBreaks.breaks[ix + 1]!;
-        const wx = xHi - xLo;
-        const cnt = counts[s * cellCount + iy * nx + ix]!;
-        if (drop && cnt === 0) continue;
-        const area = wx * wy;
-        const d = total > 0 && area > 0 ? cnt / area / total : 0;
-        outX[row] = (xLo + xHi) / 2;
-        outY[row] = (yLo + yHi) / 2;
-        outXmin[row] = xLo;
-        outXmax[row] = xHi;
-        outYmin[row] = yLo;
-        outYmax[row] = yHi;
-        outCount[row] = cnt;
-        outDensity[row] = d;
-        outNcount[row] = maxCount > 0 ? cnt / maxCount : 0;
-        outNdensity[row] = maxDensity > 0 ? d / maxDensity : 0;
-        outGroups.push(groupOrder[s]!);
-        for (const name of carriedNames) {
-          carried[name]!.push(input.carried![name]![sampleRow[s]!]!);
-        }
-        row++;
-      }
-    }
-  }
+  const output = emitCells(
+    input,
+    counts,
+    xBreaks,
+    yBreaks,
+    groupOrder,
+    sampleRow,
+    carriedNames,
+    drop,
+    nOut,
+  );
 
   return {
-    x: outX,
-    y: outY,
-    xmin: outXmin,
-    xmax: outXmax,
-    ymin: outYmin,
-    ymax: outYmax,
-    count: outCount,
-    density: outDensity,
-    ncount: outNcount,
-    ndensity: outNdensity,
-    groups: outGroups,
-    carried,
+    x: output.x,
+    y: output.y,
+    xmin: output.xmin,
+    xmax: output.xmax,
+    ymin: output.ymin,
+    ymax: output.ymax,
+    count: output.count,
+    density: output.densities,
+    ncount: output.ncount,
+    ndensity: output.ndensity,
+    groups: output.groups,
+    carried: output.carried,
     dropped,
     usedDefaultBins,
   };

--- a/packages/core/src/stats/bin-hex.ts
+++ b/packages/core/src/stats/bin-hex.ts
@@ -189,8 +189,144 @@ function fillEmptyLatticeCells(counts: Map<string, HexCell>, groupCount: number,
   }
 }
 
+function indexGroups(input: BinHexStatInput, rowCount: number) {
+  const order: number[] = [];
+  const slots = new Map<number, number>();
+  const sampleRows: number[] = [];
+  for (let i = 0; i < rowCount; i++) {
+    const group = input.groups[i]!;
+    if (slots.has(group)) continue;
+    slots.set(group, order.length);
+    order.push(group);
+    sampleRows.push(i);
+  }
+  return { order, slots, sampleRows };
+}
+
+function collectCells(
+  input: BinHexStatInput,
+  rowCount: number,
+  ranges: { x: [number, number]; y: [number, number] },
+  size: number,
+  groupSlots: Map<number, number>,
+) {
+  const counts = new Map<string, HexCell>();
+  const spanX = ranges.x[1] - ranges.x[0];
+  const spanY = ranges.y[1] - ranges.y[0];
+  let dropped = 0;
+  for (let i = 0; i < rowCount; i++) {
+    const x = input.x[i]!;
+    const y = input.y[i]!;
+    if (!Number.isFinite(x) || !Number.isFinite(y)) {
+      dropped++;
+      continue;
+    }
+    const axial = pixelToAxial((x - ranges.x[0]) / spanX, (y - ranges.y[0]) / spanY, size);
+    const group = groupSlots.get(input.groups[i]!)!;
+    const key = hexBinKey(group, axial.q, axial.r);
+    const rawWeight = input.weights?.[i];
+    const weight = rawWeight === undefined ? 1 : Number.isFinite(rawWeight) ? rawWeight : 0;
+    const existing = counts.get(key);
+    if (existing === undefined) counts.set(key, { gs: group, ...axial, count: weight });
+    else existing.count += weight;
+  }
+  return { counts, dropped };
+}
+
+function selectedCells(counts: Map<string, HexCell>, drop: boolean): HexCell[] {
+  const cells: HexCell[] = [];
+  for (const cell of counts.values()) {
+    if (!drop || cell.count !== 0) cells.push(cell);
+  }
+  cells.sort((a, b) => a.gs - b.gs || a.r - b.r || a.q - b.q);
+  return cells;
+}
+
+function groupMetrics(cells: HexCell[], dataArea: number) {
+  const totals = new Map<number, number>();
+  const maxCounts = new Map<number, number>();
+  for (const cell of cells) {
+    totals.set(cell.gs, (totals.get(cell.gs) ?? 0) + Math.abs(cell.count));
+    maxCounts.set(cell.gs, Math.max(maxCounts.get(cell.gs) ?? 0, Math.abs(cell.count)));
+  }
+  const maxDensities = new Map<number, number>();
+  for (const cell of cells) {
+    const total = totals.get(cell.gs) ?? 0;
+    const density = total > 0 && dataArea > 0 ? cell.count / dataArea / total : 0;
+    maxDensities.set(cell.gs, Math.max(maxDensities.get(cell.gs) ?? 0, density));
+  }
+  return { totals, maxCounts, maxDensities };
+}
+
+function normalized(value: number, max: number): number {
+  return max > 0 ? value / max : 0;
+}
+
+function emitCells(
+  input: BinHexStatInput,
+  cells: HexCell[],
+  groupOrder: number[],
+  sampleRows: number[],
+  carriedNames: string[],
+  geometry: {
+    xmin: number;
+    ymin: number;
+    spanX: number;
+    spanY: number;
+    size: number;
+  },
+) {
+  const unitArea = ((3 * Math.sqrt(3)) / 2) * geometry.size * geometry.size;
+  const dataArea = unitArea * geometry.spanX * geometry.spanY;
+  const width = Math.sqrt(3) * geometry.size * geometry.spanX;
+  const height = 2 * geometry.size * geometry.spanY;
+  const metrics = groupMetrics(cells, dataArea);
+  const x = new Float64Array(cells.length);
+  const y = new Float64Array(cells.length);
+  const widths = new Float64Array(cells.length);
+  const heights = new Float64Array(cells.length);
+  const count = new Float64Array(cells.length);
+  const density = new Float64Array(cells.length);
+  const ncount = new Float64Array(cells.length);
+  const ndensity = new Float64Array(cells.length);
+  const groups: number[] = [];
+  const carried: Record<string, CellValue[]> = {};
+  for (const name of carriedNames) carried[name] = [];
+
+  for (let i = 0; i < cells.length; i++) {
+    const cell = cells[i]!;
+    const unit = axialToPixel(cell.q, cell.r, geometry.size);
+    x[i] = geometry.xmin + unit.x * geometry.spanX;
+    y[i] = geometry.ymin + unit.y * geometry.spanY;
+    widths[i] = width;
+    heights[i] = height;
+    count[i] = cell.count;
+    const total = metrics.totals.get(cell.gs) ?? 0;
+    const cellDensity = total > 0 && dataArea > 0 ? cell.count / dataArea / total : 0;
+    density[i] = cellDensity;
+    ncount[i] = normalized(cell.count, metrics.maxCounts.get(cell.gs) ?? 0);
+    ndensity[i] = normalized(cellDensity, metrics.maxDensities.get(cell.gs) ?? 0);
+    groups.push(groupOrder[cell.gs]!);
+    for (const name of carriedNames) {
+      carried[name]!.push(input.carried![name]![sampleRows[cell.gs]!]!);
+    }
+  }
+  return {
+    x,
+    y,
+    widths,
+    heights,
+    count,
+    density,
+    ncount,
+    ndensity,
+    groups,
+    carried,
+  };
+}
+
 export function statBinHex(input: BinHexStatInput): BinHexStatResult {
-  const { x, y, groups, weights } = input;
+  const { x, y } = input;
   const params = input.params ?? {};
   const drop = params.drop !== false;
   const bins = params.bins ?? 30;
@@ -225,44 +361,11 @@ export function statBinHex(input: BinHexStatInput): BinHexStatResult {
   const s = 1 / Math.max(1, bins * Math.sqrt(3));
 
   // Group first-seen order.
-  const groupOrder: number[] = [];
-  const groupSlot = new Map<number, number>();
-  const sampleRow: number[] = [];
-  for (let i = 0; i < nIn; i++) {
-    const g = groups[i]!;
-    if (!groupSlot.has(g)) {
-      groupSlot.set(g, groupOrder.length);
-      groupOrder.push(g);
-      sampleRow.push(i);
-    }
-  }
+  const { order: groupOrder, slots: groupSlot, sampleRows: sampleRow } = indexGroups(input, nIn);
 
   // Key: groupSlot | q | r  → cell (coords stored at insert so collect never
   // re-parses the composite string key).
-  const counts = new Map<string, HexCell>();
-  let dropped = 0;
-
-  for (let i = 0; i < nIn; i++) {
-    const xv = x[i]!;
-    const yv = y[i]!;
-    if (!Number.isFinite(xv) || !Number.isFinite(yv)) {
-      dropped++;
-      continue;
-    }
-    // Normalize to unit square.
-    const nx = (xv - xmin) / spanX;
-    const ny = (yv - ymin) / spanY;
-    const { q, r } = pixelToAxial(nx, ny, s);
-    const gs = groupSlot.get(groups[i]!)!;
-    const key = hexBinKey(gs, q, r);
-    let w = 1;
-    if (weights !== null && weights !== undefined) {
-      w = Number.isFinite(weights[i]!) ? weights[i]! : 0;
-    }
-    const existing = counts.get(key);
-    if (existing === undefined) counts.set(key, { gs, q, r, count: w });
-    else existing.count += w;
-  }
+  const { counts, dropped } = collectCells(input, nIn, ranges, s, groupSlot);
 
   // drop:false — materialize the full axial lattice over the unit square so
   // empty cells appear (counts Map only ever saw occupied keys). Bound by
@@ -272,90 +375,27 @@ export function statBinHex(input: BinHexStatInput): BinHexStatResult {
   }
 
   // Collect cells (coords already known — no key.split / Number re-parse).
-  const cells: HexCell[] = [];
-  for (const cell of counts.values()) {
-    if (drop && cell.count === 0) continue;
-    cells.push(cell);
-  }
+  const cells = selectedCells(counts, drop);
   if (cells.length === 0) return empty(dropped);
-
-  // Sort by group then q,r for determinism.
-  cells.sort((a, b) => a.gs - b.gs || a.r - b.r || a.q - b.q);
-
-  // Per-group totals for density.
-  const groupTotal = new Map<number, number>();
-  const groupMax = new Map<number, number>();
-  for (const c of cells) {
-    groupTotal.set(c.gs, (groupTotal.get(c.gs) ?? 0) + Math.abs(c.count));
-    groupMax.set(c.gs, Math.max(groupMax.get(c.gs) ?? 0, Math.abs(c.count)));
-  }
-
-  // Hex area in unit space: (3√3/2) s² for regular pointy-top.
-  const unitArea = ((3 * Math.sqrt(3)) / 2) * s * s;
-  // Data-space area scale.
-  const dataArea = unitArea * spanX * spanY;
-
-  // Vertex radii in data space: unit center-to-vertex s maps to (s*spanX, s*spanY)
-  // but pointy-top x extent is s*√3 (half-width), y extent is s (half-height to flat? pointy half-height = s).
-  // Full width = 2 * (s * √3 / 2)? Pointy-top: width = √3 * s, height = 2 * s (in unit space).
-  const unitWidth = Math.sqrt(3) * s;
-  const unitHeight = 2 * s;
-  const dataWidth = unitWidth * spanX;
-  const dataHeight = unitHeight * spanY;
-
-  const nOut = cells.length;
-  const outX = new Float64Array(nOut);
-  const outY = new Float64Array(nOut);
-  const outW = new Float64Array(nOut);
-  const outH = new Float64Array(nOut);
-  const outCount = new Float64Array(nOut);
-  const outDensity = new Float64Array(nOut);
-  const outNcount = new Float64Array(nOut);
-  const outNdensity = new Float64Array(nOut);
-  const outGroups: number[] = [];
-  const carried: Record<string, CellValue[]> = {};
-  for (const name of carriedNames) carried[name] = [];
-
-  // Max density per group for ndensity.
-  const groupMaxDensity = new Map<number, number>();
-  for (const c of cells) {
-    const total = groupTotal.get(c.gs) ?? 0;
-    const d = total > 0 && dataArea > 0 ? c.count / dataArea / total : 0;
-    groupMaxDensity.set(c.gs, Math.max(groupMaxDensity.get(c.gs) ?? 0, d));
-  }
-
-  for (let i = 0; i < nOut; i++) {
-    const c = cells[i]!;
-    const { x: ux, y: uy } = axialToPixel(c.q, c.r, s);
-    outX[i] = xmin + ux * spanX;
-    outY[i] = ymin + uy * spanY;
-    outW[i] = dataWidth;
-    outH[i] = dataHeight;
-    outCount[i] = c.count;
-    const total = groupTotal.get(c.gs) ?? 0;
-    const d = total > 0 && dataArea > 0 ? c.count / dataArea / total : 0;
-    outDensity[i] = d;
-    const maxC = groupMax.get(c.gs) ?? 0;
-    outNcount[i] = maxC > 0 ? c.count / maxC : 0;
-    const maxD = groupMaxDensity.get(c.gs) ?? 0;
-    outNdensity[i] = maxD > 0 ? d / maxD : 0;
-    outGroups.push(groupOrder[c.gs]!);
-    for (const name of carriedNames) {
-      carried[name]!.push(input.carried![name]![sampleRow[c.gs]!]!);
-    }
-  }
+  const output = emitCells(input, cells, groupOrder, sampleRow, carriedNames, {
+    xmin,
+    ymin,
+    spanX,
+    spanY,
+    size: s,
+  });
 
   return {
-    x: outX,
-    y: outY,
-    width: outW,
-    height: outH,
-    count: outCount,
-    density: outDensity,
-    ncount: outNcount,
-    ndensity: outNdensity,
-    groups: outGroups,
-    carried,
+    x: output.x,
+    y: output.y,
+    width: output.widths,
+    height: output.heights,
+    count: output.count,
+    density: output.density,
+    ncount: output.ncount,
+    ndensity: output.ndensity,
+    groups: output.groups,
+    carried: output.carried,
     dropped,
     usedDefaultBins,
   };

--- a/packages/core/src/stats/bin.ts
+++ b/packages/core/src/stats/bin.ts
@@ -77,21 +77,72 @@ export interface BinStatResult {
   cut: { fuzzy: readonly number[]; rightClosed: boolean; binIndex: Int32Array };
 }
 
+type BinBreaks = ReturnType<typeof binBreaksBins>;
+
+function finiteRange(values: Float64Array): [number, number] | undefined {
+  let min = Infinity;
+  let max = -Infinity;
+  for (const value of values) {
+    if (!Number.isFinite(value)) continue;
+    if (value < min) min = value;
+    if (value > max) max = value;
+  }
+  return min > max ? undefined : [min, max];
+}
+
+function indexGroups(input: BinStatInput) {
+  const order: number[] = [];
+  const slots = new Map<number, number>();
+  const sampleRows: number[] = [];
+  for (let i = 0; i < input.x.length; i++) {
+    const group = input.groups[i]!;
+    if (slots.has(group)) continue;
+    slots.set(group, order.length);
+    order.push(group);
+    sampleRows.push(i);
+  }
+  return { order, slots, sampleRows };
+}
+
+function countBins(input: BinStatInput, breaks: BinBreaks, groupSlots: Map<number, number>) {
+  const binCount = breaks.breaks.length - 1;
+  const counts = new Float64Array(groupSlots.size * binCount);
+  let dropped = 0;
+  for (let i = 0; i < input.x.length; i++) {
+    const value = input.x[i]!;
+    if (!Number.isFinite(value)) {
+      dropped++;
+      continue;
+    }
+    const bin = binIndexOf(value, breaks.fuzzy, breaks.rightClosed);
+    if (bin === -1) {
+      dropped++;
+      continue;
+    }
+    const rawWeight = input.weights?.[i];
+    const weight = rawWeight === undefined ? 1 : Number.isFinite(rawWeight) ? rawWeight : 0;
+    const slot = groupSlots.get(input.groups[i]!)! * binCount + bin;
+    counts[slot] = counts[slot]! + weight;
+  }
+  return { counts, dropped };
+}
+
+function density(count: number, width: number, total: number): number {
+  return total > 0 ? count / width / total : 0;
+}
+
+function normalized(value: number, max: number): number {
+  return max > 0 ? value / max : 0;
+}
+
 export function statBin(input: BinStatInput): BinStatResult {
-  const { x, groups, weights } = input;
+  const { x } = input;
   const params = input.params ?? {};
   const carriedNames = Object.keys(input.carried ?? {});
   const usedDefaultBins = params.bins === undefined && params.binwidth === undefined;
 
   // Layer-wide finite range (shared breaks across groups).
-  let min = Infinity;
-  let max = -Infinity;
-  for (let i = 0; i < x.length; i++) {
-    const v = x[i]!;
-    if (!Number.isFinite(v)) continue;
-    if (v < min) min = v;
-    if (v > max) max = v;
-  }
+  const dataRange = finiteRange(x);
   const empty: BinStatResult = {
     x: new Float64Array(0),
     xmin: new Float64Array(0),
@@ -106,10 +157,10 @@ export function statBin(input: BinStatInput): BinStatResult {
     usedDefaultBins,
     cut: { fuzzy: [], rightClosed: true, binIndex: new Int32Array(0) },
   };
-  if (min > max) return empty;
+  if (dataRange === undefined) return empty;
 
   const closed = params.closed ?? "right";
-  const range: [number, number] = input.range ?? [min, max];
+  const range: [number, number] = input.range ?? dataRange;
   const breaks =
     params.binwidth === undefined
       ? binBreaksBins(range, params.bins ?? 30, params.boundary, params.center, closed)
@@ -117,40 +168,10 @@ export function statBin(input: BinStatInput): BinStatResult {
   const binCount = breaks.breaks.length - 1;
 
   // Present groups in first-seen order, with one carried sample row each.
-  const groupOrder: number[] = [];
-  const groupSlot = new Map<number, number>();
-  const sampleRow: number[] = [];
-  for (let i = 0; i < x.length; i++) {
-    const g = groups[i]!;
-    if (!groupSlot.has(g)) {
-      groupSlot.set(g, groupOrder.length);
-      groupOrder.push(g);
-      sampleRow.push(i);
-    }
-  }
+  const { order: groupOrder, slots: groupSlot, sampleRows: sampleRow } = indexGroups(input);
 
   // Count per (group, bin).
-  const counts = new Float64Array(groupOrder.length * binCount);
-  let dropped = 0;
-  for (let i = 0; i < x.length; i++) {
-    const v = x[i]!;
-    if (!Number.isFinite(v)) {
-      dropped++;
-      continue;
-    }
-    const bin = binIndexOf(v, breaks.fuzzy, breaks.rightClosed);
-    if (bin === -1) {
-      dropped++;
-      continue;
-    }
-    let w = 1;
-    if (weights !== null && weights !== undefined) {
-      // ggplot2: missing weights count as 0.
-      w = Number.isFinite(weights[i]!) ? weights[i]! : 0;
-    }
-    const slot = groupSlot.get(groups[i]!)! * binCount + bin;
-    counts[slot] = counts[slot]! + w;
-  }
+  const { counts, dropped } = countBins(input, breaks, groupSlot);
 
   // Emit all (group × bin) rows, zero-count bins included.
   const n = groupOrder.length * binCount;
@@ -177,7 +198,7 @@ export function statBin(input: BinStatInput): BinStatResult {
     let maxDensity = 0;
     for (let b = 0; b < binCount; b++) {
       const width = breaks.breaks[b + 1]! - breaks.breaks[b]!;
-      const d = total > 0 ? counts[s * binCount + b]! / width / total : 0;
+      const d = density(counts[s * binCount + b]!, width, total);
       if (d > maxDensity) maxDensity = d;
     }
     for (let b = 0; b < binCount; b++) {
@@ -191,9 +212,9 @@ export function statBin(input: BinStatInput): BinStatResult {
       outXmin[row] = lo;
       outXmax[row] = hi;
       outCount[row] = c;
-      outDensity[row] = total > 0 ? c / width / total : 0;
-      outNcount[row] = maxCount > 0 ? c / maxCount : 0;
-      outNdensity[row] = maxDensity > 0 ? (total > 0 ? c / width / total : 0) / maxDensity : 0;
+      outDensity[row] = density(c, width, total);
+      outNcount[row] = normalized(c, maxCount);
+      outNdensity[row] = normalized(density(c, width, total), maxDensity);
       outGroups.push(groupOrder[s]!);
       for (const name of carriedNames) {
         carried[name]!.push(input.carried![name]![sampleRow[s]!]!);

--- a/packages/core/src/stats/bindot.ts
+++ b/packages/core/src/stats/bindot.ts
@@ -80,8 +80,57 @@ function stackPosition(
   }
 }
 
+type BinBreaks = ReturnType<typeof binBreaksBins>;
+
+function finiteExtent(values: Float64Array): [number, number] | undefined {
+  let min = Infinity;
+  let max = -Infinity;
+  let count = 0;
+  for (const value of values) {
+    if (!Number.isFinite(value)) continue;
+    count++;
+    if (value < min) min = value;
+    if (value > max) max = value;
+  }
+  return count === 0 ? undefined : [min, max];
+}
+
+function collectBuckets(input: BindotStatInput, breaks: BinBreaks) {
+  const buckets = new Map<string, { rows: number[] }>();
+  const groupOrder: number[] = [];
+  const seenGroup = new Set<number>();
+  const binCount = breaks.breaks.length - 1;
+  let dropped = 0;
+
+  for (let i = 0; i < input.x.length; i++) {
+    const value = input.x[i]!;
+    if (!Number.isFinite(value)) {
+      dropped++;
+      continue;
+    }
+    const bin = binIndexOf(value, breaks.fuzzy, breaks.rightClosed);
+    if (bin < 0 || bin >= binCount) {
+      dropped++;
+      continue;
+    }
+    const group = input.groups[i]!;
+    if (!seenGroup.has(group)) {
+      seenGroup.add(group);
+      groupOrder.push(group);
+    }
+    const key = `${group}\0${bin}`;
+    let bucket = buckets.get(key);
+    if (bucket === undefined) {
+      bucket = { rows: [] };
+      buckets.set(key, bucket);
+    }
+    bucket.rows.push(i);
+  }
+  return { buckets, groupOrder, dropped };
+}
+
 export function statBindot(input: BindotStatInput): BindotStatResult {
-  const { x, groups } = input;
+  const { x } = input;
   const params = input.params ?? {};
   const carriedNames = Object.keys(input.carried ?? {});
   const usedDefaultBins = params.bins === undefined && params.binwidth === undefined;
@@ -102,20 +151,11 @@ export function statBindot(input: BindotStatInput): BindotStatResult {
     effectiveBinwidth: 0,
   });
 
-  let min = Infinity;
-  let max = -Infinity;
-  let finite = 0;
-  for (let i = 0; i < x.length; i++) {
-    const v = x[i]!;
-    if (!Number.isFinite(v)) continue;
-    finite++;
-    if (v < min) min = v;
-    if (v > max) max = v;
-  }
-  if (finite === 0) return empty(x.length);
+  const extent = finiteExtent(x);
+  if (extent === undefined) return empty(x.length);
 
   const closed = params.closed ?? "right";
-  const range: [number, number] = input.range ?? [min, max];
+  const range: [number, number] = input.range ?? extent;
   const breaks =
     params.binwidth === undefined
       ? binBreaksBins(range, params.bins ?? 30, params.boundary, params.center, closed)
@@ -125,33 +165,7 @@ export function statBindot(input: BindotStatInput): BindotStatResult {
     binCount > 0 ? breaks.breaks[1]! - breaks.breaks[0]! : (params.binwidth ?? 0);
 
   // Collect kept rows per (group, bin), preserving input order within bucket.
-  type Bucket = { rows: number[] };
-  const buckets = new Map<string, Bucket>();
-  const groupOrder: number[] = [];
-  const seenGroup = new Set<number>();
-  let dropped = x.length - finite;
-
-  for (let i = 0; i < x.length; i++) {
-    const v = x[i]!;
-    if (!Number.isFinite(v)) continue;
-    const bin = binIndexOf(v, breaks.fuzzy, breaks.rightClosed);
-    if (bin < 0 || bin >= binCount) {
-      dropped++;
-      continue;
-    }
-    const g = groups[i]!;
-    if (!seenGroup.has(g)) {
-      seenGroup.add(g);
-      groupOrder.push(g);
-    }
-    const key = `${g}\0${bin}`;
-    let bucket = buckets.get(key);
-    if (bucket === undefined) {
-      bucket = { rows: [] };
-      buckets.set(key, bucket);
-    }
-    bucket.rows.push(i);
-  }
+  const { buckets, groupOrder, dropped } = collectBuckets(input, breaks);
 
   // Emit in first-seen group order, then ascending bin index, then input order.
   const outX: number[] = [];

--- a/packages/core/src/stats/contour.ts
+++ b/packages/core/src/stats/contour.ts
@@ -93,6 +93,16 @@ function edgeInterp(
   return { x: ax + (bx - ax) * u, y: ay + (by - ay) * u };
 }
 
+function cellMask(values: readonly number[], level: number): number {
+  if (!values.every((value) => Number.isFinite(value)) || !Number.isFinite(level)) return -1;
+  let mask = 0;
+  if (values[0]! >= level) mask |= 1;
+  if (values[1]! >= level) mask |= 2;
+  if (values[3]! >= level) mask |= 4;
+  if (values[2]! >= level) mask |= 8;
+  return mask;
+}
+
 /** Emit 0–2 undirected segments for one cell at one level (marching squares). */
 export function cellSegments(
   x0: number,
@@ -105,15 +115,9 @@ export function cellSegments(
   z11: number,
   level: number,
 ): Array<[Pt, Pt]> {
-  if (![z00, z10, z01, z11].every((z) => Number.isFinite(z)) || !Number.isFinite(level)) {
-    return [];
-  }
   // Bitmask: corner ≥ level. corners: 0=SW, 1=SE, 2=NE, 3=NW
-  let mask = 0;
-  if (z00 >= level) mask |= 1;
-  if (z10 >= level) mask |= 2;
-  if (z11 >= level) mask |= 4;
-  if (z01 >= level) mask |= 8;
+  const mask = cellMask([z00, z10, z01, z11], level);
+  if (mask < 0) return [];
   if (mask === 0 || mask === 15) return [];
 
   const bottom = () => edgeInterp(x0, y0, z00, x1, y0, z10, level);
@@ -321,30 +325,83 @@ export function stitchSegments(segments: Array<[Pt, Pt]>): Pt[][] {
   return polylines;
 }
 
+function collectFiniteRows(input: ContourStatInput) {
+  const order: number[] = [];
+  const rowsByGroup = new Map<number, number[]>();
+  let dropped = 0;
+  for (let i = 0; i < input.x.length; i++) {
+    const finite =
+      Number.isFinite(input.x[i]!) && Number.isFinite(input.y[i]!) && Number.isFinite(input.z[i]!);
+    if (!finite) {
+      dropped++;
+      continue;
+    }
+    const group = input.groups[i]!;
+    let rows = rowsByGroup.get(group);
+    if (rows === undefined) {
+      rows = [];
+      rowsByGroup.set(group, rows);
+      order.push(group);
+    }
+    rows.push(i);
+  }
+  return { order, rowsByGroup, dropped };
+}
+
+type ContourVertex = Pt & { level: number; piece: number };
+
+function contourGroup(
+  input: ContourStatInput,
+  rows: number[],
+  params: ContourParamsInput,
+): ContourVertex[] | null {
+  const gx = Float64Array.from(rows, (row) => input.x[row]!);
+  const gy = Float64Array.from(rows, (row) => input.y[row]!);
+  const gz = Float64Array.from(rows, (row) => input.z[row]!);
+  const xs = uniqueSorted(gx);
+  const ys = uniqueSorted(gy);
+  if (xs.length < 2 || ys.length < 2) return null;
+  const xi = new Map(xs.map((value, i) => [value, i]));
+  const yi = new Map(ys.map((value, i) => [value, i]));
+  const grid: (number | null)[][] = Array.from({ length: ys.length }, () =>
+    Array.from({ length: xs.length }, () => null),
+  );
+  for (let k = 0; k < rows.length; k++) grid[yi.get(gy[k]!)!]![xi.get(gx[k]!)!] = gz[k]!;
+
+  let zmin = Infinity;
+  let zmax = -Infinity;
+  for (const row of grid) {
+    for (const value of row) {
+      if (value === null || !Number.isFinite(value)) continue;
+      if (value < zmin) zmin = value;
+      if (value > zmax) zmax = value;
+    }
+  }
+  if (!(zmax > zmin) && params.breaks === undefined) return null;
+  const levels = contourLevels(
+    Number.isFinite(zmin) ? zmin : 0,
+    Number.isFinite(zmax) ? zmax : 1,
+    params,
+  );
+  if (levels.length === 0) return null;
+
+  const vertices: ContourVertex[] = [];
+  let piece = 0;
+  for (const level of levels) {
+    for (const line of stitchSegments(gridCellSegments(xs, ys, grid, level))) {
+      const pieceId = piece++;
+      for (const point of line) vertices.push({ ...point, level, piece: pieceId });
+    }
+  }
+  return vertices;
+}
+
 export function statContour(input: ContourStatInput): ContourStatResult {
-  const { x, y, z, groups } = input;
   const params = input.params ?? {};
   const carriedNames = Object.keys(input.carried ?? {});
 
   // Group order first-seen
-  const groupOrder: number[] = [];
-  const groupRows = new Map<number, number[]>();
-  let dropped = 0;
-  for (let i = 0; i < x.length; i++) {
-    const ok = Number.isFinite(x[i]!) && Number.isFinite(y[i]!) && Number.isFinite(z[i]!);
-    if (!ok) {
-      dropped++;
-      continue;
-    }
-    const g = groups[i]!;
-    let list = groupRows.get(g);
-    if (list === undefined) {
-      list = [];
-      groupRows.set(g, list);
-      groupOrder.push(g);
-    }
-    list.push(i);
-  }
+  const { order: groupOrder, rowsByGroup: groupRows, dropped } = collectFiniteRows(input);
 
   const outX: number[] = [];
   const outY: number[] = [];
@@ -356,65 +413,19 @@ export function statContour(input: ContourStatInput): ContourStatResult {
 
   for (const g of groupOrder) {
     const rows = groupRows.get(g)!;
-    const gx = Float64Array.from(rows, (r) => x[r]!);
-    const gy = Float64Array.from(rows, (r) => y[r]!);
-    const gz = Float64Array.from(rows, (r) => z[r]!);
-    const xs = uniqueSorted(gx);
-    const ys = uniqueSorted(gy);
-    if (xs.length < 2 || ys.length < 2) {
+    const vertices = contourGroup(input, rows, params);
+    if (vertices === null) {
       droppedGroups++;
       continue;
     }
-    const xi = new Map(xs.map((v, i) => [v, i]));
-    const yi = new Map(ys.map((v, i) => [v, i]));
-    const grid: (number | null)[][] = Array.from({ length: ys.length }, () =>
-      Array.from({ length: xs.length }, () => null),
-    );
-    for (let k = 0; k < rows.length; k++) {
-      const i = xi.get(gx[k]!)!;
-      const j = yi.get(gy[k]!)!;
-      grid[j]![i] = gz[k]!;
-    }
-
-    let zmin = Infinity;
-    let zmax = -Infinity;
-    for (const row of grid) {
-      for (const v of row) {
-        if (v === null || !Number.isFinite(v)) continue;
-        if (v < zmin) zmin = v;
-        if (v > zmax) zmax = v;
-      }
-    }
-    if (!(zmax > zmin) && params.breaks === undefined) {
-      droppedGroups++;
-      continue;
-    }
-    const levels = contourLevels(
-      Number.isFinite(zmin) ? zmin : 0,
-      Number.isFinite(zmax) ? zmax : 1,
-      params,
-    );
-    if (levels.length === 0) {
-      droppedGroups++;
-      continue;
-    }
-
     const sample = rows[0]!;
-    let pieceCounter = 0;
-    for (const level of levels) {
-      const segs = gridCellSegments(xs, ys, grid, level);
-      const lines = stitchSegments(segs);
-      for (const line of lines) {
-        const piece = pieceCounter++;
-        for (const p of line) {
-          outX.push(p.x);
-          outY.push(p.y);
-          outLevel.push(level);
-          outGroups.push(g);
-          outPiece.push(piece);
-          sampleRows.push(sample);
-        }
-      }
+    for (const vertex of vertices) {
+      outX.push(vertex.x);
+      outY.push(vertex.y);
+      outLevel.push(vertex.level);
+      outGroups.push(g);
+      outPiece.push(vertex.piece);
+      sampleRows.push(sample);
     }
   }
 

--- a/packages/core/src/stats/density-2d.ts
+++ b/packages/core/src/stats/density-2d.ts
@@ -100,6 +100,47 @@ export type ProductKdeGridResult = number[][] & {
   examinations?: number;
 };
 
+function sortedPairs(xs: Float64Array, ys: Float64Array) {
+  const order = Array.from({ length: xs.length }, (_, i) => i).toSorted(
+    (a, b) => xs[a]! - xs[b]! || a - b,
+  );
+  const x = new Float64Array(xs.length);
+  const y = new Float64Array(xs.length);
+  for (let i = 0; i < xs.length; i++) {
+    x[i] = xs[order[i]!]!;
+    y[i] = ys[order[i]!]!;
+  }
+  return { x, y };
+}
+
+function extent(values: Float64Array): [number, number] {
+  let min = Number.POSITIVE_INFINITY;
+  let max = Number.NEGATIVE_INFINITY;
+  for (const value of values) {
+    if (value < min) min = value;
+    if (value > max) max = value;
+  }
+  return [min, max];
+}
+
+function packRow(
+  y: number,
+  window: number,
+  sortedX: Float64Array,
+  sortedY: Float64Array,
+  rowX: Float64Array,
+  rowY: Float64Array,
+): number {
+  let count = 0;
+  for (let i = 0; i < sortedX.length; i++) {
+    if (Math.abs(y - sortedY[i]!) > window) continue;
+    rowX[count] = sortedX[i]!;
+    rowY[count] = sortedY[i]!;
+    count++;
+  }
+  return count;
+}
+
 /**
  * Product-Gaussian KDE on a regular grid.
  *
@@ -134,15 +175,7 @@ export function productKdeGrid(
     return z;
   }
 
-  const order = Array.from({ length: nx }, (_, i) => i).toSorted(
-    (a, b) => xs[a]! - xs[b]! || a - b,
-  );
-  const sortedX = new Float64Array(nx);
-  const sortedY = new Float64Array(nx);
-  for (let i = 0; i < nx; i++) {
-    sortedX[i] = xs[order[i]!]!;
-    sortedY[i] = ys[order[i]!]!;
-  }
+  const { x: sortedX, y: sortedY } = sortedPairs(xs, ys);
 
   const wx = 8 * hx;
   const wy = 8 * hy;
@@ -154,20 +187,8 @@ export function productKdeGrid(
   // fits inside the window, no gather can remove anything, so read the sorted
   // arrays directly. That is the wide-bandwidth case, where the gather would be
   // pure overhead.
-  let yMin = Number.POSITIVE_INFINITY;
-  let yMax = Number.NEGATIVE_INFINITY;
-  for (let k = 0; k < nx; k++) {
-    const v = sortedY[k]!;
-    if (v < yMin) yMin = v;
-    if (v > yMax) yMax = v;
-  }
-  let gyMin = Number.POSITIVE_INFINITY;
-  let gyMax = Number.NEGATIVE_INFINITY;
-  for (let j = 0; j < gridNY; j++) {
-    const v = gy[j]!;
-    if (v < gyMin) gyMin = v;
-    if (v > gyMax) gyMax = v;
-  }
+  const [yMin, yMax] = extent(sortedY);
+  const [gyMin, gyMax] = extent(gy);
   const everyRowTakesEverySample = Math.max(gyMax - yMin, yMax - gyMin) <= wy;
 
   // Samples inside the current row's y window, packed by value in the same
@@ -181,15 +202,7 @@ export function productKdeGrid(
   for (let j = 0; j < gridNY; j++) {
     const yj = gy[j]!;
     if (!everyRowTakesEverySample) {
-      rowCount = 0;
-      for (let k = 0; k < nx; k++) {
-        // Negated so a non-finite dy is admitted, as the per-cell test was.
-        if (!(Math.abs(yj - sortedY[k]!) > wy)) {
-          rowX[rowCount] = sortedX[k]!;
-          rowY[rowCount] = sortedY[k]!;
-          rowCount++;
-        }
-      }
+      rowCount = packRow(yj, wy, sortedX, sortedY, rowX, rowY);
     }
     let lo = 0;
     for (let i = 0; i < gridNX; i++) {
@@ -269,29 +282,133 @@ function resolveH(
   return [(hx * adjust) / 4, (hy * adjust) / 4];
 }
 
+function collectFiniteRows(input: Density2dStatInput) {
+  const order: number[] = [];
+  const rowsByGroup = new Map<number, number[]>();
+  let dropped = 0;
+  for (let i = 0; i < input.x.length; i++) {
+    if (!Number.isFinite(input.x[i]!) || !Number.isFinite(input.y[i]!)) {
+      dropped++;
+      continue;
+    }
+    const group = input.groups[i]!;
+    let rows = rowsByGroup.get(group);
+    if (rows === undefined) {
+      rows = [];
+      rowsByGroup.set(group, rows);
+      order.push(group);
+    }
+    rows.push(i);
+  }
+  return { order, rowsByGroup, dropped };
+}
+
+function groupValues(input: Density2dStatInput, rows: number[]) {
+  const x = new Float64Array(rows.length);
+  const y = new Float64Array(rows.length);
+  let xmin = Infinity;
+  let xmax = -Infinity;
+  let ymin = Infinity;
+  let ymax = -Infinity;
+  for (let i = 0; i < rows.length; i++) {
+    x[i] = input.x[rows[i]!]!;
+    y[i] = input.y[rows[i]!]!;
+    if (x[i]! < xmin) xmin = x[i]!;
+    if (x[i]! > xmax) xmax = x[i]!;
+    if (y[i]! < ymin) ymin = y[i]!;
+    if (y[i]! > ymax) ymax = y[i]!;
+  }
+  return { x, y, xmin, xmax, ymin, ymax };
+}
+
+function densitySurface(
+  input: Density2dStatInput,
+  rows: number[],
+  params: Density2dParamsInput,
+  gridN: number,
+) {
+  const values = groupValues(input, rows);
+  let bandwidth: [number, number];
+  try {
+    bandwidth = resolveH(values.x, values.y, params);
+  } catch {
+    return null;
+  }
+  const [hx, hy] = bandwidth;
+  if (!(hx > 0) || !(hy > 0)) return null;
+  const [x0, x1] = expandRange(values.xmin, values.xmax, 0.05);
+  const [y0, y1] = expandRange(values.ymin, values.ymax, 0.05);
+  const gx = linspace(x0, x1, gridN);
+  const gy = linspace(y0, y1, gridN);
+  const z = productKdeGrid(values.x, values.y, gx, gy, hx, hy);
+  let zmin = Infinity;
+  let zmax = -Infinity;
+  for (const row of z) {
+    for (const value of row) {
+      if (value < zmin) zmin = value;
+      if (value > zmax) zmax = value;
+    }
+  }
+  const levels = contourLevels(zmin, zmax, {
+    bins: params.bins,
+    breaks: params.breaks,
+    binwidth: params.binwidth,
+  });
+  return levels.length === 0 || !(zmax > zmin) ? null : { gx, gy, z, zmin, zmax, levels };
+}
+
+type DensityContourVertex = {
+  x: number;
+  y: number;
+  level: number;
+  piece: number;
+};
+
+function densityContours(
+  surface: NonNullable<ReturnType<typeof densitySurface>>,
+  filled: boolean,
+): { vertices: DensityContourVertex[]; openRingsDropped: number } {
+  const vertices: DensityContourVertex[] = [];
+  let openRingsDropped = 0;
+  let piece = 0;
+  for (const level of surface.levels) {
+    if (level <= surface.zmin || level >= surface.zmax) continue;
+    const segments: Array<[{ x: number; y: number }, { x: number; y: number }]> = [];
+    for (let j = 0; j < surface.gy.length - 1; j++) {
+      for (let i = 0; i < surface.gx.length - 1; i++) {
+        segments.push(
+          ...cellSegments(
+            surface.gx[i]!,
+            surface.gx[i + 1]!,
+            surface.gy[j]!,
+            surface.gy[j + 1]!,
+            surface.z[j]![i]!,
+            surface.z[j]![i + 1]!,
+            surface.z[j + 1]![i]!,
+            surface.z[j + 1]![i + 1]!,
+            level,
+          ),
+        );
+      }
+    }
+    for (const line of stitchSegments(segments)) {
+      if (filled && !isClosedRing(line)) {
+        openRingsDropped++;
+        continue;
+      }
+      const pieceId = piece++;
+      for (const point of line) vertices.push({ ...point, level, piece: pieceId });
+    }
+  }
+  return { vertices, openRingsDropped };
+}
+
 export function statDensity2d(input: Density2dStatInput): Density2dStatResult {
-  const { x, y, groups } = input;
   const params = input.params ?? {};
   const gridN = params.n ?? 100;
   const carriedNames = Object.keys(input.carried ?? {});
 
-  const groupOrder: number[] = [];
-  const groupRows = new Map<number, number[]>();
-  let dropped = 0;
-  for (let i = 0; i < x.length; i++) {
-    if (!Number.isFinite(x[i]!) || !Number.isFinite(y[i]!)) {
-      dropped++;
-      continue;
-    }
-    const g = groups[i]!;
-    let list = groupRows.get(g);
-    if (list === undefined) {
-      list = [];
-      groupRows.set(g, list);
-      groupOrder.push(g);
-    }
-    list.push(i);
-  }
+  const { order: groupOrder, rowsByGroup: groupRows, dropped } = collectFiniteRows(input);
 
   const outX: number[] = [];
   const outY: number[] = [];
@@ -310,104 +427,22 @@ export function statDensity2d(input: Density2dStatInput): Density2dStatResult {
       droppedGroups++;
       continue;
     }
-    const nx = rows.length;
-    const xs = new Float64Array(nx);
-    const ys = new Float64Array(nx);
-    let xmin = Infinity;
-    let xmax = -Infinity;
-    let ymin = Infinity;
-    let ymax = -Infinity;
-    for (let j = 0; j < nx; j++) {
-      const xv = x[rows[j]!]!;
-      const yv = y[rows[j]!]!;
-      xs[j] = xv;
-      ys[j] = yv;
-      if (xv < xmin) xmin = xv;
-      if (xv > xmax) xmax = xv;
-      if (yv < ymin) ymin = yv;
-      if (yv > ymax) ymax = yv;
-    }
-
-    let hx: number;
-    let hy: number;
-    try {
-      [hx, hy] = resolveH(xs, ys, params);
-    } catch {
+    const surface = densitySurface(input, rows, params, gridN);
+    if (surface === null) {
       droppedGroups++;
       continue;
     }
-    if (!(hx > 0) || !(hy > 0)) {
-      droppedGroups++;
-      continue;
-    }
-
-    const [x0, x1] = expandRange(xmin, xmax, 0.05);
-    const [y0, y1] = expandRange(ymin, ymax, 0.05);
-    const gx = linspace(x0, x1, gridN);
-    const gy = linspace(y0, y1, gridN);
-    // Sorted-x sliding window (same ±8σ / invN contract as the direct product).
-    const z = productKdeGrid(xs, ys, gx, gy, hx, hy);
-
-    let zmin = Infinity;
-    let zmax = -Infinity;
-    for (let j = 0; j < gridN; j++) {
-      for (let i = 0; i < gridN; i++) {
-        const v = z[j]![i]!;
-        if (v < zmin) zmin = v;
-        if (v > zmax) zmax = v;
-      }
-    }
-    const levels = contourLevels(zmin, zmax, {
-      bins: params.bins,
-      breaks: params.breaks,
-      binwidth: params.binwidth,
-    });
-    if (levels.length === 0 || !(zmax > zmin)) {
-      droppedGroups++;
-      continue;
-    }
-
+    const contours = densityContours(surface, filled);
+    openRingsDropped += contours.openRingsDropped;
     const sample = rows[0]!;
-    let pieceCounter = 0;
-    for (const level of levels) {
-      // Endpoints of the density surface rarely produce isolines.
-      if (level <= zmin || level >= zmax) continue;
-      const segs: Array<[{ x: number; y: number }, { x: number; y: number }]> = [];
-      for (let j = 0; j < gridN - 1; j++) {
-        for (let i = 0; i < gridN - 1; i++) {
-          segs.push(
-            ...cellSegments(
-              gx[i]!,
-              gx[i + 1]!,
-              gy[j]!,
-              gy[j + 1]!,
-              z[j]![i]!,
-              z[j]![i + 1]!,
-              z[j + 1]![i]!,
-              z[j + 1]![i + 1]!,
-              level,
-            ),
-          );
-        }
-      }
-      const lines = stitchSegments(segs);
-      for (const line of lines) {
-        if (filled && !isClosedRing(line)) {
-          openRingsDropped++;
-          continue;
-        }
-        const piece = pieceCounter++;
-        // Encode group as composite later in frame; store source group id here.
-        for (const p of line) {
-          outX.push(p.x);
-          outY.push(p.y);
-          outLevel.push(level);
-          outDensity.push(level);
-          outGroups.push(g);
-          outPiece.push(piece);
-          sampleRows.push(sample);
-        }
-      }
+    for (const vertex of contours.vertices) {
+      outX.push(vertex.x);
+      outY.push(vertex.y);
+      outLevel.push(vertex.level);
+      outDensity.push(vertex.level);
+      outGroups.push(g);
+      outPiece.push(vertex.piece);
+      sampleRows.push(sample);
     }
   }
 

--- a/packages/core/src/stats/density.ts
+++ b/packages/core/src/stats/density.ts
@@ -111,8 +111,112 @@ function directWindowDensities(
   }
 }
 
+function collectFiniteRows(input: DensityStatInput) {
+  const order: number[] = [];
+  const rowsByGroup = new Map<number, number[]>();
+  let dropped = 0;
+  for (let i = 0; i < input.x.length; i++) {
+    if (!Number.isFinite(input.x[i]!)) {
+      dropped++;
+      continue;
+    }
+    const group = input.groups[i]!;
+    let rows = rowsByGroup.get(group);
+    if (rows === undefined) {
+      rows = [];
+      rowsByGroup.set(group, rows);
+      order.push(group);
+    }
+    rows.push(i);
+  }
+  return { order, rowsByGroup, dropped };
+}
+
+function normalizedWeights(weights: Float64Array | null | undefined, rows: number[]) {
+  if (weights === null || weights === undefined) return null;
+  const normalized = new Float64Array(rows.length);
+  let sum = 0;
+  for (let i = 0; i < rows.length; i++) {
+    const weight = weights[rows[i]!]!;
+    normalized[i] = Number.isFinite(weight) ? weight : 0;
+    sum += normalized[i]!;
+  }
+  if (!(sum > 0)) return null;
+  for (let i = 0; i < normalized.length; i++) normalized[i] = normalized[i]! / sum;
+  return normalized;
+}
+
+function sortedValues(input: DensityStatInput, rows: number[]) {
+  const values = new Float64Array(rows.length);
+  for (let i = 0; i < rows.length; i++) values[i] = input.x[rows[i]!]!;
+  const weights = normalizedWeights(input.weights, rows);
+  const order = Array.from({ length: rows.length }, (_, i) => i).toSorted(
+    (a, b) => values[a]! - values[b]!,
+  );
+  const sorted = new Float64Array(rows.length);
+  const sortedWeights = weights === null ? null : new Float64Array(rows.length);
+  for (let i = 0; i < rows.length; i++) {
+    sorted[i] = values[order[i]!]!;
+    if (sortedWeights !== null) sortedWeights[i] = weights![order[i]!]!;
+  }
+  return { sorted, sortedWeights };
+}
+
+function binnedDensities(
+  sorted: Float64Array,
+  sortedWeights: Float64Array | null,
+  bw: number,
+  from: number,
+  step: number,
+  gridN: number,
+  window: number,
+): Float64Array {
+  const densities = new Float64Array(gridN);
+  const binned = new Float64Array(gridN);
+  for (let j = 0; j < sorted.length; j++) {
+    const t = (sorted[j]! - from) / step;
+    const i0 = Math.floor(t);
+    const fraction = t - i0;
+    const weight = sortedWeights === null ? 1 / sorted.length : sortedWeights[j]!;
+    if (i0 >= 0 && i0 < gridN) binned[i0] = binned[i0]! + weight * (1 - fraction);
+    if (fraction > 0 && i0 + 1 < gridN) {
+      binned[i0 + 1] = binned[i0 + 1]! + weight * fraction;
+    }
+  }
+  const support = Math.min(gridN - 1, Math.ceil(window / step));
+  const taps = new Float64Array(support + 1);
+  for (let offset = 0; offset <= support; offset++) {
+    const z = (offset * step) / bw;
+    taps[offset] = (INV_SQRT_2PI * Math.exp(-0.5 * z * z)) / bw;
+  }
+  for (let k = 0; k < gridN; k++) {
+    const lo = Math.max(0, k - support);
+    const hi = Math.min(gridN - 1, k + support);
+    let density = 0;
+    for (let j = lo; j <= hi; j++) density += binned[j]! * taps[Math.abs(k - j)]!;
+    densities[k] = density;
+  }
+  return densities;
+}
+
+function densityGrid(
+  sorted: Float64Array,
+  sortedWeights: Float64Array | null,
+  bw: number,
+  from: number,
+  step: number,
+  gridN: number,
+): Float64Array {
+  const window = 8 * bw;
+  if (sorted.length > 4 * gridN && step > 0 && step <= bw / 4) {
+    return binnedDensities(sorted, sortedWeights, bw, from, step, gridN, window);
+  }
+  const densities = new Float64Array(gridN);
+  directWindowDensities(sorted, sortedWeights, bw, from, step, gridN, window, densities);
+  return densities;
+}
+
 export function statDensity(input: DensityStatInput): DensityStatResult {
-  const { x, groups, weights } = input;
   const params = input.params ?? {};
   const gridN = params.n ?? 512;
   const cut = params.cut ?? 3;
@@ -120,23 +224,7 @@ export function statDensity(input: DensityStatInput): DensityStatResult {
   const carriedNames = Object.keys(input.carried ?? {});
 
   // Partition finite rows per group (first-seen group order).
-  const groupOrder: number[] = [];
-  const groupRows = new Map<number, number[]>();
-  let dropped = 0;
-  for (let i = 0; i < x.length; i++) {
-    if (!Number.isFinite(x[i]!)) {
-      dropped++;
-      continue;
-    }
-    const g = groups[i]!;
-    let rows = groupRows.get(g);
-    if (rows === undefined) {
-      rows = [];
-      groupRows.set(g, rows);
-      groupOrder.push(g);
-    }
-    rows.push(i);
-  }
+  const { order: groupOrder, rowsByGroup: groupRows, dropped } = collectFiniteRows(input);
 
   const outX: number[] = [];
   const outDensity: number[] = [];
@@ -154,41 +242,14 @@ export function statDensity(input: DensityStatInput): DensityStatResult {
       continue;
     }
     const nx = rows.length;
-    const values = new Float64Array(nx);
-    for (let j = 0; j < nx; j++) values[j] = x[rows[j]!]!;
-    // Normalized weights (sum 1 within the group; missing weights count 0).
-    let w: Float64Array | null = null;
-    if (weights !== null && weights !== undefined) {
-      w = new Float64Array(nx);
-      let sum = 0;
-      for (let j = 0; j < nx; j++) {
-        const wv = weights[rows[j]!]!;
-        w[j] = Number.isFinite(wv) ? wv : 0;
-        sum += w[j]!;
-      }
-      if (sum > 0) {
-        for (let j = 0; j < nx; j++) w[j] = w[j]! / sum;
-      } else {
-        w = null;
-      }
-    }
     // Sort values (weights follow) so each grid point only visits the
     // ±8·bw window — the gaussian kernel is < 1.3e-14 beyond it, so the
     // cut is exact to double precision (unlike R's FFT binning).
-    const order = Array.from({ length: nx }, (_, j) => j).toSorted(
-      (a, b) => values[a]! - values[b]!,
-    );
-    const sorted = new Float64Array(nx);
-    const sortedW = w === null ? null : new Float64Array(nx);
-    for (let j = 0; j < nx; j++) {
-      sorted[j] = values[order[j]!]!;
-      if (sortedW !== null) sortedW[j] = w![order[j]!]!;
-    }
+    const { sorted, sortedWeights } = sortedValues(input, rows);
     const bw = adjust * (params.bw ?? bwNRD0(sorted));
     const from = sorted[0]! - cut * bw;
     const to = sorted[nx - 1]! + cut * bw;
     const step = gridN === 1 ? 0 : (to - from) / (gridN - 1);
-    const window = 8 * bw;
 
     // Density per grid node. Large groups (well above the grid size) use
     // linear binning onto the grid + an exact discrete gaussian
@@ -202,33 +263,7 @@ export function statDensity(input: DensityStatInput): DensityStatResult {
     // user-coarsened grid (step ≈ bw) would over-smooth by percent levels.
     // step ≤ bw/4 bounds that widening to ~0.5%; coarse grids are cheap
     // for the direct path anyway (gridN small).
-    const densities = new Float64Array(gridN);
-    if (nx > 4 * gridN && step > 0 && step <= bw / 4) {
-      const binned = new Float64Array(gridN);
-      for (let j = 0; j < nx; j++) {
-        const t = (sorted[j]! - from) / step;
-        const i0 = Math.floor(t);
-        const frac = t - i0;
-        const wv = sortedW === null ? 1 / nx : sortedW[j]!;
-        if (i0 >= 0 && i0 < gridN) binned[i0] = binned[i0]! + wv * (1 - frac);
-        if (frac > 0 && i0 + 1 < gridN) binned[i0 + 1] = binned[i0 + 1]! + wv * frac;
-      }
-      const support = Math.min(gridN - 1, Math.ceil(window / step));
-      const taps = new Float64Array(support + 1);
-      for (let m = 0; m <= support; m++) {
-        const z = (m * step) / bw;
-        taps[m] = (INV_SQRT_2PI * Math.exp(-0.5 * z * z)) / bw;
-      }
-      for (let k = 0; k < gridN; k++) {
-        const mLo = Math.max(0, k - support);
-        const mHi = Math.min(gridN - 1, k + support);
-        let d = 0;
-        for (let j = mLo; j <= mHi; j++) d += binned[j]! * taps[Math.abs(k - j)]!;
-        densities[k] = d;
-      }
-    } else {
-      directWindowDensities(sorted, sortedW, bw, from, step, gridN, window, densities);
-    }
+    const densities = densityGrid(sorted, sortedWeights, bw, from, step, gridN);
 
     let maxDensity = 0;
     for (let k = 0; k < gridN; k++) if (densities[k]! > maxDensity) maxDensity = densities[k]!;

--- a/packages/core/src/stats/ecdf.ts
+++ b/packages/core/src/stats/ecdf.ts
@@ -40,6 +40,44 @@ export interface EcdfStatResult {
   dropped: number;
 }
 
+function collectFiniteRows(x: Float64Array, groups: readonly number[]) {
+  const order: number[] = [];
+  const rowsByGroup = new Map<number, number[]>();
+  let dropped = 0;
+  for (let i = 0; i < x.length; i++) {
+    if (!Number.isFinite(x[i]!)) {
+      dropped++;
+      continue;
+    }
+    const group = groups[i]!;
+    let rows = rowsByGroup.get(group);
+    if (rows === undefined) {
+      rows = [];
+      rowsByGroup.set(group, rows);
+      order.push(group);
+    }
+    rows.push(i);
+  }
+  return { order, rowsByGroup, dropped };
+}
+
+function evaluationGrid(values: Float64Array, gridN: number | undefined): number[] {
+  const xmin = values[0]!;
+  const xmax = values.at(-1)!;
+  if (gridN !== undefined && Number.isFinite(gridN) && gridN >= 1) {
+    const n = Math.floor(gridN);
+    if (n === 1 || xmin === xmax) return [xmin];
+    const step = (xmax - xmin) / (n - 1);
+    return Array.from({ length: n }, (_, i) => xmin + i * step);
+  }
+
+  const unique: number[] = [];
+  for (const value of values) {
+    if (unique.length === 0 || unique.at(-1)! !== value) unique.push(value);
+  }
+  return unique;
+}
+
 export function statEcdf(input: EcdfStatInput): EcdfStatResult {
   const { x, groups } = input;
   const params = input.params ?? {};
@@ -47,23 +85,7 @@ export function statEcdf(input: EcdfStatInput): EcdfStatResult {
   const gridN = params.n;
   const carriedNames = Object.keys(input.carried ?? {});
 
-  const groupOrder: number[] = [];
-  const groupRows = new Map<number, number[]>();
-  let dropped = 0;
-  for (let i = 0; i < x.length; i++) {
-    if (!Number.isFinite(x[i]!)) {
-      dropped++;
-      continue;
-    }
-    const g = groups[i]!;
-    let rows = groupRows.get(g);
-    if (rows === undefined) {
-      rows = [];
-      groupRows.set(g, rows);
-      groupOrder.push(g);
-    }
-    rows.push(i);
-  }
+  const { order: groupOrder, rowsByGroup: groupRows, dropped } = collectFiniteRows(x, groups);
 
   const outX: number[] = [];
   const outEcdf: number[] = [];
@@ -79,25 +101,7 @@ export function statEcdf(input: EcdfStatInput): EcdfStatResult {
     values.sort();
     const nObs = values.length;
     const xmin = values[0]!;
-    const xmax = values[nObs - 1]!;
-
-    let evalX: number[];
-    if (gridN !== undefined && Number.isFinite(gridN) && gridN >= 1) {
-      const n = Math.floor(gridN);
-      evalX = [];
-      if (n === 1 || xmin === xmax) {
-        evalX.push(xmin);
-      } else {
-        const step = (xmax - xmin) / (n - 1);
-        for (let k = 0; k < n; k++) evalX.push(xmin + k * step);
-      }
-    } else {
-      evalX = [];
-      for (let j = 0; j < nObs; j++) {
-        const v = values[j]!;
-        if (evalX.length === 0 || evalX.at(-1)! !== v) evalX.push(v);
-      }
-    }
+    const evalX = evaluationGrid(values, gridN);
 
     const pushRow = (xv: number, yv: number) => {
       outX.push(xv);

--- a/packages/core/src/stats/loess.ts
+++ b/packages/core/src/stats/loess.ts
@@ -1,38 +1,14 @@
 /**
- * LOESS — local polynomial regression.
+ * LOESS local polynomial regression with direct/exact and
+ * interpolate/approximate surfaces (decision 0010). The direct surface uses
+ * q ≈ span·n neighborhoods and exact operator statistics for fixture-sized
+ * inputs. The large-n surface fits partition vertices and Hermite-interpolates
+ * values, derivatives, and SE norms in O(nv·q + n).
  *
- * Two surfaces (chosen automatically by n unless overridden):
- *
- *  - **direct + exact** (n ≤ INTERPOLATE_DIRECT_LIMIT, or surface:"direct"):
- *    R's `surface="direct", statistics="exact"` — the reference the R fixtures
- *    pin (decision 0010). Fit at every evaluation / data point with window
- *    q ≈ span·n. Exact δ1 / δ2 / σ when statistics are requested (δ2 exact
- *    only for n ≤ DELTA2_EXACT_LIMIT; above that δ2 falls back to δ1).
- *
- *  - **interpolate + approximate** (n > INTERPOLATE_DIRECT_LIMIT by default):
- *    R's default `surface="interpolate", statistics="approximate"` spirit
- *    that ggplot2's geom_smooth uses. Build a 1D kd-tree-style partition of
- *    the x-range (leaf capacity floor(n·span·cell)), fit only at cell
- *    vertices, cubic-Hermite blend value + derivative for ŷ(x0), and
- *    approximate the SE band from residual RSS + vertex ‖l‖ interpolation.
- *    Cost O(nv·q + n) with nv ≪ n, not O(n·q).
- *
- * Adapted in structure (nearest-neighbor window walk, tricube kernel) from
- * SveltePlot's ISC-licensed `regression/loess.ts`, itself derived from
- * d3-regression (Harry Stevens), science.js (Jason Davies), and
- * vega-statistics (Jeffrey Heer) — see the repo NOTICE file. Substantially
- * rewritten for R parity: span-based neighborhoods (q = floor(span·n)),
- * configurable degree (2 = R default; the reference is degree-1 only),
- * evaluation at arbitrary points (predict), and exact operator statistics
- * (trace(L), δ1, δ2, σ) for the confidence band on the direct path. The
- * reference's robustness iterations are intentionally absent: R's gaussian
- * family fits by weighted least squares with NO robustness iterations.
- *
- * Statistics (direct/exact): ŷ(x0) = l(x0)ᵀ y with Var(ŷ(x0)) = σ²·‖l(x0)‖².
- * σ² = RSS/δ1, δ1 = n − 2·tr(L) + tr(LᵀL) (exact, O(n·q)); δ2 =
- * tr(((I−L)ᵀ(I−L))²) is computed EXACTLY for n ≤ DELTA2_EXACT_LIMIT (dense
- * O(n²·q + n³) algebra — fixture-sized inputs) and approximated by δ1 above
- * it (t quantiles are insensitive to df at those sizes; decision 0010).
+ * The nearest-neighbor walk and tricube-kernel structure began from
+ * SveltePlot's ISC-licensed regression/loess.ts; see NOTICE. This version adds
+ * R-compatible spans, degree-2 fits, arbitrary prediction, and direct-surface
+ * δ1/δ2/σ statistics without robustness iterations.
  */
 
 import { solveFirstColumn, solveSystem } from "./loess-linear-system.js";
@@ -81,6 +57,150 @@ export interface LoessModel {
   delta2: number;
   /** Look-up degrees of freedom for t quantiles: δ1² / δ2. */
   df: number;
+}
+
+type LocalWeights = { i0: number; l: Float64Array };
+type LocalFit = { fit: number; deriv: number; seNorm: number };
+
+interface LoessContext {
+  n: number;
+  span: number;
+  degree: 1 | 2;
+  statistics: boolean;
+  cell: number | undefined;
+  xs: Float64Array;
+  ys: Float64Array;
+  q: number;
+  windowFor: (x: number) => number;
+  localWeightsAt: (x: number, start: number) => LocalWeights | null;
+  localFitAt: (x: number, start: number) => LocalFit | null;
+}
+
+function interpolatedModel(context: LoessContext): LoessModel | null {
+  const { n, span, degree, xs, ys, q, windowFor, localFitAt } = context;
+  const verts = buildVertices1D(xs, n, span, context.cell ?? DEFAULT_CELL);
+  const nv = verts.length;
+  const vFit = new Float64Array(nv);
+  const vDeriv = new Float64Array(nv);
+  const vSe = new Float64Array(nv);
+  let ok = true;
+  let windowStart = windowFor(verts[0]!);
+  for (let vertex = 0; vertex < nv; vertex++) {
+    const x = verts[vertex]!;
+    while (windowStart + q < n && xs[windowStart + q]! - x < x - xs[windowStart]!) windowStart++;
+    if (xs[windowStart] === xs[windowStart + q - 1]) windowStart = windowFor(x);
+    const fit = localFitAt(x, windowStart);
+    if (fit === null) {
+      ok = false;
+      break;
+    }
+    vFit[vertex] = fit.fit;
+    vDeriv[vertex] = fit.deriv;
+    vSe[vertex] = fit.seNorm;
+  }
+  if (!ok) return null;
+
+  const predict = (x: number): number => {
+    if (nv === 1) return vFit[0]!;
+    const i = cellIndex(verts, x);
+    const start = verts[i]!;
+    const width = verts[i + 1]! - start;
+    if (!(width > 0)) return vFit[i]!;
+    const t = Math.min(1, Math.max(0, (x - start) / width));
+    return hermite(t, vFit[i]!, vFit[i + 1]!, vDeriv[i]!, vDeriv[i + 1]!, width);
+  };
+  const seNorm = (x: number): number => {
+    if (nv === 1) return vSe[0]!;
+    const i = cellIndex(verts, x);
+    const start = verts[i]!;
+    const width = verts[i + 1]! - start;
+    if (!(width > 0)) return vSe[i]!;
+    const t = Math.min(1, Math.max(0, (x - start) / width));
+    return (1 - t) * vSe[i]! + t * vSe[i + 1]!;
+  };
+
+  let sigma = NaN;
+  let delta1 = NaN;
+  let delta2 = NaN;
+  let df = NaN;
+  if (context.statistics) {
+    let rss = 0;
+    for (let i = 0; i < n; i++) {
+      const error = ys[i]! - predict(xs[i]!);
+      rss += error * error;
+    }
+    const tau = degree + 1;
+    const trL = tau * (1 + Math.max(0, (1 - span) / span));
+    delta1 = n - trL;
+    if (!(delta1 > 0)) delta1 = Math.max(1, n - trL);
+    sigma = Math.sqrt(rss / delta1);
+    delta2 = delta1;
+    df = (delta1 * delta1) / delta2;
+  }
+  return { predict, seNorm, sigma, delta1, delta2, df };
+}
+
+function directModel(context: LoessContext): LoessModel | null {
+  const { n, xs, ys, q, windowFor, localWeightsAt } = context;
+  const localWeights = (x: number): LocalWeights | null => localWeightsAt(x, windowFor(x));
+  const predictAt = (x: number): { fit: number; norm: number } | null => {
+    const weights = localWeights(x);
+    if (weights === null) return null;
+    let fit = 0;
+    let norm2 = 0;
+    for (let j = 0; j < q; j++) {
+      const weight = weights.l[j]!;
+      fit += weight * ys[weights.i0 + j]!;
+      norm2 += weight * weight;
+    }
+    return { fit, norm: Math.sqrt(norm2) };
+  };
+
+  let sigma = NaN;
+  let delta1 = NaN;
+  let delta2 = NaN;
+  let df = NaN;
+  if (context.statistics) {
+    const dense = n <= DELTA2_EXACT_LIMIT ? new Float64Array(n * n) : null;
+    let trL = 0;
+    let trLtL = 0;
+    let rss = 0;
+    let ok = true;
+    let windowStart = windowFor(xs[0]!);
+    for (let i = 0; i < n; i++) {
+      const x = xs[i]!;
+      while (windowStart + q < n && xs[windowStart + q]! - x < x - xs[windowStart]!) windowStart++;
+      if (xs[windowStart] === xs[windowStart + q - 1]) windowStart = windowFor(x);
+      const weights = localWeightsAt(x, windowStart);
+      if (weights === null) {
+        ok = false;
+        break;
+      }
+      let fit = 0;
+      for (let j = 0; j < q; j++) {
+        const weight = weights.l[j]!;
+        fit += weight * ys[weights.i0 + j]!;
+        trLtL += weight * weight;
+        if (weights.i0 + j === i) trL += weight;
+        if (dense !== null) dense[i * n + weights.i0 + j] = weight;
+      }
+      const error = ys[i]! - fit;
+      rss += error * error;
+    }
+    if (!ok) return null;
+    delta1 = n - 2 * trL + trLtL;
+    sigma = Math.sqrt(rss / delta1);
+    delta2 = dense === null ? delta1 : exactDelta2(dense, n);
+    df = (delta1 * delta1) / delta2;
+  }
+  return {
+    predict: (x) => predictAt(x)?.fit ?? NaN,
+    seNorm: (x) => predictAt(x)?.norm ?? NaN,
+    sigma,
+    delta1,
+    delta2,
+    df,
+  };
 }
 
 function tricube(u: number): number {
@@ -325,167 +445,20 @@ export function loessFit(
     return null;
   };
 
-  // ── Interpolate surface (large n) ──────────────────────────────────────
-  if (surface === "interpolate") {
-    const cell = options.cell ?? DEFAULT_CELL;
-    const verts = buildVertices1D(xs, n, span, cell);
-    const nv = verts.length;
-    const vFit = new Float64Array(nv);
-    const vDeriv = new Float64Array(nv);
-    const vSe = new Float64Array(nv);
-    let ok = true;
-    // Vertices are sorted ascending — warm-slide the nearest-q window.
-    let i0w = windowFor(verts[0]!);
-    for (let v = 0; v < nv; v++) {
-      const x0 = verts[v]!;
-      while (i0w + q < n && xs[i0w + q]! - x0 < x0 - xs[i0w]!) i0w++;
-      const windowFirst = xs[i0w]!;
-      const windowLast = xs[i0w + q - 1]!;
-      if (windowFirst === windowLast) i0w = windowFor(x0);
-      const lf = localFitAt(x0, i0w);
-      if (lf === null) {
-        ok = false;
-        break;
-      }
-      vFit[v] = lf.fit;
-      vDeriv[v] = lf.deriv;
-      vSe[v] = lf.seNorm;
-    }
-    if (!ok) return null;
-
-    const predictInterp = (x0: number): number => {
-      if (nv === 1) return vFit[0]!;
-      const i = cellIndex(verts, x0);
-      const va = verts[i]!;
-      const vb = verts[i + 1]!;
-      const width = vb - va;
-      if (!(width > 0)) return vFit[i]!;
-      // Clamp to the vertex hull (ggplot eval grid sits inside data range).
-      const t = Math.min(1, Math.max(0, (x0 - va) / width));
-      return hermite(t, vFit[i]!, vFit[i + 1]!, vDeriv[i]!, vDeriv[i + 1]!, width);
-    };
-
-    const seNormInterp = (x0: number): number => {
-      if (nv === 1) return vSe[0]!;
-      const i = cellIndex(verts, x0);
-      const va = verts[i]!;
-      const vb = verts[i + 1]!;
-      const width = vb - va;
-      if (!(width > 0)) return vSe[i]!;
-      const t = Math.min(1, Math.max(0, (x0 - va) / width));
-      // Linear blend of ‖l‖ (no derivative of the influence row).
-      return (1 - t) * vSe[i]! + t * vSe[i + 1]!;
-    };
-
-    let sigma = NaN;
-    let delta1 = NaN;
-    let delta2 = NaN;
-    let df = NaN;
-    if (options.statistics) {
-      // Residuals from the interpolated surface at the data; approximate
-      // equivalent parameters (R statistics="approximate" spirit — not the
-      // full ehg141 calibration table). τ = degree+1; inflate when span < 1.
-      let rss = 0;
-      for (let i = 0; i < n; i++) {
-        const e = ys[i]! - predictInterp(xs[i]!);
-        rss += e * e;
-      }
-      const tau = degree + 1;
-      const trL = tau * (1 + Math.max(0, (1 - span) / span));
-      // Near-projection: tr(LᵀL) ≈ tr(L) for a smoother.
-      const trLtL = trL;
-      delta1 = n - 2 * trL + trLtL;
-      if (!(delta1 > 0)) delta1 = Math.max(1, n - trL);
-      sigma = Math.sqrt(rss / delta1);
-      delta2 = delta1;
-      df = (delta1 * delta1) / delta2;
-    }
-
-    return {
-      predict: predictInterp,
-      seNorm: seNormInterp,
-      sigma,
-      delta1,
-      delta2,
-      df,
-    };
-  }
-
-  // ── Direct surface (small n / exact) ───────────────────────────────────
-  const localWeights = (x0: number): { i0: number; l: Float64Array } | null =>
-    localWeightsAt(x0, windowFor(x0));
-
-  const predictAt = (x0: number): { fit: number; norm: number } | null => {
-    const lw = localWeights(x0);
-    if (lw === null) return null;
-    let fit = 0;
-    let norm2 = 0;
-    for (let j = 0; j < q; j++) {
-      const lj = lw.l[j]!;
-      fit += lj * ys[lw.i0 + j]!;
-      norm2 += lj * lj;
-    }
-    return { fit, norm: Math.sqrt(norm2) };
+  const context: LoessContext = {
+    n,
+    span,
+    degree,
+    statistics: options.statistics,
+    cell: options.cell,
+    xs,
+    ys,
+    q,
+    windowFor,
+    localWeightsAt,
+    localFitAt,
   };
-
-  let sigma = NaN;
-  let delta1 = NaN;
-  let delta2 = NaN;
-  let df = NaN;
-  if (options.statistics) {
-    // Fit at every data point: residuals, tr(L), tr(LᵀL) — and the dense L
-    // for exact δ2 on fixture-sized inputs.
-    const dense = n <= DELTA2_EXACT_LIMIT ? new Float64Array(n * n) : null;
-    let trL = 0;
-    let trLtL = 0;
-    let rss = 0;
-    let ok = true;
-    // Warm-start window walk: evaluation points xs[i] are sorted ascending,
-    // so the nearest-q window only slides right — amortized O(n) total
-    // instead of O(n·q). The slide never moves on an exact tie (matches the
-    // cold two-pointer's left preference), and boundary tie-swaps exchange
-    // zero-weight endpoints at dmax, leaving fits, tr(L), tr(LᵀL), and the
-    // dense L bit-identical. The one window-dependent case is dmax = 0
-    // (more than q points share one x): fall back to the cold selection.
-    let i0w = windowFor(xs[0]!);
-    for (let i = 0; i < n; i++) {
-      const x0 = xs[i]!;
-      while (i0w + q < n && xs[i0w + q]! - x0 < x0 - xs[i0w]!) i0w++;
-      const windowFirst = xs[i0w]!;
-      const windowLast = xs[i0w + q - 1]!;
-      if (windowFirst === windowLast) i0w = windowFor(x0);
-      const lw = localWeightsAt(x0, i0w);
-      if (lw === null) {
-        ok = false;
-        break;
-      }
-      let fit = 0;
-      for (let j = 0; j < q; j++) {
-        const lj = lw.l[j]!;
-        fit += lj * ys[lw.i0 + j]!;
-        trLtL += lj * lj;
-        if (lw.i0 + j === i) trL += lj;
-        if (dense !== null) dense[i * n + lw.i0 + j] = lj;
-      }
-      const e = ys[i]! - fit;
-      rss += e * e;
-    }
-    if (!ok) return null;
-    delta1 = n - 2 * trL + trLtL;
-    sigma = Math.sqrt(rss / delta1);
-    // Documented approximation beyond the exact limit: δ2 = δ1.
-    delta2 = dense === null ? delta1 : exactDelta2(dense, n);
-    df = (delta1 * delta1) / delta2;
-  }
-
-  return {
-    predict: (x0: number) => predictAt(x0)?.fit ?? NaN,
-    seNorm: (x0: number) => predictAt(x0)?.norm ?? NaN,
-    sigma,
-    delta1,
-    delta2,
-    df,
-  };
+  return surface === "interpolate" ? interpolatedModel(context) : directModel(context);
 }
 
 /** Exported for tests / docs — size at which default surface flips. */

--- a/packages/core/src/stats/smooth.ts
+++ b/packages/core/src/stats/smooth.ts
@@ -72,8 +72,149 @@ export interface SmoothStatResult {
   methodInferred: boolean;
 }
 
+type SmoothEvaluator = {
+  evaluate: (x: number) => { fit: number; seFit: number };
+  ciMult: number;
+};
+
+function collectFiniteRows(input: SmoothStatInput) {
+  const order: number[] = [];
+  const rowsByGroup = new Map<number, number[]>();
+  let dropped = 0;
+  for (let i = 0; i < input.x.length; i++) {
+    if (!Number.isFinite(input.x[i]!) || !Number.isFinite(input.y[i]!)) {
+      dropped++;
+      continue;
+    }
+    const group = input.groups[i]!;
+    let rows = rowsByGroup.get(group);
+    if (rows === undefined) {
+      rows = [];
+      rowsByGroup.set(group, rows);
+      order.push(group);
+    }
+    rows.push(i);
+  }
+  return { order, rowsByGroup, dropped };
+}
+
+function groupValues(input: SmoothStatInput, rows: number[]) {
+  const x = new Float64Array(rows.length);
+  const y = new Float64Array(rows.length);
+  let min = Infinity;
+  let max = -Infinity;
+  for (let i = 0; i < rows.length; i++) {
+    x[i] = input.x[rows[i]!]!;
+    y[i] = input.y[rows[i]!]!;
+    if (x[i]! < min) min = x[i]!;
+    if (x[i]! > max) max = x[i]!;
+  }
+  return { x, y, min, max };
+}
+
+function lmEvaluator(x: Float64Array, y: Float64Array, level: number): SmoothEvaluator | null {
+  const n = x.length;
+  if (n < 2) return null;
+  let sx = 0;
+  let sy = 0;
+  for (let i = 0; i < n; i++) {
+    sx += x[i]!;
+    sy += y[i]!;
+  }
+  const xbar = sx / n;
+  const ybar = sy / n;
+  let sxx = 0;
+  let sxy = 0;
+  for (let i = 0; i < n; i++) {
+    const dx = x[i]! - xbar;
+    sxx += dx * dx;
+    sxy += dx * (y[i]! - ybar);
+  }
+  const slope = sxy / sxx;
+  const intercept = ybar - slope * xbar;
+  let rss = 0;
+  for (let i = 0; i < n; i++) {
+    const error = y[i]! - (intercept + slope * x[i]!);
+    rss += error * error;
+  }
+  const sigma = n > 2 ? Math.sqrt(rss / (n - 2)) : NaN;
+  return {
+    ciMult: qt((1 + level) / 2, n - 2),
+    evaluate: (x0) => ({
+      fit: intercept + slope * x0,
+      seFit: sigma * Math.sqrt(1 / n + ((x0 - xbar) * (x0 - xbar)) / sxx),
+    }),
+  };
+}
+
+function makeEvaluator(
+  method: "lm" | "loess",
+  x: Float64Array,
+  y: Float64Array,
+  range: { min: number; max: number },
+  options: { level: number; span: number; degree: 1 | 2; wantSE: boolean },
+): SmoothEvaluator | null {
+  if (method === "lm") {
+    return range.min === range.max ? null : lmEvaluator(x, y, options.level);
+  }
+  const model = loessFit(x, y, {
+    span: options.span,
+    degree: options.degree,
+    statistics: options.wantSE,
+  });
+  if (model === null) return null;
+  return {
+    ciMult: options.wantSE ? qt((1 + options.level) / 2, model.df) : NaN,
+    evaluate: (x0: number) => ({
+      fit: model.predict(x0),
+      seFit: options.wantSE ? model.sigma * model.seNorm(x0) : NaN,
+    }),
+  };
+}
+
+type SmoothOutput = {
+  x: number[];
+  y: number[];
+  ymin: number[];
+  ymax: number[];
+  se: number[];
+  groups: number[];
+  carried: Record<string, CellValue[]>;
+};
+
+function emitGrid(
+  output: SmoothOutput,
+  evaluator: SmoothEvaluator,
+  group: number,
+  rows: number[],
+  range: { min: number; max: number },
+  input: SmoothStatInput,
+  options: { evalN: number; wantSE: boolean; carriedNames: string[] },
+): void {
+  const step = options.evalN === 1 ? 0 : (range.max - range.min) / (options.evalN - 1);
+  const hasBand = options.wantSE && Number.isFinite(evaluator.ciMult);
+  for (let k = 0; k < options.evalN; k++) {
+    const x = range.min + k * step;
+    const { fit, seFit } = evaluator.evaluate(x);
+    output.x.push(x);
+    output.y.push(fit);
+    if (hasBand && Number.isFinite(seFit)) {
+      output.ymin.push(fit - evaluator.ciMult * seFit);
+      output.ymax.push(fit + evaluator.ciMult * seFit);
+      output.se.push(seFit);
+    } else {
+      output.ymin.push(NaN);
+      output.ymax.push(NaN);
+      output.se.push(NaN);
+    }
+    output.groups.push(group);
+    for (const name of options.carriedNames) {
+      output.carried[name]!.push(input.carried![name]![rows[0]!]!);
+    }
+  }
+}
+
 export function statSmooth(input: SmoothStatInput): SmoothStatResult {
-  const { x, y, groups } = input;
   const params = input.params ?? {};
   const level = params.level ?? 0.95;
   const wantSE = params.se ?? true;
@@ -83,23 +224,7 @@ export function statSmooth(input: SmoothStatInput): SmoothStatResult {
   const carriedNames = Object.keys(input.carried ?? {});
 
   // Partition finite pairs per group (first-seen group order).
-  const groupOrder: number[] = [];
-  const groupRows = new Map<number, number[]>();
-  let dropped = 0;
-  for (let i = 0; i < x.length; i++) {
-    if (!Number.isFinite(x[i]!) || !Number.isFinite(y[i]!)) {
-      dropped++;
-      continue;
-    }
-    const g = groups[i]!;
-    let rows = groupRows.get(g);
-    if (rows === undefined) {
-      rows = [];
-      groupRows.set(g, rows);
-      groupOrder.push(g);
-    }
-    rows.push(i);
-  }
+  const { order: groupOrder, rowsByGroup: groupRows, dropped } = collectFiniteRows(input);
 
   let maxGroup = 0;
   for (const rows of groupRows.values()) maxGroup = Math.max(maxGroup, rows.length);
@@ -118,89 +243,29 @@ export function statSmooth(input: SmoothStatInput): SmoothStatResult {
 
   for (const g of groupOrder) {
     const rows = groupRows.get(g)!;
-    const nx = rows.length;
-    const gx = new Float64Array(nx);
-    const gy = new Float64Array(nx);
-    let min = Infinity;
-    let max = -Infinity;
-    for (let j = 0; j < nx; j++) {
-      gx[j] = x[rows[j]!]!;
-      gy[j] = y[rows[j]!]!;
-      if (gx[j]! < min) min = gx[j]!;
-      if (gx[j]! > max) max = gx[j]!;
+    const { x: gx, y: gy, min, max } = groupValues(input, rows);
+    const evaluator = makeEvaluator(method, gx, gy, { min, max }, { level, span, degree, wantSE });
+    if (evaluator === null) {
+      droppedGroups++;
+      continue;
     }
-
-    // Per-eval-point fit + se·norm, method-specific.
-    let evaluate: ((x0: number) => { fit: number; seFit: number }) | null = null;
-    let ciMult = NaN;
-
-    if (method === "lm") {
-      if (nx < 2 || min === max) {
-        droppedGroups++;
-        continue;
-      }
-      let sx = 0;
-      let sy = 0;
-      for (let j = 0; j < nx; j++) {
-        sx += gx[j]!;
-        sy += gy[j]!;
-      }
-      const xbar = sx / nx;
-      const ybar = sy / nx;
-      let sxx = 0;
-      let sxy = 0;
-      for (let j = 0; j < nx; j++) {
-        const dx = gx[j]! - xbar;
-        sxx += dx * dx;
-        sxy += dx * (gy[j]! - ybar);
-      }
-      const slope = sxy / sxx;
-      const intercept = ybar - slope * xbar;
-      let rss = 0;
-      for (let j = 0; j < nx; j++) {
-        const e = gy[j]! - (intercept + slope * gx[j]!);
-        rss += e * e;
-      }
-      const sigma = nx > 2 ? Math.sqrt(rss / (nx - 2)) : NaN;
-      ciMult = qt((1 + level) / 2, nx - 2);
-      evaluate = (x0: number) => ({
-        fit: intercept + slope * x0,
-        seFit: sigma * Math.sqrt(1 / nx + ((x0 - xbar) * (x0 - xbar)) / sxx),
-      });
-    } else {
-      const model = loessFit(gx, gy, { span, degree, statistics: wantSE });
-      if (model === null) {
-        droppedGroups++;
-        continue;
-      }
-      ciMult = wantSE ? qt((1 + level) / 2, model.df) : NaN;
-      evaluate = (x0: number) => ({
-        fit: model.predict(x0),
-        seFit: wantSE ? model.sigma * model.seNorm(x0) : NaN,
-      });
-    }
-
-    const step = evalN === 1 ? 0 : (max - min) / (evalN - 1);
-    const bandOK = wantSE && Number.isFinite(ciMult);
-    for (let k = 0; k < evalN; k++) {
-      const x0 = min + k * step;
-      const { fit, seFit } = evaluate(x0);
-      outX.push(x0);
-      outY.push(fit);
-      if (bandOK && Number.isFinite(seFit)) {
-        outYmin.push(fit - ciMult * seFit);
-        outYmax.push(fit + ciMult * seFit);
-        outSE.push(seFit);
-      } else {
-        outYmin.push(NaN);
-        outYmax.push(NaN);
-        outSE.push(NaN);
-      }
-      outGroups.push(g);
-      for (const name of carriedNames) {
-        carried[name]!.push(input.carried![name]![rows[0]!]!);
-      }
-    }
+    emitGrid(
+      {
+        x: outX,
+        y: outY,
+        ymin: outYmin,
+        ymax: outYmax,
+        se: outSE,
+        groups: outGroups,
+        carried,
+      },
+      evaluator,
+      g,
+      rows,
+      { min, max },
+      input,
+      { evalN, wantSE, carriedNames },
+    );
   }
 
   return {

--- a/packages/core/src/stats/summary-bin.ts
+++ b/packages/core/src/stats/summary-bin.ts
@@ -57,8 +57,59 @@ export interface SummaryBinStatResult {
   cut: { fuzzy: readonly number[]; rightClosed: boolean; binIndex: Int32Array };
 }
 
+type BinBreaks = ReturnType<typeof binBreaksBins>;
+type SummaryBucket = { rows: number[]; sampleRow: number };
+
+function finiteExtent(values: Float64Array): [number, number] | undefined {
+  let min = Infinity;
+  let max = -Infinity;
+  let count = 0;
+  for (const value of values) {
+    if (!Number.isFinite(value)) continue;
+    count++;
+    if (value < min) min = value;
+    if (value > max) max = value;
+  }
+  return count === 0 ? undefined : [min, max];
+}
+
+function collectBuckets(input: SummaryBinStatInput, breaks: BinBreaks) {
+  const buckets = new Map<string, SummaryBucket>();
+  const groupOrder: number[] = [];
+  const seenGroup = new Set<number>();
+  const binCount = breaks.breaks.length - 1;
+  let dropped = 0;
+
+  for (let i = 0; i < input.x.length; i++) {
+    const x = input.x[i]!;
+    const y = input.y[i]!;
+    if (!Number.isFinite(x) || !Number.isFinite(y)) {
+      dropped++;
+      continue;
+    }
+    const bin = binIndexOf(x, breaks.fuzzy, breaks.rightClosed);
+    if (bin < 0 || bin >= binCount) {
+      dropped++;
+      continue;
+    }
+    const group = input.groups[i]!;
+    if (!seenGroup.has(group)) {
+      seenGroup.add(group);
+      groupOrder.push(group);
+    }
+    const key = `${group}\0${bin}`;
+    let bucket = buckets.get(key);
+    if (bucket === undefined) {
+      bucket = { rows: [], sampleRow: i };
+      buckets.set(key, bucket);
+    }
+    bucket.rows.push(i);
+  }
+  return { buckets, groupOrder, dropped };
+}
+
 export function statSummaryBin(input: SummaryBinStatInput): SummaryBinStatResult {
-  const { x, y, groups } = input;
+  const { x, y } = input;
   const params = input.params ?? {};
   const fun: SummaryFunName = params.fun ?? "mean";
   const carriedNames = Object.keys(input.carried ?? {});
@@ -78,57 +129,18 @@ export function statSummaryBin(input: SummaryBinStatInput): SummaryBinStatResult
     cut: { fuzzy: [], rightClosed: true, binIndex: new Int32Array(0) },
   });
 
-  let min = Infinity;
-  let max = -Infinity;
-  let finiteX = 0;
-  for (let i = 0; i < x.length; i++) {
-    const xv = x[i]!;
-    if (!Number.isFinite(xv)) continue;
-    finiteX++;
-    if (xv < min) min = xv;
-    if (xv > max) max = xv;
-  }
-  if (finiteX === 0) return empty(x.length);
+  const extent = finiteExtent(x);
+  if (extent === undefined) return empty(x.length);
 
   const closed = params.closed ?? "right";
-  const range: [number, number] = input.range ?? [min, max];
+  const range: [number, number] = input.range ?? extent;
   const breaks =
     params.binwidth === undefined
       ? binBreaksBins(range, params.bins ?? 30, params.boundary, params.center, closed)
       : binBreaksWidth(range, params.binwidth, params.boundary, params.center, closed);
   const binCount = breaks.breaks.length - 1;
 
-  type Bucket = { rows: number[]; sampleRow: number };
-  const buckets = new Map<string, Bucket>();
-  const groupOrder: number[] = [];
-  const seenGroup = new Set<number>();
-  let dropped = 0;
-
-  for (let i = 0; i < x.length; i++) {
-    const xv = x[i]!;
-    const yv = y[i]!;
-    if (!Number.isFinite(xv) || !Number.isFinite(yv)) {
-      dropped++;
-      continue;
-    }
-    const bin = binIndexOf(xv, breaks.fuzzy, breaks.rightClosed);
-    if (bin < 0 || bin >= binCount) {
-      dropped++;
-      continue;
-    }
-    const g = groups[i]!;
-    if (!seenGroup.has(g)) {
-      seenGroup.add(g);
-      groupOrder.push(g);
-    }
-    const key = `${g}\0${bin}`;
-    let bucket = buckets.get(key);
-    if (bucket === undefined) {
-      bucket = { rows: [], sampleRow: i };
-      buckets.set(key, bucket);
-    }
-    bucket.rows.push(i);
-  }
+  const { buckets, groupOrder, dropped } = collectBuckets(input, breaks);
 
   const outX: number[] = [];
   const outXmin: number[] = [];

--- a/packages/core/src/stats/summary-rolling.ts
+++ b/packages/core/src/stats/summary-rolling.ts
@@ -49,8 +49,30 @@ export interface SummaryRollingStatResult {
   dropped: number;
 }
 
+function collectFiniteRows(input: SummaryRollingStatInput) {
+  const { x, y, groups } = input;
+  const order: number[] = [];
+  const rowsByGroup = new Map<number, number[]>();
+  let dropped = 0;
+  for (let i = 0; i < x.length; i++) {
+    if (!Number.isFinite(x[i]) || !Number.isFinite(y[i])) {
+      dropped++;
+      continue;
+    }
+    const group = groups[i]!;
+    let rows = rowsByGroup.get(group);
+    if (rows === undefined) {
+      rows = [];
+      rowsByGroup.set(group, rows);
+      order.push(group);
+    }
+    rows.push(i);
+  }
+  return { order, rowsByGroup, dropped };
+}
+
 export function statSummaryRolling(input: SummaryRollingStatInput): SummaryRollingStatResult {
-  const { x, y, groups, carried = {}, params = {} } = input;
+  const { x, y, carried = {}, params = {} } = input;
   const window = params.window;
   if (window === undefined || !Number.isFinite(window) || window <= 0) {
     throw new Error(
@@ -62,24 +84,7 @@ export function statSummaryRolling(input: SummaryRollingStatInput): SummaryRolli
 
   // Row order grouped by group id, x ascending within each group. Groups
   // appear in first-occurrence order (the pipeline's group id order).
-  const n = x.length;
-  const groupOrder: number[] = [];
-  const byGroup = new Map<number, number[]>();
-  let dropped = 0;
-  for (let i = 0; i < n; i++) {
-    if (!Number.isFinite(x[i]) || !Number.isFinite(y[i])) {
-      dropped++;
-      continue;
-    }
-    const g = groups[i]!;
-    let rows = byGroup.get(g);
-    if (rows === undefined) {
-      rows = [];
-      byGroup.set(g, rows);
-      groupOrder.push(g);
-    }
-    rows.push(i);
-  }
+  const { order: groupOrder, rowsByGroup: byGroup, dropped } = collectFiniteRows(input);
 
   const outX: number[] = [];
   const outY: number[] = [];

--- a/packages/core/src/stats/ydensity.ts
+++ b/packages/core/src/stats/ydensity.ts
@@ -56,8 +56,42 @@ interface Bucket {
   rows: number[];
 }
 
+type PartialViolin = {
+  x: CellValue;
+  group: number;
+  y: Float64Array;
+  density: Float64Array;
+  scaled: Float64Array;
+  count: Float64Array;
+  n: number;
+  firstRow: number;
+};
+
+function collectBuckets(input: YDensityStatInput) {
+  const buckets = new Map<string, Bucket>();
+  const order: string[] = [];
+  let dropped = 0;
+  for (let i = 0; i < input.y.length; i++) {
+    if (!Number.isFinite(input.y[i]!)) {
+      dropped++;
+      continue;
+    }
+    const x = input.x[i] ?? null;
+    const group = input.groups[i]!;
+    const key = `${encodeKey(x)}\0${group}`;
+    let bucket = buckets.get(key);
+    if (bucket === undefined) {
+      bucket = { x, group, rows: [] };
+      buckets.set(key, bucket);
+      order.push(key);
+    }
+    bucket.rows.push(i);
+  }
+  return { buckets, order, dropped };
+}
+
 export function statYDensity(input: YDensityStatInput): YDensityStatResult {
-  const { y, x, groups } = input;
+  const { y } = input;
   const params = input.params ?? {};
   const scaleMode: ViolinScale = params.scale ?? "area";
   const trim = params.trim ?? true;
@@ -65,36 +99,7 @@ export function statYDensity(input: YDensityStatInput): YDensityStatResult {
   const gridN = params.n ?? 512;
   const carriedNames = Object.keys(input.carried ?? {});
 
-  const buckets = new Map<string, Bucket>();
-  const order: string[] = [];
-  let dropped = 0;
-  for (let i = 0; i < y.length; i++) {
-    if (!Number.isFinite(y[i]!)) {
-      dropped++;
-      continue;
-    }
-    const xv = x[i] ?? null;
-    const g = groups[i]!;
-    const key = `${encodeKey(xv)}\0${g}`;
-    let b = buckets.get(key);
-    if (b === undefined) {
-      b = { x: xv, group: g, rows: [] };
-      buckets.set(key, b);
-      order.push(key);
-    }
-    b.rows.push(i);
-  }
-
-  type PartialViolin = {
-    x: CellValue;
-    group: number;
-    y: Float64Array;
-    density: Float64Array;
-    scaled: Float64Array;
-    count: Float64Array;
-    n: number;
-    firstRow: number;
-  };
+  const { buckets, order, dropped } = collectBuckets(input);
   const violins: PartialViolin[] = [];
   let droppedGroups = 0;
   let maxN = 1;


### PR DESCRIPTION
## Summary
- re-enable the max-20 cyclomatic complexity rule for `packages/core/src/stats/**`
- split stat orchestration into focused collection, model, and emission helpers
- preserve numerical ordering and keep LOESS hot-path builders colocated after benchmark validation

## Validation
- `bun run check`
- `bun run lint:type-aware`
- `bun run test` (5068 pass, 4 skip)
- focused stats suite (127 pass)
- `pre-commit run --all-files` twice clean
- stats oxlint: zero complexity violations
- max-LOC guard clean

## Benchmarks
Captured pre-change baselines and post-change retained-memory/timing results. Shared-host load invalidated the stale timing comparison, so I ran alternating contemporaneous `origin/main` and branch worktrees. The clean adjacent pair showed no regression in the changed workloads: LOESS 3.370 ms vs main 3.468 ms, histogram 13.445 ms vs 13.983 ms, and density 47.024 ms vs 49.231 ms. Retained memory changed by +0.04% / -0.01%.