### PR TITLE
refactor(core): enforce complexity in mark geometry

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -137,6 +137,16 @@
       }
     },
     {
+      "files": [
+        "packages/core/src/pipeline/geometry-points.ts",
+        "packages/core/src/pipeline/geometry-rug.ts",
+        "packages/core/src/pipeline/geometry-rects-slot.ts"
+      ],
+      "rules": {
+        "eslint/complexity": ["error", { "max": 20 }]
+      }
+    },
+    {
       // Tests + benchmarks: fixture literals are cast deliberately (invalid
       // specs, RuntimeSpec shapes) and test files run long by design.
       "files": ["**/tests/**", "benchmarks/**"],

--- a/packages/core/src/pipeline/geometry-points.ts
+++ b/packages/core/src/pipeline/geometry-points.ts
@@ -22,6 +22,33 @@ import {
   packPointPixels,
 } from "./geometry-points-collect.js";
 
+type PointParams = {
+  size?: number;
+  alpha?: number;
+  shape?: PointShape;
+  binwidth?: number;
+  dotsize?: number;
+};
+
+function pointParams(binding: LayerFrame["binding"]): PointParams {
+  switch (binding.layer.geom) {
+    case "point":
+    case "count":
+    case "qq":
+    case "dotplot":
+    case "sf":
+      return binding.layer.params ?? {};
+    default:
+      return {};
+  }
+}
+
+function pointParamShape(geom: string, params: PointParams): PointShape | undefined {
+  return geom === "point" || geom === "count" || geom === "qq" || geom === "dotplot"
+    ? params.shape
+    : undefined;
+}
+
 /** Diameter ≈ binwidth in x data units × dotsize, converted to px radius. */
 function dotplotRadiusPx(
   frame: LayerFrame,
@@ -47,6 +74,59 @@ function dotplotRadiusPx(
   const dotsize = params.dotsize ?? 1;
   const diameterPx = (binwidth / span) * fx.innerWidth * dotsize;
   return Math.max(0.5, diameterPx / 2);
+}
+
+function pointMarkSize(
+  frame: LayerFrame,
+  fx: Frame,
+  params: PointParams,
+  literalSize: unknown,
+): number {
+  if (typeof literalSize === "number") return literalSize;
+  if (typeof params.size === "number") return params.size;
+  return frame.binding.layer.geom === "dotplot"
+    ? dotplotRadiusPx(frame, fx, params)
+    : DEFAULT_POINT_SIZE;
+}
+
+function attachMappedPointStyles(
+  batch: PointsBatch,
+  frame: LayerFrame,
+  styles: ResolvedStyleScales,
+  keptRows: Uint32Array,
+): void {
+  const sizes = numericStyleVector(frame, "size", keptRows, styles);
+  const alphas = numericStyleVector(frame, "alpha", keptRows, styles);
+  const shapeIndexes = indexedStyleVector(frame, "shape", keptRows, styles, (value) =>
+    pointShapeIndex(value as PointShape),
+  );
+  if (sizes !== undefined) batch.sizes = sizes;
+  if (alphas !== undefined) {
+    batch.alpha = 1;
+    batch.alphas = alphas;
+  }
+  if (shapeIndexes !== undefined) batch.shapeIndexes = shapeIndexes;
+}
+
+function attachMappedPointPaint(
+  batch: PointsBatch,
+  frame: LayerFrame,
+  paintKey: "color" | "fill",
+  paintScale: ResolvedColorScale | null,
+  paintValues: LayerFrame["colorValues"],
+  paintChannel: LayerFrame["binding"]["color"],
+  keptRows: Uint32Array,
+): void {
+  if (paintScale === null || (paintValues === null && paintChannel.scaledConstant === null)) return;
+  const indexed = mappedPaintIndexVector(frame, paintKey, paintScale, keptRows);
+  if (indexed === null) {
+    batch.colors = mappedPaintVector(frame, paintKey, paintScale, keptRows);
+  } else if (indexed.palette.length === 1) {
+    batch.fill = indexed.palette[0]!;
+  } else {
+    batch.colorPalette = indexed.palette;
+    batch.colorIndexes = indexed.indexes;
+  }
 }
 
 export function pointsBatch(
@@ -81,26 +161,11 @@ export function pointsBatch(
   // point / count / qq / dotplot / geom_sf point family share this builder.
   // SfParams has size/alpha (not shape); DotplotParams adds binwidth/dotsize.
   const geom = binding.layer.geom;
-  const params =
-    geom === "point" || geom === "count" || geom === "qq" || geom === "dotplot" || geom === "sf"
-      ? ((binding.layer.params ?? {}) as {
-          size?: number;
-          alpha?: number;
-          shape?: PointShape;
-          binwidth?: number;
-          dotsize?: number;
-        })
-      : {};
-  const paramShape =
-    geom === "point" || geom === "count" || geom === "qq" || geom === "dotplot"
-      ? params.shape
-      : undefined;
+  const params = pointParams(binding);
+  const paramShape = pointParamShape(geom, params);
   const literalSize = binding.size.constant;
   const literalShape = binding.shape.constant;
-  let markSize = DEFAULT_POINT_SIZE;
-  if (typeof literalSize === "number") markSize = literalSize;
-  else if (typeof params.size === "number") markSize = params.size;
-  else if (geom === "dotplot") markSize = dotplotRadiusPx(frame, fx, params);
+  const markSize = pointMarkSize(frame, fx, params, literalSize);
 
   // geom_dotplot paints with fill when present (schema: "Map fill/color for groups").
   // Solid point marks only have one paint channel; fill wins over color when both map.
@@ -126,27 +191,15 @@ export function pointsBatch(
       typeof literalShape === "string" ? (literalShape as PointShape) : (paramShape ?? "circle"),
     fill: paintChannel.constant,
   };
-  const sizes = numericStyleVector(frame, "size", collectedKeptRows, styles);
-  const alphas = numericStyleVector(frame, "alpha", collectedKeptRows, styles);
-  const shapeIndexes = indexedStyleVector(frame, "shape", collectedKeptRows, styles, (value) =>
-    pointShapeIndex(value as PointShape),
+  attachMappedPointStyles(batch, frame, styles, collectedKeptRows);
+  attachMappedPointPaint(
+    batch,
+    frame,
+    paintKey,
+    paintScale,
+    paintValues,
+    paintChannel,
+    collectedKeptRows,
   );
-  if (sizes !== undefined) batch.sizes = sizes;
-  if (alphas !== undefined) {
-    batch.alpha = 1;
-    batch.alphas = alphas;
-  }
-  if (shapeIndexes !== undefined) batch.shapeIndexes = shapeIndexes;
-  if (paintScale !== null && (paintValues !== null || paintChannel.scaledConstant !== null)) {
-    const indexed = mappedPaintIndexVector(frame, paintKey, paintScale, collectedKeptRows);
-    if (indexed === null) {
-      batch.colors = mappedPaintVector(frame, paintKey, paintScale, collectedKeptRows);
-    } else if (indexed.palette.length === 1) {
-      batch.fill = indexed.palette[0]!;
-    } else {
-      batch.colorPalette = indexed.palette;
-      batch.colorIndexes = indexed.indexes;
-    }
-  }
   return batch;
 }

--- a/packages/core/src/pipeline/geometry-rects-slot.ts
+++ b/packages/core/src/pipeline/geometry-rects-slot.ts
@@ -1,95 +1,107 @@
 /**
  * Resolve bar/col rect center/width and y-bounds in normalized [0,1] space.
  */
+import type { BandScale, ContinuousScale } from "../scales/train.js";
+
 import type { LayerFrame } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
 
-export function resolveRectSlot(input: {
+type RectSlotInput = {
   frame: LayerFrame;
   fx: Frame;
   row: number;
   binned: boolean;
   widthFrac: number;
-}): { center: number; w: number; t0: number; t1: number } | null {
-  const { frame, fx, row, binned, widthFrac } = input;
-  // frame.ymin/ymax/xmin/xmax are already-transformed (scale-space) frame
-  // arrays (source-applied or stat-generated); normalizeTransformed skips the
-  // forward so they are never transformed twice.
-  const t0 = fx.yScale.type === "band" ? NaN : fx.yScale.normalizeTransformed(frame.ymin![row]!);
-  const t1 = fx.yScale.type === "band" ? NaN : fx.yScale.normalizeTransformed(frame.ymax![row]!);
+};
 
-  let center: number;
-  let w: number;
-  if (fx.xScale.type === "band") {
-    if (binned) return null;
-    const tc = fx.xScale.normalize(frame.xValues?.[row] ?? null);
-    if (tc === undefined || Number.isNaN(tc) || Number.isNaN(t0) || Number.isNaN(t1)) {
-      return null;
-    }
-    center = tc;
-    w = widthFrac;
-    if (frame.dodge !== null) {
-      const slotCount = Math.max(1, frame.dodge.slotCounts[row]!);
-      const full = w;
-      w = full / slotCount;
-      center += full * ((frame.dodge.slot[row]! + 0.5) / slotCount - 0.5);
-    }
-  } else {
-    let sourceLeft: number;
-    let sourceRight: number;
-    if (binned) {
-      if (frame.xmin !== null && frame.xmax !== null) {
-        // Stat-bin rects already carry transformed [xmin, xmax] edges.
-        sourceLeft = frame.xmin[row]!;
-        sourceRight = frame.xmax[row]!;
-      } else {
-        // A binned position scale snaps identity/count rows to a transformed
-        // center. Recover edges via the stable integer bin id (built once at
-        // frame construction) — Θ(1) per row, not centers.findIndex (Θ(B)).
-        // bin.xId is the discrete source of truth for stack/dodge/count too;
-        // float-center Object.is is only a defensive fallback when ids are absent.
-        const boundaries = frame.binding.xBinning;
-        const transformedCenter = frame.xNumeric?.[row];
-        if (boundaries === undefined || transformedCenter === undefined) return null;
-        const bin = frame.bin;
-        const xBinId = bin === undefined || bin === null ? null : bin.xId;
-        const index =
-          xBinId === null
-            ? boundaries.centers.findIndex((value) => Object.is(value, transformedCenter))
-            : xBinId[row]!;
-        if (index < 0) return null;
-        sourceLeft = boundaries.edges[index]!;
-        sourceRight = boundaries.edges[index + 1]!;
-      }
-      if (widthFrac !== 0) {
-        const midpoint = (sourceLeft + sourceRight) / 2;
-        const half = ((sourceRight - sourceLeft) * widthFrac) / 2;
-        sourceLeft = midpoint - half;
-        sourceRight = midpoint + half;
-      }
-    } else {
-      const transformedCenter = frame.xNumeric?.[row];
-      if (transformedCenter === undefined) return null;
-      const scaleSpan = fx.xScale.transformedDomain[1] - fx.xScale.transformedDomain[0];
-      const half = (widthFrac * scaleSpan) / 2;
-      sourceLeft = transformedCenter - half;
-      sourceRight = transformedCenter + half;
-    }
-    // Dodge in scale space, then project both final edges independently.
-    if (frame.dodge !== null) {
-      const slotCount = Math.max(1, frame.dodge.slotCounts[row]!);
-      const slot = frame.dodge.slot[row]!;
-      const full = sourceRight - sourceLeft;
-      sourceRight = sourceLeft + (full * (slot + 1)) / slotCount;
-      sourceLeft += (full * slot) / slotCount;
-    }
-    const tx0 = fx.xScale.normalizeTransformed(sourceLeft);
-    const tx1 = fx.xScale.normalizeTransformed(sourceRight);
-    if (Number.isNaN(tx0) || Number.isNaN(tx1) || Number.isNaN(t0) || Number.isNaN(t1)) {
-      return null;
-    }
-    center = (tx0 + tx1) / 2;
-    w = Math.abs(tx1 - tx0);
+type RectSlot = { center: number; w: number; t0: number; t1: number };
+
+function resolveBandRectSlot(
+  input: RectSlotInput,
+  xScale: BandScale,
+  t0: number,
+  t1: number,
+): RectSlot | null {
+  const { frame, row, binned, widthFrac } = input;
+  if (binned) return null;
+  const tc = xScale.normalize(frame.xValues?.[row] ?? null);
+  if (tc === undefined || Number.isNaN(tc) || Number.isNaN(t0) || Number.isNaN(t1)) return null;
+  let center = tc;
+  let w = widthFrac;
+  if (frame.dodge !== null) {
+    const slotCount = Math.max(1, frame.dodge.slotCounts[row]!);
+    const full = w;
+    w = full / slotCount;
+    center += full * ((frame.dodge.slot[row]! + 0.5) / slotCount - 0.5);
   }
   return { center, w, t0, t1 };
+}
+
+function binnedRectEdges(frame: LayerFrame, row: number): [number, number] | null {
+  if (frame.xmin !== null && frame.xmax !== null) {
+    return [frame.xmin[row]!, frame.xmax[row]!];
+  }
+  // A binned position scale snaps identity/count rows to a transformed center.
+  // Prefer the stable integer bin id; float lookup is the defensive fallback.
+  const boundaries = frame.binding.xBinning;
+  const transformedCenter = frame.xNumeric?.[row];
+  if (boundaries === undefined || transformedCenter === undefined) return null;
+  const xBinId = frame.bin?.xId ?? null;
+  const index =
+    xBinId === null
+      ? boundaries.centers.findIndex((value) => Object.is(value, transformedCenter))
+      : xBinId[row]!;
+  if (index < 0) return null;
+  return [boundaries.edges[index]!, boundaries.edges[index + 1]!];
+}
+
+function resolveContinuousRectSlot(
+  input: RectSlotInput,
+  xScale: ContinuousScale,
+  t0: number,
+  t1: number,
+): RectSlot | null {
+  const { frame, row, binned, widthFrac } = input;
+  let sourceLeft: number;
+  let sourceRight: number;
+  if (binned) {
+    const edges = binnedRectEdges(frame, row);
+    if (edges === null) return null;
+    [sourceLeft, sourceRight] = edges;
+    if (widthFrac !== 0) {
+      const midpoint = (sourceLeft + sourceRight) / 2;
+      const half = ((sourceRight - sourceLeft) * widthFrac) / 2;
+      sourceLeft = midpoint - half;
+      sourceRight = midpoint + half;
+    }
+  } else {
+    const transformedCenter = frame.xNumeric?.[row];
+    if (transformedCenter === undefined) return null;
+    const scaleSpan = xScale.transformedDomain[1] - xScale.transformedDomain[0];
+    const half = (widthFrac * scaleSpan) / 2;
+    sourceLeft = transformedCenter - half;
+    sourceRight = transformedCenter + half;
+  }
+  // Dodge in scale space, then project both final edges independently.
+  if (frame.dodge !== null) {
+    const slotCount = Math.max(1, frame.dodge.slotCounts[row]!);
+    const slot = frame.dodge.slot[row]!;
+    const full = sourceRight - sourceLeft;
+    sourceRight = sourceLeft + (full * (slot + 1)) / slotCount;
+    sourceLeft += (full * slot) / slotCount;
+  }
+  const tx0 = xScale.normalizeTransformed(sourceLeft);
+  const tx1 = xScale.normalizeTransformed(sourceRight);
+  if (Number.isNaN(tx0) || Number.isNaN(tx1) || Number.isNaN(t0) || Number.isNaN(t1)) return null;
+  return { center: (tx0 + tx1) / 2, w: Math.abs(tx1 - tx0), t0, t1 };
+}
+
+export function resolveRectSlot(input: RectSlotInput): RectSlot | null {
+  const { frame, fx, row } = input;
+  // Frame bounds are already transformed; do not apply the forward transform twice.
+  const t0 = fx.yScale.type === "band" ? NaN : fx.yScale.normalizeTransformed(frame.ymin![row]!);
+  const t1 = fx.yScale.type === "band" ? NaN : fx.yScale.normalizeTransformed(frame.ymax![row]!);
+  return fx.xScale.type === "band"
+    ? resolveBandRectSlot(input, fx.xScale, t0, t1)
+    : resolveContinuousRectSlot(input, fx.xScale, t0, t1);
 }

--- a/packages/core/src/pipeline/geometry-rug.ts
+++ b/packages/core/src/pipeline/geometry-rug.ts
@@ -27,6 +27,83 @@ function parseRugSides(sides: string | undefined): Set<"b" | "l" | "t" | "r"> {
   return out;
 }
 
+function rugLength(value: number | undefined): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.min(value, 1)
+    : DEFAULT_LENGTH;
+}
+
+function emitRugSegments(
+  frame: LayerFrame,
+  fx: Frame,
+  sides: ReadonlySet<"b" | "l" | "t" | "r">,
+  length: number,
+): {
+  segments: Float32Array;
+  rowIndex: Uint32Array;
+  styleRows: Uint32Array;
+  kept: number;
+  removed: number;
+} {
+  const capacity = frame.n * sides.size;
+  const segments = new Float32Array(capacity * 4);
+  const rowIndex = new Uint32Array(capacity);
+  const styleRows = new Uint32Array(capacity);
+  const needX = sides.has("b") || sides.has("t");
+  const needY = sides.has("l") || sides.has("r");
+  const width = fx.innerWidth;
+  const height = fx.innerHeight;
+  const tickHeight = length * height;
+  const tickWidth = length * width;
+  let kept = 0;
+  let removed = 0;
+
+  const push = (row: number, x0: number, y0: number, x1: number, y1: number): void => {
+    const offset = kept * 4;
+    segments[offset] = x0;
+    segments[offset + 1] = y0;
+    segments[offset + 2] = x1;
+    segments[offset + 3] = y1;
+    rowIndex[kept] = frame.rowIndex[row]!;
+    styleRows[kept] = row;
+    kept++;
+  };
+
+  for (let row = 0; row < frame.n; row++) {
+    let emitted = 0;
+    if (needX) {
+      const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row);
+      if (!Number.isNaN(tx)) {
+        const x = tx * width;
+        if (sides.has("b")) {
+          push(row, x, height, x, height - tickHeight);
+          emitted++;
+        }
+        if (sides.has("t")) {
+          push(row, x, 0, x, tickHeight);
+          emitted++;
+        }
+      }
+    }
+    if (needY) {
+      const ty = positionOf(fx.yScale, frame.yNumeric, frame.yValues, row);
+      if (!Number.isNaN(ty)) {
+        const y = height - ty * height;
+        if (sides.has("l")) {
+          push(row, 0, y, tickWidth, y);
+          emitted++;
+        }
+        if (sides.has("r")) {
+          push(row, width, y, width - tickWidth, y);
+          emitted++;
+        }
+      }
+    }
+    if (emitted === 0) removed++;
+  }
+  return { segments, rowIndex, styleRows, kept, removed };
+}
+
 export function rugBatch(
   frame: LayerFrame,
   fx: Frame,
@@ -37,10 +114,7 @@ export function rugBatch(
   const { binding } = frame;
   const params = (binding.layer.params ?? {}) as RugParams;
   const sides = parseRugSides(params.sides);
-  const length =
-    typeof params.length === "number" && Number.isFinite(params.length) && params.length > 0
-      ? Math.min(params.length, 1)
-      : DEFAULT_LENGTH;
+  const length = rugLength(params.length);
 
   const needX = sides.has("b") || sides.has("t");
   const needY = sides.has("l") || sides.has("r");
@@ -54,65 +128,14 @@ export function rugBatch(
   const capacity = frame.n * sides.size;
   if (capacity === 0) return null;
 
-  const segments = new Float32Array(capacity * 4);
-  const rowIndex = new Uint32Array(capacity);
-  const styleRows = new Uint32Array(capacity);
-  let kept = 0;
-  let removed = 0;
+  const { segments, rowIndex, styleRows, kept, removed } = emitRugSegments(
+    frame,
+    fx,
+    sides,
+    length,
+  );
 
-  const W = fx.innerWidth;
-  const H = fx.innerHeight;
-  const tickH = length * H;
-  const tickW = length * W;
-
-  const push = (row: number, x0: number, y0: number, x1: number, y1: number): void => {
-    const o = kept * 4;
-    segments[o] = x0;
-    segments[o + 1] = y0;
-    segments[o + 2] = x1;
-    segments[o + 3] = y1;
-    rowIndex[kept] = frame.rowIndex[row]!;
-    styleRows[kept] = row;
-    kept++;
-  };
-
-  for (let row = 0; row < frame.n; row++) {
-    let emitted = 0;
-
-    if (needX) {
-      const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row);
-      if (!Number.isNaN(tx)) {
-        const sx = tx * W;
-        if (sides.has("b")) {
-          push(row, sx, H, sx, H - tickH);
-          emitted++;
-        }
-        if (sides.has("t")) {
-          push(row, sx, 0, sx, tickH);
-          emitted++;
-        }
-      }
-    }
-
-    if (needY) {
-      const ty = positionOf(fx.yScale, frame.yNumeric, frame.yValues, row);
-      if (!Number.isNaN(ty)) {
-        const sy = H - ty * H;
-        if (sides.has("l")) {
-          push(row, 0, sy, tickW, sy);
-          emitted++;
-        }
-        if (sides.has("r")) {
-          push(row, W, sy, W - tickW, sy);
-          emitted++;
-        }
-      }
-    }
-
-    // One removal unit per row that produced no ticks (all requested channels non-finite).
-    if (emitted === 0) removed++;
-  }
-
+  // One removal unit per row that produced no ticks (all requested channels non-finite).
   removedWarning(removed, binding.index, warnings);
   if (kept === 0) return null;
 


### PR DESCRIPTION
## Summary
- enforce cyclomatic complexity max 20 for point, rug, and rect-slot geometry
- separate point style/paint application and rug emission into focused batch-level helpers
- split rect-slot resolution into band, binned-edge, and continuous paths while preserving integer-bin lookup

## Validation
- `bun run test` (5068 pass, 4 skip)
- focused point/rug/rect tests (40 pass)
- `bun run check`
- `bun run lint:type-aware`
- `bun run knip`
- `pre-commit run --all-files --show-diff-on-failure`

## Benchmark
Captured the full 40-workload baseline before edits. The first comparison suggested a point-path slowdown, so publication stopped for reversed-order A/B. The result flipped: coord-identity points measured 12.96 ms on this branch versus 19.26 ms baseline, coord-log10 points 21.73 ms versus 29.19 ms, and histogram was within 1.2%. The inconsistent direction shows run-order/system noise rather than a coherent regression.