### PR TITLE
refactor(core): enforce complexity in area geometry

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -147,6 +147,16 @@
       }
     },
     {
+      "files": [
+        "packages/core/src/pipeline/geometry-violin.ts",
+        "packages/core/src/pipeline/geometry-ribbon.ts",
+        "packages/core/src/pipeline/geometry-ribbon-batches.ts"
+      ],
+      "rules": {
+        "eslint/complexity": ["error", { "max": 20 }]
+      }
+    },
+    {
       // Tests + benchmarks: fixture literals are cast deliberately (invalid
       // specs, RuntimeSpec shapes) and test files run long by design.
       "files": ["**/tests/**", "benchmarks/**"],

--- a/packages/core/src/pipeline/geometry-ribbon-batches.ts
+++ b/packages/core/src/pipeline/geometry-ribbon-batches.ts
@@ -1,0 +1,165 @@
+/** Assemble closed and outline ribbon path batches from written buffers. */
+import type { PathsBatch } from "../scene.js";
+import type { Linetype } from "../scales/style.js";
+
+type LineCap = "butt" | "round" | "square";
+type LineJoin = "miter" | "round" | "bevel";
+
+type ClosedRibbonBuffers = {
+  positions: Float32Array;
+  rowIndex: Uint32Array;
+  closedFrameRows: Uint32Array;
+  pathOffsets: Uint32Array;
+  fills: (string | null)[];
+  strokes: (string | null)[];
+};
+
+type OpenRibbonBuffers = {
+  positions: Float32Array;
+  rowIndex: Uint32Array;
+  frameRowIndex: Uint32Array;
+  pathOffsets: Uint32Array;
+  strokes: (string | null)[];
+};
+
+function expandEdgeStyles<T>(
+  values: T[] | Float32Array | Uint8Array | undefined,
+  edgeCount: number,
+): T[] | Float32Array | Uint8Array | undefined {
+  if (values === undefined || edgeCount === 1) return values;
+  if (values instanceof Float32Array) {
+    const expanded = new Float32Array(values.length * edgeCount);
+    for (let i = 0; i < values.length; i++) {
+      for (let edge = 0; edge < edgeCount; edge++) {
+        expanded[i * edgeCount + edge] = values[i]!;
+      }
+    }
+    return expanded;
+  }
+  if (values instanceof Uint8Array) {
+    const expanded = new Uint8Array(values.length * edgeCount);
+    for (let i = 0; i < values.length; i++) {
+      for (let edge = 0; edge < edgeCount; edge++) {
+        expanded[i * edgeCount + edge] = values[i]!;
+      }
+    }
+    return expanded;
+  }
+  const expanded: T[] = [];
+  for (const value of values) {
+    for (let edge = 0; edge < edgeCount; edge++) expanded.push(value);
+  }
+  return expanded;
+}
+
+export function closedRibbonBatch(input: {
+  layerIndex: number;
+  closed: ClosedRibbonBuffers;
+  fullStroke: boolean;
+  outlineWidth: number;
+  constantAlpha: number;
+  alphas: Float32Array | undefined;
+  linewidths: Float32Array | undefined;
+  linetypeIndexes: Uint8Array | undefined;
+  literalLinetype: unknown;
+  linecap: LineCap;
+  linejoin: LineJoin;
+  fillPaintResolved: PathsBatch["fillPaint"] | undefined;
+  strokePaintResolved: PathsBatch["strokePaint"] | undefined;
+  glowResolved: PathsBatch["glow"] | undefined;
+}): PathsBatch {
+  const {
+    layerIndex,
+    closed,
+    fullStroke,
+    outlineWidth,
+    constantAlpha,
+    alphas,
+    linewidths,
+    linetypeIndexes,
+    literalLinetype,
+    linecap,
+    linejoin,
+    fillPaintResolved,
+    strokePaintResolved,
+    glowResolved,
+  } = input;
+  return {
+    kind: "paths",
+    layerIndex,
+    panelIndex: 0,
+    positions: closed.positions,
+    rowIndex: closed.rowIndex,
+    closedFrameRows: closed.closedFrameRows,
+    pathOffsets: closed.pathOffsets,
+    strokes: closed.strokes,
+    fills: closed.fills,
+    closed: true,
+    linewidth: fullStroke ? outlineWidth : 0,
+    ...(fullStroke && linewidths !== undefined && { linewidths }),
+    alpha: alphas === undefined ? constantAlpha : 1,
+    ...(alphas !== undefined && { alphas }),
+    ...(fullStroke &&
+      typeof literalLinetype === "string" && { linetype: literalLinetype as Linetype }),
+    ...(fullStroke && linetypeIndexes !== undefined && { linetypeIndexes }),
+    ...(fullStroke && { linecap, linejoin }),
+    curve: "linear",
+    ...(fillPaintResolved !== undefined && { fillPaint: fillPaintResolved }),
+    ...(fullStroke && strokePaintResolved !== undefined && { strokePaint: strokePaintResolved }),
+    ...(glowResolved !== undefined && { glow: glowResolved }),
+  };
+}
+
+export function openRibbonBatch(input: {
+  layerIndex: number;
+  open: OpenRibbonBuffers;
+  edgeCount: number;
+  outlineWidth: number;
+  constantAlpha: number;
+  alphas: Float32Array | undefined;
+  linewidths: Float32Array | undefined;
+  linetypeIndexes: Uint8Array | undefined;
+  literalLinetype: unknown;
+  linecap: LineCap;
+  linejoin: LineJoin;
+  strokePaintResolved: PathsBatch["strokePaint"] | undefined;
+}): PathsBatch {
+  const {
+    layerIndex,
+    open,
+    edgeCount,
+    outlineWidth,
+    constantAlpha,
+    alphas,
+    linewidths,
+    linetypeIndexes,
+    literalLinetype,
+    linecap,
+    linejoin,
+    strokePaintResolved,
+  } = input;
+  const outlineLinewidths = expandEdgeStyles(linewidths, edgeCount);
+  const outlineAlphas = expandEdgeStyles(alphas, edgeCount);
+  const outlineLinetypes = expandEdgeStyles(linetypeIndexes, edgeCount);
+  return {
+    kind: "paths",
+    layerIndex,
+    panelIndex: 0,
+    positions: open.positions,
+    rowIndex: open.rowIndex,
+    frameRowIndex: open.frameRowIndex,
+    pathOffsets: open.pathOffsets,
+    strokes: open.strokes,
+    linewidth: outlineWidth,
+    ...(outlineLinewidths !== undefined && { linewidths: outlineLinewidths as Float32Array }),
+    alpha: outlineAlphas === undefined ? constantAlpha : 1,
+    ...(outlineAlphas !== undefined && { alphas: outlineAlphas as Float32Array }),
+    ...(typeof literalLinetype === "string" && { linetype: literalLinetype as Linetype }),
+    ...(strokePaintResolved !== undefined && { strokePaint: strokePaintResolved }),
+    ...(outlineLinetypes !== undefined && { linetypeIndexes: outlineLinetypes as Uint8Array }),
+    linecap,
+    linejoin,
+    curve: "linear",
+    candidates: false,
+  };
+}

--- a/packages/core/src/pipeline/geometry-ribbon.ts
+++ b/packages/core/src/pipeline/geometry-ribbon.ts
@@ -22,8 +22,8 @@ import {
   paintVector,
   type ResolvedStyleScales,
 } from "./geometry-style.js";
-// paint helpers imported below
 import { areaGroupFillsOf } from "./geometry-paths-area-fill.js";
+import { closedRibbonBatch, openRibbonBatch } from "./geometry-ribbon-batches.js";
 
 type Outline = "both" | "upper" | "lower" | "full";
 type LineCap = "butt" | "round" | "square";
@@ -41,6 +41,20 @@ interface RibbonParams {
 interface RibbonRun {
   rows: number[];
   group: number;
+}
+
+function groupRibbonRows(frame: LayerFrame): number[][] {
+  const byGroup = new Map<number, number[]>();
+  for (let row = 0; row < frame.n; row++) {
+    const group = frame.groups[row]!;
+    let rows = byGroup.get(group);
+    if (rows === undefined) {
+      rows = [];
+      byGroup.set(group, rows);
+    }
+    rows.push(row);
+  }
+  return [...byGroup.values()];
 }
 
 function ribbonParams(frame: LayerFrame): RibbonParams {
@@ -115,6 +129,46 @@ function sortGroupRowsByRunning(
   for (const rows of groupRows) sortFiniteSlotsInPlace(rows, y);
 }
 
+function scanFiniteRibbonRuns(
+  frame: LayerFrame,
+  fx: Frame,
+  orientation: "x" | "y",
+  groupRows: readonly number[][],
+  lo: Float64Array,
+  hi: Float64Array,
+): { runs: RibbonRun[]; removed: number } {
+  const runs: RibbonRun[] = [];
+  let removed = 0;
+  for (const rows of groupRows) {
+    if (rows.length === 0) continue;
+    const group = frame.groups[rows[0]!]!;
+    let current: number[] = [];
+    for (const row of rows) {
+      const a = lo[row]!;
+      const b = hi[row]!;
+      const running = projectRunning(frame, fx, orientation, row);
+      const lower = projectMeasure(frame, fx, orientation, a);
+      const upper = projectMeasure(frame, fx, orientation, b);
+      if (
+        !Number.isFinite(a) ||
+        !Number.isFinite(b) ||
+        !Number.isFinite(running) ||
+        !Number.isFinite(lower) ||
+        !Number.isFinite(upper)
+      ) {
+        removed++;
+        if (current.length >= 2) runs.push({ rows: current, group });
+        current = [];
+        continue;
+      }
+      current.push(row);
+    }
+    if (current.length >= 2) runs.push({ rows: current, group });
+    else if (current.length === 1) removed++;
+  }
+  return { runs, removed };
+}
+
 /**
  * Collect finite runs: running + both bounds finite. Gaps split groups into
  * multiple closed subpaths (ggplot2 ribbon NA handling).
@@ -136,51 +190,12 @@ function finiteRibbonRuns(
   if (orientation === "y" && frame.yNumeric === null && frame.yValues === null) return [];
 
   // Bucket by group without requiring the orthogonal axis.
-  const byGroup = new Map<number, number[]>();
-  for (let row = 0; row < frame.n; row++) {
-    const g = frame.groups[row]!;
-    let rows = byGroup.get(g);
-    if (rows === undefined) {
-      rows = [];
-      byGroup.set(g, rows);
-    }
-    rows.push(row);
-  }
-  const groupRows = [...byGroup.values()];
+  const groupRows = groupRibbonRows(frame);
   if (groupRows.length === 0) return [];
   sortGroupRowsByRunning(groupRows, frame, fx, orientation);
 
-  const runs: RibbonRun[] = [];
-  let removed = 0;
-  for (const rows of groupRows) {
-    if (rows.length === 0) continue;
-    const group = frame.groups[rows[0]!]!;
-    let current: number[] = [];
-    for (const row of rows) {
-      const a = lo[row]!;
-      const b = hi[row]!;
-      // Require bounds finite, running coord projectable (band or continuous), and
-      // measure bounds projectable (band measure axes yield NaN — drop the row).
-      const runningPx = projectRunning(frame, fx, orientation, row);
-      const loPx = projectMeasure(frame, fx, orientation, a);
-      const hiPx = projectMeasure(frame, fx, orientation, b);
-      if (
-        !Number.isFinite(a) ||
-        !Number.isFinite(b) ||
-        !Number.isFinite(runningPx) ||
-        !Number.isFinite(loPx) ||
-        !Number.isFinite(hiPx)
-      ) {
-        removed++;
-        if (current.length >= 2) runs.push({ rows: current, group });
-        current = [];
-        continue;
-      }
-      current.push(row);
-    }
-    if (current.length >= 2) runs.push({ rows: current, group });
-    else if (current.length === 1) removed++;
-  }
+  // Require finite bounds plus projectable running and measure coordinates.
+  const { runs, removed } = scanFiniteRibbonRuns(frame, fx, orientation, groupRows, lo, hi);
   if (removed > 0) removedWarning(removed, frame.binding.index, warnings);
   return runs;
 }
@@ -394,7 +409,6 @@ export function ribbonBatches(
     (solidStrokes !== null && solidStrokes.some((s) => s !== null));
   const outlineWidth = constantStyle(frame.binding, params, "linewidth", DEFAULT_LINEWIDTH);
 
-  const out: PathsBatch[] = [];
   const fullStroke = outline === "full" && hasExplicitColor;
   const closed = writeClosedRuns({
     frame,
@@ -405,88 +419,44 @@ export function ribbonBatches(
     strokeOf,
     strokeWidth: fullStroke ? outlineWidth : 0,
   });
-
-  out.push({
-    kind: "paths",
-    layerIndex,
-    panelIndex: 0,
-    positions: closed.positions,
-    rowIndex: closed.rowIndex,
-    closedFrameRows: closed.closedFrameRows,
-    pathOffsets: closed.pathOffsets,
-    strokes: closed.strokes,
-    fills: closed.fills,
-    closed: true,
-    linewidth: fullStroke ? outlineWidth : 0,
-    ...(fullStroke && linewidths !== undefined && { linewidths }),
-    alpha: alphas === undefined ? constantAlpha : 1,
-    ...(alphas !== undefined && { alphas }),
-    ...(fullStroke &&
-      typeof literalLinetype === "string" && { linetype: literalLinetype as Linetype }),
-    ...(fullStroke && linetypeIndexes !== undefined && { linetypeIndexes }),
-    ...(fullStroke && { linecap, linejoin }),
-    curve: "linear",
-    ...(fillPaintResolved !== undefined && { fillPaint: fillPaintResolved }),
-    ...(fullStroke && strokePaintResolved !== undefined && { strokePaint: strokePaintResolved }),
-    ...(glowResolved !== undefined && { glow: glowResolved }),
-  });
-
-  if (outline !== "full" && hasExplicitColor) {
-    const open = writeOpenEdges({
-      frame,
-      fx,
-      orientation,
-      runs,
-      edge: outline,
-      strokeOf,
-    });
-    // "both" emits two subpaths per run — repeat style vectors to match.
-    const edgeCount = outline === "both" ? 2 : 1;
-    const expand = <T>(values: T[] | Float32Array | Uint8Array | undefined) => {
-      if (values === undefined || edgeCount === 1) return values;
-      if (values instanceof Float32Array) {
-        const expanded = new Float32Array(values.length * edgeCount);
-        for (let i = 0; i < values.length; i++) {
-          for (let e = 0; e < edgeCount; e++) expanded[i * edgeCount + e] = values[i]!;
-        }
-        return expanded;
-      }
-      if (values instanceof Uint8Array) {
-        const expanded = new Uint8Array(values.length * edgeCount);
-        for (let i = 0; i < values.length; i++) {
-          for (let e = 0; e < edgeCount; e++) expanded[i * edgeCount + e] = values[i]!;
-        }
-        return expanded;
-      }
-      const expanded: T[] = [];
-      for (const value of values) for (let e = 0; e < edgeCount; e++) expanded.push(value);
-      return expanded;
-    };
-    const outlineLinewidths = expand(linewidths);
-    const outlineAlphas = expand(alphas);
-    const outlineLinetypes = expand(linetypeIndexes);
-    // Open outline batches are presentation-only (no candidate duplication).
-    out.push({
-      kind: "paths",
+  const out: PathsBatch[] = [
+    closedRibbonBatch({
       layerIndex,
-      panelIndex: 0,
-      positions: open.positions,
-      rowIndex: open.rowIndex,
-      frameRowIndex: open.frameRowIndex,
-      pathOffsets: open.pathOffsets,
-      strokes: open.strokes,
-      linewidth: outlineWidth,
-      ...(outlineLinewidths !== undefined && { linewidths: outlineLinewidths as Float32Array }),
-      alpha: outlineAlphas === undefined ? constantAlpha : 1,
-      ...(outlineAlphas !== undefined && { alphas: outlineAlphas as Float32Array }),
-      ...(typeof literalLinetype === "string" && { linetype: literalLinetype as Linetype }),
-      ...(strokePaintResolved !== undefined && { strokePaint: strokePaintResolved }),
-      ...(outlineLinetypes !== undefined && { linetypeIndexes: outlineLinetypes as Uint8Array }),
+      closed,
+      fullStroke,
+      outlineWidth,
+      constantAlpha,
+      alphas,
+      linewidths,
+      linetypeIndexes,
+      literalLinetype,
       linecap,
       linejoin,
-      curve: "linear",
-      candidates: false,
-    });
+      fillPaintResolved,
+      strokePaintResolved,
+      glowResolved,
+    }),
+  ];
+
+  if (outline !== "full" && hasExplicitColor) {
+    // Open outline batches are presentation-only (no candidate duplication).
+    const open = writeOpenEdges({ frame, fx, orientation, runs, edge: outline, strokeOf });
+    out.push(
+      openRibbonBatch({
+        layerIndex,
+        open,
+        edgeCount: outline === "both" ? 2 : 1,
+        outlineWidth,
+        constantAlpha,
+        alphas,
+        linewidths,
+        linetypeIndexes,
+        literalLinetype,
+        linecap,
+        linejoin,
+        strokePaintResolved,
+      }),
+    );
   }
 
   return out;

--- a/packages/core/src/pipeline/geometry-violin.ts
+++ b/packages/core/src/pipeline/geometry-violin.ts
@@ -28,6 +28,32 @@ function sortRowsByY(rows: number[], y: Float64Array): number[] {
   return rows.toSorted((a, b) => y[a]! - y[b]!);
 }
 
+function sortedViolinGroups(
+  groupRows: readonly number[][],
+  y: Float64Array,
+): {
+  groups: number[][];
+  totalVertices: number;
+} {
+  const groups: number[][] = [];
+  let totalVertices = 0;
+  for (const rows of groupRows) {
+    const sorted = sortRowsByY(rows, y);
+    if (sorted.length < 2) continue;
+    groups.push(sorted);
+    totalVertices += sorted.length * 2;
+  }
+  return { groups, totalVertices };
+}
+
+function violinWidthFraction(fx: Frame, params: ViolinParams): number {
+  const width = params.width ?? DEFAULT_BOXPLOT_WIDTH;
+  const widthFraction = width * (fx.xScale.type === "band" ? fx.xScale.step : 1);
+  return params.width === undefined && fx.xScale.type === "band"
+    ? Math.min(widthFraction, MAX_BOXPLOT_PANEL_FRAC)
+    : widthFraction;
+}
+
 /** Bucket by (x category, group) so each violin is a separate closed path. */
 function bucketViolinRows(
   frame: LayerFrame,
@@ -58,6 +84,86 @@ function bucketViolinRows(
   return order.map((k) => map.get(k)!);
 }
 
+function writeViolinBuffers(input: {
+  frame: LayerFrame;
+  fx: Frame;
+  violinwidth: Float64Array;
+  groups: readonly number[][];
+  totalVertices: number;
+  widthFraction: number;
+  fillPaints: readonly (string | null)[];
+  strokePaints: readonly (string | null)[];
+  fillFallback: string | undefined;
+  strokeFallback: string | undefined;
+}): {
+  positions: Float32Array;
+  rowIndex: Uint32Array;
+  closedFrameRows: Uint32Array;
+  pathOffsets: Uint32Array;
+  fills: (string | null)[];
+  strokes: (string | null)[];
+} {
+  const {
+    frame,
+    fx,
+    violinwidth,
+    groups,
+    totalVertices,
+    widthFraction,
+    fillPaints,
+    strokePaints,
+    fillFallback,
+    strokeFallback,
+  } = input;
+  const positions = new Float32Array(totalVertices * 2);
+  const rowIndex = new Uint32Array(totalVertices);
+  const closedFrameRows = new Uint32Array(totalVertices);
+  const pathOffsets = new Uint32Array(groups.length + 1);
+  const fills: (string | null)[] = [];
+  const strokes: (string | null)[] = [];
+  let cursor = 0;
+  for (let groupIndex = 0; groupIndex < groups.length; groupIndex++) {
+    pathOffsets[groupIndex] = cursor;
+    const rows = groups[groupIndex]!;
+    const first = rows[0]!;
+    let center = positionOf(fx.xScale, frame.xNumeric, frame.xValues, first);
+    let width = widthFraction;
+    if (frame.dodge !== null) {
+      const slotCount = Math.max(1, frame.dodge.slotCounts[first]!);
+      const slot = frame.dodge.slot[first]!;
+      width = widthFraction / slotCount;
+      center += widthFraction * ((slot + 0.5) / slotCount - 0.5);
+    }
+    const centerPx = center * fx.innerWidth;
+    const halfMaxPx = (width / 2) * fx.innerWidth;
+    for (const row of rows) {
+      const y = positionOf(fx.yScale, frame.yNumeric, frame.yValues, row);
+      const half = halfMaxPx * Math.max(0, violinwidth[row]!);
+      positions[cursor * 2] = centerPx + half;
+      positions[cursor * 2 + 1] = fx.innerHeight - y * fx.innerHeight;
+      rowIndex[cursor] = frame.rowIndex[row]!;
+      closedFrameRows[cursor] = row;
+      cursor++;
+    }
+    for (let i = rows.length - 1; i >= 0; i--) {
+      const row = rows[i]!;
+      const y = positionOf(fx.yScale, frame.yNumeric, frame.yValues, row);
+      const half = halfMaxPx * Math.max(0, violinwidth[row]!);
+      positions[cursor * 2] = centerPx - half;
+      positions[cursor * 2 + 1] = fx.innerHeight - y * fx.innerHeight;
+      rowIndex[cursor] = frame.rowIndex[row]!;
+      closedFrameRows[cursor] = row;
+      cursor++;
+    }
+    fills.push(fillPaints[groupIndex] ?? fillFallback ?? null);
+    let stroke = strokePaints[groupIndex]!;
+    if (stroke === null && strokeFallback !== undefined) stroke = strokeFallback;
+    strokes.push(stroke);
+  }
+  pathOffsets[groups.length] = cursor;
+  return { positions, rowIndex, closedFrameRows, pathOffsets, fills, strokes };
+}
+
 export function violinBatch(
   frame: LayerFrame,
   fx: Frame,
@@ -76,12 +182,8 @@ export function violinBatch(
   if (groupRows.length === 0) return null;
 
   const params = (binding.layer.params ?? {}) as ViolinParams;
-  const widthParam = params.width ?? DEFAULT_BOXPLOT_WIDTH;
   // Same band-fraction model as boxplot (normalized units, not px yet).
-  let widthFrac = widthParam * (fx.xScale.type === "band" ? fx.xScale.step : 1);
-  if (params.width === undefined && fx.xScale.type === "band") {
-    widthFrac = Math.min(widthFrac, MAX_BOXPLOT_PANEL_FRAC);
-  }
+  const widthFraction = violinWidthFraction(fx, params);
 
   const paint = layerPaintFromParams(binding.layer.params);
   const fillPaintResolved =
@@ -94,71 +196,25 @@ export function violinBatch(
       : resolveGradientPaint(paint.strokePaint, binding.index, "stroke");
   const glowResolved = paint.glow === null ? undefined : resolveGlow(paint.glow, binding.index);
 
-  const sortedGroups: number[][] = [];
-  let total = 0;
-  for (const rows of groupRows) {
-    const sorted = sortRowsByY(rows, y);
-    if (sorted.length < 2) continue;
-    sortedGroups.push(sorted);
-    total += sorted.length * 2;
-  }
+  const { groups: sortedGroups, totalVertices } = sortedViolinGroups(groupRows, y);
   if (sortedGroups.length === 0) return null;
 
-  const positions = new Float32Array(total * 2);
-  const rowIndex = new Uint32Array(total);
-  const closedFrameRows = new Uint32Array(total);
-  const pathOffsets = new Uint32Array(sortedGroups.length + 1);
-  const fills: (string | null)[] = [];
-  const strokes: (string | null)[] = [];
   // One fill/stroke paint vector for all violins (#1309).
   const styleRows = sortedGroups.map((rows) => rows[0]!);
   const fillPaints = areaGroupFillsOf(frame, fill, styleRows);
   const strokePaints = paintVector(frame, "color", color, styleRows);
-  let cursor = 0;
-
-  for (let s = 0; s < sortedGroups.length; s++) {
-    pathOffsets[s] = cursor;
-    const rows = sortedGroups[s]!;
-    const first = rows[0]!;
-    let center = positionOf(fx.xScale, frame.xNumeric, frame.xValues, first);
-    let w = widthFrac;
-    if (frame.dodge !== null) {
-      const slotCount = Math.max(1, frame.dodge.slotCounts[first]!);
-      const slot = frame.dodge.slot[first]!;
-      w = widthFrac / slotCount;
-      center = center + widthFrac * ((slot + 0.5) / slotCount - 0.5);
-    }
-    const centerPx = center * fx.innerWidth;
-    const halfMaxPx = (w / 2) * fx.innerWidth;
-
-    // Right edge ascending in y, then left edge descending → closed violin.
-    for (const row of rows) {
-      const ty = positionOf(fx.yScale, frame.yNumeric, frame.yValues, row);
-      const half = halfMaxPx * Math.max(0, violinwidth[row]!);
-      positions[cursor * 2] = centerPx + half;
-      positions[cursor * 2 + 1] = fx.innerHeight - ty * fx.innerHeight;
-      rowIndex[cursor] = frame.rowIndex[row]!;
-      closedFrameRows[cursor] = row;
-      cursor++;
-    }
-    for (let i = rows.length - 1; i >= 0; i--) {
-      const row = rows[i]!;
-      const ty = positionOf(fx.yScale, frame.yNumeric, frame.yValues, row);
-      const half = halfMaxPx * Math.max(0, violinwidth[row]!);
-      positions[cursor * 2] = centerPx - half;
-      positions[cursor * 2 + 1] = fx.innerHeight - ty * fx.innerHeight;
-      rowIndex[cursor] = frame.rowIndex[row]!;
-      closedFrameRows[cursor] = row;
-      cursor++;
-    }
-    fills.push(fillPaints[s] ?? fillPaintResolved?.fallback ?? null);
-    let stroke = strokePaints[s]!;
-    if (stroke === null && strokePaintResolved !== undefined) {
-      stroke = strokePaintResolved.fallback;
-    }
-    strokes.push(stroke);
-  }
-  pathOffsets[sortedGroups.length] = cursor;
+  const { positions, rowIndex, closedFrameRows, pathOffsets, fills, strokes } = writeViolinBuffers({
+    frame,
+    fx,
+    violinwidth,
+    groups: sortedGroups,
+    totalVertices,
+    widthFraction,
+    fillPaints,
+    strokePaints,
+    fillFallback: fillPaintResolved?.fallback,
+    strokeFallback: strokePaintResolved?.fallback,
+  });
 
   const mappedAlphas = numericStyleVector(frame, "alpha", styleRows, styles);
   const subpathCount = pathOffsets.length - 1;
@@ -174,9 +230,9 @@ export function violinBatch(
     kind: "paths",
     layerIndex: binding.index,
     panelIndex: 0,
-    positions: positions.subarray(0, cursor * 2).slice(),
-    rowIndex: rowIndex.subarray(0, cursor).slice(),
-    closedFrameRows: closedFrameRows.subarray(0, cursor).slice(),
+    positions,
+    rowIndex,
+    closedFrameRows,
     pathOffsets,
     strokes,
     fills,


### PR DESCRIPTION
## Summary
- enforce cyclomatic complexity max 20 for violin and ribbon geometry
- extract focused grouping, finite-run scanning, and violin buffer writers
- split ribbon batch-object assembly into a dedicated under-500-line module

## Validation
- `bun run test` (5068 pass, 4 skip)
- focused ribbon/violin tests (43 pass)
- `bun run check`
- `bun run lint:type-aware`
- `bun run knip`
- `pre-commit run --all-files --show-diff-on-failure`

## Benchmark
Captured all 40 workloads before edits. The first comparison flagged transform-log10 smooth, so publication stopped for reversed A/B. The result flipped: smooth measured 14.24 ms on this branch versus 18.13 ms baseline, while density varied independently. This indicates run-order/system noise rather than a coherent regression.