### PR TITLE
refactor(core): enforce complexity in scales

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -70,6 +70,12 @@
       }
     },
     {
+      "files": ["packages/core/src/scales/**"],
+      "rules": {
+        "eslint/complexity": ["error", { "max": 20 }]
+      }
+    },
+    {
       // Tests + benchmarks: fixture literals are cast deliberately (invalid
       // specs, RuntimeSpec shapes) and test files run long by design.
       "files": ["**/tests/**", "benchmarks/**"],

--- a/packages/core/src/scales/state.ts
+++ b/packages/core/src/scales/state.ts
@@ -257,6 +257,54 @@ export interface TrainResult {
   warnings: ScaleWarning[];
 }
 
+function trainPinned(
+  values: Iterable<unknown>,
+  spec: DiscreteScaleSpec,
+  domain: readonly unknown[],
+  prevState: ScaleState | null | undefined,
+  fingerprint: string,
+  onExhaust: "cycle" | "error",
+  warnings: ScaleWarning[],
+): TrainResult {
+  const rangeSize = spec.range.length;
+  const pinned = new Map<string, number>();
+  for (const value of domain) {
+    const key = encodeKey(value);
+    if (!pinned.has(key)) pinned.set(key, pinned.size);
+  }
+  if (pinned.size > rangeSize) {
+    if (onExhaust === "error") throw new PaletteExhaustedError(pinned.size, rangeSize);
+    warnings.push({
+      code: "palette-exhausted",
+      message: `Explicit domain has ${pinned.size} values for a range of ${rangeSize}; cycling.`,
+    });
+  }
+  const unknownKeys = new Set<string>();
+  for (const value of values) {
+    const key = encodeKey(value);
+    if (!pinned.has(key)) unknownKeys.add(key);
+  }
+  if (unknownKeys.size > 0) {
+    warnings.push({
+      code: "out-of-domain",
+      message: `${unknownKeys.size} data value(s) outside the explicit domain map to the 'unknown' output.`,
+      values: [...unknownKeys].map((key) => decodeKey(key)),
+    });
+  }
+  const state = prevState ?? freshScaleState(fingerprint);
+  return {
+    mode: "pinned",
+    state,
+    domain: [...pinned.keys()].map((key) => decodeKey(key)),
+    indexOf: (value) => pinned.get(encodeKey(value)),
+    rangeValueOf: (value) => {
+      const index = pinned.get(encodeKey(value));
+      return index === undefined ? undefined : spec.range[index % rangeSize];
+    },
+    warnings,
+  };
+}
+
 export function trainDiscrete(
   values: Iterable<unknown>,
   spec: DiscreteScaleSpec,
@@ -269,48 +317,7 @@ export function trainDiscrete(
 
   // ---- pinned mode: explicit domain SUSPENDS stored assignments -----------
   if (spec.domain !== undefined) {
-    const pinned = new Map<string, number>();
-    for (const v of spec.domain) {
-      const k = encodeKey(v);
-      if (!pinned.has(k)) pinned.set(k, pinned.size);
-    }
-    if (pinned.size > rangeSize) {
-      if (onExhaust === "error") {
-        throw new PaletteExhaustedError(pinned.size, rangeSize);
-      }
-      warnings.push({
-        code: "palette-exhausted",
-        message: `Explicit domain has ${pinned.size} values for a range of ${rangeSize}; cycling.`,
-      });
-    }
-    // Deduplicated out-of-domain notice.
-    const unknownKeys = new Set<string>();
-    for (const v of values) {
-      const k = encodeKey(v);
-      if (!pinned.has(k)) unknownKeys.add(k);
-    }
-    if (unknownKeys.size > 0) {
-      const offenders = [...unknownKeys].map((k) => decodeKey(k));
-      warnings.push({
-        code: "out-of-domain",
-        message: `${unknownKeys.size} data value(s) outside the explicit domain map to the 'unknown' output.`,
-        values: offenders,
-      });
-    }
-    // Stored assignments survive untouched; they restore when the explicit
-    // domain is removed (fingerprint is re-checked at that point).
-    const state = prevState ?? freshScaleState(fingerprint);
-    return {
-      mode: "pinned",
-      state,
-      domain: [...pinned.keys()].map((k) => decodeKey(k)),
-      indexOf: (v) => pinned.get(encodeKey(v)),
-      rangeValueOf: (v) => {
-        const i = pinned.get(encodeKey(v));
-        return i === undefined ? undefined : spec.range[i % rangeSize];
-      },
-      warnings,
-    };
+    return trainPinned(values, spec, spec.domain, prevState, fingerprint, onExhaust, warnings);
   }
 
   // ---- grow / data modes ---------------------------------------------------


### PR DESCRIPTION
## Summary
- enforce oxlint cyclomatic complexity ≤20 for the core scales scope
- extract explicit-domain training into a focused helper
- preserve scale state, palette exhaustion, and out-of-domain behavior

## Validation
- `bun run knip`
- `bun run check`
- `bun run lint:type-aware`
- `bun test packages/core/tests/scale-state.test.ts` (22 pass)
- `bun run test` (5,068 pass, 4 skip)
- `pre-commit run --all-files` (two consecutive clean runs)

## Benchmarks
Pre-change baseline compared with the final implementation:

- color-log10: 73.8391 → 54.3386 (-26.4%)
- color-binned: 64.6467 → 63.3682 (-2.0%)
- color-manual: 27.7551 → 27.4315 (-1.17%)
- mapped-style: 41.05 → 41.5936 (+1.32%)
- scatter memory: +0.0227%
- grouped memory: -0.0485%

There is no coherent runtime or memory regression.