### PR TITLE
refactor(core): enforce complexity in temporal helpers

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -106,6 +106,15 @@
       }
     },
     {
+      "files": [
+        "packages/core/src/pipeline/temporal-position.ts",
+        "packages/core/src/pipeline/temporal-preflight-annotations.ts"
+      ],
+      "rules": {
+        "eslint/complexity": ["error", { "max": 20 }]
+      }
+    },
+    {
       // Tests + benchmarks: fixture literals are cast deliberately (invalid
       // specs, RuntimeSpec shapes) and test files run long by design.
       "files": ["**/tests/**", "benchmarks/**"],

--- a/packages/core/src/pipeline/temporal-position.ts
+++ b/packages/core/src/pipeline/temporal-position.ts
@@ -312,12 +312,8 @@ export function positionValueToScaleSpace(
   return transform.transform.valid(numeric) ? transform.transform.forward(numeric) : Number.NaN;
 }
 
-export function positionConversionContext(
-  config: PositionScaleSpec | undefined,
-): PositionConversionContext {
-  if (config === undefined) return AUTO_POSITION_CONVERSION;
-  if (config.type === "band") return DISCRETE_POSITION_CONVERSION;
-  const requestedTime =
+function requestsTemporalPosition(config: PositionScaleSpec): boolean {
+  return (
     config.type === "time" ||
     config.parse !== undefined ||
     config.temporalKind !== undefined ||
@@ -328,7 +324,16 @@ export function positionConversionContext(
     config.dateMinorBreaks !== undefined ||
     config.dateLabels !== undefined ||
     config.locale !== undefined ||
-    config.weekStart !== undefined;
+    config.weekStart !== undefined
+  );
+}
+
+export function positionConversionContext(
+  config: PositionScaleSpec | undefined,
+): PositionConversionContext {
+  if (config === undefined) return AUTO_POSITION_CONVERSION;
+  if (config.type === "band") return DISCRETE_POSITION_CONVERSION;
+  const requestedTime = requestsTemporalPosition(config);
   const forcedNonTemporal =
     (config.type === "linear" || config.type === "log" || config.type === "binned") &&
     !requestedTime;

--- a/packages/core/src/pipeline/temporal-preflight-annotations.ts
+++ b/packages/core/src/pipeline/temporal-preflight-annotations.ts
@@ -1,4 +1,6 @@
 /** Temporal preflight for rowless annotation intercepts. */
+import type { TemporalDecision } from "@ggsvelte/spec";
+
 import { getTemporalRuntime } from "../temporal-runtime.js";
 
 import type { CellValue } from "../table.js";
@@ -7,6 +9,141 @@ import { kindReducesFullValue, type PositionConversionContext } from "./temporal
 import { temporalPreflightDocs } from "./temporal-preflight-shared.js";
 import type { LayerBinding, PipelineWarning, ScaleDiagnostic } from "./types.js";
 import { PipelineError } from "./types.js";
+
+type AnnotationAxis = "x" | "y";
+
+function annotationPath(binding: LayerBinding, axis: AnnotationAxis): string {
+  return `/layers/${binding.index}/params/${axis}intercept`;
+}
+
+function assertAutoAnnotationParsed(
+  binding: LayerBinding,
+  axis: AnnotationAxis,
+  conversion: PositionConversionContext,
+  inferredTemporalAxes: ReadonlySet<string>,
+  decision: TemporalDecision,
+): void {
+  if (
+    conversion.parser !== "auto" ||
+    !inferredTemporalAxes.has(axis) ||
+    decision.status === "temporal"
+  )
+    return;
+  throw new PipelineError(
+    "temporal-parse-failed",
+    annotationPath(binding, axis),
+    `The ${axis} axis is temporal, but the annotation intercept could not be parsed unambiguously. Set a concrete intercept format or force a band scale.`,
+  );
+}
+
+function assertAnnotationKind(
+  binding: LayerBinding,
+  axis: AnnotationAxis,
+  conversion: PositionConversionContext,
+  decision: TemporalDecision,
+): void {
+  if (
+    decision.kind === null ||
+    conversion.requestedKind === undefined ||
+    decision.kind === conversion.requestedKind ||
+    (kindReducesFullValue(conversion) && decision.kind !== "time")
+  )
+    return;
+  throw new PipelineError(
+    "temporal-parse-failed",
+    annotationPath(binding, axis),
+    `The annotation parses as ${decision.kind}, not ${conversion.requestedKind}.`,
+  );
+}
+
+function reportCensoredAnnotation(
+  binding: LayerBinding,
+  axis: AnnotationAxis,
+  conversion: PositionConversionContext,
+  decision: TemporalDecision,
+  warnings: PipelineWarning[],
+  diagnostics: ScaleDiagnostic[],
+): boolean {
+  if (
+    conversion.parser === "auto" ||
+    decision.failedCount === 0 ||
+    conversion.options.failurePolicy !== "censor"
+  )
+    return false;
+  const message = `Temporal parser ${JSON.stringify(conversion.parser)} censored ${decision.failedCount} annotation intercept value(s) in layer ${binding.index}.`;
+  warnings.push({ code: "temporal-values-censored", message });
+  diagnostics.push({
+    code: "temporal-values-censored",
+    severity: "warning",
+    path: annotationPath(binding, axis),
+    problem: `${decision.failedCount} temporal annotation value(s) were censored.`,
+    cause: message,
+    fixes: [{ description: "Correct the rejected annotation values." }],
+    evidence: { failedCount: decision.failedCount },
+    documentationUrl: temporalPreflightDocs("temporal-values-censored"),
+  });
+  return true;
+}
+
+function assertAnnotationTemporal(
+  binding: LayerBinding,
+  axis: AnnotationAxis,
+  decision: TemporalDecision,
+): void {
+  if (decision.status === "temporal") return;
+  const message = `The ${axis} scale requests temporal values, but ${axis}intercept in layer ${binding.index} could not be parsed strictly.`;
+  throw new PipelineError("temporal-parse-failed", annotationPath(binding, axis), message, {
+    code: "temporal-parse-failed",
+    severity: "error",
+    path: annotationPath(binding, axis),
+    problem: "Temporal annotation parsing failed.",
+    cause: message,
+    fixes: [{ description: "Correct the annotation value or choose its parser." }],
+    evidence: { values: decision.evidence, failedCount: decision.failedCount },
+    documentationUrl: temporalPreflightDocs("temporal-parse-failed"),
+  });
+}
+
+function preflightTemporalAnnotationAxis(input: {
+  binding: LayerBinding;
+  axis: AnnotationAxis;
+  warnings: PipelineWarning[];
+  diagnostics: ScaleDiagnostic[];
+  inferredTemporalAxes: ReadonlySet<string>;
+}): void {
+  const { binding, axis, warnings, diagnostics, inferredTemporalAxes } = input;
+  const params = binding.layer.params as
+    | { xintercept?: CellValue | CellValue[]; yintercept?: CellValue | CellValue[] }
+    | undefined;
+  const raw = axis === "x" ? params?.xintercept : params?.yintercept;
+  if (raw === undefined) return;
+  const values = Array.isArray(raw) ? raw : [raw];
+  const conversion = axis === "x" ? binding.xConversion : binding.yConversion;
+  if (
+    conversion.forcedDiscrete ||
+    (!conversion.requestedTime && conversion.parser === "auto" && !inferredTemporalAxes.has(axis))
+  )
+    return;
+  // Annotation numbers are already-semantic epoch milliseconds. Source
+  // epoch-unit parsing happens earlier for mapped columns/domains/breaks.
+  const sourceValues = values.filter(
+    (value) => typeof value !== "number" || !Number.isFinite(value),
+  );
+  if (sourceValues.length === 0) return;
+  const runtime = getTemporalRuntime();
+  // Lean builds without temporal install cannot preflight annotation
+  // strings; full package installs the runtime for time scales.
+  if (runtime === null) return;
+  const decision = runtime.parseColumn(
+    sourceValues,
+    conversion.parser,
+    conversion.options,
+  ).decision;
+  assertAutoAnnotationParsed(binding, axis, conversion, inferredTemporalAxes, decision);
+  assertAnnotationKind(binding, axis, conversion, decision);
+  if (reportCensoredAnnotation(binding, axis, conversion, decision, warnings, diagnostics)) return;
+  assertAnnotationTemporal(binding, axis, decision);
+}
 
 export function preflightTemporalAnnotations(input: {
   bindings: readonly LayerBinding[];
@@ -17,100 +154,17 @@ export function preflightTemporalAnnotations(input: {
   inferredTemporalAxes: ReadonlySet<string>;
 }): void {
   const { bindings, warnings, diagnostics, xConversion, yConversion, inferredTemporalAxes } = input;
-  const docs = temporalPreflightDocs;
   for (const binding of bindings) {
     if (binding.xField === null) binding.xConversion = xConversion;
     if (binding.yField === null) binding.yConversion = yConversion;
-    const params = binding.layer.params as
-      | { xintercept?: CellValue | CellValue[]; yintercept?: CellValue | CellValue[] }
-      | undefined;
     for (const axis of ["x", "y"] as const) {
-      const raw = axis === "x" ? params?.xintercept : params?.yintercept;
-      if (raw === undefined) continue;
-      const values = Array.isArray(raw) ? raw : [raw];
-      const conversion = axis === "x" ? binding.xConversion : binding.yConversion;
-      if (
-        conversion.forcedDiscrete ||
-        (!conversion.requestedTime &&
-          conversion.parser === "auto" &&
-          !inferredTemporalAxes.has(axis))
-      )
-        continue;
-      // Annotation numbers are already-semantic epoch milliseconds. Source
-      // epoch-unit parsing happens earlier for mapped columns/domains/breaks.
-      const sourceValues = values.filter(
-        (value) => typeof value !== "number" || !Number.isFinite(value),
-      );
-      if (sourceValues.length === 0) continue;
-      const runtime = getTemporalRuntime();
-      // Lean builds without temporal install cannot preflight annotation
-      // strings; full package installs the runtime for time scales.
-      if (runtime === null) continue;
-      const decision = runtime.parseColumn(
-        sourceValues,
-        conversion.parser,
-        conversion.options,
-      ).decision;
-      if (
-        conversion.parser === "auto" &&
-        inferredTemporalAxes.has(axis) &&
-        decision.status !== "temporal"
-      ) {
-        throw new PipelineError(
-          "temporal-parse-failed",
-          `/layers/${binding.index}/params/${axis}intercept`,
-          `The ${axis} axis is temporal, but the annotation intercept could not be parsed unambiguously. Set a concrete intercept format or force a band scale.`,
-        );
-      }
-      if (
-        decision.kind !== null &&
-        conversion.requestedKind !== undefined &&
-        decision.kind !== conversion.requestedKind &&
-        !(kindReducesFullValue(conversion) && decision.kind !== "time")
-      ) {
-        throw new PipelineError(
-          "temporal-parse-failed",
-          `/layers/${binding.index}/params/${axis}intercept`,
-          `The annotation parses as ${decision.kind}, not ${conversion.requestedKind}.`,
-        );
-      }
-      if (
-        conversion.parser !== "auto" &&
-        decision.failedCount > 0 &&
-        conversion.options.failurePolicy === "censor"
-      ) {
-        const message = `Temporal parser ${JSON.stringify(conversion.parser)} censored ${decision.failedCount} annotation intercept value(s) in layer ${binding.index}.`;
-        warnings.push({ code: "temporal-values-censored", message });
-        diagnostics.push({
-          code: "temporal-values-censored",
-          severity: "warning",
-          path: `/layers/${binding.index}/params/${axis}intercept`,
-          problem: `${decision.failedCount} temporal annotation value(s) were censored.`,
-          cause: message,
-          fixes: [{ description: "Correct the rejected annotation values." }],
-          evidence: { failedCount: decision.failedCount },
-          documentationUrl: docs("temporal-values-censored"),
-        });
-        continue;
-      }
-      if (decision.status !== "temporal") {
-        const message = `The ${axis} scale requests temporal values, but ${axis}intercept in layer ${binding.index} could not be parsed strictly.`;
-        throw new PipelineError(
-          "temporal-parse-failed",
-          `/layers/${binding.index}/params/${axis}intercept`,
-          message,
-          {
-            code: "temporal-parse-failed",
-            severity: "error",
-            path: `/layers/${binding.index}/params/${axis}intercept`,
-            problem: "Temporal annotation parsing failed.",
-            cause: message,
-            fixes: [{ description: "Correct the annotation value or choose its parser." }],
-            evidence: { values: decision.evidence, failedCount: decision.failedCount },
-            documentationUrl: docs("temporal-parse-failed"),
-          },
-        );
-      }
+      preflightTemporalAnnotationAxis({
+        binding,
+        axis,
+        warnings,
+        diagnostics,
+        inferredTemporalAxes,
+      });
     }
   }
 }


### PR DESCRIPTION
## Summary
- enable max-20 complexity enforcement for temporal position conversion and annotation preflight
- name the temporal-position request predicate
- split annotation parsing, kind checks, censor diagnostics, and strict failure reporting into focused helpers

## Verification
- `bun run test` — 5,068 pass, 4 skip
- `bun run test:temporal-pipeline` — 65 pass
- `bun run check`
- `bun run lint:type-aware`
- `bun run knip`
- `pre-commit run`

## Performance
Captured all 40 workloads before production edits. A globally degraded post-change run affected unrelated scatter, canvas, transform, and color workloads, so rollout stopped for interleaved A/B checks. In both run orders temporal free-facets was faster with the refactor; temporal-line varied by about ±6–10%, while unrelated scatter moved by 13–21%. This is host/run-order noise rather than a coherent regression. The changed position helper runs during scale construction, and the other helpers are annotation-only.