### PR TITLE
refactor(core): enforce complexity in range geometry

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -157,6 +157,12 @@
       }
     },
     {
+      "files": ["packages/core/src/pipeline/geometry-range.ts"],
+      "rules": {
+        "eslint/complexity": ["error", { "max": 20 }]
+      }
+    },
+    {
       // Tests + benchmarks: fixture literals are cast deliberately (invalid
       // specs, RuntimeSpec shapes) and test files run long by design.
       "files": ["**/tests/**", "benchmarks/**"],

--- a/packages/core/src/pipeline/geometry-range.ts
+++ b/packages/core/src/pipeline/geometry-range.ts
@@ -8,6 +8,7 @@ import type { CrossbarParams, ErrorbarParams, PointrangeParams } from "@ggsvelte
 
 import type { GeometryBatch, PointsBatch, RectsBatch, SegmentsBatch } from "../scene.js";
 import { linetypeIndex, pointShapeIndex, type Linetype, type PointShape } from "../scales/style.js";
+import type { ContinuousScale } from "../scales/train.js";
 
 import type { LayerFrame, PipelineWarning, ResolvedColorScale } from "./types.js";
 import type { Frame } from "./geometry-shared.js";
@@ -73,6 +74,295 @@ function packStrokeBatch(
   return batch;
 }
 
+function collectMidPoints(
+  frame: LayerFrame,
+  fx: Frame,
+): { positions: Float32Array; rowIndex: Uint32Array; styleRows: Uint32Array; kept: number } {
+  const { n } = frame;
+  const positions = new Float32Array(n * 2);
+  const rowIndex = new Uint32Array(n);
+  const styleRows = new Uint32Array(n);
+  let kept = 0;
+  for (let row = 0; row < n; row++) {
+    const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row);
+    const ty =
+      frame.yNumeric !== null || frame.yValues !== null
+        ? positionOf(fx.yScale, frame.yNumeric, frame.yValues, row)
+        : NaN;
+    const t0 = fx.yScale.type === "band" ? NaN : fx.yScale.normalizeTransformed(frame.ymin![row]!);
+    const t1 = fx.yScale.type === "band" ? NaN : fx.yScale.normalizeTransformed(frame.ymax![row]!);
+    if (
+      Number.isNaN(tx) ||
+      Number.isNaN(ty) ||
+      t0 === undefined ||
+      t1 === undefined ||
+      Number.isNaN(t0) ||
+      Number.isNaN(t1)
+    ) {
+      continue;
+    }
+    const offset = kept * 2;
+    positions[offset] = tx * fx.innerWidth;
+    positions[offset + 1] = fx.innerHeight - ty * fx.innerHeight;
+    rowIndex[kept] = frame.rowIndex[row]!;
+    styleRows[kept] = row;
+    kept++;
+  }
+  return { positions, rowIndex, styleRows, kept };
+}
+
+type SegmentBuffers = {
+  segments: Float32Array;
+  rowIndex: Uint32Array;
+  styleRows: Uint32Array;
+  kept: number;
+  removed: number;
+};
+
+function collectLineRange(frame: LayerFrame, fx: Frame, yScale: ContinuousScale): SegmentBuffers {
+  const { n } = frame;
+  const segments = new Float32Array(n * 4);
+  const rowIndex = new Uint32Array(n);
+  const styleRows = new Uint32Array(n);
+  let kept = 0;
+  let removed = 0;
+  for (let row = 0; row < n; row++) {
+    const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row);
+    const t0 = yScale.normalizeTransformed(frame.ymin![row]!);
+    const t1 = yScale.normalizeTransformed(frame.ymax![row]!);
+    if (
+      Number.isNaN(tx) ||
+      t0 === undefined ||
+      t1 === undefined ||
+      Number.isNaN(t0) ||
+      Number.isNaN(t1)
+    ) {
+      removed++;
+      continue;
+    }
+    const offset = kept * 4;
+    const cx = tx * fx.innerWidth;
+    segments[offset] = cx;
+    segments[offset + 1] = fx.innerHeight - t0 * fx.innerHeight;
+    segments[offset + 2] = cx;
+    segments[offset + 3] = fx.innerHeight - t1 * fx.innerHeight;
+    rowIndex[kept] = frame.rowIndex[row]!;
+    styleRows[kept] = row;
+    kept++;
+  }
+  return { segments, rowIndex, styleRows, kept, removed };
+}
+
+type CrossbarBuffers = {
+  rects: Float32Array;
+  rectRows: Uint32Array;
+  rectStyle: Uint32Array;
+  segs: Float32Array;
+  segRows: Uint32Array;
+  segStyle: Uint32Array;
+  kept: number;
+  removed: number;
+};
+
+function collectCrossbar(
+  frame: LayerFrame,
+  fx: Frame,
+  yScale: ContinuousScale,
+  xSpanOf: (row: number, tx: number) => readonly [number, number],
+): CrossbarBuffers {
+  const { n } = frame;
+  const rects = new Float32Array(n * 4);
+  const rectRows = new Uint32Array(n);
+  const rectStyle = new Uint32Array(n);
+  const segs = new Float32Array(n * 4);
+  const segRows = new Uint32Array(n);
+  const segStyle = new Uint32Array(n);
+  let kept = 0;
+  let removed = 0;
+  for (let row = 0; row < n; row++) {
+    const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row);
+    const t0 = yScale.normalizeTransformed(frame.ymin![row]!);
+    const t1 = yScale.normalizeTransformed(frame.ymax![row]!);
+    const ty = positionOf(fx.yScale, frame.yNumeric, frame.yValues, row);
+    if (
+      Number.isNaN(tx) ||
+      t0 === undefined ||
+      t1 === undefined ||
+      Number.isNaN(t0) ||
+      Number.isNaN(t1) ||
+      Number.isNaN(ty)
+    ) {
+      removed++;
+      continue;
+    }
+    const [x0n, x1n] = xSpanOf(row, tx);
+    if (!Number.isFinite(x0n) || !Number.isFinite(x1n)) {
+      removed++;
+      continue;
+    }
+    const px0 = Math.min(x0n, x1n) * fx.innerWidth;
+    const px1 = Math.max(x0n, x1n) * fx.innerWidth;
+    const yTop = fx.innerHeight - Math.max(t0, t1) * fx.innerHeight;
+    const yBot = fx.innerHeight - Math.min(t0, t1) * fx.innerHeight;
+    const midY = fx.innerHeight - ty * fx.innerHeight;
+    const offset = kept * 4;
+    rects[offset] = px0;
+    rects[offset + 1] = yTop;
+    rects[offset + 2] = Math.max(px1 - px0, 0);
+    rects[offset + 3] = Math.max(yBot - yTop, 0);
+    rectRows[kept] = frame.rowIndex[row]!;
+    rectStyle[kept] = row;
+    segs[offset] = px0;
+    segs[offset + 1] = midY;
+    segs[offset + 2] = px1;
+    segs[offset + 3] = midY;
+    segRows[kept] = frame.rowIndex[row]!;
+    segStyle[kept] = row;
+    kept++;
+  }
+  return { rects, rectRows, rectStyle, segs, segRows, segStyle, kept, removed };
+}
+
+function buildCrossbarRectBatch(input: {
+  frame: LayerFrame;
+  styles: ResolvedStyleScales;
+  rects: Float32Array;
+  rowIndex: Uint32Array;
+  styleRows: Uint32Array;
+  params: CrossbarParams;
+  fills: string[] | null;
+  strokes: string[] | null;
+}): RectsBatch {
+  const { frame, styles, rects, rowIndex, styleRows, params, fills, strokes } = input;
+  const { binding } = frame;
+  const strokeWidth = constantStyle(binding, params, "linewidth", DEFAULT_RULE_LINEWIDTH);
+  const hasFill =
+    binding.fill.constant !== null ||
+    binding.fill.field !== null ||
+    binding.fill.scaledConstant !== null ||
+    fills !== null;
+  const batch: RectsBatch = {
+    kind: "rects",
+    layerIndex: binding.index,
+    panelIndex: 0,
+    rects,
+    rowIndex,
+    fill: binding.fill.constant,
+    ...(hasFill ? {} : { fillRole: "paper" as const }),
+    alpha: constantStyle(binding, params, "alpha", 1),
+    stroke: binding.color.constant,
+    strokeWidth,
+    anchor: "center",
+  };
+  const alphas = numericStyleVector(frame, "alpha", styleRows, styles);
+  if (alphas !== undefined) {
+    batch.alpha = 1;
+    batch.alphas = alphas;
+  }
+  if (fills !== null) batch.fills = fills;
+  if (strokes !== null) batch.strokes = strokes;
+  const linewidths = numericStyleVector(frame, "linewidth", styleRows, styles);
+  if (linewidths !== undefined) batch.strokeWidths = linewidths;
+  if (typeof binding.linetype?.constant === "string") {
+    batch.linetype = binding.linetype.constant as Linetype;
+  }
+  const linetypeIndexes = indexedStyleVector(frame, "linetype", styleRows, styles, (value) =>
+    linetypeIndex(value as Linetype),
+  );
+  if (linetypeIndexes !== undefined) batch.linetypeIndexes = linetypeIndexes;
+  return batch;
+}
+
+function buildMidPointBatch(input: {
+  frame: LayerFrame;
+  styles: ResolvedStyleScales;
+  positions: Float32Array;
+  rowIndex: Uint32Array;
+  styleRows: Uint32Array;
+  params: PointrangeParams;
+  colors: string[] | null;
+}): PointsBatch {
+  const { frame, styles, positions, rowIndex, styleRows, params, colors } = input;
+  const { binding } = frame;
+  const batch: PointsBatch = {
+    kind: "points",
+    layerIndex: binding.index,
+    panelIndex: 0,
+    positions,
+    rowIndex,
+    size:
+      typeof binding.size?.constant === "number"
+        ? binding.size.constant
+        : (params.size ?? DEFAULT_POINT_SIZE),
+    alpha: constantStyle(binding, params, "alpha", 1),
+    shape:
+      typeof binding.shape?.constant === "string"
+        ? (binding.shape.constant as PointShape)
+        : (params.shape ?? "circle"),
+    fill: binding.color.constant,
+  };
+  const sizes = numericStyleVector(frame, "size", styleRows, styles);
+  const alphas = numericStyleVector(frame, "alpha", styleRows, styles);
+  const shapeIndexes = indexedStyleVector(frame, "shape", styleRows, styles, (value) =>
+    pointShapeIndex(value as PointShape),
+  );
+  if (sizes !== undefined) batch.sizes = sizes;
+  if (alphas !== undefined) {
+    batch.alpha = 1;
+    batch.alphas = alphas;
+  }
+  if (shapeIndexes !== undefined) batch.shapeIndexes = shapeIndexes;
+  if (colors !== null) batch.colors = colors;
+  return batch;
+}
+
+function buildCrossbarBatches(input: {
+  frame: LayerFrame;
+  styles: ResolvedStyleScales;
+  params: CrossbarParams;
+  color: ResolvedColorScale | null;
+  fill: ResolvedColorScale | null;
+  fatten: number;
+  wantsStroke: boolean;
+  wantsFill: boolean;
+  buffers: CrossbarBuffers;
+}): GeometryBatch[] {
+  const { frame, styles, params, color, fill, fatten, wantsStroke, wantsFill, buffers } = input;
+  const { n } = frame;
+  const { rects, rectRows, rectStyle, segs, segRows, segStyle, kept } = buffers;
+  const outRects = kept === n ? rects : rects.subarray(0, kept * 4).slice();
+  const outRectRows = kept === n ? rectRows : rectRows.subarray(0, kept).slice();
+  const outRectStyle = kept === n ? rectStyle : rectStyle.subarray(0, kept).slice();
+  const outSegs = kept === n ? segs : segs.subarray(0, kept * 4).slice();
+  const outSegRows = kept === n ? segRows : segRows.subarray(0, kept).slice();
+  const outSegStyle = kept === n ? segStyle : segStyle.subarray(0, kept).slice();
+  const outFills =
+    wantsFill && fill !== null ? mappedPaintVector(frame, "fill", fill, outRectStyle) : null;
+  const outStrokes =
+    wantsStroke && color !== null ? mappedPaintVector(frame, "color", color, outRectStyle) : null;
+  const rectBatch = buildCrossbarRectBatch({
+    frame,
+    styles,
+    rects: outRects,
+    rowIndex: outRectRows,
+    styleRows: outRectStyle,
+    params,
+    fills: outFills,
+    strokes: outStrokes,
+  });
+  const mid = packStrokeBatch(
+    frame,
+    styles,
+    outSegs,
+    outSegRows,
+    outSegStyle,
+    outStrokes,
+    params,
+    fatten,
+  );
+  return [rectBatch, mid];
+}
+
 /** Vertical stem only — one segment per kept row. */
 export function linerangeBatch(
   frame: LayerFrame,
@@ -87,38 +377,8 @@ export function linerangeBatch(
   const wantsColors =
     color !== null && (frame.colorValues !== null || binding.color.scaledConstant !== null);
 
-  const segments = new Float32Array(n * 4);
-  const rowIndex = new Uint32Array(n);
-  const styleRows = new Uint32Array(n);
-  let kept = 0;
-  let removed = 0;
-
-  for (let row = 0; row < n; row++) {
-    const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row);
-    const t0 = fx.yScale.normalizeTransformed(frame.ymin[row]!);
-    const t1 = fx.yScale.normalizeTransformed(frame.ymax[row]!);
-    if (
-      Number.isNaN(tx) ||
-      t0 === undefined ||
-      t1 === undefined ||
-      Number.isNaN(t0) ||
-      Number.isNaN(t1)
-    ) {
-      removed++;
-      continue;
-    }
-    const cx = tx * fx.innerWidth;
-    const y0 = fx.innerHeight - t0 * fx.innerHeight;
-    const y1 = fx.innerHeight - t1 * fx.innerHeight;
-    const so = kept * 4;
-    segments[so] = cx;
-    segments[so + 1] = y0;
-    segments[so + 2] = cx;
-    segments[so + 3] = y1;
-    rowIndex[kept] = frame.rowIndex[row]!;
-    styleRows[kept] = row;
-    kept++;
-  }
+  const collected = collectLineRange(frame, fx, fx.yScale);
+  const { segments, rowIndex, styleRows, kept, removed } = collected;
 
   removedWarning(removed, binding.index, warnings);
   if (kept === 0) return null;
@@ -155,78 +415,31 @@ function midPointsBatch(
   if (frame.yNumeric === null && frame.yValues === null) return null;
   // Same band/ymin/ymax gate as linerangeBatch — continuous interval only.
   if (frame.ymin === null || frame.ymax === null || fx.yScale.type === "band") return null;
-  const yScale = fx.yScale;
   const { binding, n } = frame;
   const params = (binding.layer.params ?? {}) as PointrangeParams;
   const wantsColors =
     color !== null && (frame.colorValues !== null || binding.color.scaledConstant !== null);
 
-  const positions = new Float32Array(n * 2);
-  const rowIndex = new Uint32Array(n);
-  const styleRows = new Uint32Array(n);
-  let kept = 0;
-
-  for (let row = 0; row < n; row++) {
-    const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row);
-    const ty = positionOf(fx.yScale, frame.yNumeric, frame.yValues, row);
-    // Match linerangeBatch: drop when interval bounds are missing so a
-    // pointrange never draws a floating mid point without a stem.
-    const t0 = yScale.normalizeTransformed(frame.ymin[row]!);
-    const t1 = yScale.normalizeTransformed(frame.ymax[row]!);
-    if (
-      Number.isNaN(tx) ||
-      Number.isNaN(ty) ||
-      t0 === undefined ||
-      t1 === undefined ||
-      Number.isNaN(t0) ||
-      Number.isNaN(t1)
-    ) {
-      continue;
-    }
-    const o = kept * 2;
-    positions[o] = tx * fx.innerWidth;
-    positions[o + 1] = fx.innerHeight - ty * fx.innerHeight;
-    rowIndex[kept] = frame.rowIndex[row]!;
-    styleRows[kept] = row;
-    kept++;
-  }
+  // Match linerangeBatch: drop missing interval bounds so a pointrange never
+  // draws a floating mid point without a stem.
+  const collected = collectMidPoints(frame, fx);
+  const { positions, rowIndex, styleRows, kept } = collected;
   if (kept === 0) return null;
 
   const outPos = kept === n ? positions : positions.subarray(0, kept * 2).slice();
   const outRows = kept === n ? rowIndex : rowIndex.subarray(0, kept).slice();
   const outStyle = kept === n ? styleRows : styleRows.subarray(0, kept).slice();
-  const batch: PointsBatch = {
-    kind: "points",
-    layerIndex: binding.index,
-    panelIndex: 0,
+  const colors =
+    wantsColors && color !== null ? mappedPaintVector(frame, "color", color, outStyle) : null;
+  return buildMidPointBatch({
+    frame,
+    styles,
     positions: outPos,
     rowIndex: outRows,
-    size:
-      typeof binding.size?.constant === "number"
-        ? binding.size.constant
-        : (params.size ?? DEFAULT_POINT_SIZE),
-    alpha: constantStyle(binding, params, "alpha", 1),
-    shape:
-      typeof binding.shape?.constant === "string"
-        ? (binding.shape.constant as PointShape)
-        : (params.shape ?? "circle"),
-    fill: binding.color.constant,
-  };
-  const sizes = numericStyleVector(frame, "size", outStyle, styles);
-  const alphas = numericStyleVector(frame, "alpha", outStyle, styles);
-  const shapeIndexes = indexedStyleVector(frame, "shape", outStyle, styles, (value) =>
-    pointShapeIndex(value as PointShape),
-  );
-  if (sizes !== undefined) batch.sizes = sizes;
-  if (alphas !== undefined) {
-    batch.alpha = 1;
-    batch.alphas = alphas;
-  }
-  if (shapeIndexes !== undefined) batch.shapeIndexes = shapeIndexes;
-  if (wantsColors && color !== null) {
-    batch.colors = mappedPaintVector(frame, "color", color, outStyle);
-  }
-  return batch;
+    styleRows: outStyle,
+    params,
+    colors,
+  });
 }
 
 /** Crossbar: vertical box (ymin–ymax × width) + mid horizontal line at y. */
@@ -239,7 +452,7 @@ export function crossbarBatches(
   warnings: PipelineWarning[],
 ): GeometryBatch[] {
   if (frame.ymin === null || frame.ymax === null || fx.yScale.type === "band") return [];
-  const { binding, n } = frame;
+  const { binding } = frame;
   const params = (binding.layer.params ?? {}) as CrossbarParams;
   const widthParam = params.width ?? DEFAULT_WIDTH;
   const fatten =
@@ -252,133 +465,21 @@ export function crossbarBatches(
   const wantsFill =
     fill !== null && (frame.fillValues !== null || binding.fill.scaledConstant !== null);
 
-  // Rect: 1 per row (x0,y0,x1,y1 packed as left,top,right,bottom in pixel space)
-  const rects = new Float32Array(n * 4);
-  const rectRows = new Uint32Array(n);
-  const rectStyle = new Uint32Array(n);
-  // Mid line: 1 segment per row
-  const segs = new Float32Array(n * 4);
-  const segRows = new Uint32Array(n);
-  const segStyle = new Uint32Array(n);
-
-  let kept = 0;
-  let removed = 0;
-
-  for (let row = 0; row < n; row++) {
-    const tx = positionOf(fx.xScale, frame.xNumeric, frame.xValues, row);
-    const t0 = fx.yScale.normalizeTransformed(frame.ymin[row]!);
-    const t1 = fx.yScale.normalizeTransformed(frame.ymax[row]!);
-    const ty =
-      frame.yNumeric !== null || frame.yValues !== null
-        ? positionOf(fx.yScale, frame.yNumeric, frame.yValues, row)
-        : NaN;
-    if (
-      Number.isNaN(tx) ||
-      t0 === undefined ||
-      t1 === undefined ||
-      Number.isNaN(t0) ||
-      Number.isNaN(t1) ||
-      Number.isNaN(ty)
-    ) {
-      removed++;
-      continue;
-    }
-    const [x0n, x1n] = xSpanOf(row, tx);
-    if (!Number.isFinite(x0n) || !Number.isFinite(x1n)) {
-      removed++;
-      continue;
-    }
-    const px0 = Math.min(x0n, x1n) * fx.innerWidth;
-    const px1 = Math.max(x0n, x1n) * fx.innerWidth;
-    const yTop = fx.innerHeight - Math.max(t0, t1) * fx.innerHeight;
-    const yBot = fx.innerHeight - Math.min(t0, t1) * fx.innerHeight;
-    const midY = fx.innerHeight - ty * fx.innerHeight;
-    const wPx = Math.max(px1 - px0, 0);
-    const hPx = Math.max(yBot - yTop, 0);
-
-    const ro = kept * 4;
-    // RectsBatch packs x, y, width, height (top-left origin).
-    rects[ro] = px0;
-    rects[ro + 1] = yTop;
-    rects[ro + 2] = wPx;
-    rects[ro + 3] = hPx;
-    rectRows[kept] = frame.rowIndex[row]!;
-    rectStyle[kept] = row;
-
-    segs[ro] = px0;
-    segs[ro + 1] = midY;
-    segs[ro + 2] = px1;
-    segs[ro + 3] = midY;
-    segRows[kept] = frame.rowIndex[row]!;
-    segStyle[kept] = row;
-    kept++;
-  }
+  const collected = collectCrossbar(frame, fx, fx.yScale, xSpanOf);
+  const { kept, removed } = collected;
 
   removedWarning(removed, binding.index, warnings);
   if (kept === 0) return [];
 
-  const outRects = kept === n ? rects : rects.subarray(0, kept * 4).slice();
-  const outRectRows = kept === n ? rectRows : rectRows.subarray(0, kept).slice();
-  const outRectStyle = kept === n ? rectStyle : rectStyle.subarray(0, kept).slice();
-  const outSegs = kept === n ? segs : segs.subarray(0, kept * 4).slice();
-  const outSegRows = kept === n ? segRows : segRows.subarray(0, kept).slice();
-  const outSegStyle = kept === n ? segStyle : segStyle.subarray(0, kept).slice();
-
-  const strokeWidth = constantStyle(binding, params, "linewidth", DEFAULT_RULE_LINEWIDTH);
-  const outFills =
-    wantsFill && fill !== null ? mappedPaintVector(frame, "fill", fill, outRectStyle) : null;
-  const outStrokes =
-    wantsStroke && color !== null ? mappedPaintVector(frame, "color", color, outRectStyle) : null;
-  // ggplot2 geom_crossbar defaults fill = NA (outlined box). Match boxplot
-  // body: paper fillRole when no fill is mapped/constant.
-  const hasFill =
-    binding.fill.constant !== null ||
-    binding.fill.field !== null ||
-    binding.fill.scaledConstant !== null ||
-    outFills !== null;
-  const rectBatch: RectsBatch = {
-    kind: "rects",
-    layerIndex: binding.index,
-    panelIndex: 0,
-    rects: outRects,
-    rowIndex: outRectRows,
-    fill: binding.fill.constant,
-    ...(hasFill ? {} : { fillRole: "paper" as const }),
-    alpha: constantStyle(binding, params, "alpha", 1),
-    stroke: binding.color.constant,
-    strokeWidth,
-    anchor: "center",
-  };
-  const alphas = numericStyleVector(frame, "alpha", outRectStyle, styles);
-  if (alphas !== undefined) {
-    rectBatch.alpha = 1;
-    rectBatch.alphas = alphas;
-  }
-  if (outFills !== null) rectBatch.fills = outFills;
-  if (outStrokes !== null) rectBatch.strokes = outStrokes;
-  // Mapped linewidth/linetype must style the box outline as well as the mid
-  // line (STYLE_AESTHETIC_GEOMS enrolls crossbar on both).
-  const linewidths = numericStyleVector(frame, "linewidth", outRectStyle, styles);
-  if (linewidths !== undefined) rectBatch.strokeWidths = linewidths;
-  if (typeof binding.linetype?.constant === "string") {
-    rectBatch.linetype = binding.linetype.constant as Linetype;
-  }
-  const linetypeIndexes = indexedStyleVector(frame, "linetype", outRectStyle, styles, (value) =>
-    linetypeIndex(value as Linetype),
-  );
-  if (linetypeIndexes !== undefined) rectBatch.linetypeIndexes = linetypeIndexes;
-
-  const mid = packStrokeBatch(
+  return buildCrossbarBatches({
     frame,
     styles,
-    outSegs,
-    outSegRows,
-    outSegStyle,
-    outStrokes,
     params,
+    color,
+    fill,
     fatten,
-  );
-
-  // Draw order: box first, mid line on top (single layerIndex).
-  return [rectBatch, mid];
+    wantsStroke,
+    wantsFill,
+    buffers: collected,
+  });
 }


### PR DESCRIPTION
Enforce oxlint complexity max 20 for pipeline geometry-range.

Extract row collection and batch styling helpers while preserving linerange, pointrange, and crossbar behavior.

Validation: full test suite, type-aware lint, formatting, knip, and benchmark A/B.