### PR TITLE
refactor(core): enforce complexity in candidate construction

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -88,6 +88,12 @@
       }
     },
     {
+      "files": ["packages/core/src/pipeline/candidate-construction/**"],
+      "rules": {
+        "eslint/complexity": ["error", { "max": 20 }]
+      }
+    },
+    {
       // Tests + benchmarks: fixture literals are cast deliberately (invalid
       // specs, RuntimeSpec shapes) and test files run long by design.
       "files": ["**/tests/**", "benchmarks/**"],

--- a/packages/core/src/pipeline/candidate-construction/frame-row.ts
+++ b/packages/core/src/pipeline/candidate-construction/frame-row.ts
@@ -106,6 +106,124 @@ function resolveClosedBandFrameRow(
   };
 }
 
+type PathBatch = Extract<GeometryBatch, { kind: "paths" }>;
+type SegmentBatch = Extract<GeometryBatch, { kind: "segments" }>;
+
+interface FrameRowResolution {
+  frameRow: number;
+  derivedGroup: number;
+}
+
+function defaultFrameRow(
+  frame: LayerFrame | undefined,
+  primitiveIndex: number,
+): FrameRowResolution {
+  const frameRow = Math.min(primitiveIndex, Math.max(0, (frame?.n ?? 1) - 1));
+  return { frameRow, derivedGroup: frame?.groups[frameRow] ?? 0 };
+}
+
+function resolveUnprojectedPathRow(
+  frame: LayerFrame,
+  batch: PathBatch,
+  primitiveIndex: number,
+  orderedGroups: readonly number[],
+  fallback: FrameRowResolution,
+): FrameRowResolution {
+  const subpath = pathSubpathIndex(batch.pathOffsets, primitiveIndex);
+  if (subpath === null) return fallback;
+  const derivedGroup = orderedGroups[Math.min(subpath, orderedGroups.length - 1)] ?? 0;
+  const rowsInGroup = getPathGroupSortedRows(frame).get(derivedGroup) ?? [];
+  const local = primitiveIndex - (batch.pathOffsets[subpath] ?? 0);
+  const reflected =
+    local < rowsInGroup.length ? local : Math.max(0, rowsInGroup.length * 2 - 1 - local);
+  return {
+    frameRow: rowsInGroup[Math.min(reflected, rowsInGroup.length - 1)] ?? fallback.frameRow,
+    derivedGroup,
+  };
+}
+
+function resolveProjectedClosedPathRow(
+  frame: LayerFrame,
+  primitiveIndex: number,
+  orderedGroups: readonly number[],
+  fallback: FrameRowResolution,
+): FrameRowResolution {
+  const resolved = resolveClosedBandFrameRow(
+    getClosedBandLayout(frame, orderedGroups),
+    primitiveIndex,
+  );
+  if (resolved !== null) return resolved;
+  const frameRow = Math.min(Math.max(0, primitiveIndex), Math.max(0, frame.n - 1));
+  return {
+    frameRow,
+    derivedGroup: frame.groups[frameRow] ?? fallback.derivedGroup,
+  };
+}
+
+function resolvePathFrameRow(
+  frame: LayerFrame,
+  batch: PathBatch,
+  primitiveIndex: number,
+  orderedGroups: readonly number[],
+  fallback: FrameRowResolution,
+): FrameRowResolution {
+  const explicitFrameRow = batch.frameRowIndex?.[primitiveIndex];
+  if (explicitFrameRow !== undefined && explicitFrameRow < frame.n) {
+    return {
+      frameRow: explicitFrameRow,
+      derivedGroup: frame.groups[explicitFrameRow] ?? fallback.derivedGroup,
+    };
+  }
+  const emittedClosedRow =
+    batch.closed === true ? batch.closedFrameRows?.[primitiveIndex] : undefined;
+  if (emittedClosedRow !== undefined) {
+    return {
+      frameRow: emittedClosedRow,
+      derivedGroup: frame.groups[emittedClosedRow] ?? fallback.derivedGroup,
+    };
+  }
+  if (batch.semanticIndex === undefined) {
+    return resolveUnprojectedPathRow(frame, batch, primitiveIndex, orderedGroups, fallback);
+  }
+  if (batch.closed === true) {
+    return resolveProjectedClosedPathRow(frame, primitiveIndex, orderedGroups, fallback);
+  }
+  const frameRow = Math.min(Math.max(0, primitiveIndex), Math.max(0, frame.n - 1));
+  return {
+    frameRow,
+    derivedGroup: frame.groups[frameRow] ?? fallback.derivedGroup,
+  };
+}
+
+function resolveSegmentFrameRow(
+  frame: LayerFrame,
+  batch: SegmentBatch,
+  primitiveIndex: number,
+  fallback: FrameRowResolution,
+): FrameRowResolution {
+  let frameRow = fallback.frameRow;
+  if (frame.binding.layer.geom === "errorbar") frameRow = Math.floor(primitiveIndex / 3);
+  else if (frame.binding.layer.geom === "boxplot" && batch.rowIndex.length >= frame.n * 2)
+    frameRow = Math.floor(primitiveIndex / 2);
+  return {
+    frameRow,
+    derivedGroup:
+      frame.groups[Math.min(frameRow, frame.groups.length - 1)] ?? fallback.derivedGroup,
+  };
+}
+
+function resolveBoxplotOutlierRow(
+  frame: LayerFrame,
+  primitiveIndex: number,
+  fallback: FrameRowResolution,
+): FrameRowResolution {
+  const frameRow = frame.box?.outlierBox[primitiveIndex] ?? fallback.frameRow;
+  return {
+    frameRow,
+    derivedGroup: frame.groups[frameRow] ?? fallback.derivedGroup,
+  };
+}
+
 export function resolveCandidateFrameRow(input: {
   frame: LayerFrame | undefined;
   batch: GeometryBatch;
@@ -113,81 +231,14 @@ export function resolveCandidateFrameRow(input: {
   orderedGroups: readonly number[];
   outlierLocalRow: number | null;
 }): { frameRow: number; derivedGroup: number } {
-  const { frame, batch, primitiveIndex, orderedGroups, outlierLocalRow } = input;
-  let frameRow = Math.min(primitiveIndex, Math.max(0, (frame?.n ?? 1) - 1));
-  let derivedGroup = frame?.groups[frameRow] ?? 0;
-
-  if (frame !== undefined && batch.kind === "paths") {
-    const explicitFrameRow = batch.frameRowIndex?.[primitiveIndex];
-    // Emitted closed-path frame rows are exact in both primitive-index spaces:
-    // with no coord they index render vertices, and after projection
-    // `semanticIndex` is a post-hole-strip vertex id keyed to this same array
-    // (hole stripping rewrites it alongside positions; projection leaves it).
-    const emittedClosedRow =
-      batch.closed === true ? batch.closedFrameRows?.[primitiveIndex] : undefined;
-    if (explicitFrameRow !== undefined && explicitFrameRow < frame.n) {
-      // Style-split lines emit exact frame rows so candidate identity survives
-      // subpath reindexing after mapped stroke-style breaks.
-      frameRow = explicitFrameRow;
-      derivedGroup = frame.groups[frameRow] ?? derivedGroup;
-    } else if (emittedClosedRow !== undefined) {
-      // Prefer emitted rows for every closed path, coord or not. Polygon rings
-      // (geom_polygon / geom_sf / density_2d_filled) keep authored winding and
-      // are not a 2×N reflected band, so the sorted-row reconstruction below
-      // would claim a neighbouring ring's row (#916); filtered ribbons need the
-      // same exactness after non-finite edge drops (#502).
-      frameRow = emittedClosedRow;
-      derivedGroup = frame.groups[frameRow] ?? derivedGroup;
-    } else if (batch.semanticIndex === undefined) {
-      // After coord projection, candidate facts pass semanticIndex (pre-render
-      // topology) as primitiveIndex. Render pathOffsets are post-tessellation and
-      // cannot index that space; reconstruct group/local from frame groups instead.
-      // O(log P) subpath lookup (was linear O(P) per vertex → O(V·P) at build).
-      // Null = OOB / empty offsets: keep default frameRow/derivedGroup (codex P1).
-      const subpath = pathSubpathIndex(batch.pathOffsets, primitiveIndex);
-      if (subpath !== null) {
-        derivedGroup = orderedGroups[Math.min(subpath, orderedGroups.length - 1)] ?? 0;
-        const rowsInGroup = getPathGroupSortedRows(frame).get(derivedGroup) ?? [];
-        const local = primitiveIndex - (batch.pathOffsets[subpath] ?? 0);
-        const reflected =
-          local < rowsInGroup.length ? local : Math.max(0, rowsInGroup.length * 2 - 1 - local);
-        frameRow = rowsInGroup[Math.min(reflected, rowsInGroup.length - 1)] ?? frameRow;
-      }
-    } else if (batch.closed === true) {
-      // Closed band with no emitted rows (handled above): reconstruct the 2×N
-      // upper/lower reflection from full frame groups.
-      const resolved = resolveClosedBandFrameRow(
-        getClosedBandLayout(frame, orderedGroups),
-        primitiveIndex,
-      );
-      if (resolved === null) {
-        frameRow = Math.min(Math.max(0, primitiveIndex), Math.max(0, frame.n - 1));
-        derivedGroup = frame.groups[frameRow] ?? derivedGroup;
-      } else {
-        frameRow = resolved.frameRow;
-        derivedGroup = resolved.derivedGroup;
-      }
-    } else {
-      // Open paths: semantic index is the pre-split vertex / frame row.
-      frameRow = Math.min(Math.max(0, primitiveIndex), Math.max(0, frame.n - 1));
-      derivedGroup = frame.groups[frameRow] ?? derivedGroup;
-    }
-  } else if (frame !== undefined && batch.kind === "segments") {
-    if (frame.binding.layer.geom === "errorbar") frameRow = Math.floor(primitiveIndex / 3);
-    else if (frame.binding.layer.geom === "boxplot" && batch.rowIndex.length >= frame.n * 2)
-      frameRow = Math.floor(primitiveIndex / 2);
-    derivedGroup = frame.groups[Math.min(frameRow, frame.groups.length - 1)] ?? derivedGroup;
-  } else if (
-    frame?.box !== null &&
-    frame?.binding.layer.geom === "boxplot" &&
-    batch.kind === "points"
-  ) {
-    frameRow = frame.box.outlierBox[primitiveIndex] ?? frameRow;
-    derivedGroup = frame.groups[frameRow] ?? derivedGroup;
-  } else if (outlierLocalRow !== null && frame !== undefined) {
-    // outlier points already resolved via outlierBox above when geom matches;
-    // keep default frameRow for other point batches.
-  }
-
-  return { frameRow, derivedGroup };
+  const { frame, batch, primitiveIndex, orderedGroups } = input;
+  const fallback = defaultFrameRow(frame, primitiveIndex);
+  if (frame === undefined) return fallback;
+  if (batch.kind === "paths")
+    return resolvePathFrameRow(frame, batch, primitiveIndex, orderedGroups, fallback);
+  if (batch.kind === "segments")
+    return resolveSegmentFrameRow(frame, batch, primitiveIndex, fallback);
+  if (frame.box !== null && frame.binding.layer.geom === "boxplot" && batch.kind === "points")
+    return resolveBoxplotOutlierRow(frame, primitiveIndex, fallback);
+  return fallback;
 }

--- a/packages/core/src/pipeline/candidate-construction/identity-buckets.ts
+++ b/packages/core/src/pipeline/candidate-construction/identity-buckets.ts
@@ -18,7 +18,11 @@ export type AggregateLineageXView =
       readonly transformed: Float64Array;
       readonly xBinning: BinnedBoundaries;
     }
-  | { readonly kind: "semantic"; readonly semantic: Float64Array; readonly valid: Uint8Array }
+  | {
+      readonly kind: "semantic";
+      readonly semantic: Float64Array;
+      readonly valid: Uint8Array;
+    }
   | { readonly kind: "raw"; readonly column: readonly CellValue[] };
 
 /** Resolve conversion/parsed/position columns once for a frame's x field. */
@@ -102,6 +106,103 @@ interface BinEdge {
   bucket: number[];
 }
 
+function groupFrameRows(frame: FinalizedLayerFrame): Map<number, number[]> {
+  const rowsByGroup = new Map<number, number[]>();
+  for (let frameRow = 0; frameRow < frame.n; frameRow++) {
+    const group = frame.groups[frameRow] ?? 0;
+    const rows = rowsByGroup.get(group);
+    if (rows === undefined) rowsByGroup.set(group, [frameRow]);
+    else rows.push(frameRow);
+  }
+  return rowsByGroup;
+}
+
+function buildWholeGroupBinBuckets(input: {
+  frame: FinalizedLayerFrame;
+  panelIndex: number;
+  layerIndex: number;
+  sourceRowsByGroupBin: Map<string, number[]>;
+}): void {
+  const membersByGroup = new Map<number, number[]>();
+  for (let localRow = 0; localRow < input.frame.inputGroups.length; localRow++) {
+    const group = input.frame.inputGroups[localRow]!;
+    const sourceRow = globalSourceRowForInputRow(input.frame, localRow);
+    const members = membersByGroup.get(group);
+    if (members === undefined) membersByGroup.set(group, [sourceRow]);
+    else members.push(sourceRow);
+  }
+  for (const [group, frameRows] of groupFrameRows(input.frame)) {
+    const members = membersByGroup.get(group) ?? [];
+    for (const frameRow of frameRows) {
+      input.sourceRowsByGroupBin.set(
+        `${input.panelIndex}:${input.layerIndex}:${group}:${frameRow}`,
+        members,
+      );
+    }
+  }
+}
+
+function buildBinEdges(input: {
+  frame: FinalizedLayerFrame;
+  panelIndex: number;
+  layerIndex: number;
+  sourceRowsByGroupBin: Map<string, number[]>;
+}): Map<number, BinEdge[]> {
+  const binsByGroup = new Map<number, BinEdge[]>();
+  for (let frameRow = 0; frameRow < input.frame.n; frameRow++) {
+    const group = input.frame.groups[frameRow] ?? 0;
+    const bucket: number[] = [];
+    input.sourceRowsByGroupBin.set(
+      `${input.panelIndex}:${input.layerIndex}:${group}:${frameRow}`,
+      bucket,
+    );
+    const list = binsByGroup.get(group);
+    const edge: BinEdge = { frameRow, bucket };
+    if (list === undefined) binsByGroup.set(group, [edge]);
+    else list.push(edge);
+  }
+  return binsByGroup;
+}
+
+function indexEdgesByGridBin(
+  binsByGroup: ReadonlyMap<number, readonly BinEdge[]>,
+  binIndex: ArrayLike<number>,
+): Map<number, Map<number, BinEdge>> {
+  const edgeByGridBin = new Map<number, Map<number, BinEdge>>();
+  for (const [group, bins] of binsByGroup) {
+    const byGridBin = new Map<number, BinEdge>();
+    for (const edge of bins) byGridBin.set(binIndex[edge.frameRow]!, edge);
+    edgeByGridBin.set(group, byGridBin);
+  }
+  return edgeByGridBin;
+}
+
+function populateBinEdges(input: {
+  frame: FinalizedLayerFrame;
+  field: string;
+  binsByGroup: ReadonlyMap<number, readonly BinEdge[]>;
+}): void {
+  const { frame, field } = input;
+  const cut = frame.binCut!;
+  const edgeByGridBin = indexEdgesByGridBin(input.binsByGroup, cut.binIndex);
+  const xNumeric = positionColumn(
+    frame.table,
+    field,
+    xConversionOf(frame.binding),
+    frame.binding.xTransform,
+  );
+  for (let localRow = 0; localRow < frame.inputGroups.length; localRow++) {
+    const group = frame.inputGroups[localRow]!;
+    const byGridBin = edgeByGridBin.get(group);
+    if (byGridBin === undefined || byGridBin.size === 0) continue;
+    const value = xNumeric[localRow]!;
+    if (!Number.isFinite(value)) continue;
+    const edge = byGridBin.get(binIndexOf(value, cut.fuzzy, cut.rightClosed));
+    if (edge === undefined) continue;
+    edge.bucket.push(globalSourceRowForInputRow(frame, localRow));
+  }
+}
+
 /**
  * Assign each source row to at most one bin in a single pass over the panel
  * rows, replaying the stat's own cut (O(n log B) binary search over the fuzzed
@@ -117,85 +218,16 @@ export function buildBinLineageBuckets(input: {
   layerIndex: number;
   sourceRowsByGroupBin: Map<string, number[]>;
 }): void {
-  const { frame, panelIndex, layerIndex, sourceRowsByGroupBin } = input;
+  const { frame } = input;
   const field = frame.binding.xField;
   if (field === null) return;
-
-  // Pre-stat groups cached on the frame during buildFrame (issue #217).
-  const inputGroups = frame.inputGroups;
-  const binsByGroup = new Map<number, BinEdge[]>();
   // Without the stat's own cut we cannot reproduce its fuzzed membership, so
   // fall back to the same conservative "mark represents the whole group"
   // behaviour used when bin edges are absent.
   const cut = frame.binCut;
-  const missingEdges =
-    frame.xmin === null || frame.xmax === null || cut === undefined || cut === null;
-  /** group → frame rows (missing-edges path only; enables O(n+k) fill). */
-  const frameRowsByGroup = missingEdges ? new Map<number, number[]>() : null;
-
-  for (let frameRow = 0; frameRow < frame.n; frameRow++) {
-    const group = frame.groups[frameRow] ?? 0;
-    if (frameRowsByGroup !== null) {
-      const rows = frameRowsByGroup.get(group);
-      if (rows === undefined) frameRowsByGroup.set(group, [frameRow]);
-      else rows.push(frameRow);
-      continue;
-    }
-    const bucket: number[] = [];
-    sourceRowsByGroupBin.set(`${panelIndex}:${layerIndex}:${group}:${frameRow}`, bucket);
-    const edge: BinEdge = { frameRow, bucket };
-    const list = binsByGroup.get(group);
-    if (list === undefined) binsByGroup.set(group, [edge]);
-    else list.push(edge);
-  }
-
-  // No bin edges: every output mark represents the full group (filter fallback).
-  // Pre-index group → frame rows, collect members O(n), share one array per group O(k).
-  if (frameRowsByGroup !== null) {
-    const membersByGroup = new Map<number, number[]>();
-    for (let localRow = 0; localRow < inputGroups.length; localRow++) {
-      const group = inputGroups[localRow]!;
-      const sourceRow = globalSourceRowForInputRow(frame, localRow);
-      const members = membersByGroup.get(group);
-      if (members === undefined) membersByGroup.set(group, [sourceRow]);
-      else members.push(sourceRow);
-    }
-    for (const [group, frameRows] of frameRowsByGroup) {
-      const members = membersByGroup.get(group) ?? [];
-      for (const frameRow of frameRows) {
-        sourceRowsByGroupBin.set(`${panelIndex}:${layerIndex}:${group}:${frameRow}`, members);
-      }
-    }
+  if (frame.xmin === null || frame.xmax === null || cut === undefined || cut === null) {
+    buildWholeGroupBinBuckets(input);
     return;
   }
-
-  // Grid bin index → the frame row that emitted it. summary_bin omits empty
-  // bins, so the grid index is not the frame row.
-  const edgeByGridBin = new Map<number, Map<number, BinEdge>>();
-  for (const [group, bins] of binsByGroup) {
-    const byGridBin = new Map<number, BinEdge>();
-    for (const edge of bins) byGridBin.set(cut!.binIndex[edge.frameRow]!, edge);
-    edgeByGridBin.set(group, byGridBin);
-  }
-
-  // Bin edges are in scale space after pre-stat transforms; compare source
-  // rows in the same space so log/sqrt histograms retain lineage.
-  const xNumeric = positionColumn(
-    frame.table,
-    field,
-    xConversionOf(frame.binding),
-    frame.binding.xTransform,
-  );
-  for (let localRow = 0; localRow < inputGroups.length; localRow++) {
-    const group = inputGroups[localRow]!;
-    const byGridBin = edgeByGridBin.get(group);
-    if (byGridBin === undefined || byGridBin.size === 0) continue;
-    const value = xNumeric[localRow]!;
-    if (!Number.isFinite(value)) continue;
-    // Replay the stat's own cut (fuzzed breaks) — exact-edge predicates
-    // disagree with it inside the fuzz band around a break (#905).
-    const edge = byGridBin.get(binIndexOf(value, cut!.fuzzy, cut!.rightClosed));
-    if (edge === undefined) continue;
-    edge.bucket.push(globalSourceRowForInputRow(frame, localRow));
-  }
+  populateBinEdges({ frame, field, binsByGroup: buildBinEdges(input) });
 }

--- a/packages/core/src/pipeline/candidate-construction/identity-index.ts
+++ b/packages/core/src/pipeline/candidate-construction/identity-index.ts
@@ -3,6 +3,7 @@ import { positionColumn, xConversionOf, yConversionOf } from "../temporal-positi
 import type { FinalizedLayerFrame } from "../types.js";
 import { NO_ROW } from "../types.js";
 import {
+  type AggregateLineageXView,
   aggregateLineageXKey,
   appendSourceRowByGroupKey,
   appendSourceRowByGroupX,
@@ -37,115 +38,151 @@ export interface CandidateIdentityIndex {
   readonly frameGroups: Map<string, number[]>;
 }
 
+type CandidateIdentityMaps = CandidateIdentityIndex;
+
+interface FrameIdentityViews {
+  readonly frameKey: string;
+  readonly layerIndex: number;
+  readonly lineageXView: AggregateLineageXView | null;
+  readonly stat: string;
+  readonly xField: string | null;
+  readonly xNumericForSmooth: Float64Array | null;
+  readonly yNumeric: Float64Array | null;
+}
+
+function createCandidateIdentityMaps(): CandidateIdentityMaps {
+  return {
+    seriesByRow: new Map(),
+    sourceRowsByGroup: new Map(),
+    sourceRowsByGroupX: new Map(),
+    sourceRowsByGroupBin: new Map(),
+    sourceRowsByGroupY: new Map(),
+    frameGroups: new Map(),
+  };
+}
+
+function frameIdentityViews(frame: FinalizedLayerFrame, panelIndex: number): FrameIdentityViews {
+  const layerIndex = frame.binding.index;
+  const stat = frame.binding.layer.stat ?? "identity";
+  const xField = frame.binding.xField;
+  const yField = frame.binding.yField;
+  const bucketByX = stat === "count" || stat === "summary" || stat === "boxplot";
+  const finiteY =
+    (stat === "smooth" || stat === "summary" || stat === "boxplot") && yField !== null;
+  const yNumeric =
+    finiteY && yField !== null
+      ? positionColumn(frame.table, yField, yConversionOf(frame.binding), frame.binding.yTransform)
+      : null;
+  const xNumericForSmooth =
+    stat === "smooth" && xField !== null
+      ? positionColumn(frame.table, xField, xConversionOf(frame.binding), frame.binding.xTransform)
+      : null;
+  const lineageXView =
+    bucketByX && xField !== null
+      ? resolveAggregateLineageXView(frame.table, xField, frame.binding)
+      : null;
+  return {
+    frameKey: `${panelIndex}:${layerIndex}`,
+    layerIndex,
+    lineageXView,
+    stat,
+    xField,
+    xNumericForSmooth,
+    yNumeric,
+  };
+}
+
+function indexFrameInputRows(
+  frame: FinalizedLayerFrame,
+  panelIndex: number,
+  maps: CandidateIdentityMaps,
+  views: FrameIdentityViews,
+): void {
+  for (let localRow = 0; localRow < frame.inputGroups.length; localRow++) {
+    const group = frame.inputGroups[localRow]!;
+    const sourceRow = globalSourceRowForInputRow(frame, localRow);
+    const key = `${views.frameKey}:${group}`;
+    appendSourceRowByGroupKey(maps.sourceRowsByGroup, key, sourceRow);
+    if (views.lineageXView !== null && views.xField !== null) {
+      appendSourceRowByGroupX({
+        sourceRowsByGroupX: maps.sourceRowsByGroupX,
+        panelIndex,
+        layerIndex: views.layerIndex,
+        group,
+        xKey: aggregateLineageXKey(
+          frame.table,
+          views.xField,
+          localRow,
+          frame.binding,
+          views.lineageXView,
+        ),
+        sourceRow,
+        include: views.yNumeric === null || Number.isFinite(views.yNumeric[localRow]!),
+      });
+    }
+    const yOk = views.yNumeric !== null && Number.isFinite(views.yNumeric[localRow]!);
+    const xOk =
+      views.xNumericForSmooth === null || Number.isFinite(views.xNumericForSmooth[localRow]!);
+    if (yOk && xOk) appendSourceRowByGroupKey(maps.sourceRowsByGroupY, key, sourceRow);
+  }
+}
+
+function indexFrameSeriesRows(
+  frame: FinalizedLayerFrame,
+  panelIndex: number,
+  layerIndex: number,
+  seriesByRow: Map<string, number>,
+): void {
+  for (let row = 0; row < frame.rowIndex.length; row++) {
+    const sourceRow = frame.rowIndex[row]!;
+    if (sourceRow !== NO_ROW) {
+      seriesByRow.set(`${panelIndex}:${layerIndex}:${sourceRow}`, frame.groups[row] ?? 0);
+    }
+  }
+}
+
+function indexFrame(
+  frame: FinalizedLayerFrame,
+  panelIndex: number,
+  maps: CandidateIdentityMaps,
+): void {
+  const views = frameIdentityViews(frame, panelIndex);
+  maps.frameGroups.set(views.frameKey, [...new Set(frame.groups)]);
+  indexFrameInputRows(frame, panelIndex, maps, views);
+  if (views.stat === "bin" || views.stat === "summary_bin") {
+    buildBinLineageBuckets({
+      frame,
+      panelIndex,
+      layerIndex: views.layerIndex,
+      sourceRowsByGroupBin: maps.sourceRowsByGroupBin,
+    });
+  }
+  indexFrameSeriesRows(frame, panelIndex, views.layerIndex, maps.seriesByRow);
+}
+
+function freezeIdentityBuckets(maps: CandidateIdentityMaps): void {
+  for (const map of [
+    maps.sourceRowsByGroup,
+    maps.sourceRowsByGroupX,
+    maps.sourceRowsByGroupBin,
+    maps.sourceRowsByGroupY,
+  ]) {
+    for (const [key, rows] of map) map.set(key, Object.freeze(rows) as number[]);
+  }
+}
+
 export function buildCandidateIdentityIndex(
   panelFrames: readonly (readonly FinalizedLayerFrame[])[],
   _facetPanels: readonly FacetPanelDef[],
 ): CandidateIdentityIndex {
-  const seriesByRow = new Map<string, number>();
-  const sourceRowsByGroup = new Map<string, number[]>();
-  const sourceRowsByGroupX = new Map<string, number[]>();
-  const sourceRowsByGroupBin = new Map<string, number[]>();
-  const sourceRowsByGroupY = new Map<string, number[]>();
-  const frameGroups = new Map<string, number[]>();
+  const maps = createCandidateIdentityMaps();
   for (let panelIndex = 0; panelIndex < panelFrames.length; panelIndex++) {
     for (const frame of panelFrames[panelIndex] ?? []) {
-      const layerIndex = frame.binding.index;
-      const frameKey = `${panelIndex}:${layerIndex}`;
-      frameGroups.set(frameKey, [...new Set(frame.groups)]);
-      // Pre-stat groups cached on the frame during buildFrame (issue #217).
-      const inputGroups = frame.inputGroups;
-      const stat = frame.binding.layer.stat ?? "identity";
-      // Only count/summary/boxplot resolve via group×x buckets; skip for other layers.
-      const bucketByX = stat === "count" || stat === "summary" || stat === "boxplot";
-      const xField = frame.binding.xField;
-      // Panel-local input rows → finalized global source ids (issue #626).
-      const yField = frame.binding.yField;
-      const finiteY =
-        (stat === "smooth" || stat === "summary" || stat === "boxplot") && yField !== null;
-      // Match stat reads: finite membership is after the pre-stat transform so
-      // log/sqrt OOD rows do not appear in candidate lineage for the fit.
-      const yNumeric =
-        finiteY && yField !== null
-          ? positionColumn(
-              frame.table,
-              yField,
-              yConversionOf(frame.binding),
-              frame.binding.yTransform,
-            )
-          : null;
-      const xNumericForSmooth =
-        stat === "smooth" && xField !== null
-          ? positionColumn(
-              frame.table,
-              xField,
-              xConversionOf(frame.binding),
-              frame.binding.xTransform,
-            )
-          : null;
-      // Resolve conversion/parsed/position columns once per frame (#1307).
-      const lineageXView =
-        bucketByX && xField !== null
-          ? resolveAggregateLineageXView(frame.table, xField, frame.binding)
-          : null;
-      for (let localRow = 0; localRow < inputGroups.length; localRow++) {
-        const group = inputGroups[localRow]!;
-        const sourceRow = globalSourceRowForInputRow(frame, localRow);
-        const key = `${frameKey}:${group}`;
-        appendSourceRowByGroupKey(sourceRowsByGroup, key, sourceRow);
-        if (lineageXView !== null && xField !== null) {
-          // Summary/boxplot: only finite y belongs in the final represented
-          // membership. Always create the group×x key (include=false) so an
-          // all-non-finite bucket is an empty frozen array, not a map miss.
-          const includeInX = yNumeric === null || Number.isFinite(yNumeric[localRow]!);
-          appendSourceRowByGroupX({
-            sourceRowsByGroupX,
-            panelIndex,
-            layerIndex,
-            group,
-            xKey: aggregateLineageXKey(frame.table, xField, localRow, frame.binding, lineageXView),
-            sourceRow,
-            include: includeInX,
-          });
-        }
-        const yOk = yNumeric !== null && Number.isFinite(yNumeric[localRow]!);
-        const xOk = xNumericForSmooth === null || Number.isFinite(xNumericForSmooth[localRow]!);
-        if (yOk && xOk) {
-          appendSourceRowByGroupKey(sourceRowsByGroupY, key, sourceRow);
-        }
-      }
-      if (stat === "bin" || stat === "summary_bin") {
-        buildBinLineageBuckets({
-          frame,
-          panelIndex,
-          layerIndex,
-          sourceRowsByGroupBin,
-        });
-      }
-      for (let i = 0; i < frame.rowIndex.length; i++) {
-        const sourceRow = frame.rowIndex[i]!;
-        if (sourceRow !== NO_ROW) {
-          seriesByRow.set(`${panelIndex}:${layerIndex}:${sourceRow}`, frame.groups[i] ?? 0);
-        }
-      }
+      indexFrame(frame, panelIndex, maps);
     }
   }
-  // Seal bucket arrays so resolve-time consumers cannot mutate shared lineage.
-  for (const map of [
-    sourceRowsByGroup,
-    sourceRowsByGroupX,
-    sourceRowsByGroupBin,
-    sourceRowsByGroupY,
-  ]) {
-    for (const [key, rows] of map) map.set(key, Object.freeze(rows) as number[]);
-  }
-  return {
-    seriesByRow,
-    sourceRowsByGroup,
-    sourceRowsByGroupX,
-    sourceRowsByGroupBin,
-    sourceRowsByGroupY,
-    frameGroups,
-  };
+  freezeIdentityBuckets(maps);
+  return maps;
 }
 
 export function createLazyIdentityIndex(

--- a/packages/core/src/pipeline/candidate-construction/represented-rows.ts
+++ b/packages/core/src/pipeline/candidate-construction/represented-rows.ts
@@ -68,7 +68,7 @@ export function filterAggregateYRows(input: {
   return input.baseRows.filter((row) => Number.isFinite(numeric[row]!));
 }
 
-export function filterRepresentedSourceRows(input: {
+interface RepresentedRowsInput {
   frame: LayerFrame;
   table: ColumnTable;
   frameRow: number;
@@ -81,20 +81,29 @@ export function filterRepresentedSourceRows(input: {
   sourceRowsByGroupBin?: Map<string, number[]>;
   /** Precomputed finite-y rows per `${panel}:${layer}:${group}` (smooth/summary/boxplot). */
   sourceRowsByGroupY?: Map<string, number[]>;
-}): readonly number[] {
-  const { frame, table, frameRow } = input;
+}
+
+interface RepresentedRowsContext {
+  readonly aggregateXField: string | null;
+  readonly aggregateYField: string | null;
+  readonly indexKeyPrefix: string | null;
+  readonly needsBin: boolean;
+  readonly needsX: boolean;
+  readonly needsY: boolean;
+  readonly outputX: unknown;
+}
+
+function representedRowsContext(input: RepresentedRowsInput): RepresentedRowsContext {
+  const { frame, frameRow } = input;
   const stat = frame.binding.layer.stat ?? "identity";
   const aggregateXField = frame.binding.xField;
   const aggregateYField = frame.binding.yField;
   const outputX = frame.xValues?.[frameRow] ?? frame.xNumeric?.[frameRow] ?? null;
   const group = input.group ?? frame.groups[frameRow] ?? 0;
-  const panelIndex = input.panelIndex;
-  const layerIndex = input.layerIndex;
   const indexKeyPrefix =
-    panelIndex !== undefined && layerIndex !== undefined
-      ? `${panelIndex}:${layerIndex}:${group}`
+    input.panelIndex !== undefined && input.layerIndex !== undefined
+      ? `${input.panelIndex}:${input.layerIndex}:${group}`
       : null;
-
   const needsX =
     aggregateXField !== null &&
     outputX !== null &&
@@ -104,6 +113,23 @@ export function filterRepresentedSourceRows(input: {
   const needsBin = (stat === "bin" || stat === "summary_bin") && aggregateXField !== null;
   const needsY =
     (stat === "smooth" || stat === "summary" || stat === "boxplot") && aggregateYField !== null;
+  return {
+    aggregateXField,
+    aggregateYField,
+    indexKeyPrefix,
+    needsBin,
+    needsX,
+    needsY,
+    outputX,
+  };
+}
+
+function indexedRepresentedRows(
+  input: RepresentedRowsInput,
+  context: RepresentedRowsContext,
+): readonly number[] | undefined {
+  const { frame, frameRow } = input;
+  const { indexKeyPrefix, needsBin, needsX, needsY, outputX } = context;
 
   // Full-group finite-y path (smooth; summary/boxplot without x/bin): return the
   // shared cached array before cloning baseRows — keeps resolve O(1) per mark.
@@ -133,6 +159,16 @@ export function filterRepresentedSourceRows(input: {
     if (indexed !== undefined) return indexed;
   }
 
+  return undefined;
+}
+
+function filterRepresentedRowsFallback(
+  input: RepresentedRowsInput,
+  context: RepresentedRowsContext,
+): readonly number[] {
+  const { frame, table, frameRow } = input;
+  const { aggregateXField, aggregateYField, needsBin, needsX, needsY, outputX } = context;
+
   // Nothing to narrow: hand back the shared frozen bucket, exactly as the
   // indexed arms above do. A clone is not frozen and so misses LineageStore's
   // identity cache, which made every mark re-tokenize its whole group.
@@ -143,7 +179,7 @@ export function filterRepresentedSourceRows(input: {
   if (needsX) {
     representedRows = filterAggregateXRows({
       table,
-      field: aggregateXField,
+      field: aggregateXField!,
       outputX,
       baseRows: representedRows,
       binding: frame.binding,
@@ -153,7 +189,7 @@ export function filterRepresentedSourceRows(input: {
       frame,
       table,
       frameRow,
-      field: aggregateXField,
+      field: aggregateXField!,
       baseRows: representedRows,
     });
   }
@@ -162,10 +198,16 @@ export function filterRepresentedSourceRows(input: {
     representedRows = filterAggregateYRows({
       frame,
       table,
-      field: aggregateYField,
+      field: aggregateYField!,
       baseRows: representedRows,
     });
   }
 
   return representedRows;
+}
+
+export function filterRepresentedSourceRows(input: RepresentedRowsInput): readonly number[] {
+  const context = representedRowsContext(input);
+  const indexed = indexedRepresentedRows(input, context);
+  return indexed ?? filterRepresentedRowsFallback(input, context);
 }


### PR DESCRIPTION
## Summary
- enforce the max-20 cyclomatic complexity rule for `packages/core/src/pipeline/candidate-construction/**`
- split candidate frame-row resolution into path, segment, and boxplot helpers
- separate lineage bucket setup, population, lookup, and fallback paths
- preserve cached/frozen lineage arrays and the existing O(n+k) bin fallback

## Verification
- `bun test packages/core/tests/candidate-construction packages/core/tests/lineage-group-intern.test.ts` (78 pass)
- `bun run test` (5068 pass, 4 skip)
- `pre-commit run --all-files --show-diff-on-failure`
- `bun run check`
- `bun run lint:type-aware`
- `bun run knip`

## Benchmark
Captured the full 40-workload `bun run bench:json` suite before production edits and after. Host load varied substantially across runs, so I also ran a temporary-stash warm baseline/post pair. Candidate-heavy paths showed no clear regression: hit-index build 100k was 290.5 ms before vs 208.2 ms after, and canvas cold scatter 100k was 800.6 ms before vs 396.5 ms after. Unrelated workloads moved in both directions, consistent with host variance.