### PR TITLE
refactor(core): enforce complexity in layer binding

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -94,6 +94,12 @@
       }
     },
     {
+      "files": ["packages/core/src/pipeline/bind-layer-*.ts"],
+      "rules": {
+        "eslint/complexity": ["error", { "max": 20 }]
+      }
+    },
+    {
       // Tests + benchmarks: fixture literals are cast deliberately (invalid
       // specs, RuntimeSpec shapes) and test files run long by design.
       "files": ["**/tests/**", "benchmarks/**"],

--- a/packages/core/src/pipeline/bind-layer-extras.ts
+++ b/packages/core/src/pipeline/bind-layer-extras.ts
@@ -12,6 +12,73 @@ import { applyColorOnFillGeomWarning } from "./bind-layer-color-warn.js";
 import type { ColorBinding, PipelineWarning, StyleBinding } from "./types.js";
 import { PipelineError } from "./types.js";
 
+function resolveLabel(input: {
+  aes: Aes;
+  geom: NormalizedGeomName;
+  index: number;
+  table: ColumnTable;
+  warnings: PipelineWarning[];
+}): { labelField: string | null; labelConstant: string | null } {
+  let labelField: string | null = null;
+  let labelConstant: string | null = null;
+  const label = input.aes.label;
+  if (label !== undefined && label !== null) {
+    if ("field" in label)
+      labelField = checkField(label, "label", input.index, input.table, input.warnings);
+    else if ("value" in label) labelConstant = String(label.value);
+  }
+  const requiresLabel =
+    input.geom === "text" ||
+    input.geom === "label" ||
+    input.geom === "sf_text" ||
+    input.geom === "sf_label";
+  if (requiresLabel && labelField === null && labelConstant === null) {
+    throw new PipelineError(
+      "missing-channel",
+      `/layers/${input.index}/aes/label`,
+      `The ${input.geom} geom requires a "label" channel (map it with aes).`,
+    );
+  }
+  return { labelField, labelConstant };
+}
+
+function requireExtraField(input: {
+  mapping: Aes[keyof Aes];
+  channel: "sample" | "z" | "map_id";
+  required: boolean;
+  index: number;
+  table: ColumnTable;
+  warnings: PipelineWarning[];
+  message: string;
+}): string | null {
+  const field = checkField(input.mapping, input.channel, input.index, input.table, input.warnings);
+  if (input.required && field === null) {
+    throw new PipelineError(
+      "missing-channel",
+      `/layers/${input.index}/aes/${input.channel}`,
+      input.message,
+    );
+  }
+  return field;
+}
+
+function warnUnsupportedWeight(
+  weightField: string | null,
+  stat: StatName,
+  index: number,
+  warnings: PipelineWarning[],
+): void {
+  if (
+    weightField === null ||
+    (stat !== "boxplot" && stat !== "smooth" && stat !== "summary" && stat !== "summary_bin")
+  )
+    return;
+  warnings.push({
+    code: "weight-unsupported",
+    message: `Layer ${index}: the ${stat} stat does not support aes.weight; the weight mapping is ignored.`,
+  });
+}
+
 export function resolveLabelWeightColorFill(input: {
   aes: Aes;
   geom: NormalizedGeomName;
@@ -36,49 +103,35 @@ export function resolveLabelWeightColorFill(input: {
 } {
   const { aes, geom, stat, index, table, warnings } = input;
 
-  let labelField: string | null = null;
-  let labelConstant: string | null = null;
-  const label = aes.label;
-  if (label !== undefined && label !== null) {
-    if ("field" in label) labelField = checkField(label, "label", index, table, warnings);
-    else if ("value" in label) labelConstant = String(label.value);
-  }
-  if (
-    (geom === "text" || geom === "label" || geom === "sf_text" || geom === "sf_label") &&
-    labelField === null &&
-    labelConstant === null
-  ) {
-    throw new PipelineError(
-      "missing-channel",
-      `/layers/${index}/aes/label`,
-      `The ${geom} geom requires a "label" channel (map it with aes).`,
-    );
-  }
+  const { labelField, labelConstant } = resolveLabel(input);
   const weightField = checkField(aes.weight, "weight", index, table, warnings);
-  const sampleField = checkField(aes.sample, "sample", index, table, warnings);
-  if ((geom === "qq" || geom === "qq_line") && sampleField === null) {
-    throw new PipelineError(
-      "missing-channel",
-      `/layers/${index}/aes/sample`,
-      `The ${geom} geom requires a "sample" channel (map the distribution column with aes.sample).`,
-    );
-  }
-  const zField = checkField(aes.z, "z", index, table, warnings);
-  if (geom === "contour" && zField === null) {
-    throw new PipelineError(
-      "missing-channel",
-      `/layers/${index}/aes/z`,
-      'The contour geom requires a continuous "z" channel (map it with aes).',
-    );
-  }
-  const mapIdField = checkField(aes.map_id, "map_id", index, table, warnings);
-  if (geom === "map" && mapIdField === null) {
-    throw new PipelineError(
-      "missing-channel",
-      `/layers/${index}/aes/map_id`,
-      'The map geom requires a "map_id" channel (map it with aes).',
-    );
-  }
+  const sampleField = requireExtraField({
+    mapping: aes.sample,
+    channel: "sample",
+    required: geom === "qq" || geom === "qq_line",
+    index,
+    table,
+    warnings,
+    message: `The ${geom} geom requires a "sample" channel (map the distribution column with aes.sample).`,
+  });
+  const zField = requireExtraField({
+    mapping: aes.z,
+    channel: "z",
+    required: geom === "contour",
+    index,
+    table,
+    warnings,
+    message: 'The contour geom requires a continuous "z" channel (map it with aes).',
+  });
+  const mapIdField = requireExtraField({
+    mapping: aes.map_id,
+    channel: "map_id",
+    required: geom === "map",
+    index,
+    table,
+    warnings,
+    message: 'The map geom requires a "map_id" channel (map it with aes).',
+  });
 
   const color = colorBinding(aes.color, "color", stat, index, table, warnings);
   const fill = colorBinding(aes.fill, "fill", stat, index, table, warnings);
@@ -88,15 +141,7 @@ export function resolveLabelWeightColorFill(input: {
   const alpha = styleBinding(aes.alpha, "alpha", geom, stat, index, table, warnings);
   const shape = styleBinding(aes.shape, "shape", geom, stat, index, table, warnings);
   const linetype = styleBinding(aes.linetype, "linetype", geom, stat, index, table, warnings);
-  if (
-    weightField !== null &&
-    (stat === "boxplot" || stat === "smooth" || stat === "summary" || stat === "summary_bin")
-  ) {
-    warnings.push({
-      code: "weight-unsupported",
-      message: `Layer ${index}: the ${stat} stat does not support aes.weight; the weight mapping is ignored.`,
-    });
-  }
+  warnUnsupportedWeight(weightField, stat, index, warnings);
 
   return {
     labelField,

--- a/packages/core/src/pipeline/bind-layer-position.ts
+++ b/packages/core/src/pipeline/bind-layer-position.ts
@@ -14,6 +14,88 @@ import { positionFieldType, type PositionConversionContext } from "./temporal-po
 import { PipelineError } from "./types.js";
 import type { LayerBinding, PipelineWarning } from "./types.js";
 
+function normalizeTileSizes(layer: NormalizedLayerSpec, aes: Aes, index: number): void {
+  if (layer.geom !== "tile") return;
+  const params = { ...layer.params } as Record<string, unknown>;
+  let mutated = false;
+  for (const channel of ["width", "height"] as const) {
+    const mapping = aes[channel];
+    if (mapping === undefined || mapping === null || !("value" in mapping)) continue;
+    if (mapping.scale === true) {
+      throw new PipelineError(
+        "unsupported-param",
+        `/layers/${index}/aes/${channel}`,
+        `Tile aes.${channel} does not support { value, scale: true }; use params.${channel} or a field mapping.`,
+      );
+    }
+    const value = mapping.value;
+    if (typeof value !== "number" || !(value > 0) || !Number.isFinite(value)) {
+      throw new PipelineError(
+        "tile-nonpositive-size",
+        `/layers/${index}/aes/${channel}`,
+        `The tile geom requires positive finite ${channel}; got ${String(value)}.`,
+      );
+    }
+    if (params[channel] === undefined) {
+      params[channel] = value;
+      mutated = true;
+    }
+  }
+  if (mutated) (layer as { params?: Record<string, unknown> }).params = params;
+}
+
+function validateRectEdges(input: {
+  layer: NormalizedLayerSpec;
+  index: number;
+  table: ColumnTable;
+  edges: readonly (readonly [
+    "xmin" | "xmax" | "ymin" | "ymax",
+    string | null,
+    PositionConversionContext,
+  ])[];
+}): void {
+  if (input.layer.geom !== "rect") return;
+  for (const [channel, field, conversion] of input.edges) {
+    if (field === null) continue;
+    if (positionFieldType(input.table, field, conversion) === "nominal") {
+      throw new PipelineError(
+        "channel-type-mismatch",
+        `/layers/${input.index}/aes/${channel}`,
+        `The rect geom needs quantitative edges, but field "${field}" (${channel}) is nominal.`,
+      );
+    }
+  }
+}
+
+function activeRibbonBounds(input: {
+  orientation: "x" | "y" | undefined;
+  yminField: string | null;
+  ymaxField: string | null;
+  xminField: string | null;
+  xmaxField: string | null;
+}): {
+  yminField: string | null;
+  ymaxField: string | null;
+  xminField: string | null;
+  xmaxField: string | null;
+} {
+  if (input.orientation === "x")
+    return {
+      yminField: input.yminField,
+      ymaxField: input.ymaxField,
+      xminField: null,
+      xmaxField: null,
+    };
+  if (input.orientation === "y")
+    return {
+      yminField: null,
+      ymaxField: null,
+      xminField: input.xminField,
+      xmaxField: input.xmaxField,
+    };
+  return input;
+}
+
 export function resolveLayerPositionChannels(input: {
   layer: NormalizedLayerSpec;
   aes: Aes;
@@ -67,36 +149,7 @@ export function resolveLayerPositionChannels(input: {
   const angleField = checkField(aes.angle, "angle", index, table, warnings);
   const radiusField = checkField(aes.radius, "radius", index, table, warnings);
 
-  if (geom === "tile") {
-    const params = { ...layer.params } as Record<string, unknown>;
-    let mutated = false;
-    for (const channel of ["width", "height"] as const) {
-      const mapping = aes[channel];
-      if (mapping === undefined || mapping === null || !("value" in mapping)) continue;
-      if (mapping.scale === true) {
-        throw new PipelineError(
-          "unsupported-param",
-          `/layers/${index}/aes/${channel}`,
-          `Tile aes.${channel} does not support { value, scale: true }; use params.${channel} or a field mapping.`,
-        );
-      }
-      const value = mapping.value;
-      if (typeof value !== "number" || !(value > 0) || !Number.isFinite(value)) {
-        throw new PipelineError(
-          "tile-nonpositive-size",
-          `/layers/${index}/aes/${channel}`,
-          `The tile geom requires positive finite ${channel}; got ${String(value)}.`,
-        );
-      }
-      if (params[channel] === undefined) {
-        params[channel] = value;
-        mutated = true;
-      }
-    }
-    if (mutated) {
-      (layer as { params?: Record<string, unknown> }).params = params;
-    }
-  }
+  normalizeTileSizes(layer, aes, index);
 
   const ribbonOrientation =
     geom === "ribbon"
@@ -141,48 +194,34 @@ export function resolveLayerPositionChannels(input: {
     ...(rugSides !== undefined && { rugSides }),
   });
 
-  if (geom === "rect") {
-    for (const [channel, field, conversion] of [
+  validateRectEdges({
+    layer,
+    index,
+    table,
+    edges: [
       ["xmin", xminField, xConversion],
       ["xmax", xmaxField, xConversion],
       ["ymin", yminField, yConversion],
       ["ymax", ymaxField, yConversion],
-    ] as const) {
-      if (field === null) continue;
-      const fieldType = positionFieldType(table, field, conversion);
-      if (fieldType === "nominal") {
-        throw new PipelineError(
-          "channel-type-mismatch",
-          `/layers/${index}/aes/${channel}`,
-          `The rect geom needs quantitative edges, but field "${field}" (${channel}) is nominal.`,
-        );
-      }
-    }
-  }
+    ],
+  });
 
   // When orientation is pinned, drop the inactive bound pair so scale training
   // does not train the measure axis from unused interval channels.
-  let outYmin = yminField;
-  let outYmax = ymaxField;
-  let outXmin = xminField;
-  let outXmax = xmaxField;
-  if (ribbonOrientation === "x") {
-    outXmin = null;
-    outXmax = null;
-  } else if (ribbonOrientation === "y") {
-    outYmin = null;
-    outYmax = null;
-  }
+  const activeBounds = activeRibbonBounds({
+    orientation: ribbonOrientation,
+    yminField,
+    ymaxField,
+    xminField,
+    xmaxField,
+  });
 
   return {
     ruleForm,
     xField,
     yField,
     yStatColumn,
-    yminField: outYmin,
-    ymaxField: outYmax,
-    xminField: outXmin,
-    xmaxField: outXmax,
+    ...activeBounds,
     widthField,
     heightField,
     xendField,

--- a/packages/core/src/pipeline/bind-layer-required.ts
+++ b/packages/core/src/pipeline/bind-layer-required.ts
@@ -12,6 +12,162 @@ import type { NormalizedGeomName, StatName } from "@ggsvelte/spec";
 import { requireField } from "./bind-layer-check-field.js";
 import type { RuleForm } from "./types.js";
 
+type RequirementKind =
+  | "xy"
+  | "x"
+  | "range"
+  | "rect"
+  | "ribbon"
+  | "rule"
+  | "segment"
+  | "spoke"
+  | "rug"
+  | "none";
+
+const GEOM_REQUIREMENT = {
+  point: "xy",
+  count: "xy",
+  line: "xy",
+  path: "xy",
+  step: "xy",
+  col: "xy",
+  area: "xy",
+  polygon: "xy",
+  text: "xy",
+  label: "xy",
+  smooth: "xy",
+  quantile: "xy",
+  boxplot: "xy",
+  violin: "xy",
+  tile: "xy",
+  raster: "xy",
+  hex: "xy",
+  density_2d: "xy",
+  density_2d_filled: "xy",
+  bin_2d: "xy",
+  contour: "xy",
+  bar: "x",
+  density: "x",
+  dotplot: "x",
+  errorbar: "range",
+  linerange: "range",
+  pointrange: "range",
+  crossbar: "range",
+  rect: "rect",
+  ribbon: "ribbon",
+  rule: "rule",
+  segment: "segment",
+  curve: "segment",
+  spoke: "spoke",
+  rug: "rug",
+  function: "none",
+  abline: "none",
+  map: "none",
+  sf: "none",
+  sf_text: "none",
+  sf_label: "none",
+  blank: "none",
+  qq: "none",
+  qq_line: "none",
+} as const satisfies Record<NormalizedGeomName, RequirementKind>;
+
+function requireRangeChannels(input: {
+  geom: NormalizedGeomName;
+  stat: StatName;
+  index: number;
+  xField: string | null;
+  yField: string | null;
+  yminField: string | null;
+  ymaxField: string | null;
+}): void {
+  requireField(input.xField, "x", input.index, input.geom);
+  if (input.stat === "summary" || input.stat === "summary_bin") {
+    requireField(input.yField, "y", input.index, input.geom);
+    return;
+  }
+  requireField(input.yminField, "ymin", input.index, input.geom);
+  requireField(input.ymaxField, "ymax", input.index, input.geom);
+  if (input.geom === "pointrange" || input.geom === "crossbar")
+    requireField(input.yField, "y", input.index, input.geom);
+}
+
+function requireRibbonChannels(input: {
+  geom: NormalizedGeomName;
+  index: number;
+  orientation: "x" | "y";
+  xField: string | null;
+  yField: string | null;
+  yminField: string | null;
+  ymaxField: string | null;
+  xminField: string | null;
+  xmaxField: string | null;
+}): void {
+  if (input.orientation === "x") {
+    requireField(input.xField, "x", input.index, input.geom);
+    requireField(input.yminField, "ymin", input.index, input.geom);
+    requireField(input.ymaxField, "ymax", input.index, input.geom);
+    return;
+  }
+  requireField(input.yField, "y", input.index, input.geom);
+  requireField(input.xminField, "xmin", input.index, input.geom);
+  requireField(input.xmaxField, "xmax", input.index, input.geom);
+}
+
+function requireSpokeChannels(input: {
+  geom: NormalizedGeomName;
+  index: number;
+  xField: string | null;
+  yField: string | null;
+  angleField: string | null;
+  radiusField: string | null;
+  layerParams: unknown;
+}): void {
+  requireField(input.xField, "x", input.index, input.geom);
+  requireField(input.yField, "y", input.index, input.geom);
+  const params =
+    typeof input.layerParams === "object" && input.layerParams !== null
+      ? (input.layerParams as Record<string, unknown>)
+      : {};
+  if (input.angleField === null && params["angle"] === undefined)
+    requireField(input.angleField, "angle", input.index, input.geom);
+  if (input.radiusField === null && params["radius"] === undefined)
+    requireField(input.radiusField, "radius", input.index, input.geom);
+}
+
+function requireXYChannels(input: {
+  geom: NormalizedGeomName;
+  index: number;
+  xField: string | null;
+  yField: string | null;
+  yStatColumn: string | null;
+}): void {
+  requireField(input.xField, "x", input.index, input.geom);
+  if (input.yStatColumn === null) requireField(input.yField, "y", input.index, input.geom);
+}
+
+function requireRuleChannels(
+  geom: NormalizedGeomName,
+  index: number,
+  ruleForm: RuleForm | null,
+  xField: string | null,
+  yField: string | null,
+): void {
+  if (ruleForm === "vertical") requireField(xField, "x", index, geom);
+  if (ruleForm === "horizontal") requireField(yField, "y", index, geom);
+}
+
+function requireRugChannels(
+  geom: NormalizedGeomName,
+  index: number,
+  rugSides: string | undefined,
+  xField: string | null,
+  yField: string | null,
+): void {
+  const sides = rugSides !== undefined && rugSides.length > 0 ? rugSides : "bl";
+  if (/[bt]/.test(sides)) requireField(xField, "x", index, geom);
+  if (/[lr]/.test(sides)) requireField(yField, "y", index, geom);
+}
+
 export function assertRequiredChannels(input: {
   geom: NormalizedGeomName;
   stat: StatName;
@@ -54,57 +210,17 @@ export function assertRequiredChannels(input: {
     rugSides,
   } = input;
 
-  switch (geom) {
-    case "point":
-    case "count":
-    case "line":
-    case "path":
-    case "step":
-    case "col":
-    case "area":
-    case "polygon":
-    case "text":
-    case "label":
-    case "smooth":
-    case "quantile":
-    case "boxplot":
-    case "violin":
-    case "tile":
-    case "raster":
-    case "hex":
-    case "density_2d":
-    case "density_2d_filled":
-    case "bin_2d": {
-      requireField(xField, "x", index, geom);
-      // yStatColumn set (e.g. ecdf) means y is computed — skip field requirement.
-      if (yStatColumn === null) requireField(yField, "y", index, geom);
+  switch (GEOM_REQUIREMENT[geom]) {
+    case "xy": {
+      requireXYChannels({ geom, index, xField, yField, yStatColumn });
       break;
     }
-    case "bar":
-    case "density":
-    case "dotplot": {
+    case "x": {
       requireField(xField, "x", index, geom);
       break;
     }
-    case "contour": {
-      requireField(xField, "x", index, geom);
-      requireField(yField, "y", index, geom);
-      break;
-    }
-    case "errorbar":
-    case "linerange":
-    case "pointrange":
-    case "crossbar": {
-      requireField(xField, "x", index, geom);
-      if (stat === "summary" || stat === "summary_bin") {
-        requireField(yField, "y", index, geom);
-      } else {
-        requireField(yminField, "ymin", index, geom);
-        requireField(ymaxField, "ymax", index, geom);
-        if (geom === "pointrange" || geom === "crossbar") {
-          requireField(yField, "y", index, geom);
-        }
-      }
+    case "range": {
+      requireRangeChannels({ geom, stat, index, xField, yField, yminField, ymaxField });
       break;
     }
     case "rect": {
@@ -115,26 +231,24 @@ export function assertRequiredChannels(input: {
       break;
     }
     case "ribbon": {
-      const orientation = ribbonOrientation ?? "x";
-      if (orientation === "x") {
-        requireField(xField, "x", index, geom);
-        requireField(yminField, "ymin", index, geom);
-        requireField(ymaxField, "ymax", index, geom);
-      } else {
-        requireField(yField, "y", index, geom);
-        requireField(xminField, "xmin", index, geom);
-        requireField(xmaxField, "xmax", index, geom);
-      }
+      requireRibbonChannels({
+        geom,
+        index,
+        orientation: ribbonOrientation ?? "x",
+        xField,
+        yField,
+        yminField,
+        ymaxField,
+        xminField,
+        xmaxField,
+      });
       break;
     }
     case "rule": {
-      if (ruleForm === "vertical") requireField(xField, "x", index, geom);
-      if (ruleForm === "horizontal") requireField(yField, "y", index, geom);
-      // annotation form: intercepts live on params (resolveRuleForm already ran).
+      requireRuleChannels(geom, index, ruleForm, xField, yField);
       break;
     }
-    case "segment":
-    case "curve": {
+    case "segment": {
       requireField(xField, "x", index, geom);
       requireField(yField, "y", index, geom);
       requireField(xendField, "xend", index, geom);
@@ -142,53 +256,26 @@ export function assertRequiredChannels(input: {
       break;
     }
     case "spoke": {
-      requireField(xField, "x", index, geom);
-      requireField(yField, "y", index, geom);
-      const params =
-        typeof layerParams === "object" && layerParams !== null
-          ? (layerParams as Record<string, unknown>)
-          : {};
-      if (angleField === null && params["angle"] === undefined) {
-        requireField(angleField, "angle", index, geom);
-      }
-      if (radiusField === null && params["radius"] === undefined) {
-        requireField(radiusField, "radius", index, geom);
-      }
+      requireSpokeChannels({
+        geom,
+        index,
+        xField,
+        yField,
+        angleField,
+        radiusField,
+        layerParams,
+      });
       break;
     }
     case "rug": {
-      const sides = rugSides !== undefined && rugSides.length > 0 ? rugSides : "bl";
-      if (/[bt]/.test(sides)) requireField(xField, "x", index, geom);
-      if (/[lr]/.test(sides)) requireField(yField, "y", index, geom);
+      requireRugChannels(geom, index, rugSides, xField, yField);
       break;
     }
-    // --- intentional no x/y requirements (channels elsewhere or params) ---
-    case "function":
-      // Domain from params.xlim / peer layers; y from fun (stat_function).
-      break;
-    case "abline":
-      // Annotation slope/intercept params only.
-      break;
-    case "map":
-      // map_id required in bind-layer-extras; geometry from fortified map.
-      break;
-    case "sf":
-    case "sf_text":
-    case "sf_label":
-      // Geometry column in frame-stats-sf; label for text/label in extras.
-      break;
-    case "blank":
-      // Scale training only; no marks.
-      break;
-    case "qq":
-    case "qq_line":
-      // sample channel required in bind-layer-extras.
+    case "none":
       break;
     default: {
-      // No silent fall-through: a geom with no arm above is a compile error
-      // here, not a layer that quietly requires nothing (#1042).
-      const exhaustive: never = geom;
-      throw new Error(`unhandled geom in required channels: ${String(exhaustive)}`);
+      const exhaustive: never = GEOM_REQUIREMENT[geom];
+      throw new Error(`unhandled requirement in required channels: ${String(exhaustive)}`);
     }
   }
 }

--- a/packages/core/src/pipeline/bind-layer-style-config.ts
+++ b/packages/core/src/pipeline/bind-layer-style-config.ts
@@ -7,6 +7,38 @@ import { styleBinExtent } from "./frame-group-columns.js";
 import type { LayerBinding } from "./types.js";
 
 const STYLE_AESTHETICS = ["size", "linewidth", "alpha", "shape", "linetype"] as const;
+type StyleAesthetic = (typeof STYLE_AESTHETICS)[number];
+type StyleScaleConfig = NonNullable<NonNullable<PortableSpec["scales"]>[StyleAesthetic]>;
+const TEMPORAL_CONFIG_KEYS = ["temporalKind", "parse", "timezone", "disambiguation"] as const;
+
+function configureTemporalStyle(
+  style: LayerBinding[StyleAesthetic],
+  config: StyleScaleConfig & {
+    temporalKind?: unknown;
+    parse?: LayerBinding[StyleAesthetic]["binParse"];
+    timezone?: LayerBinding[StyleAesthetic]["binTimezone"];
+    disambiguation?: LayerBinding[StyleAesthetic]["binDisambiguation"];
+  },
+): void {
+  style.binTemporal = TEMPORAL_CONFIG_KEYS.some((key) => config[key] !== undefined);
+  if (config.parse !== undefined) style.binParse = config.parse;
+  if (config.timezone !== undefined) style.binTimezone = config.timezone;
+  if (config.disambiguation !== undefined) style.binDisambiguation = config.disambiguation;
+}
+
+function configureBinnedStyle(
+  style: LayerBinding[StyleAesthetic],
+  aesthetic: StyleAesthetic,
+  config: StyleScaleConfig,
+  table: ColumnTable | undefined,
+): void {
+  if (aesthetic === "shape" || aesthetic === "linetype") {
+    style.binCount = Math.min(config.range?.length ?? (aesthetic === "shape" ? 6 : 5), 5);
+  }
+  if (config.breaks !== undefined || config.domain !== undefined || table === undefined) return;
+  const extent = styleBinExtent(style, table);
+  if (extent !== undefined) style.binExtent = extent;
+}
 
 export function configureStyleBindings(
   binding: LayerBinding,
@@ -17,51 +49,16 @@ export function configureStyleBindings(
     const config = scales?.[aesthetic];
     const type = config?.type;
     const style = binding[aesthetic];
+    const discreteAesthetic = aesthetic === "shape" || aesthetic === "linetype";
     style.forcedDiscrete =
-      aesthetic === "shape" ||
-      aesthetic === "linetype" ||
-      type === "ordinal" ||
-      type === "manual" ||
-      type === "binned";
-    style.forcedContinuous =
-      aesthetic !== "shape" &&
-      aesthetic !== "linetype" &&
-      (type === "sequential" || type === "identity");
+      discreteAesthetic || type === "ordinal" || type === "manual" || type === "binned";
+    style.forcedContinuous = !discreteAesthetic && (type === "sequential" || type === "identity");
     style.binned = type === "binned";
-    const breaks = config?.breaks;
-    if (breaks !== undefined) style.binBreaks = breaks;
-    const domain = config?.domain;
-    if (domain !== undefined) style.binDomain = domain;
-    if (
-      config !== undefined &&
-      ("temporalKind" in config ||
-        "parse" in config ||
-        "timezone" in config ||
-        "disambiguation" in config)
-    ) {
-      style.binTemporal =
-        config.temporalKind !== undefined ||
-        config.parse !== undefined ||
-        config.timezone !== undefined ||
-        config.disambiguation !== undefined;
-      if (config.parse !== undefined) style.binParse = config.parse;
-      if (config.timezone !== undefined) style.binTimezone = config.timezone;
-      if (config.disambiguation !== undefined) style.binDisambiguation = config.disambiguation;
-    }
-    if (config !== undefined && "oob" in config && config.oob !== undefined) {
-      style.binOob = config.oob;
-    }
-    const range = config?.range;
-    if (type === "binned" && (aesthetic === "shape" || aesthetic === "linetype")) {
-      const defaultLength = aesthetic === "shape" ? 6 : 5;
-      style.binCount = Math.min(range?.length ?? defaultLength, 5);
-    }
-    // Capture the global bin extent before faceting so per-panel grouping bins
-    // match the globally-trained style scale. Only needed when the user did not
-    // author explicit breaks/domain (those already pin the extent).
-    if (type === "binned" && breaks === undefined && domain === undefined && table !== undefined) {
-      const extent = styleBinExtent(style, table);
-      if (extent !== undefined) style.binExtent = extent;
-    }
+    if (config === undefined) continue;
+    if (config.breaks !== undefined) style.binBreaks = config.breaks;
+    if (config.domain !== undefined) style.binDomain = config.domain;
+    if (TEMPORAL_CONFIG_KEYS.some((key) => key in config)) configureTemporalStyle(style, config);
+    if ("oob" in config && config.oob !== undefined) style.binOob = config.oob;
+    if (config.type === "binned") configureBinnedStyle(style, aesthetic, config, table);
   }
 }

--- a/packages/core/src/pipeline/bind-layer-type-contracts-computed.ts
+++ b/packages/core/src/pipeline/bind-layer-type-contracts-computed.ts
@@ -8,6 +8,51 @@ import type { ColumnTable } from "../table.js";
 import { positionFieldType, type PositionConversionContext } from "./temporal-position.js";
 import { PipelineError } from "./types.js";
 
+function computedYMessage(geom: LayerSpec["geom"], stat: string): string | null {
+  if (geom === "bar")
+    return `The bar geom computes y with the ${stat} stat, so aes.y must not map data. Use geom "col" for pre-computed heights.`;
+  if (geom === "density")
+    return "The density geom computes y with the density stat, so aes.y must not map data. Map only x.";
+  if (geom === "function" || stat === "function")
+    return "The function geom/stat computes y from the named function, so aes.y must not map data.";
+  if (stat === "ecdf")
+    return "The ecdf stat computes y (cumulative proportion), so aes.y must not map data. Map only x.";
+  if (geom === "dotplot" || stat === "bindot")
+    return "The dotplot geom computes y with the bindot stat, so aes.y must not map data. Map only x.";
+  return null;
+}
+
+function validateBinContracts(input: {
+  stat: string;
+  params: LayerSpec["params"];
+  index: number;
+  table: ColumnTable;
+  xField: string | null;
+  xConversion: PositionConversionContext;
+}): void {
+  if (input.stat !== "bin" && input.stat !== "summary_bin" && input.stat !== "bindot") return;
+  const params = input.params as BarParams;
+  if (params.center !== undefined && params.boundary !== undefined) {
+    throw new PipelineError(
+      "bin-center-and-boundary",
+      `/layers/${input.index}/params`,
+      `The ${input.stat} stat accepts params.center OR params.boundary (both align the bin grid), never both.`,
+    );
+  }
+  if (
+    input.xField === null ||
+    positionFieldType(input.table, input.xField, input.xConversion) !== "nominal"
+  )
+    return;
+  const msg =
+    input.stat === "summary_bin"
+      ? `The summary_bin stat needs a continuous x, but field "${input.xField}" is nominal.`
+      : input.stat === "bindot"
+        ? `The bindot stat needs a continuous x, but field "${input.xField}" is nominal.`
+        : `The bin stat needs a continuous x, but field "${input.xField}" is nominal. Use geom "bar" (the count stat) to count categories instead.`;
+  throw new PipelineError("channel-type-mismatch", `/layers/${input.index}/aes/x`, msg);
+}
+
 export function validateComputedYAndBinContracts(input: {
   layer: LayerSpec;
   index: number;
@@ -20,60 +65,9 @@ export function validateComputedYAndBinContracts(input: {
   const { layer, index, table, xField, yField, xConversion } = input;
   const geom = layer.geom;
   const stat = layer.stat ?? "identity";
-  const params = layer.params ?? {};
-
-  if (geom === "bar" && yField !== null) {
-    throw new PipelineError(
-      "computed-y-mapped",
-      `/layers/${index}/aes/y`,
-      `The bar geom computes y with the ${stat} stat, so aes.y must not map data. Use geom "col" for pre-computed heights.`,
-    );
+  const message = computedYMessage(geom, stat);
+  if (yField !== null && message !== null) {
+    throw new PipelineError("computed-y-mapped", `/layers/${index}/aes/y`, message);
   }
-  if (geom === "density" && yField !== null) {
-    throw new PipelineError(
-      "computed-y-mapped",
-      `/layers/${index}/aes/y`,
-      "The density geom computes y with the density stat, so aes.y must not map data. Map only x.",
-    );
-  }
-  if ((geom === "function" || stat === "function") && yField !== null) {
-    throw new PipelineError(
-      "computed-y-mapped",
-      `/layers/${index}/aes/y`,
-      "The function geom/stat computes y from the named function, so aes.y must not map data.",
-    );
-  }
-  if (stat === "ecdf" && yField !== null) {
-    throw new PipelineError(
-      "computed-y-mapped",
-      `/layers/${index}/aes/y`,
-      "The ecdf stat computes y (cumulative proportion), so aes.y must not map data. Map only x.",
-    );
-  }
-  if ((geom === "dotplot" || stat === "bindot") && yField !== null) {
-    throw new PipelineError(
-      "computed-y-mapped",
-      `/layers/${index}/aes/y`,
-      "The dotplot geom computes y with the bindot stat, so aes.y must not map data. Map only x.",
-    );
-  }
-  if (stat === "bin" || stat === "summary_bin" || stat === "bindot") {
-    const p = params as BarParams;
-    if (p.center !== undefined && p.boundary !== undefined) {
-      throw new PipelineError(
-        "bin-center-and-boundary",
-        `/layers/${index}/params`,
-        `The ${stat} stat accepts params.center OR params.boundary (both align the bin grid), never both.`,
-      );
-    }
-    if (xField !== null && positionFieldType(table, xField, xConversion) === "nominal") {
-      const msg =
-        stat === "summary_bin"
-          ? `The summary_bin stat needs a continuous x, but field "${xField}" is nominal.`
-          : stat === "bindot"
-            ? `The bindot stat needs a continuous x, but field "${xField}" is nominal.`
-            : `The bin stat needs a continuous x, but field "${xField}" is nominal. Use geom "bar" (the count stat) to count categories instead.`;
-      throw new PipelineError("channel-type-mismatch", `/layers/${index}/aes/x`, msg);
-    }
-  }
+  validateBinContracts({ stat, params: layer.params ?? {}, index, table, xField, xConversion });
 }

--- a/packages/core/src/pipeline/bind-layer-type-contracts-geom.ts
+++ b/packages/core/src/pipeline/bind-layer-type-contracts-geom.ts
@@ -8,6 +8,51 @@ import type { ColumnTable } from "../table.js";
 import { positionFieldType, type PositionConversionContext } from "./temporal-position.js";
 import { PipelineError } from "./types.js";
 
+interface ChannelTypeContext {
+  index: number;
+  table: ColumnTable;
+  xField: string | null;
+  yField: string | null;
+  xConversion: PositionConversionContext;
+  yConversion: PositionConversionContext;
+}
+
+function assertContinuousChannels(
+  context: ChannelTypeContext,
+  channels: readonly ("x" | "y")[],
+  message: (field: string, channel: "x" | "y") => string,
+): void {
+  for (const channel of channels) {
+    const field = channel === "x" ? context.xField : context.yField;
+    const conversion = channel === "x" ? context.xConversion : context.yConversion;
+    if (field === null || positionFieldType(context.table, field, conversion) !== "nominal")
+      continue;
+    throw new PipelineError(
+      "channel-type-mismatch",
+      `/layers/${context.index}/aes/${channel}`,
+      message(field, channel),
+    );
+  }
+}
+
+function validateBoxplotChannels(context: ChannelTypeContext): void {
+  const { index, table, xField, yField, xConversion, yConversion } = context;
+  if (xField !== null && positionFieldType(table, xField, xConversion) !== "nominal") {
+    throw new PipelineError(
+      "channel-type-mismatch",
+      `/layers/${index}/aes/x`,
+      `The boxplot geom needs a DISCRETE x this milestone, but field "${xField}" is ${positionFieldType(table, xField, xConversion)}. Map x to a categorical field.`,
+    );
+  }
+  if (yField !== null && positionFieldType(table, yField, yConversion) === "nominal") {
+    throw new PipelineError(
+      "channel-type-mismatch",
+      `/layers/${index}/aes/y`,
+      `The boxplot stat needs a quantitative y, but field "${yField}" is nominal.`,
+    );
+  }
+}
+
 export function validateGeomChannelTypeContracts(input: {
   layer: LayerSpec;
   index: number;
@@ -19,94 +64,43 @@ export function validateGeomChannelTypeContracts(input: {
 }): void {
   const { layer, index, table, xField, yField, xConversion, yConversion } = input;
   const geom = layer.geom;
+  const context = { index, table, xField, yField, xConversion, yConversion };
 
-  if (
-    geom === "density" &&
-    xField !== null &&
-    positionFieldType(table, xField, xConversion) === "nominal"
-  ) {
-    throw new PipelineError(
-      "channel-type-mismatch",
-      `/layers/${index}/aes/x`,
-      `The density stat needs a continuous x, but field "${xField}" is nominal. Use geom "bar" (the count stat) to count categories instead.`,
+  if (geom === "density")
+    assertContinuousChannels(
+      context,
+      ["x"],
+      (field) =>
+        `The density stat needs a continuous x, but field "${field}" is nominal. Use geom "bar" (the count stat) to count categories instead.`,
+    );
+  if (geom === "smooth" || geom === "quantile") {
+    assertContinuousChannels(
+      context,
+      ["x", "y"],
+      (field, channel) =>
+        `The ${geom} stat needs quantitative x and y, but field "${field}" (${channel}) is nominal.`,
     );
   }
-  if (geom === "smooth" || geom === "quantile") {
-    for (const [channel, field] of [
-      ["x", xField],
-      ["y", yField],
-    ] as const) {
-      const conversion = channel === "x" ? xConversion : yConversion;
-      if (field !== null && positionFieldType(table, field, conversion) === "nominal") {
-        throw new PipelineError(
-          "channel-type-mismatch",
-          `/layers/${index}/aes/${channel}`,
-          `The ${geom} stat needs quantitative x and y, but field "${field}" (${channel}) is nominal.`,
-        );
-      }
-    }
-  }
-  if (layer.stat === "ellipse") {
-    for (const [channel, field] of [
-      ["x", xField],
-      ["y", yField],
-    ] as const) {
-      const conversion = channel === "x" ? xConversion : yConversion;
-      if (field !== null && positionFieldType(table, field, conversion) === "nominal") {
-        throw new PipelineError(
-          "channel-type-mismatch",
-          `/layers/${index}/aes/${channel}`,
-          `The ellipse stat needs quantitative x and y, but field "${field}" (${channel}) is nominal.`,
-        );
-      }
-    }
-  }
-  if (geom === "boxplot") {
-    if (xField !== null && positionFieldType(table, xField, xConversion) !== "nominal") {
-      throw new PipelineError(
-        "channel-type-mismatch",
-        `/layers/${index}/aes/x`,
-        `The boxplot geom needs a DISCRETE x this milestone, but field "${xField}" is ${positionFieldType(table, xField, xConversion)}. Map x to a categorical field.`,
-      );
-    }
-    if (yField !== null && positionFieldType(table, yField, yConversion) === "nominal") {
-      throw new PipelineError(
-        "channel-type-mismatch",
-        `/layers/${index}/aes/y`,
-        `The boxplot stat needs a quantitative y, but field "${yField}" is nominal.`,
-      );
-    }
-  }
-  if (geom === "raster") {
-    if (xField !== null && positionFieldType(table, xField, xConversion) === "nominal") {
-      throw new PipelineError(
-        "channel-type-mismatch",
-        `/layers/${index}/aes/x`,
-        `The raster geom needs continuous x, but field "${xField}" is nominal. Use geom "tile" for discrete axes.`,
-      );
-    }
-    if (yField !== null && positionFieldType(table, yField, yConversion) === "nominal") {
-      throw new PipelineError(
-        "channel-type-mismatch",
-        `/layers/${index}/aes/y`,
-        `The raster geom needs continuous y, but field "${yField}" is nominal. Use geom "tile" for discrete axes.`,
-      );
-    }
-  }
-  if (geom === "spoke") {
-    if (xField !== null && positionFieldType(table, xField, xConversion) === "nominal") {
-      throw new PipelineError(
-        "channel-type-mismatch",
-        `/layers/${index}/aes/x`,
-        `The spoke geom needs continuous x for endpoint math (x + radius·cos(angle)); field "${xField}" is nominal.`,
-      );
-    }
-    if (yField !== null && positionFieldType(table, yField, yConversion) === "nominal") {
-      throw new PipelineError(
-        "channel-type-mismatch",
-        `/layers/${index}/aes/y`,
-        `The spoke geom needs continuous y for endpoint math (y + radius·sin(angle)); field "${yField}" is nominal.`,
-      );
-    }
-  }
+  if (layer.stat === "ellipse")
+    assertContinuousChannels(
+      context,
+      ["x", "y"],
+      (field, channel) =>
+        `The ellipse stat needs quantitative x and y, but field "${field}" (${channel}) is nominal.`,
+    );
+  if (geom === "boxplot") validateBoxplotChannels(context);
+  if (geom === "raster")
+    assertContinuousChannels(
+      context,
+      ["x", "y"],
+      (field, channel) =>
+        `The raster geom needs continuous ${channel}, but field "${field}" is nominal. Use geom "tile" for discrete axes.`,
+    );
+  if (geom === "spoke")
+    assertContinuousChannels(
+      context,
+      ["x", "y"],
+      (field, channel) =>
+        `The spoke geom needs continuous ${channel} for endpoint math (${channel} + radius·${channel === "x" ? "cos" : "sin"}(angle)); field "${field}" is nominal.`,
+    );
 }


### PR DESCRIPTION
## Summary
- enforce max-20 cyclomatic complexity for `packages/core/src/pipeline/bind-layer-*.ts`
- replace the required-channel mega-switch with an exhaustive geom-to-requirement table and focused validators
- separate label/extra-channel, position, and type-contract checks without changing diagnostics
- keep the five-aesthetic style loop inline on its common path; call helpers only for authored temporal/binned configuration

## Verification
- focused binding/geom/style suite (137 pass)
- corrected regression suite for bin params (67 pass)
- `bun run test` (5068 pass, 4 skip)
- `pre-commit run --all-files --show-diff-on-failure`
- `bun run check`
- `bun run lint:type-aware`
- `bun run knip`

## Benchmark
Captured the full 40-workload suite before production edits. The first refactor produced a clear small-pipeline regression, so it was stopped and redesigned. Isolation identified unconditional helper dispatch inside the five-aesthetic style loop. After keeping the common path inline, scatter returned to baseline: 10k 4.55 ms vs 4.43 ms before; 100k 19.93 ms vs 19.53 ms before. The remaining workload movement was mixed host variance, with no coherent regression.