### PR TITLE
refactor(core): enforce complexity in svg live patching

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -76,6 +76,12 @@
       }
     },
     {
+      "files": ["packages/core/src/svg-live/**"],
+      "rules": {
+        "eslint/complexity": ["error", { "max": 20 }]
+      }
+    },
+    {
       // Tests + benchmarks: fixture literals are cast deliberately (invalid
       // specs, RuntimeSpec shapes) and test files run long by design.
       "files": ["**/tests/**", "benchmarks/**"],

--- a/packages/core/src/svg-live/patch-paths.ts
+++ b/packages/core/src/svg-live/patch-paths.ts
@@ -76,6 +76,137 @@ function dashStr(dash: readonly number[]): string {
   return dash.length === 0 ? "" : dash.join(" ");
 }
 
+function sameRingStarts(prev: Uint32Array | undefined, next: Uint32Array | undefined): boolean {
+  if (prev === undefined || next === undefined) return prev === next;
+  if (prev.length !== next.length) return false;
+  for (let i = 0; i < next.length; i++) if (prev[i] !== next[i]) return false;
+  return true;
+}
+
+function samePathGeometry(
+  prev: PathsBatch,
+  next: PathsBatch,
+  s: number,
+  start: number,
+  end: number,
+): boolean {
+  const prevStart = prev.pathOffsets[s]!;
+  const prevEnd = prev.pathOffsets[s + 1]!;
+  const length = end - start;
+  if (length !== prevEnd - prevStart) return false;
+  if (prev.curve !== next.curve || (prev.closed === true) !== (next.closed === true)) return false;
+  if (!sameRingStarts(prev.ringStarts, next.ringStarts)) return false;
+  for (let i = 0; i < length * 2; i++) {
+    if (prev.positions[prevStart * 2 + i] !== next.positions[start * 2 + i]) return false;
+  }
+  return true;
+}
+
+type PathStyle = ReturnType<typeof resolvePathMark>;
+
+function writePathStyle(
+  el: Element,
+  prev: PathsBatch,
+  next: PathsBatch,
+  styleP: PathStyle,
+  styleN: PathStyle,
+  branch: number,
+  themeColors: { ink: string; accent: string },
+  ctx: BatchPatchContext,
+): void {
+  const w = writeOrRemove;
+  if (branch === 0) {
+    w(
+      el,
+      "fill",
+      paintFill(
+        styleN.fill === "none" ? themeColors.accent : styleN.fill,
+        next.fillPaint,
+        ctx.paintMode,
+      ),
+      paintFill(
+        styleP.fill === "none" ? themeColors.accent : styleP.fill,
+        prev.fillPaint,
+        ctx.paintMode,
+      ),
+    );
+    return;
+  }
+  w(
+    el,
+    "stroke",
+    paintStroke(
+      branch === 2 && styleN.stroke === "none" ? themeColors.ink : styleN.stroke,
+      next.strokePaint,
+      ctx.paintMode,
+    ),
+    paintStroke(
+      branch === 2 && styleP.stroke === "none" ? themeColors.ink : styleP.stroke,
+      prev.strokePaint,
+      ctx.paintMode,
+    ),
+  );
+  if (styleN.width !== styleP.width) el.setAttribute("stroke-width", px(styleN.width));
+  w(el, "stroke-dasharray", dashStr(styleN.dash), dashStr(styleP.dash));
+  w(el, "stroke-linejoin", styleN.linejoin, styleP.linejoin);
+  w(el, "stroke-linecap", styleN.linecap, styleP.linecap);
+  if (branch === 1) {
+    w(
+      el,
+      "fill",
+      paintFill(
+        styleN.fill === "none" ? themeColors.accent : styleN.fill,
+        next.fillPaint,
+        ctx.paintMode,
+      ),
+      paintFill(
+        styleP.fill === "none" ? themeColors.accent : styleP.fill,
+        prev.fillPaint,
+        ctx.paintMode,
+      ),
+    );
+  }
+}
+
+function patchPath(
+  el: Element,
+  prev: PathsBatch,
+  next: PathsBatch,
+  s: number,
+  start: number,
+  end: number,
+  themeColors: { ink: string; accent: string },
+  ctx: BatchPatchContext,
+): boolean {
+  const styleN = resolvePathMark(next, s, themeColors);
+  const styleP = resolvePathMark(prev, s, themeColors);
+  const branch = pathBranch(next, styleN.stroke);
+  if (branch !== pathBranch(prev, styleP.stroke)) {
+    const nextAttrs = pathAttrs(next, s, themeColors, ctx);
+    const prevAttrs = pathAttrs(prev, s, themeColors, ctx);
+    if (nextAttrs === null || prevAttrs === null) return false;
+    writeAttrs(el, nextAttrs, prevAttrs);
+    return true;
+  }
+  if (!samePathGeometry(prev, next, s, start, end)) {
+    const d = pathData(
+      next.positions,
+      start,
+      end,
+      next.curve,
+      next.closed === true,
+      next.ringStarts,
+    );
+    if (d === "") return false;
+    el.setAttribute("d", d);
+  }
+  writePathStyle(el, prev, next, styleP, styleN, branch, themeColors, ctx);
+  writeOrRemove(el, "fill-rule", next.fillRule ?? "", prev.fillRule ?? "");
+  const alphaN = next.alphas?.[s] ?? 1;
+  if (alphaN !== (prev.alphas?.[s] ?? 1)) writeAlpha(el, alphaN);
+  return true;
+}
+
 /**
  * Hot path for dense line/area updates: the `d` rebuild is skipped when the
  * span's vertices are bit-identical between scenes (raw Float32 compares —
@@ -93,7 +224,6 @@ export function patchPaths(
   const themeColors = { ink: themeVar("ink", ctx.theme), accent: themeVar("accent", ctx.theme) };
   const kids = group.children;
   const subpaths = next.pathOffsets.length - 1;
-  const w = writeOrRemove;
   // Signature equality guarantees the non-empty span sequence aligns 1:1.
   let k = 0;
   for (let s = 0; s < subpaths; s++) {
@@ -103,101 +233,7 @@ export function patchPaths(
     const el = kids[k]!;
     k++;
     if (el === undefined || el.tagName !== "path") return false;
-    const styleN = resolvePathMark(next, s, themeColors);
-    const styleP = resolvePathMark(prev, s, themeColors);
-    if (pathBranch(next, styleN.stroke) !== pathBranch(prev, styleP.stroke)) {
-      const na = pathAttrs(next, s, themeColors, ctx);
-      const pa = pathAttrs(prev, s, themeColors, ctx);
-      if (na === null || pa === null) return false;
-      writeAttrs(el, na, pa);
-      continue;
-    }
-    const pStart = prev.pathOffsets[s]!;
-    const pEnd = prev.pathOffsets[s + 1]!;
-    const len = end - start;
-    let same =
-      len === pEnd - pStart &&
-      prev.curve === next.curve &&
-      (prev.closed === true) === (next.closed === true);
-    const rn = next.ringStarts;
-    const rp = prev.ringStarts;
-    if (same && (rn !== undefined || rp !== undefined)) {
-      same =
-        rn !== undefined &&
-        rp !== undefined &&
-        rn.length === rp.length &&
-        Array.from(rn).every((v, i) => v === rp[i]);
-    }
-    for (let i = 0; same && i < len * 2; i++) {
-      if (prev.positions[pStart * 2 + i] !== next.positions[start * 2 + i]) same = false;
-    }
-    if (!same) {
-      const d = pathData(
-        next.positions,
-        start,
-        end,
-        next.curve,
-        next.closed === true,
-        next.ringStarts,
-      );
-      if (d === "") return false;
-      el.setAttribute("d", d);
-    }
-    const b = pathBranch(next, styleN.stroke);
-    if (b === 0) {
-      w(
-        el,
-        "fill",
-        paintFill(
-          styleN.fill === "none" ? themeColors.accent : styleN.fill,
-          next.fillPaint,
-          ctx.paintMode,
-        ),
-        paintFill(
-          styleP.fill === "none" ? themeColors.accent : styleP.fill,
-          prev.fillPaint,
-          ctx.paintMode,
-        ),
-      );
-    } else {
-      w(
-        el,
-        "stroke",
-        paintStroke(
-          b === 2 && styleN.stroke === "none" ? themeColors.ink : styleN.stroke,
-          next.strokePaint,
-          ctx.paintMode,
-        ),
-        paintStroke(
-          b === 2 && styleP.stroke === "none" ? themeColors.ink : styleP.stroke,
-          prev.strokePaint,
-          ctx.paintMode,
-        ),
-      );
-      if (styleN.width !== styleP.width) el.setAttribute("stroke-width", px(styleN.width));
-      w(el, "stroke-dasharray", dashStr(styleN.dash), dashStr(styleP.dash));
-      w(el, "stroke-linejoin", styleN.linejoin, styleP.linejoin);
-      w(el, "stroke-linecap", styleN.linecap, styleP.linecap);
-      if (b === 1) {
-        w(
-          el,
-          "fill",
-          paintFill(
-            styleN.fill === "none" ? themeColors.accent : styleN.fill,
-            next.fillPaint,
-            ctx.paintMode,
-          ),
-          paintFill(
-            styleP.fill === "none" ? themeColors.accent : styleP.fill,
-            prev.fillPaint,
-            ctx.paintMode,
-          ),
-        );
-      }
-    }
-    w(el, "fill-rule", next.fillRule ?? "", prev.fillRule ?? "");
-    const alphaN = next.alphas?.[s] ?? 1;
-    if (alphaN !== (prev.alphas?.[s] ?? 1)) writeAlpha(el, alphaN);
+    if (!patchPath(el, prev, next, s, start, end, themeColors, ctx)) return false;
   }
   return k === kids.length;
 }

--- a/packages/core/src/svg-live/patch-points.ts
+++ b/packages/core/src/svg-live/patch-points.ts
@@ -107,6 +107,187 @@ function sameStringList(
   return true;
 }
 
+function canCompareColorIndexes(
+  prev: PointsBatch,
+  next: PointsBatch,
+  paletteSame: boolean,
+): boolean {
+  return paletteSame && prev.colorIndexes !== undefined && next.colorIndexes !== undefined;
+}
+
+function canPatchIndexedCircles(prev: PointsBatch, next: PointsBatch, indexed: boolean): boolean {
+  return (
+    indexed &&
+    prev.shape === "circle" &&
+    next.shape === "circle" &&
+    prev.shapeIndexes === undefined &&
+    next.shapeIndexes === undefined &&
+    prev.sizes === undefined &&
+    next.sizes === undefined &&
+    prev.size === next.size
+  );
+}
+
+function patchIndexedCircles(
+  kids: HTMLCollection,
+  prev: PointsBatch,
+  next: PointsBatch,
+  themeInk: string,
+): boolean {
+  const palette = next.colorPalette!;
+  for (let j = 0; j < next.rowIndex.length; j++) {
+    const el = kids[j]!;
+    if (el.tagName !== "circle") return false;
+    const x = next.positions[j * 2]!;
+    const y = next.positions[j * 2 + 1]!;
+    if (x !== prev.positions[j * 2]) el.setAttribute("cx", px(x));
+    if (y !== prev.positions[j * 2 + 1]) el.setAttribute("cy", px(y));
+    const colorIndex = next.colorIndexes![j]!;
+    let fillChanged = colorIndex !== prev.colorIndexes![j]! || palette[colorIndex] === undefined;
+    if (fillChanged && palette[colorIndex] === undefined && prev.colorIndexes![j] === colorIndex) {
+      fillChanged = pointFillAt(next, j, themeInk) !== pointFillAt(prev, j, themeInk);
+    }
+    if (fillChanged) el.setAttribute("fill", pointFillAt(next, j, themeInk));
+    const alpha = next.alphas?.[j] ?? 1;
+    if (alpha !== (prev.alphas?.[j] ?? 1)) writeAlpha(el, alpha);
+  }
+  return true;
+}
+
+function pointFillChanged(
+  prev: PointsBatch,
+  next: PointsBatch,
+  j: number,
+  themeInk: string,
+  indexedCompare: boolean,
+): boolean {
+  if (!indexedCompare) return pointFillAt(next, j, themeInk) !== pointFillAt(prev, j, themeInk);
+  const colorIndex = next.colorIndexes![j]!;
+  const changed =
+    colorIndex !== prev.colorIndexes![j]! || next.colorPalette![colorIndex] === undefined;
+  if (
+    changed &&
+    next.colorPalette![colorIndex] === undefined &&
+    prev.colorIndexes![j] === colorIndex
+  ) {
+    return pointFillAt(next, j, themeInk) !== pointFillAt(prev, j, themeInk);
+  }
+  return changed;
+}
+
+type RectGeometry = Extract<PointShapeGeometry, { kind: "rect" }>;
+type PolygonGeometry = Extract<PointShapeGeometry, { kind: "polygon" }>;
+type LinesGeometry = Extract<PointShapeGeometry, { kind: "lines" }>;
+
+function patchRect(
+  el: Element,
+  geometry: RectGeometry,
+  xChanged: boolean,
+  yChanged: boolean,
+  sizeChanged: boolean,
+  fillChanged: boolean,
+  fill: string,
+): boolean {
+  if (el.tagName !== "rect") return false;
+  if (xChanged || sizeChanged) {
+    el.setAttribute("x", px(geometry.x));
+    el.setAttribute("width", px(geometry.width));
+  }
+  if (yChanged || sizeChanged) {
+    el.setAttribute("y", px(geometry.y));
+    el.setAttribute("height", px(geometry.height));
+  }
+  if (fillChanged) el.setAttribute("fill", fill);
+  return true;
+}
+
+function patchPolygon(
+  el: Element,
+  geometry: PolygonGeometry,
+  fillChanged: boolean,
+  fill: string,
+): boolean {
+  if (el.tagName !== "path") return false;
+  el.setAttribute("d", pointShapePathD(geometry, px));
+  if (fillChanged) el.setAttribute("fill", fill);
+  return true;
+}
+
+function patchLines(
+  el: Element,
+  geometry: LinesGeometry,
+  fillChanged: boolean,
+  fill: string,
+): boolean {
+  if (el.tagName !== "path") return false;
+  el.setAttribute("d", pointShapePathD(geometry, px));
+  el.setAttribute("stroke-width", px(geometry.strokeWidth));
+  if (fillChanged) el.setAttribute("stroke", fill);
+  return true;
+}
+
+function patchPointGeometry(
+  el: Element,
+  geometry: PointShapeGeometry,
+  xChanged: boolean,
+  yChanged: boolean,
+  sizeChanged: boolean,
+  fillChanged: boolean,
+  fill: string,
+): boolean {
+  switch (geometry.kind) {
+    case "circle": {
+      if (el.tagName !== "circle") return false;
+      if (xChanged) el.setAttribute("cx", px(geometry.cx));
+      if (yChanged) el.setAttribute("cy", px(geometry.cy));
+      if (sizeChanged) {
+        el.setAttribute("r", px(geometry.r));
+        if (geometry.mode === "stroke") {
+          el.setAttribute("stroke-width", px(geometry.strokeWidth));
+        }
+      }
+      if (fillChanged) el.setAttribute(geometry.mode === "stroke" ? "stroke" : "fill", fill);
+      return true;
+    }
+    case "rect":
+      return patchRect(el, geometry, xChanged, yChanged, sizeChanged, fillChanged, fill);
+    case "polygon":
+      return patchPolygon(el, geometry, fillChanged, fill);
+    case "lines":
+      return patchLines(el, geometry, fillChanged, fill);
+  }
+  return false;
+}
+
+function patchChangedShape(
+  el: Element,
+  prev: PointsBatch,
+  next: PointsBatch,
+  j: number,
+  themeInk: string,
+): boolean {
+  const nextMark = pointAttrs(next, j, themeInk);
+  const prevMark = pointAttrs(prev, j, themeInk);
+  if (nextMark === null || prevMark === null || el.tagName !== nextMark.tag) return false;
+  writeAttrs(el, nextMark.attrs, prevMark.attrs);
+  return true;
+}
+
+function writeStablePoint(
+  el: Element,
+  shape: PointShape,
+  x: number,
+  y: number,
+  size: number,
+  fillChanged: boolean,
+  fill: string,
+  alphaChanged: boolean,
+  alpha: number,
+): void {
+  if (fillChanged) writePointFill(el, pointShapeGeometry(shape, x, y, size), fill);
+  if (alphaChanged) writeAlpha(el, alpha);
+}
+
 /**
  * Hot path for the 10k+ scatter case: compare RAW batch values (positions,
  * sizes, fill strings, alphas) before any px() formatting, so unchanged
@@ -129,98 +310,34 @@ export function patchPoints(
   // skips two string resolutions per point. Anything else (palette churn,
   // mixed colors/palette paths, fill scalar moves) compares resolved strings.
   const paletteSame = sameStringList(prev.colorPalette, next.colorPalette);
-  const indexedCompare =
-    paletteSame && prev.colorIndexes !== undefined && next.colorIndexes !== undefined;
+  const indexedCompare = canCompareColorIndexes(prev, next, paletteSame);
+  if (canPatchIndexedCircles(prev, next, indexedCompare)) {
+    return patchIndexedCircles(kids, prev, next, themeInk);
+  }
   for (let j = 0; j < n; j++) {
     const el = kids[j]!;
     const shape = shapeAt(next, j);
     if (shape !== shapeAt(prev, j)) {
-      const nextMark = pointAttrs(next, j, themeInk);
-      const prevMark = pointAttrs(prev, j, themeInk);
-      if (nextMark === null || prevMark === null) return false;
-      if (el.tagName !== nextMark.tag) return false;
-      writeAttrs(el, nextMark.attrs, prevMark.attrs);
+      if (!patchChangedShape(el, prev, next, j, themeInk)) return false;
       continue;
     }
     const x = next.positions[j * 2]!;
     const y = next.positions[j * 2 + 1]!;
     const size = next.sizes?.[j] ?? next.size;
-    const prevX = prev.positions[j * 2]!;
-    const prevY = prev.positions[j * 2 + 1]!;
-    const prevSize = prev.sizes?.[j] ?? prev.size;
-    const xChanged = x !== prevX;
-    const yChanged = y !== prevY;
-    const sizeChanged = size !== prevSize;
-    const geometrySame = !xChanged && !yChanged && !sizeChanged;
-    let fillChanged: boolean;
-    if (indexedCompare) {
-      const ci = next.colorIndexes![j]!;
-      fillChanged = ci !== prev.colorIndexes![j]! || next.colorPalette![ci] === undefined;
-      // A palette hole falls through to fill/themeInk — resolve strings then.
-      if (fillChanged && next.colorPalette![ci] === undefined && prev.colorIndexes![j] === ci) {
-        fillChanged = pointFillAt(next, j, themeInk) !== pointFillAt(prev, j, themeInk);
-      }
-    } else {
-      fillChanged = pointFillAt(next, j, themeInk) !== pointFillAt(prev, j, themeInk);
-    }
+    const xChanged = x !== prev.positions[j * 2]!;
+    const yChanged = y !== prev.positions[j * 2 + 1]!;
+    const sizeChanged = size !== (prev.sizes?.[j] ?? prev.size);
+    const fillChanged = pointFillChanged(prev, next, j, themeInk, indexedCompare);
     const fill = fillChanged ? pointFillAt(next, j, themeInk) : "";
     const alpha = next.alphas?.[j] ?? 1;
     const alphaChanged = alpha !== (prev.alphas?.[j] ?? 1);
-    if (geometrySame) {
-      if (fillChanged) {
-        // Geometry is stable, so the fill channel target follows the shape.
-        const probe = pointShapeGeometry(shape, x, y, size);
-        writePointFill(el, probe, fill);
-      }
-      if (alphaChanged) writeAlpha(el, alpha);
+    if (!xChanged && !yChanged && !sizeChanged) {
+      writeStablePoint(el, shape, x, y, size, fillChanged, fill, alphaChanged, alpha);
       continue;
     }
     const geometry = pointShapeGeometry(shape, x, y, size);
-    switch (geometry.kind) {
-      case "circle":
-        if (el.tagName !== "circle") return false;
-        // cx/r/stroke-width map 1:1 onto raw channels: write only the
-        // channels that moved (the common update perturbs y only).
-        if (xChanged) el.setAttribute("cx", px(geometry.cx));
-        if (yChanged) el.setAttribute("cy", px(geometry.cy));
-        if (sizeChanged) {
-          el.setAttribute("r", px(geometry.r));
-          if (geometry.mode === "stroke") {
-            el.setAttribute("stroke-width", px(geometry.strokeWidth));
-          }
-        }
-        if (geometry.mode === "stroke") {
-          if (fillChanged) el.setAttribute("stroke", fill);
-        } else if (fillChanged) {
-          el.setAttribute("fill", fill);
-        }
-        break;
-      case "rect":
-        if (el.tagName !== "rect") return false;
-        // Rect x/width derive from (x, size); y/height from (y, size).
-        if (xChanged || sizeChanged) {
-          el.setAttribute("x", px(geometry.x));
-          el.setAttribute("width", px(geometry.width));
-        }
-        if (yChanged || sizeChanged) {
-          el.setAttribute("y", px(geometry.y));
-          el.setAttribute("height", px(geometry.height));
-        }
-        if (fillChanged) el.setAttribute("fill", fill);
-        break;
-      case "polygon":
-        if (el.tagName !== "path") return false;
-        el.setAttribute("d", pointShapePathD(geometry, px));
-        if (fillChanged) el.setAttribute("fill", fill);
-        break;
-      case "lines":
-        if (el.tagName !== "path") return false;
-        el.setAttribute("d", pointShapePathD(geometry, px));
-        el.setAttribute("stroke-width", px(geometry.strokeWidth));
-        if (fillChanged) el.setAttribute("stroke", fill);
-        break;
-      default:
-        return false;
+    if (!patchPointGeometry(el, geometry, xChanged, yChanged, sizeChanged, fillChanged, fill)) {
+      return false;
     }
     if (alphaChanged) writeAlpha(el, alpha);
   }


### PR DESCRIPTION
## Summary
- enforce oxlint cyclomatic complexity ≤20 for `packages/core/src/svg-live/**`
- split path geometry comparison and style writes into focused helpers
- split uncommon point geometry branches while retaining a flat, allocation-free dense circle path
- remove the per-path `Array.from` ring comparison allocation

## Validation
- `bun run check`
- `bun run knip`
- `bun run lint:type-aware`
- `bun test packages/core/tests/svg-live-signature.test.ts` (13 pass)
- `bun run --cwd packages/svelte test:browser -- tests/svg-live-patch.test.ts --project chromium` (10 pass)
- `bun run test` (5,068 pass, 4 skip)
- `pre-commit run --all-files` (two consecutive clean runs)

## Benchmarks
Paired warm Chromium live-update runs against the pre-change code:

- scatter-color-10k total: 87.7 → 69.3 ms (-21.0%)
- scatter-color-10k sync: 34.7 → 27.6 ms (-20.5%)
- line-3x10k total: 37.5 → 34.1 ms (-9.1%)
- line-3x10k sync: 25.5 → 26.6 ms (+4.3%)
- bars-stacked-50x4 total: 8.0 → 6.9 ms (-13.8%)
- bars-stacked-50x4 sync: 3.6 → 3.3 ms (-8.3%)

There is no coherent runtime regression. An earlier helper-per-mark implementation showed a coherent synchronous slowdown and was discarded before this PR.