### PR TITLE
refactor(core): enforce complexity in geometry helpers

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -116,6 +116,17 @@
       }
     },
     {
+      "files": [
+        "packages/core/src/pipeline/geometry-hex.ts",
+        "packages/core/src/pipeline/geometry-segments-pack.ts",
+        "packages/core/src/pipeline/geometry-shared-bucket.ts",
+        "packages/core/src/pipeline/geometry-glyphs-pack.ts"
+      ],
+      "rules": {
+        "eslint/complexity": ["error", { "max": 20 }]
+      }
+    },
+    {
       // Tests + benchmarks: fixture literals are cast deliberately (invalid
       // specs, RuntimeSpec shapes) and test files run long by design.
       "files": ["**/tests/**", "benchmarks/**"],

--- a/packages/core/src/pipeline/geometry-glyphs-pack.ts
+++ b/packages/core/src/pipeline/geometry-glyphs-pack.ts
@@ -21,6 +21,50 @@ const DEFAULT_LABEL_STROKE_WIDTH = 0.5;
 
 const measurer = new MetricsTableMeasurer(FONT_METRICS);
 
+function attachGlyphBoxes(input: {
+  batch: GlyphsBatch;
+  frame: LayerFrame;
+  emitted: EmittedGlyphs;
+  sizes: Float32Array | undefined;
+  fontSize: number;
+  params: {
+    padding?: number;
+    radius?: number;
+    linewidth?: number;
+  };
+  withBox: boolean;
+  wantsColors: boolean;
+  fill: ResolvedColorScale | null;
+}): void {
+  const { batch, frame, emitted, sizes, fontSize, params, withBox, wantsColors, fill } = input;
+  const { binding } = frame;
+  const padding = params.padding ?? DEFAULT_LABEL_PADDING;
+  const boxWidths = new Float32Array(emitted.kept);
+  const boxHeights = new Float32Array(emitted.kept);
+  for (let j = 0; j < emitted.kept; j++) {
+    const sz = sizes?.[j] ?? fontSize;
+    const text = emitted.texts[j]!;
+    boxWidths[j] = measurer.measureWidth(text, sz) + 2 * padding;
+    boxHeights[j] = measurer.measureHeight(sz) + 2 * padding;
+  }
+  batch.boxWidths = boxWidths;
+  batch.boxHeights = boxHeights;
+  batch.boxPadding = padding;
+  if (!withBox) return;
+  batch.boxRadius = params.radius ?? DEFAULT_LABEL_RADIUS;
+  batch.boxStrokeWidth = params.linewidth ?? DEFAULT_LABEL_STROKE_WIDTH;
+  batch.boxStroke = binding.color.constant;
+  if (wantsColors && emitted.colors !== null) batch.boxStrokes = emitted.colors;
+  const wantsFills =
+    fill !== null && (frame.fillValues !== null || binding.fill.scaledConstant !== null);
+  if (wantsFills && fill !== null) {
+    batch.boxFills = mappedPaintVector(frame, "fill", fill, emitted.styleRows);
+    batch.boxFill = null;
+  } else {
+    batch.boxFill = binding.fill.constant;
+  }
+}
+
 export function packGlyphsBatch(input: {
   frame: LayerFrame;
   emitted: EmittedGlyphs;
@@ -72,41 +116,19 @@ export function packGlyphsBatch(input: {
   }
   if (wantsColors && emitted.colors !== null) batch.colors = emitted.colors;
 
-  // Measure text extents for every glyph: inspect hover/pin chrome and hit
-  // AABB need a box that actually encloses the string (not a point ring).
-  // Visual label chrome (fill/stroke) stays opt-in via withBox (geom_label).
-  const padding = params.padding ?? DEFAULT_LABEL_PADDING;
-  const boxWidths = new Float32Array(emitted.kept);
-  const boxHeights = new Float32Array(emitted.kept);
-  for (let j = 0; j < emitted.kept; j++) {
-    const sz = sizes?.[j] ?? fontSize;
-    const text = emitted.texts[j]!;
-    boxWidths[j] = measurer.measureWidth(text, sz) + 2 * padding;
-    boxHeights[j] = measurer.measureHeight(sz) + 2 * padding;
-  }
-  batch.boxWidths = boxWidths;
-  batch.boxHeights = boxHeights;
-  batch.boxPadding = padding;
-
-  if (withBox) {
-    const radius = params.radius ?? DEFAULT_LABEL_RADIUS;
-    const strokeWidth = params.linewidth ?? DEFAULT_LABEL_STROKE_WIDTH;
-    batch.boxRadius = radius;
-    batch.boxStrokeWidth = strokeWidth;
-    // Outline follows text color (ggplot2: colour is ink + border).
-    batch.boxStroke = binding.color.constant;
-    if (wantsColors && emitted.colors !== null) batch.boxStrokes = emitted.colors;
-
-    const wantsFills =
-      fill !== null && (frame.fillValues !== null || binding.fill.scaledConstant !== null);
-    if (wantsFills && fill !== null) {
-      batch.boxFills = mappedPaintVector(frame, "fill", fill, emitted.styleRows);
-      batch.boxFill = null;
-    } else {
-      // Constant fill from binding, else theme paper at render time (null).
-      batch.boxFill = binding.fill.constant;
-    }
-  }
+  // Inspect hover/pin chrome and hit AABB need measured text boxes. Visual
+  // label fill/stroke stays opt-in via withBox (geom_label).
+  attachGlyphBoxes({
+    batch,
+    frame,
+    emitted,
+    sizes,
+    fontSize,
+    params,
+    withBox,
+    wantsColors,
+    fill,
+  });
 
   return batch;
 }

--- a/packages/core/src/pipeline/geometry-hex.ts
+++ b/packages/core/src/pipeline/geometry-hex.ts
@@ -13,6 +13,10 @@ import {
   type ResolvedStyleScales,
 } from "./geometry-style.js";
 
+function emittedNoHexes(cursor: number, subpaths: number): boolean {
+  return cursor === 0 || subpaths === 0;
+}
+
 /**
  * Project one data-space hex into panel-local vertices.
  * Uses frame x/y centers and hexWidth/hexHeight (data units) from bin_hex.
@@ -92,7 +96,7 @@ export function hexBatch(
   }
   pathOffsets[subpaths] = cursor;
 
-  if (cursor === 0 || subpaths === 0) return null;
+  if (emittedNoHexes(cursor, subpaths)) return null;
 
   const params = (binding.layer.params ?? {}) as { alpha?: number; linewidth?: number };
   // Style vectors must index by kept subpath order (not raw frame rows): dropped

--- a/packages/core/src/pipeline/geometry-segments-pack.ts
+++ b/packages/core/src/pipeline/geometry-segments-pack.ts
@@ -17,6 +17,25 @@ import {
 import type { LayerFrame } from "./types.js";
 import { DEFAULT_RULE_LINEWIDTH } from "./geometry-shared.js";
 
+function applyMappedSegmentStyles(
+  batch: SegmentsBatch,
+  frame: LayerFrame,
+  styleRows: ArrayLike<number>,
+  styles: ResolvedStyleScales,
+): void {
+  const linewidths = numericStyleVector(frame, "linewidth", styleRows, styles);
+  const alphas = numericStyleVector(frame, "alpha", styleRows, styles);
+  const linetypeIndexes = indexedStyleVector(frame, "linetype", styleRows, styles, (value) =>
+    linetypeIndex(value as Linetype),
+  );
+  if (linewidths !== undefined) batch.linewidths = linewidths;
+  if (alphas !== undefined) {
+    batch.alpha = 1;
+    batch.alphas = alphas;
+  }
+  if (linetypeIndexes !== undefined) batch.linetypeIndexes = linetypeIndexes;
+}
+
 export function packSegmentsBatch(input: {
   frame: LayerFrame;
   segments: Float32Array;
@@ -65,17 +84,7 @@ export function packSegmentsBatch(input: {
     ...(strokePaintResolved !== undefined && { strokePaint: strokePaintResolved }),
     ...(glowResolved !== undefined && { glow: glowResolved }),
   };
-  const linewidths = numericStyleVector(frame, "linewidth", styleRows, styles);
-  const alphas = numericStyleVector(frame, "alpha", styleRows, styles);
-  const linetypeIndexes = indexedStyleVector(frame, "linetype", styleRows, styles, (value) =>
-    linetypeIndex(value as Linetype),
-  );
-  if (linewidths !== undefined) batch.linewidths = linewidths;
-  if (alphas !== undefined) {
-    batch.alpha = 1;
-    batch.alphas = alphas;
-  }
-  if (linetypeIndexes !== undefined) batch.linetypeIndexes = linetypeIndexes;
+  applyMappedSegmentStyles(batch, frame, styleRows, styles);
   if (wantsColors && binding.ruleForm !== "annotation" && strokes !== null) {
     batch.strokes = strokes;
   }

--- a/packages/core/src/pipeline/geometry-shared-bucket.ts
+++ b/packages/core/src/pipeline/geometry-shared-bucket.ts
@@ -5,6 +5,61 @@ import type { LayerFrame, PipelineWarning } from "./types.js";
 import type { Frame } from "./geometry-shared-position.js";
 import { positionOf, removedWarning } from "./geometry-shared-position.js";
 
+type ContinuousPositionScale = Exclude<Frame["xScale"], { type: "band" }>;
+
+function bucketContinuousRows(
+  frame: LayerFrame,
+  groupRows: number[][],
+  xNum: Float64Array,
+  yNum: Float64Array,
+  xScale: ContinuousPositionScale,
+  yScale: ContinuousPositionScale,
+): number {
+  let removed = 0;
+  for (let row = 0; row < frame.n; row++) {
+    const xv = xNum[row];
+    const yv = yNum[row];
+    if (xv === undefined || yv === undefined || !Number.isFinite(xv) || !Number.isFinite(yv)) {
+      removed++;
+      continue;
+    }
+    const tx = xScale.normalizeTransformed(xv);
+    const ty = yScale.normalizeTransformed(yv);
+    if (Number.isNaN(tx) || Number.isNaN(ty)) {
+      removed++;
+      continue;
+    }
+    const group = frame.groups[row]!;
+    (groupRows[group] ??= []).push(row);
+  }
+  return removed;
+}
+
+function bucketGeneralRows(
+  frame: LayerFrame,
+  fx: Frame,
+  groupRows: number[][],
+  yNumericOverride: Float64Array | null,
+): number {
+  let removed = 0;
+  for (let row = 0; row < frame.n; row++) {
+    const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row);
+    const ty = positionOf(
+      fx.yScale,
+      yNumericOverride ?? frame.yNumeric,
+      yNumericOverride instanceof Float64Array ? null : frame.yValues,
+      row,
+    );
+    if (Number.isNaN(tx) || Number.isNaN(ty)) {
+      removed++;
+      continue;
+    }
+    const group = frame.groups[row]!;
+    (groupRows[group] ??= []).push(row);
+  }
+  return removed;
+}
+
 export function bucketByGroup(
   frame: LayerFrame,
   fx: Frame,
@@ -12,56 +67,29 @@ export function bucketByGroup(
   warnings: PipelineWarning[],
 ): number[][] {
   const groupRows: number[][] = [];
-  let removed = 0;
   // Continuous × continuous: monomorphic numeric + normalizeTransformed finite
   // filter (no band / column normalize branch). Still call normalizeTransformed
   // so projected panel scales (coord log/sqrt/etc.) that map out-of-range
   // fractions to NaN are dropped with removed-missing — same as positionOf.
   // Do not short-circuit on type/transform alone: projectors wrap linear
   // identity scales and override normalizeTransformed.
+  let removed: number;
   if (
     fx.xScale.type !== "band" &&
     fx.yScale.type !== "band" &&
     frame.xNumeric !== null &&
     (yNumericOverride !== null || frame.yNumeric !== null)
   ) {
-    const xNum = frame.xNumeric;
-    const yNum = yNumericOverride ?? frame.yNumeric!;
-    // PositionScale is ContinuousScale | BandScale; type guards above exclude band.
-    const xScale = fx.xScale;
-    const yScale = fx.yScale;
-    for (let row = 0; row < frame.n; row++) {
-      const xv = xNum[row];
-      const yv = yNum[row];
-      if (xv === undefined || yv === undefined || !Number.isFinite(xv) || !Number.isFinite(yv)) {
-        removed++;
-        continue;
-      }
-      const tx = xScale.normalizeTransformed(xv);
-      const ty = yScale.normalizeTransformed(yv);
-      if (Number.isNaN(tx) || Number.isNaN(ty)) {
-        removed++;
-        continue;
-      }
-      const g = frame.groups[row]!;
-      (groupRows[g] ??= []).push(row);
-    }
+    removed = bucketContinuousRows(
+      frame,
+      groupRows,
+      frame.xNumeric,
+      yNumericOverride ?? frame.yNumeric!,
+      fx.xScale,
+      fx.yScale,
+    );
   } else {
-    for (let row = 0; row < frame.n; row++) {
-      const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row);
-      const ty = positionOf(
-        fx.yScale,
-        yNumericOverride ?? frame.yNumeric,
-        yNumericOverride instanceof Float64Array ? null : frame.yValues,
-        row,
-      );
-      if (Number.isNaN(tx) || Number.isNaN(ty)) {
-        removed++;
-        continue;
-      }
-      const g = frame.groups[row]!;
-      (groupRows[g] ??= []).push(row);
-    }
+    removed = bucketGeneralRows(frame, fx, groupRows, yNumericOverride);
   }
   removedWarning(removed, frame.binding.index, warnings);
   return groupRows.filter((rows) => rows !== undefined && rows.length > 0);


### PR DESCRIPTION
## Summary
- enable max-20 complexity enforcement for hex, segment packing, group bucketing, and glyph packing
- separate continuous/general group bucketing while preserving the existing row loops
- isolate mapped segment styles and glyph box attachment at batch granularity

## Verification
- `bun run test` — 5,068 pass, 4 skip
- focused geometry suite — 28 pass
- `bun run check`
- `bun run lint:type-aware`
- `bun run knip`
- `pre-commit run`

## Performance
Captured all 40 workloads before production edits. The first post-change run was broadly slower, including untouched scatter and canvas paths, so rollout stopped for interleaved A/B checks. Results reversed with run order: with baseline first, current matched/beat scatter and line-series while tessellation moved; with current first, all three moved slightly the other way. There is no coherent regression. All per-row loops retain their operations; new calls occur once per batch.