### PR TITLE
refactor(core): enforce complexity in small helpers

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -169,6 +169,17 @@
       }
     },
     {
+      "files": [
+        "packages/core/src/pipeline/frame-identity.ts",
+        "packages/core/src/pipeline/position-jitter.ts",
+        "packages/core/src/table-coerce.ts",
+        "packages/core/src/semantic-viewport.ts"
+      ],
+      "rules": {
+        "eslint/complexity": ["error", { "max": 20 }]
+      }
+    },
+    {
       // Tests + benchmarks: fixture literals are cast deliberately (invalid
       // specs, RuntimeSpec shapes) and test files run long by design.
       "files": ["**/tests/**", "benchmarks/**"],

--- a/packages/core/src/pipeline/frame-identity.ts
+++ b/packages/core/src/pipeline/frame-identity.ts
@@ -4,6 +4,7 @@
 import type { SpokeParams } from "@ggsvelte/spec";
 
 import type { ColumnTable } from "../table.js";
+import type { CellValue } from "../table-types.js";
 
 import { spokeEndpoints } from "../stats/spoke.js";
 import { binIdColumn, snapColumnToBins, type BinnedBoundaries } from "./binned-scale.js";
@@ -75,6 +76,10 @@ function spokeAngleRadius(
   return { angle, radius };
 }
 
+function columnOrNull(table: ColumnTable, field: string | null): readonly CellValue[] | null {
+  return field === null ? null : table.column(field);
+}
+
 export function buildIdentityFrame(
   binding: LayerBinding,
   table: ColumnTable,
@@ -117,15 +122,14 @@ export function buildIdentityFrame(
       for (let i = 0; i < n; i++) rows[i] = i;
       return rows;
     })(),
-    colorValues: binding.color.field === null ? null : table.column(binding.color.field),
-    fillValues: binding.fill.field === null ? null : table.column(binding.fill.field),
-    sizeValues: binding.size.field === null ? null : table.column(binding.size.field),
-    linewidthValues:
-      binding.linewidth.field === null ? null : table.column(binding.linewidth.field),
-    alphaValues: binding.alpha.field === null ? null : table.column(binding.alpha.field),
-    shapeValues: binding.shape.field === null ? null : table.column(binding.shape.field),
-    linetypeValues: binding.linetype.field === null ? null : table.column(binding.linetype.field),
-    labelValues: binding.labelField === null ? null : table.column(binding.labelField),
+    colorValues: columnOrNull(table, binding.color.field),
+    fillValues: columnOrNull(table, binding.fill.field),
+    sizeValues: columnOrNull(table, binding.size.field),
+    linewidthValues: columnOrNull(table, binding.linewidth.field),
+    alphaValues: columnOrNull(table, binding.alpha.field),
+    shapeValues: columnOrNull(table, binding.shape.field),
+    linetypeValues: columnOrNull(table, binding.linetype.field),
+    labelValues: columnOrNull(table, binding.labelField),
     ...emptyFrameExtras(),
     bin: (() => {
       const xId =

--- a/packages/core/src/pipeline/position-jitter.ts
+++ b/packages/core/src/pipeline/position-jitter.ts
@@ -10,38 +10,19 @@ import { minBinWidth } from "./binned-scale.js";
 import { positionDiscreteness } from "./temporal-position.js";
 import type { Advisory, LayerFrame } from "./types.js";
 
-/** Apply jitter/nudge for point and text layers. Returns true when handled. */
-export function applyPointTextPosition(
+function applyJitterPosition(
   frame: LayerFrame,
   advisories: Advisory[],
   table: ColumnTable,
-): boolean {
+  params: PositionParams,
+): void {
   const { binding } = frame;
-  const layer = binding.layer;
-  const geom = layer.geom;
-  if (geom !== "point" && geom !== "count" && geom !== "text" && geom !== "label") return false;
-
-  const position = layer.position ?? "identity";
-  if (position === "identity") return true;
-  const params: PositionParams = "positionParams" in layer ? (layer.positionParams ?? {}) : {};
-  // Offsets are band-step fractions on discrete axes (resolution 1),
-  // data units on continuous axes.
   const xDiscrete =
     binding.xField !== null &&
     positionDiscreteness(table, binding.xField, binding.xConversion) === "discrete";
   const yDiscrete =
     binding.yField !== null &&
     positionDiscreteness(table, binding.yField, binding.yConversion) === "discrete";
-  if (position === "nudge") {
-    const { dx, dy } = nudgeOffsets(frame.n, params.x ?? 0, params.y ?? 0);
-    frame.offsetX = dx;
-    frame.offsetY = dy;
-    return true;
-  }
-  // jitter (point only, schema-enforced): seeded — deliberate divergence
-  // from ggplot2's random jitter (decision 0010), always surfaced.
-  // Binned axes jitter over the transformed BIN WIDTH (never the integer bin
-  // id, never the collapsed resolution of single-bin snapped centers).
   const xBinDefault =
     binding.xBinning === undefined ? undefined : 0.4 * minBinWidth(binding.xBinning);
   const yBinDefault =
@@ -62,5 +43,28 @@ export function applyPointTextPosition(
     chosen: `deterministic seeded jitter (seed ${params.seed ?? DEFAULT_JITTER_SEED}) — ggplot2 draws new random offsets every render; ggsvelte seeds for reproducibility`,
     howToOverride: `Set positionParams.seed (and width/height) on layer ${binding.index}.`,
   });
+}
+
+/** Apply jitter/nudge for point and text layers. Returns true when handled. */
+export function applyPointTextPosition(
+  frame: LayerFrame,
+  advisories: Advisory[],
+  table: ColumnTable,
+): boolean {
+  const { binding } = frame;
+  const layer = binding.layer;
+  const geom = layer.geom;
+  if (geom !== "point" && geom !== "count" && geom !== "text" && geom !== "label") return false;
+
+  const position = layer.position ?? "identity";
+  if (position === "identity") return true;
+  const params: PositionParams = "positionParams" in layer ? (layer.positionParams ?? {}) : {};
+  if (position === "nudge") {
+    const { dx, dy } = nudgeOffsets(frame.n, params.x ?? 0, params.y ?? 0);
+    frame.offsetX = dx;
+    frame.offsetY = dy;
+    return true;
+  }
+  applyJitterPosition(frame, advisories, table, params);
   return true;
 }

--- a/packages/core/src/semantic-viewport.ts
+++ b/packages/core/src/semantic-viewport.ts
@@ -194,23 +194,13 @@ function bandSpanForKeys(
   return [first!, first!];
 }
 
-function projectedSpan(
+function selectionSpan(
   scale: PositionScale,
-  selection: SemanticViewportAxisSelection | undefined,
-  coord: PanelCoordProjector["x"] | undefined,
+  selection: SemanticViewportAxisSelection,
   bandValuesByKey: ReadonlyMap<string, BandKeyEntry>,
 ): readonly [number, number] {
-  if (selection === undefined) return [0, 1];
-  let first: number | undefined;
-  let last: number | undefined;
   if (selection.kind === "band") {
     if (scale.type !== "band") return [0, 1];
-    // Span is min/max of band centers, expanded by half a step. Centers are
-    // monotone in domain index (including reverse), so track the extreme
-    // indices and normalize only those two values — not every selected key
-    // (#1332). Still one pass over keys: non-contiguous selections can put
-    // extremes anywhere in the list. Never `Math.min(...centers)`: spreading
-    // unbounded keys RangeErrors (same hazard as grouping.ts).
     let minIndex = Infinity;
     let maxIndex = -Infinity;
     let minValue: CellValue | undefined;
@@ -231,19 +221,24 @@ function projectedSpan(
     const c0 = scale.normalize(minValue);
     const c1 = minIndex === maxIndex ? c0 : scale.normalize(maxValue);
     if (c0 === undefined || c1 === undefined) return [0, 1];
-    const minCenter = Math.min(c0, c1);
-    const maxCenter = Math.max(c0, c1);
     const halfStep = scale.step / 2;
-    first = Math.max(0, minCenter - halfStep);
-    last = Math.min(1, maxCenter + halfStep);
-  } else {
-    if (scale.type === "band") return [0, 1];
-    const firstValue = scale.normalize(selection.domain[0]);
-    const lastValue = scale.normalize(selection.domain[1]);
-    if (!Number.isFinite(firstValue) || !Number.isFinite(lastValue)) return [0, 1];
-    first = Math.max(0, Math.min(firstValue, lastValue));
-    last = Math.min(1, Math.max(firstValue, lastValue));
+    return [Math.max(0, Math.min(c0, c1) - halfStep), Math.min(1, Math.max(c0, c1) + halfStep)];
   }
+  if (scale.type === "band") return [0, 1];
+  const first = scale.normalize(selection.domain[0]);
+  const last = scale.normalize(selection.domain[1]);
+  if (!Number.isFinite(first) || !Number.isFinite(last)) return [0, 1];
+  return [Math.max(0, Math.min(first, last)), Math.min(1, Math.max(first, last))];
+}
+
+function projectedSpan(
+  scale: PositionScale,
+  selection: SemanticViewportAxisSelection | undefined,
+  coord: PanelCoordProjector["x"] | undefined,
+  bandValuesByKey: ReadonlyMap<string, BandKeyEntry>,
+): readonly [number, number] {
+  if (selection === undefined) return [0, 1];
+  const [first, last] = selectionSpan(scale, selection, bandValuesByKey);
   const projectedFirst = coord?.projectFraction(first) ?? first;
   const projectedLast = coord?.projectFraction(last) ?? last;
   if (!Number.isFinite(projectedFirst) || !Number.isFinite(projectedLast)) return [0, 1];

--- a/packages/core/src/table-coerce.ts
+++ b/packages/core/src/table-coerce.ts
@@ -40,17 +40,7 @@ export function nonTemporalFieldType(column: readonly CellValue[]): FieldType {
   return "quantitative";
 }
 
-/**
- * Deterministic field type inference. With the temporal runtime installed
- * (full package / tests), uses the shared strict registry. On the lean
- * render path, only ISO-like strings and Date values count as temporal.
- */
-export function inferFieldType(column: readonly CellValue[]): FieldType {
-  const runtime = getTemporalRuntime();
-  if (runtime !== null) {
-    const decision = runtime.parseColumn(column, "auto", {}).decision;
-    return decision.status === "temporal" ? "temporal" : nonTemporalFieldType(column);
-  }
+function inferLeanFieldType(column: readonly CellValue[]): FieldType {
   let sawIso = false;
   let sawNonIsoString = false;
   let sawNumber = false;
@@ -79,6 +69,20 @@ export function inferFieldType(column: readonly CellValue[]): FieldType {
   if (sawIso && sawNumber) return "nominal";
   if (sawDate && sawNumber) return "nominal";
   return "quantitative";
+}
+
+/**
+ * Deterministic field type inference. With the temporal runtime installed
+ * (full package / tests), uses the shared strict registry. On the lean
+ * render path, only ISO-like strings and Date values count as temporal.
+ */
+export function inferFieldType(column: readonly CellValue[]): FieldType {
+  const runtime = getTemporalRuntime();
+  if (runtime !== null) {
+    const decision = runtime.parseColumn(column, "auto", {}).decision;
+    return decision.status === "temporal" ? "temporal" : nonTemporalFieldType(column);
+  }
+  return inferLeanFieldType(column);
 }
 
 export function discretenessOf(type: FieldType): Discreteness {


### PR DESCRIPTION
Enforce oxlint complexity max 20 for identity frames, point/text jitter, field inference, and semantic viewport projection.

Extract cohesive helpers while preserving behavior.

Validation: focused tests, core type build, formatting, targeted lint, and benchmark A/B.