### PR TITLE
refactor(core): enforce complexity in canvas DOM

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -82,6 +82,12 @@
       }
     },
     {
+      "files": ["packages/core/src/dom/**"],
+      "rules": {
+        "eslint/complexity": ["error", { "max": 20 }]
+      }
+    },
+    {
       // Tests + benchmarks: fixture literals are cast deliberately (invalid
       // specs, RuntimeSpec shapes) and test files run long by design.
       "files": ["**/tests/**", "benchmarks/**"],

--- a/packages/core/src/dom/canvas-marks-paths.ts
+++ b/packages/core/src/dom/canvas-marks-paths.ts
@@ -111,6 +111,82 @@ function strokePath(
   ctx.stroke();
 }
 
+function isSolidLineHot(batch: PathsBatch, isArea: boolean, needBounds: boolean): boolean {
+  return (
+    !isArea &&
+    !needBounds &&
+    batch.glow === undefined &&
+    batch.alphas === undefined &&
+    batch.linewidths === undefined &&
+    batch.linetypeIndexes === undefined &&
+    (batch.linetype === undefined || batch.linetype === "solid") &&
+    batch.curve === "linear"
+  );
+}
+
+function drawSolidLines(
+  ctx: CanvasRenderingContext2D,
+  batch: PathsBatch,
+  ink: string,
+  resolve: ColorResolver,
+): void {
+  ctx.lineWidth = batch.linewidth;
+  ctx.lineJoin = batch.linejoin ?? "round";
+  ctx.lineCap = batch.linecap ?? "round";
+  if (typeof ctx.setLineDash === "function") ctx.setLineDash([]);
+  for (let s = 0; s + 1 < batch.pathOffsets.length; s++) {
+    const start = batch.pathOffsets[s]!;
+    const end = batch.pathOffsets[s + 1]!;
+    if (end <= start) continue;
+    ctx.strokeStyle = resolve(batch.strokes[s] ?? batch.strokePaint?.fallback ?? ink);
+    ctx.beginPath();
+    ctx.moveTo(batch.positions[start * 2]!, batch.positions[start * 2 + 1]!);
+    for (let i = start + 1; i < end; i++) {
+      ctx.lineTo(batch.positions[i * 2]!, batch.positions[i * 2 + 1]!);
+    }
+    ctx.stroke();
+  }
+}
+
+function drawResolvedPath(
+  ctx: CanvasRenderingContext2D,
+  batch: PathsBatch,
+  s: number,
+  start: number,
+  end: number,
+  baseAlpha: number,
+  isArea: boolean,
+  needBounds: boolean,
+  themeColors: { ink: string; accent: string },
+  resolve: ColorResolver,
+): void {
+  const bounds = needBounds ? subpathBounds(batch.positions, start, end) : null;
+  const style = resolvePathMark(batch, s, themeColors);
+  ctx.beginPath();
+  traceSubpath(ctx, batch, start, end);
+  ctx.globalAlpha = baseAlpha * style.alpha;
+  if (isArea) {
+    const solid = style.fill === "none" ? themeColors.accent : style.fill;
+    ctx.fillStyle =
+      bounds === null
+        ? resolve(solid)
+        : resolvePaintStyle(ctx, solid, batch.fillPaint, bounds, resolve);
+    if (batch.fillRule === "evenodd") ctx.fill("evenodd");
+    else ctx.fill();
+    if (style.stroke === "none") return;
+  }
+  const solid = style.stroke === "none" ? themeColors.ink : style.stroke;
+  ctx.strokeStyle =
+    bounds === null
+      ? resolve(solid)
+      : resolvePaintStyle(ctx, solid, batch.strokePaint, bounds, resolve);
+  ctx.lineWidth = style.width;
+  if (typeof ctx.setLineDash === "function") ctx.setLineDash([...style.dash]);
+  ctx.lineJoin = style.linejoin;
+  ctx.lineCap = style.linecap;
+  ctx.stroke();
+}
+
 export function drawPaths(
   ctx: CanvasRenderingContext2D,
   batch: PathsBatch,
@@ -127,38 +203,8 @@ export function drawPaths(
   // Solid multi-series lines (competitive line-3×N): no fills, no per-subpath
   // alpha/linewidth/linetype, no gradient paint — one monomorphic stroke loop
   // without resolvePathMark allocations or setLineDash per subpath (#1468).
-  const solidLineHot =
-    !isArea &&
-    !needBounds &&
-    batch.glow === undefined &&
-    batch.alphas === undefined &&
-    batch.linewidths === undefined &&
-    batch.linetypeIndexes === undefined &&
-    (batch.linetype === undefined || batch.linetype === "solid") &&
-    batch.curve === "linear";
-  if (solidLineHot) {
-    const linewidth = batch.linewidth;
-    const linejoin = batch.linejoin ?? "round";
-    const linecap = batch.linecap ?? "round";
-    const ink = themeColors.ink;
-    ctx.lineWidth = linewidth;
-    ctx.lineJoin = linejoin;
-    ctx.lineCap = linecap;
-    if (typeof ctx.setLineDash === "function") ctx.setLineDash([]);
-    for (let s = 0; s < subpaths; s++) {
-      const start = batch.pathOffsets[s]!;
-      const end = batch.pathOffsets[s + 1]!;
-      if (end <= start) continue;
-      const stroke = batch.strokes[s];
-      ctx.strokeStyle = resolve(stroke ?? batch.strokePaint?.fallback ?? ink);
-      ctx.beginPath();
-      // Linear open path: no step corners / ring holes.
-      ctx.moveTo(batch.positions[start * 2]!, batch.positions[start * 2 + 1]!);
-      for (let i = start + 1; i < end; i++) {
-        ctx.lineTo(batch.positions[i * 2]!, batch.positions[i * 2 + 1]!);
-      }
-      ctx.stroke();
-    }
+  if (isSolidLineHot(batch, isArea, needBounds)) {
+    drawSolidLines(ctx, batch, themeColors.ink, resolve);
     restoreGlow();
     ctx.globalAlpha = baseAlpha;
     return;
@@ -168,43 +214,18 @@ export function drawPaths(
     const start = batch.pathOffsets[s]!;
     const end = batch.pathOffsets[s + 1]!;
     if (end <= start) continue;
-    // Bounds only for gradient paint (solid strokes skip the O(vertices) scan).
-    const bounds = needBounds ? subpathBounds(batch.positions, start, end) : null;
-    const style = resolvePathMark(batch, s, themeColors);
-    ctx.beginPath();
-    traceSubpath(ctx, batch, start, end);
-    ctx.globalAlpha = baseAlpha * style.alpha;
-    if (isArea) {
-      const solid = style.fill === "none" ? themeColors.accent : style.fill;
-      ctx.fillStyle =
-        bounds === null
-          ? resolve(solid)
-          : resolvePaintStyle(ctx, solid, batch.fillPaint, bounds, resolve);
-      if (batch.fillRule === "evenodd") ctx.fill("evenodd");
-      else ctx.fill();
-      if (style.stroke !== "none") {
-        ctx.strokeStyle =
-          bounds === null
-            ? resolve(style.stroke)
-            : resolvePaintStyle(ctx, style.stroke, batch.strokePaint, bounds, resolve);
-        ctx.lineWidth = style.width;
-        if (typeof ctx.setLineDash === "function") ctx.setLineDash([...style.dash]);
-        ctx.lineJoin = style.linejoin;
-        ctx.lineCap = style.linecap;
-        ctx.stroke();
-      }
-    } else {
-      const solid = style.stroke === "none" ? themeColors.ink : style.stroke;
-      ctx.strokeStyle =
-        bounds === null
-          ? resolve(solid)
-          : resolvePaintStyle(ctx, solid, batch.strokePaint, bounds, resolve);
-      ctx.lineWidth = style.width;
-      if (typeof ctx.setLineDash === "function") ctx.setLineDash([...style.dash]);
-      ctx.lineJoin = style.linejoin;
-      ctx.lineCap = style.linecap;
-      ctx.stroke();
-    }
+    drawResolvedPath(
+      ctx,
+      batch,
+      s,
+      start,
+      end,
+      baseAlpha,
+      isArea,
+      needBounds,
+      themeColors,
+      resolve,
+    );
   }
   restoreGlow();
   ctx.globalAlpha = baseAlpha;

--- a/packages/core/src/dom/canvas-marks-points.ts
+++ b/packages/core/src/dom/canvas-marks-points.ts
@@ -208,64 +208,82 @@ function drawIndexedColorPoints(
   }
 }
 
-export function drawPoints(
-  ctx: CanvasRenderingContext2D,
-  batch: PointsBatch,
-  theme: ThemeTokens,
-  resolve: ColorResolver,
-): void {
-  const themeInk = resolve(themeVar("ink", theme));
-  const n = batch.rowIndex.length;
-  // plus/cross/circle-open are open stroke paths — even a literal shape
-  // constant cannot use the fill-only fast path (it would paint nothing).
-  const needsPerPointPaint =
+function needsIndividualPaint(batch: PointsBatch): boolean {
+  return (
     batch.sizes !== undefined ||
     batch.alphas !== undefined ||
     batch.shapeIndexes !== undefined ||
     batch.shape === "plus" ||
     batch.shape === "cross" ||
-    batch.shape === "circle-open";
-  if (needsPerPointPaint) {
-    const baseAlpha = ctx.globalAlpha;
-    for (let j = 0; j < n; j++) {
-      const style = resolvePointMark(batch, j, themeInk);
-      ctx.globalAlpha = baseAlpha * style.alpha;
-      ctx.beginPath();
-      traceGeometry(ctx, style.geometry);
-      if (style.geometry.mode === "stroke") {
-        ctx.strokeStyle = resolve(style.fill);
-        ctx.lineWidth = style.geometry.strokeWidth;
-        ctx.stroke();
-      } else {
-        ctx.fillStyle = resolve(style.fill);
-        ctx.fill();
-      }
-    }
-    ctx.globalAlpha = baseAlpha;
-    return;
-  }
-  if (batch.colorIndexes !== undefined && batch.colorPalette !== undefined) {
-    drawIndexedColorPoints(ctx, batch, resolve, null);
-    return;
-  }
-  if (batch.colors === undefined) {
-    // Single fill: one path for the whole batch (the fast path that makes
-    // canvas worth it at high counts).
-    ctx.fillStyle = batch.fill === null ? themeInk : resolve(batch.fill);
+    batch.shape === "circle-open"
+  );
+}
+
+function drawIndividualPoints(
+  ctx: CanvasRenderingContext2D,
+  batch: PointsBatch,
+  themeInk: string,
+  resolve: ColorResolver,
+  include: ((index: number) => boolean) | null,
+): void {
+  const baseAlpha = ctx.globalAlpha;
+  for (let j = 0; j < batch.rowIndex.length; j++) {
+    if (include !== null && !include(j)) continue;
+    const style = resolvePointMark(batch, j, themeInk);
+    ctx.globalAlpha = baseAlpha * style.alpha;
     ctx.beginPath();
-    if (isFilledCircleBatch(batch)) traceFilledCircles(ctx, batch, null);
-    else for (let j = 0; j < n; j++) tracePoint(ctx, batch, j);
-    ctx.fill();
-    return;
+    traceGeometry(ctx, style.geometry);
+    if (style.geometry.mode === "stroke") {
+      ctx.strokeStyle = resolve(style.fill);
+      ctx.lineWidth = style.geometry.strokeWidth;
+      ctx.stroke();
+    } else {
+      ctx.fillStyle = resolve(style.fill);
+      ctx.fill();
+    }
   }
-  // Per-mark colors: bucket by color when cardinality is small (typical
-  // categorical scatter: 5 series interleaved → run-length would be 1).
-  // Contiguous runs stay as the high-cardinality fallback (O(n) one pass).
+  ctx.globalAlpha = baseAlpha;
+}
+
+function drawSingleColorPoints(
+  ctx: CanvasRenderingContext2D,
+  batch: PointsBatch,
+  themeInk: string,
+  resolve: ColorResolver,
+  include: ((index: number) => boolean) | null,
+): void {
+  ctx.fillStyle = batch.fill === null ? themeInk : resolve(batch.fill);
+  ctx.beginPath();
+  let traced = false;
+  const circles = isFilledCircleBatch(batch);
+  for (let j = 0; j < batch.rowIndex.length; j++) {
+    if (include !== null && !include(j)) continue;
+    if (circles) {
+      traceFilledCircle(ctx, batch.positions[j * 2]!, batch.positions[j * 2 + 1]!, batch.size);
+    } else {
+      tracePoint(ctx, batch, j);
+    }
+    traced = true;
+  }
+  if (traced) ctx.fill();
+}
+
+type PointColorBuckets = {
+  uniqueColors: string[];
+  indicesByColor: Map<string, number[]>;
+  highCardinality: boolean;
+};
+
+function bucketPointColors(
+  batch: PointsBatch,
+  themeInk: string,
+  include: ((index: number) => boolean) | null,
+): PointColorBuckets {
   const uniqueColors: string[] = [];
   const indicesByColor = new Map<string, number[]>();
   let highCardinality = false;
-  for (let j = 0; j < n; j++) {
-    const color = batch.colors[j] ?? batch.fill ?? themeInk;
+  for (let j = 0; j < batch.rowIndex.length; j++) {
+    const color = batch.colors![j] ?? batch.fill ?? themeInk;
     let list = indicesByColor.get(color);
     if (list === undefined) {
       list = [];
@@ -276,39 +294,95 @@ export function drawPoints(
         break;
       }
     }
-    list.push(j);
+    if (include === null || include(j)) list.push(j);
   }
-  if (!highCardinality) {
-    const circles = isFilledCircleBatch(batch);
-    for (const color of uniqueColors) {
-      const list = indicesByColor.get(color)!;
-      ctx.fillStyle = resolve(color);
-      ctx.beginPath();
-      if (circles) traceFilledCircles(ctx, batch, list);
-      else for (const j of list) tracePoint(ctx, batch, j);
-      ctx.fill();
-    }
-    return;
+  return { uniqueColors, indicesByColor, highCardinality };
+}
+
+function drawBucketedPointColors(
+  ctx: CanvasRenderingContext2D,
+  batch: PointsBatch,
+  resolve: ColorResolver,
+  buckets: PointColorBuckets,
+): void {
+  const circles = isFilledCircleBatch(batch);
+  for (const color of buckets.uniqueColors) {
+    const list = buckets.indicesByColor.get(color)!;
+    if (list.length === 0) continue;
+    ctx.fillStyle = resolve(color);
+    ctx.beginPath();
+    if (circles) traceFilledCircles(ctx, batch, list);
+    else for (const j of list) tracePoint(ctx, batch, j);
+    ctx.fill();
   }
-  // High-cardinality: batch consecutive same-color runs.
+}
+
+function drawPointColorRuns(
+  ctx: CanvasRenderingContext2D,
+  batch: PointsBatch,
+  themeInk: string,
+  resolve: ColorResolver,
+  include: ((index: number) => boolean) | null,
+): void {
+  const n = batch.rowIndex.length;
   const circles = isFilledCircleBatch(batch);
   let runStart = 0;
   while (runStart < n) {
-    const color = batch.colors[runStart] ?? batch.fill ?? themeInk;
+    const color = batch.colors![runStart] ?? batch.fill ?? themeInk;
     let runEnd = runStart + 1;
-    while (runEnd < n && (batch.colors[runEnd] ?? batch.fill ?? themeInk) === color) runEnd++;
+    while (runEnd < n && (batch.colors![runEnd] ?? batch.fill ?? themeInk) === color) runEnd++;
     ctx.fillStyle = resolve(color);
     ctx.beginPath();
-    if (circles) {
-      for (let j = runStart; j < runEnd; j++) {
+    let traced = false;
+    for (let j = runStart; j < runEnd; j++) {
+      if (include !== null && !include(j)) continue;
+      if (circles) {
         traceFilledCircle(ctx, batch.positions[j * 2]!, batch.positions[j * 2 + 1]!, batch.size);
+      } else {
+        tracePoint(ctx, batch, j);
       }
-    } else {
-      for (let j = runStart; j < runEnd; j++) tracePoint(ctx, batch, j);
+      traced = true;
     }
-    ctx.fill();
+    if (traced) ctx.fill();
     runStart = runEnd;
   }
+}
+
+function drawColoredPoints(
+  ctx: CanvasRenderingContext2D,
+  batch: PointsBatch,
+  themeInk: string,
+  resolve: ColorResolver,
+  include: ((index: number) => boolean) | null,
+): void {
+  const buckets = bucketPointColors(batch, themeInk, include);
+  if (buckets.highCardinality) {
+    drawPointColorRuns(ctx, batch, themeInk, resolve, include);
+  } else {
+    drawBucketedPointColors(ctx, batch, resolve, buckets);
+  }
+}
+
+export function drawPoints(
+  ctx: CanvasRenderingContext2D,
+  batch: PointsBatch,
+  theme: ThemeTokens,
+  resolve: ColorResolver,
+): void {
+  const themeInk = resolve(themeVar("ink", theme));
+  if (needsIndividualPaint(batch)) {
+    drawIndividualPoints(ctx, batch, themeInk, resolve, null);
+    return;
+  }
+  if (batch.colorIndexes !== undefined && batch.colorPalette !== undefined) {
+    drawIndexedColorPoints(ctx, batch, resolve, null);
+    return;
+  }
+  if (batch.colors === undefined) {
+    drawSingleColorPoints(ctx, batch, themeInk, resolve, null);
+    return;
+  }
+  drawColoredPoints(ctx, batch, themeInk, resolve, null);
 }
 
 export function drawPointsSubset(
@@ -321,32 +395,8 @@ export function drawPointsSubset(
 ): void {
   const includes = (index: number) => maskIncludes(mask, index) === focused;
   const themeInk = resolve(themeVar("ink", theme));
-  const n = batch.rowIndex.length;
-  const needsPerPointPaint =
-    batch.sizes !== undefined ||
-    batch.alphas !== undefined ||
-    batch.shapeIndexes !== undefined ||
-    batch.shape === "plus" ||
-    batch.shape === "cross" ||
-    batch.shape === "circle-open";
-  if (needsPerPointPaint) {
-    const baseAlpha = ctx.globalAlpha;
-    for (let j = 0; j < n; j++) {
-      if (!includes(j)) continue;
-      const style = resolvePointMark(batch, j, themeInk);
-      ctx.globalAlpha = baseAlpha * style.alpha;
-      ctx.beginPath();
-      traceGeometry(ctx, style.geometry);
-      if (style.geometry.mode === "stroke") {
-        ctx.strokeStyle = resolve(style.fill);
-        ctx.lineWidth = style.geometry.strokeWidth;
-        ctx.stroke();
-      } else {
-        ctx.fillStyle = resolve(style.fill);
-        ctx.fill();
-      }
-    }
-    ctx.globalAlpha = baseAlpha;
+  if (needsIndividualPaint(batch)) {
+    drawIndividualPoints(ctx, batch, themeInk, resolve, includes);
     return;
   }
   if (batch.colorIndexes !== undefined && batch.colorPalette !== undefined) {
@@ -354,79 +404,8 @@ export function drawPointsSubset(
     return;
   }
   if (batch.colors === undefined) {
-    ctx.fillStyle = batch.fill === null ? themeInk : resolve(batch.fill);
-    ctx.beginPath();
-    let traced = false;
-    const circles = isFilledCircleBatch(batch);
-    for (let j = 0; j < n; j++) {
-      if (!includes(j)) continue;
-      if (circles) {
-        traceFilledCircle(ctx, batch.positions[j * 2]!, batch.positions[j * 2 + 1]!, batch.size);
-      } else {
-        tracePoint(ctx, batch, j);
-      }
-      traced = true;
-    }
-    if (traced) ctx.fill();
+    drawSingleColorPoints(ctx, batch, themeInk, resolve, includes);
     return;
   }
-  // Interactive masks must not turn alternating categorical colors into one
-  // beginPath/fill pair per point. For the normal small categorical case
-  // (≤64 global first-seen colors), bucket included indices by color in one
-  // O(n) pass — not re-scan n for each of C colors (O(C·n)). Preserve global
-  // first-seen paint order (including colors only present on the other mask
-  // half). Fall back to contiguous runs when cardinality exceeds 64.
-  const uniqueColors: string[] = [];
-  const indicesByColor = new Map<string, number[]>();
-  let highCardinality = false;
-  for (let j = 0; j < n; j++) {
-    const color = batch.colors[j] ?? batch.fill ?? themeInk;
-    let list = indicesByColor.get(color);
-    if (list === undefined) {
-      list = [];
-      indicesByColor.set(color, list);
-      uniqueColors.push(color);
-      // Mirror the prior discovery loop: collect at most 65 names, then bail
-      // to run-length (uniqueColors.length > 64). Incomplete buckets are unused.
-      if (uniqueColors.length > 64) {
-        highCardinality = true;
-        break;
-      }
-    }
-    if (includes(j)) list.push(j);
-  }
-  if (!highCardinality) {
-    const circles = isFilledCircleBatch(batch);
-    for (const color of uniqueColors) {
-      const list = indicesByColor.get(color)!;
-      if (list.length === 0) continue;
-      ctx.fillStyle = resolve(color);
-      ctx.beginPath();
-      if (circles) traceFilledCircles(ctx, batch, list);
-      else for (const j of list) tracePoint(ctx, batch, j);
-      ctx.fill();
-    }
-    return;
-  }
-  let runStart = 0;
-  while (runStart < n) {
-    const color = batch.colors[runStart] ?? batch.fill ?? themeInk;
-    let runEnd = runStart + 1;
-    while (runEnd < n && (batch.colors[runEnd] ?? batch.fill ?? themeInk) === color) runEnd++;
-    ctx.fillStyle = resolve(color);
-    ctx.beginPath();
-    let traced = false;
-    const circles = isFilledCircleBatch(batch);
-    for (let j = runStart; j < runEnd; j++) {
-      if (!includes(j)) continue;
-      if (circles) {
-        traceFilledCircle(ctx, batch.positions[j * 2]!, batch.positions[j * 2 + 1]!, batch.size);
-      } else {
-        tracePoint(ctx, batch, j);
-      }
-      traced = true;
-    }
-    if (traced) ctx.fill();
-    runStart = runEnd;
-  }
+  drawColoredPoints(ctx, batch, themeInk, resolve, includes);
 }

--- a/packages/core/src/dom/canvas-marks-segments.ts
+++ b/packages/core/src/dom/canvas-marks-segments.ts
@@ -87,6 +87,108 @@ function applyGlow(ctx: CanvasRenderingContext2D, glow: SegmentsBatch["glow"]): 
   };
 }
 
+function finishSegments(
+  ctx: CanvasRenderingContext2D,
+  restoreGlow: () => void,
+  previousLineCap: CanvasLineCap,
+): void {
+  applyDash(ctx, "solid");
+  restoreGlow();
+  ctx.lineCap = previousLineCap;
+}
+
+function drawMappedSegments(
+  ctx: CanvasRenderingContext2D,
+  batch: SegmentsBatch,
+  themeInk: string,
+  resolve: ColorResolver,
+  includes: ((index: number) => boolean) | undefined,
+): void {
+  const baseAlpha = ctx.globalAlpha;
+  for (let j = 0; j < batch.segments.length / 4; j++) {
+    if (includes !== undefined && !includes(j)) continue;
+    const mark = resolveSegmentMark(batch, j, themeInk);
+    ctx.strokeStyle = resolveSegmentStroke(
+      ctx,
+      mark.stroke,
+      batch.strokePaint,
+      segmentBounds(batch, j),
+      resolve,
+    );
+    ctx.lineWidth = mark.width;
+    ctx.globalAlpha = baseAlpha * mark.alpha;
+    if (typeof ctx.setLineDash === "function") ctx.setLineDash([...mark.dash]);
+    ctx.beginPath();
+    traceSegment(ctx, batch, j);
+    ctx.stroke();
+  }
+  ctx.globalAlpha = baseAlpha;
+}
+
+function panelStrokeStyle(
+  ctx: CanvasRenderingContext2D,
+  color: string,
+  paint: ResolvedGradientPaint | undefined,
+  resolve: ColorResolver,
+): string | CanvasGradient {
+  return paint === undefined
+    ? resolve(color)
+    : resolveSegmentStroke(ctx, color, paint, { x: 0, y: 0, width: 1, height: 1 }, resolve);
+}
+
+function drawMonoSegments(
+  ctx: CanvasRenderingContext2D,
+  batch: SegmentsBatch,
+  themeInk: string,
+  resolve: ColorResolver,
+  includes: ((index: number) => boolean) | undefined,
+): void {
+  ctx.strokeStyle = panelStrokeStyle(
+    ctx,
+    segmentStrokeAt(batch, 0, themeInk),
+    batch.strokePaint,
+    resolve,
+  );
+  ctx.beginPath();
+  let traced = false;
+  for (let j = 0; j < batch.segments.length / 4; j++) {
+    if (includes !== undefined && !includes(j)) continue;
+    traceSegment(ctx, batch, j);
+    traced = true;
+  }
+  if (traced) ctx.stroke();
+}
+
+function drawSegmentRuns(
+  ctx: CanvasRenderingContext2D,
+  batch: SegmentsBatch,
+  themeInk: string,
+  resolve: ColorResolver,
+  includes: ((index: number) => boolean) | undefined,
+): void {
+  const n = batch.segments.length / 4;
+  let runStart = 0;
+  while (runStart < n) {
+    if (includes !== undefined && !includes(runStart)) {
+      runStart++;
+      continue;
+    }
+    const color = segmentStrokeAt(batch, runStart, themeInk);
+    let runEnd = runStart + 1;
+    while (runEnd < n && segmentStrokeAt(batch, runEnd, themeInk) === color) runEnd++;
+    ctx.strokeStyle = panelStrokeStyle(ctx, color, batch.strokePaint, resolve);
+    ctx.beginPath();
+    let traced = false;
+    for (let j = runStart; j < runEnd; j++) {
+      if (includes !== undefined && !includes(j)) continue;
+      traceSegment(ctx, batch, j);
+      traced = true;
+    }
+    if (traced) ctx.stroke();
+    runStart = runEnd;
+  }
+}
+
 /**
  * Draw segments with Θ(runs) stroke() calls: mono batches (no per-segment
  * `strokes`) are one path; per-segment colors collapse contiguous same-color
@@ -126,91 +228,17 @@ export function drawSegments(
     batch.alphas !== undefined ||
     batch.linetypeIndexes !== undefined;
   if (mappedStyle || perSegmentPaint) {
-    const baseAlpha = ctx.globalAlpha;
-    for (let j = 0; j < n; j++) {
-      if (includes !== undefined && !includes(j)) continue;
-      const mark = resolveSegmentMark(batch, j, themeInk);
-      ctx.strokeStyle = resolveSegmentStroke(
-        ctx,
-        mark.stroke,
-        paint,
-        segmentBounds(batch, j),
-        resolve,
-      );
-      ctx.lineWidth = mark.width;
-      ctx.globalAlpha = baseAlpha * mark.alpha;
-      if (typeof ctx.setLineDash === "function") ctx.setLineDash([...mark.dash]);
-      ctx.beginPath();
-      traceSegment(ctx, batch, j);
-      ctx.stroke();
-    }
-    ctx.globalAlpha = baseAlpha;
-    applyDash(ctx, "solid");
-    restoreGlow();
-    ctx.lineCap = previousLineCap;
+    drawMappedSegments(ctx, batch, themeInk, resolve, includes);
+    finishSegments(ctx, restoreGlow, previousLineCap);
     return;
   }
 
   // Solid mono path, or panel-space paint (bounds unused for panel mapping).
   if (batch.strokes === undefined) {
-    const monoSolid = segmentStrokeAt(batch, 0, themeInk);
-    if (paint) {
-      // Panel-space ignores bounds; placeholder is unused for mapping.
-      ctx.strokeStyle = resolveSegmentStroke(
-        ctx,
-        monoSolid,
-        paint,
-        { x: 0, y: 0, width: 1, height: 1 },
-        resolve,
-      );
-    } else {
-      ctx.strokeStyle = resolve(monoSolid);
-    }
-    ctx.beginPath();
-    let traced = false;
-    for (let j = 0; j < n; j++) {
-      if (includes !== undefined && !includes(j)) continue;
-      traceSegment(ctx, batch, j);
-      traced = true;
-    }
-    if (traced) ctx.stroke();
-    applyDash(ctx, "solid");
-    restoreGlow();
-    ctx.lineCap = previousLineCap;
+    drawMonoSegments(ctx, batch, themeInk, resolve, includes);
+    finishSegments(ctx, restoreGlow, previousLineCap);
     return;
   }
-
-  let runStart = 0;
-  while (runStart < n) {
-    if (includes !== undefined && !includes(runStart)) {
-      runStart++;
-      continue;
-    }
-    const color = segmentStrokeAt(batch, runStart, themeInk);
-    let runEnd = runStart + 1;
-    while (runEnd < n && segmentStrokeAt(batch, runEnd, themeInk) === color) runEnd++;
-    if (paint) {
-      ctx.strokeStyle = resolveSegmentStroke(
-        ctx,
-        color,
-        paint,
-        { x: 0, y: 0, width: 1, height: 1 },
-        resolve,
-      );
-    } else {
-      ctx.strokeStyle = resolve(color);
-    }
-    ctx.beginPath();
-    let traced = false;
-    for (let j = runStart; j < runEnd; j++) {
-      if (includes !== undefined && !includes(j)) continue;
-      traceSegment(ctx, batch, j);
-      traced = true;
-    }
-    if (traced) ctx.stroke();
-    runStart = runEnd;
-  }
-  applyDash(ctx, "solid");
-  restoreGlow();
-  ctx.lineCap = previousLineCap;
+  drawSegmentRuns(ctx, batch, themeInk, resolve, includes);
+  finishSegments(ctx, restoreGlow, previousLineCap);
 }


### PR DESCRIPTION
## Summary
- enforce oxlint cyclomatic complexity ≤20 for `packages/core/src/dom/**`
- separate point paint strategies into individual, indexed, single-color, bucketed, and run-based helpers
- isolate the solid-line canvas hot path from general path painting
- separate mapped, mono, and run-based segment painting while centralizing state restoration

## Validation
- `bun run check`
- `bun run knip`
- `bun run lint:type-aware`
- `bun test packages/core/tests/dom` (71 pass)
- `bun run test` (5,068 pass, 4 skip)
- `pre-commit run --all-files` (two consecutive clean runs)

## Benchmarks
Full pre/post benchmark suite; key canvas workloads:

- canvas cold scatter 100k: 380.3715 → 307.2243 ms (-19.2%)
- canvas redraw scatter 100k: 3.0941 → 1.4100 ms (-54.4%)

The remaining 38 workloads show no coherent regression.