### PR TITLE
refactor(core): enforce complexity in path geometry

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -127,6 +127,16 @@
       }
     },
     {
+      "files": [
+        "packages/core/src/pipeline/geometry-paths-line.ts",
+        "packages/core/src/pipeline/geometry-paths-polygon.ts",
+        "packages/core/src/pipeline/geometry-curve.ts"
+      ],
+      "rules": {
+        "eslint/complexity": ["error", { "max": 20 }]
+      }
+    },
+    {
       // Tests + benchmarks: fixture literals are cast deliberately (invalid
       // specs, RuntimeSpec shapes) and test files run long by design.
       "files": ["**/tests/**", "benchmarks/**"],

--- a/packages/core/src/pipeline/geometry-curve.ts
+++ b/packages/core/src/pipeline/geometry-curve.ts
@@ -23,28 +23,21 @@ import {
   type ResolvedStyleScales,
 } from "./geometry-style.js";
 
-export function curveBatch(
+type SampledCurve = {
+  row: number;
+  positions: Float64Array;
+  count: number;
+};
+
+function sampleCurves(
   frame: LayerFrame,
   fx: Frame,
-  color: ResolvedColorScale | null,
-  styles: ResolvedStyleScales,
-  warnings: PipelineWarning[],
-): PathsBatch | null {
-  const { binding } = frame;
-  if (frame.xend === null || frame.yend === null) return null;
-
-  const params = (binding.layer.params ?? {}) as CurveParams;
+  params: Pick<CurveParams, "curvature" | "angle" | "ncp">,
+): { sampled: SampledCurve[]; removed: number; totalVerts: number } {
   const curvature = params.curvature ?? 0.5;
   const angle = params.angle ?? 90;
   const ncp = params.ncp ?? 5;
-
-  // First pass: count kept rows and samples.
-  type Sampled = {
-    row: number;
-    positions: Float64Array;
-    count: number;
-  };
-  const sampled: Sampled[] = [];
+  const sampled: SampledCurve[] = [];
   let removed = 0;
   let totalVerts = 0;
   for (let row = 0; row < frame.n; row++) {
@@ -56,42 +49,82 @@ export function curveBatch(
       removed++;
       continue;
     }
-    // Convert to panel px first, then tessellate (aspect-safe curvature).
-    const x0 = t0x * fx.innerWidth;
-    const y0 = fx.innerHeight - t0y * fx.innerHeight;
-    const x1 = t1x * fx.innerWidth;
-    const y1 = fx.innerHeight - t1y * fx.innerHeight;
-    const curve = tessellateCurve({ x0, y0, x1, y1, curvature, angle, ncp });
+    const curve = tessellateCurve({
+      x0: t0x * fx.innerWidth,
+      y0: fx.innerHeight - t0y * fx.innerHeight,
+      x1: t1x * fx.innerWidth,
+      y1: fx.innerHeight - t1y * fx.innerHeight,
+      curvature,
+      angle,
+      ncp,
+    });
     sampled.push({ row, positions: curve.positions, count: curve.count });
     totalVerts += curve.count;
   }
-  removedWarning(removed, binding.index, warnings);
-  if (sampled.length === 0) return null;
+  return { sampled, removed, totalVerts };
+}
 
+function writeSampledCurves(
+  frame: LayerFrame,
+  sampled: readonly SampledCurve[],
+  totalVerts: number,
+): {
+  positions: Float32Array;
+  rowIndex: Uint32Array;
+  semanticAnchors: Uint8Array;
+  semanticIndex: Uint32Array;
+  pathOffsets: Uint32Array;
+  styleRows: number[];
+} {
   const positions = new Float32Array(totalVerts * 2);
   const rowIndex = new Uint32Array(totalVerts);
   const semanticAnchors = new Uint8Array(totalVerts);
   const semanticIndex = new Uint32Array(totalVerts);
   const pathOffsets = new Uint32Array(sampled.length + 1);
   const styleRows: number[] = [];
-
   let cursor = 0;
   for (let s = 0; s < sampled.length; s++) {
     pathOffsets[s] = cursor;
-    const { row, positions: pts, count } = sampled[s]!;
+    const { row, positions: points, count } = sampled[s]!;
     styleRows.push(row);
     const sourceRow = frame.rowIndex[row]!;
     for (let i = 0; i < count; i++) {
-      positions[cursor * 2] = pts[i * 2]!;
-      positions[cursor * 2 + 1] = pts[i * 2 + 1]!;
+      positions[cursor * 2] = points[i * 2]!;
+      positions[cursor * 2 + 1] = points[i * 2 + 1]!;
       rowIndex[cursor] = sourceRow;
       semanticIndex[cursor] = row;
-      // One semantic candidate per curve (start vertex); tessellated samples are synthetic.
+      // One semantic candidate per curve; tessellated samples are synthetic.
       semanticAnchors[cursor] = i === 0 ? 1 : 0;
       cursor++;
     }
   }
   pathOffsets[sampled.length] = cursor;
+  return { positions, rowIndex, semanticAnchors, semanticIndex, pathOffsets, styleRows };
+}
+
+function applyStrokeFallback(strokes: (string | null)[], fallback: string | undefined): void {
+  if (fallback === undefined) return;
+  for (let i = 0; i < strokes.length; i++) strokes[i] ??= fallback;
+}
+
+export function curveBatch(
+  frame: LayerFrame,
+  fx: Frame,
+  color: ResolvedColorScale | null,
+  styles: ResolvedStyleScales,
+  warnings: PipelineWarning[],
+): PathsBatch | null {
+  const { binding } = frame;
+  if (frame.xend === null || frame.yend === null) return null;
+
+  const params = (binding.layer.params ?? {}) as CurveParams;
+  // Convert to panel px before tessellation so curvature stays aspect-safe.
+  const { sampled, removed, totalVerts } = sampleCurves(frame, fx, params);
+  removedWarning(removed, binding.index, warnings);
+  if (sampled.length === 0) return null;
+
+  const { positions, rowIndex, semanticAnchors, semanticIndex, pathOffsets, styleRows } =
+    writeSampledCurves(frame, sampled, totalVerts);
 
   // One paint vector for all kept curve rows (#1309).
   const strokes = paintVector(frame, "color", color, styleRows);
@@ -102,11 +135,7 @@ export function curveBatch(
       ? undefined
       : resolveGradientPaint(paint.strokePaint, binding.index, "stroke");
   const glowResolved = paint.glow === null ? undefined : resolveGlow(paint.glow, binding.index);
-  if (strokePaintResolved !== undefined) {
-    for (let i = 0; i < strokes.length; i++) {
-      strokes[i] ??= strokePaintResolved.fallback;
-    }
-  }
+  applyStrokeFallback(strokes, strokePaintResolved?.fallback);
 
   const linewidths = numericStyleVector(frame, "linewidth", styleRows, styles);
   const alphas = numericStyleVector(frame, "alpha", styleRows, styles);

--- a/packages/core/src/pipeline/geometry-paths-line.ts
+++ b/packages/core/src/pipeline/geometry-paths-line.ts
@@ -52,6 +52,49 @@ type LineBuffers = {
   subpaths: readonly (readonly number[])[];
 };
 
+type LineStyleParams = { alpha?: number; linewidth?: number };
+
+function applyStrokeFallback(strokes: (string | null)[], fallback: string | undefined): void {
+  if (fallback === undefined) return;
+  for (let i = 0; i < strokes.length; i++) strokes[i] ??= fallback;
+}
+
+function numericLineStyleParams(params: { alpha?: unknown; linewidth?: unknown }): LineStyleParams {
+  const styleParams: LineStyleParams = {};
+  if (typeof params.linewidth === "number") styleParams.linewidth = params.linewidth;
+  if (typeof params.alpha === "number") styleParams.alpha = params.alpha;
+  return styleParams;
+}
+
+function lineStyleParams(binding: LayerFrame["binding"]): LineStyleParams {
+  switch (binding.layer.geom) {
+    case "line":
+    case "qq_line":
+    case "path":
+    case "step":
+    case "quantile":
+    case "contour":
+    case "density_2d":
+    case "sf":
+    case "function":
+      return numericLineStyleParams(binding.layer.params ?? {});
+    default:
+      return {};
+  }
+}
+
+function lineCurve(binding: LayerFrame["binding"]): PathsBatch["curve"] {
+  if (binding.layer.geom === "step") {
+    const direction = (binding.layer.params ?? {}).direction ?? "hv";
+    if (direction === "vh") return "step-vh";
+    return direction === "mid" ? "step" : "step-hv";
+  }
+  if (binding.layer.geom === "line" || binding.layer.geom === "path") {
+    return (binding.layer.params ?? {}).curve ?? "linear";
+  }
+  return "linear";
+}
+
 /**
  * Continuous multi-series: one normalize+pixel pass that also buckets by group.
  * Falls back to bucket → sort → write when stroke style is mapped, scales are
@@ -135,34 +178,12 @@ export function lineBatch(
   const { positions, rowIndex, frameRowIndex, pathOffsets, strokes, subpaths } = buffers;
 
   // Apply strokePaint solid fallback when a stroke is still null/theme-default.
-  if (strokePaintResolved !== undefined) {
-    for (let i = 0; i < strokes.length; i++) {
-      strokes[i] ??= strokePaintResolved.fallback;
-    }
-  }
+  applyStrokeFallback(strokes, strokePaintResolved?.fallback);
 
-  // Keep geom checks inline so TS narrows layer.params (line/path vs quantile/function).
-  const params =
-    binding.layer.geom === "line" ||
-    binding.layer.geom === "qq_line" ||
-    binding.layer.geom === "path" ||
-    binding.layer.geom === "step" ||
-    binding.layer.geom === "quantile" ||
-    binding.layer.geom === "contour" ||
-    binding.layer.geom === "density_2d" ||
-    binding.layer.geom === "sf" ||
-    binding.layer.geom === "function"
-      ? (binding.layer.params ?? {})
-      : {};
+  const params = lineStyleParams(binding);
   // Quantile/contour/density_2d/function have no curve param; line/path may set step/linear.
   // geom_step instead carries params.direction, which picks the step family (#789).
-  let curve: PathsBatch["curve"] = "linear";
-  if (binding.layer.geom === "step") {
-    const direction = (binding.layer.params ?? {}).direction ?? "hv";
-    curve = direction === "vh" ? "step-vh" : direction === "mid" ? "step" : "step-hv";
-  } else if (binding.layer.geom === "line" || binding.layer.geom === "path") {
-    curve = (binding.layer.params ?? {}).curve ?? "linear";
-  }
+  const curve = lineCurve(binding);
   const styleRows = subpaths.map((rows) => rows[0]!);
   const linewidths = numericStyleVector(frame, "linewidth", styleRows, styles);
   const alphas = numericStyleVector(frame, "alpha", styleRows, styles);
@@ -170,13 +191,6 @@ export function lineBatch(
     linetypeIndex(value as Linetype),
   );
   const literalLinetype = binding.linetype.constant;
-  const styleParams: { alpha?: number; linewidth?: number } = {};
-  if ("linewidth" in params && typeof params.linewidth === "number") {
-    styleParams.linewidth = params.linewidth;
-  }
-  if ("alpha" in params && typeof params.alpha === "number") {
-    styleParams.alpha = params.alpha;
-  }
   return {
     kind: "paths",
     layerIndex: binding.index,
@@ -186,9 +200,9 @@ export function lineBatch(
     ...(frameRowIndex !== undefined && { frameRowIndex }),
     pathOffsets,
     strokes,
-    linewidth: constantStyle(binding, styleParams, "linewidth", DEFAULT_LINEWIDTH),
+    linewidth: constantStyle(binding, params, "linewidth", DEFAULT_LINEWIDTH),
     ...(linewidths !== undefined && { linewidths }),
-    alpha: alphas === undefined ? constantStyle(binding, styleParams, "alpha", 1) : 1,
+    alpha: alphas === undefined ? constantStyle(binding, params, "alpha", 1) : 1,
     ...(alphas !== undefined && { alphas }),
     ...(typeof literalLinetype === "string" && { linetype: literalLinetype as Linetype }),
     ...(linetypeIndexes !== undefined && { linetypeIndexes }),

--- a/packages/core/src/pipeline/geometry-paths-polygon.ts
+++ b/packages/core/src/pipeline/geometry-paths-polygon.ts
@@ -18,6 +18,64 @@ import {
 } from "./geometry-style.js";
 import { areaGroupFillsOf } from "./geometry-paths-area-fill.js";
 
+type PolygonBuffers = {
+  positions: Float32Array;
+  rowIndex: Uint32Array;
+  closedFrameRows: Uint32Array;
+  pathOffsets: Uint32Array;
+  fills: (string | null)[];
+  strokes: (string | null)[];
+  ringStarts: number[];
+};
+
+function writePolygonBuffers(
+  frame: LayerFrame,
+  fx: Frame,
+  groupRows: readonly (readonly number[])[],
+  fillPaints: readonly (string | null)[],
+  strokePaints: readonly (string | null)[],
+  fillFallback: string | undefined,
+  strokeFallback: string | undefined,
+): PolygonBuffers {
+  let total = 0;
+  for (const rows of groupRows) total += rows.length;
+  const positions = new Float32Array(total * 2);
+  const rowIndex = new Uint32Array(total);
+  const closedFrameRows = new Uint32Array(total);
+  const pathOffsets = new Uint32Array(groupRows.length + 1);
+  const fills: (string | null)[] = [];
+  const strokes: (string | null)[] = [];
+  const ringStarts: number[] = [];
+  const ringIndex = frame.sf?.ringIndex;
+  let cursor = 0;
+  for (let s = 0; s < groupRows.length; s++) {
+    pathOffsets[s] = cursor;
+    const rows = groupRows[s]!;
+    let prevRing = ringIndex?.[rows[0]!] ?? 0;
+    for (const row of rows) {
+      const rIdx = ringIndex?.[row] ?? 0;
+      if (rIdx !== prevRing) {
+        // Additional ring start (hole) inside this subpath — exterior is pathOffsets[s].
+        ringStarts.push(cursor);
+        prevRing = rIdx;
+      }
+      const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row);
+      const ty = positionOf(fx.yScale, frame.yNumeric, frame.yValues, row);
+      positions[cursor * 2] = tx * fx.innerWidth;
+      positions[cursor * 2 + 1] = fx.innerHeight - ty * fx.innerHeight;
+      rowIndex[cursor] = frame.rowIndex[row]!;
+      closedFrameRows[cursor] = row;
+      cursor++;
+    }
+    fills.push(fillPaints[s] ?? fillFallback ?? null);
+    let stroke = strokePaints[s]!;
+    if (stroke === null && strokeFallback !== undefined) stroke = strokeFallback;
+    strokes.push(stroke);
+  }
+  pathOffsets[groupRows.length] = cursor;
+  return { positions, rowIndex, closedFrameRows, pathOffsets, fills, strokes, ringStarts };
+}
+
 export function polygonBatch(
   frame: LayerFrame,
   fx: Frame,
@@ -48,46 +106,18 @@ export function polygonBatch(
   const fillPaints = areaGroupFillsOf(frame, fill, styleRows);
   const strokePaints = paintVector(frame, "color", color, styleRows);
 
-  let total = 0;
-  for (const rows of groupRows) total += rows.length;
-  const positions = new Float32Array(total * 2);
-  const rowIndex = new Uint32Array(total);
-  // One frame-row id per vertex so coord-projected closed paths resolve
-  // tooltips to the correct region (not ribbon 2×N layout; #808/#502).
-  const closedFrameRows = new Uint32Array(total);
-  const pathOffsets = new Uint32Array(groupRows.length + 1);
-  const fills: (string | null)[] = [];
-  const strokes: (string | null)[] = [];
-  const ringStarts: number[] = [];
-  const ringIndex = frame.sf?.ringIndex;
-  let cursor = 0;
-  for (let s = 0; s < groupRows.length; s++) {
-    pathOffsets[s] = cursor;
-    const rows = groupRows[s]!;
-    let prevRing = ringIndex?.[rows[0]!] ?? 0;
-    for (const row of rows) {
-      const rIdx = ringIndex?.[row] ?? 0;
-      if (rIdx !== prevRing) {
-        // Additional ring start (hole) inside this subpath — exterior is pathOffsets[s].
-        ringStarts.push(cursor);
-        prevRing = rIdx;
-      }
-      const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row);
-      const ty = positionOf(fx.yScale, frame.yNumeric, frame.yValues, row);
-      positions[cursor * 2] = tx * fx.innerWidth;
-      positions[cursor * 2 + 1] = fx.innerHeight - ty * fx.innerHeight;
-      rowIndex[cursor] = frame.rowIndex[row]!;
-      closedFrameRows[cursor] = row;
-      cursor++;
-    }
-    fills.push(fillPaints[s] ?? fillPaintResolved?.fallback ?? null);
-    let stroke = strokePaints[s]!;
-    if (stroke === null && strokePaintResolved !== undefined) {
-      stroke = strokePaintResolved.fallback;
-    }
-    strokes.push(stroke);
-  }
-  pathOffsets[groupRows.length] = cursor;
+  // One frame-row id per vertex keeps projected-path tooltips attached to the
+  // correct polygon region (not ribbon's 2×N layout; #808/#502).
+  const { positions, rowIndex, closedFrameRows, pathOffsets, fills, strokes, ringStarts } =
+    writePolygonBuffers(
+      frame,
+      fx,
+      groupRows,
+      fillPaints,
+      strokePaints,
+      fillPaintResolved?.fallback,
+      strokePaintResolved?.fallback,
+    );
 
   // polygon and map (geom_map is polygon-with-join; #808) share this batch.
   const params = (binding.layer.params ?? {}) as {


### PR DESCRIPTION
## Summary
- enforce cyclomatic complexity max 20 for line, polygon, and curve geometry builders
- extract focused batch-level style, sampling, and buffer-writing helpers
- preserve the existing row-level loops and geometry output semantics

## Validation
- `bun run test` (5068 pass, 4 skip)
- focused geometry tests (29 pass)
- `bun run check`
- `bun run lint:type-aware`
- `bun run knip`
- `pre-commit run --all-files --show-diff-on-failure`

## Benchmark
Captured the full 40-workload baseline before edits. The first comparison was broadly noisy; reversed-order A/B showed no coherent regression. The directly affected line-series workload measured 27.67 ms on this branch versus 32.29 ms on baseline, while temporal-line reversed direction between run orders. New helper calls occur once per batch, outside row-level hot loops.