### PR TITLE
refactor(core): split small pipeline helpers

### DIFF
--- a/packages/core/src/legend-build-shared.ts
+++ b/packages/core/src/legend-build-shared.ts
@@ -106,9 +106,34 @@ export function legendTitleHeight(title: string, titleSize: number): number {
   return title === "" ? 0 : Math.max(TITLE_HEIGHT, titleSize + TITLE_DESCENDER_GAP);
 }
 
-export function settings(input: LegendInput, position: "right" | "bottom") {
+function legendSettingsMetrics(input: LegendInput): {
+  title: string;
+  titleSize: number;
+  labelSize: number;
+  keySize: number;
+  keyGap: number;
+  rowGap: number;
+  blockGap: number;
+  rampThickness: number;
+  rampLength: number;
+} {
   const appearance = input.appearance;
   const theme = appearance?.theme;
+  return {
+    title: appearance?.title ?? input.title,
+    titleSize: theme?.titleSize ?? FONT_SIZE,
+    labelSize: theme?.labelSize ?? FONT_SIZE,
+    keySize: appearance?.keySize ?? SWATCH_SIZE,
+    keyGap: theme?.keyGap ?? SWATCH_GAP,
+    rowGap: theme?.rowGap ?? 0,
+    blockGap: theme?.blockGap ?? BLOCK_GAP,
+    rampThickness: theme?.colorbarThickness ?? RAMP_WIDTH,
+    rampLength: theme?.colorbarLength ?? HORIZONTAL_RAMP_LENGTH,
+  };
+}
+
+export function settings(input: LegendInput, position: "right" | "bottom") {
+  const appearance = input.appearance;
   const direction =
     appearance?.direction === undefined || appearance.direction === "auto"
       ? position === "bottom"
@@ -119,15 +144,7 @@ export function settings(input: LegendInput, position: "right" | "bottom") {
     appearance,
     position,
     direction,
-    title: appearance?.title ?? input.title,
-    titleSize: theme?.titleSize ?? FONT_SIZE,
-    labelSize: theme?.labelSize ?? FONT_SIZE,
-    keySize: appearance?.keySize ?? SWATCH_SIZE,
-    keyGap: theme?.keyGap ?? SWATCH_GAP,
-    rowGap: theme?.rowGap ?? 0,
-    blockGap: theme?.blockGap ?? BLOCK_GAP,
-    rampThickness: theme?.colorbarThickness ?? RAMP_WIDTH,
-    rampLength: theme?.colorbarLength ?? HORIZONTAL_RAMP_LENGTH,
+    ...legendSettingsMetrics(input),
   } as const;
 }
 

--- a/packages/core/src/pipeline/assemble-geometry-batches.ts
+++ b/packages/core/src/pipeline/assemble-geometry-batches.ts
@@ -81,6 +81,73 @@ function pathLikeGeom(frame: LayerFrame): boolean {
   return PATH_LIKE_GEOMS[geom];
 }
 
+function buildPanelGeometryBatches(input: {
+  frame: LayerFrame;
+  placement: PanelPlacement;
+  panelScale: { x: PositionScale; y: PositionScale };
+  color: ResolvedColorScale | null;
+  fill: ResolvedColorScale | null;
+  styles: ResolvedStyleScales;
+  flip: boolean;
+  projector: PanelCoordProjector | undefined;
+  warnings: PipelineWarning[];
+  panelIndex: number;
+}): GeometryBatch[] {
+  const { frame, placement, panelScale, color, fill, styles, flip, projector, warnings } = input;
+  const joint = projector?.joint === true;
+  const pathLike = joint || pathLikeGeom(frame);
+  const needsPolarScaleRemap =
+    projector !== undefined &&
+    (projector.joint ||
+      !projector.expand ||
+      projector.thetaLimits !== undefined ||
+      projector.rLimits !== undefined);
+  const panelScalesForGeom =
+    projector !== undefined && needsPolarScaleRemap
+      ? scalesForCoordExpand(panelScale, projector.expand, {
+          ...(projector.polarTheta !== undefined && { theta: projector.polarTheta }),
+          ...(projector.thetaLimits !== undefined && { thetaLimits: projector.thetaLimits }),
+          ...(projector.rLimits !== undefined && { rLimits: projector.rLimits }),
+        })
+      : panelScale;
+  const built = buildBatch(
+    frame,
+    geometryPanelFrame(placement, panelScalesForGeom, flip, pathLike ? undefined : projector),
+    color,
+    fill,
+    styles,
+    warnings,
+  );
+  const tessellationBudget = createCoordTessellationBudget(built);
+  let panelBatches: GeometryBatch[] = [];
+  for (const batch of built) {
+    if (flip) flipBatchInPlace(batch, placement.width, placement.height);
+    if (projector !== undefined) {
+      projectGeometryBatch(
+        batch,
+        projector,
+        placement.width,
+        placement.height,
+        warnings,
+        tessellationBudget,
+      );
+    }
+    batch.panelIndex = input.panelIndex;
+    panelBatches.push(batch);
+  }
+  if (projector?.polar !== undefined) {
+    panelBatches = projectPolarGeometryBatches(
+      panelBatches,
+      projector,
+      placement.width,
+      placement.height,
+      warnings,
+      tessellationBudget,
+    );
+  }
+  return panelBatches;
+}
+
 export function buildGeometryBatches(input: {
   layerCount: number;
   facetPanels: readonly FacetPanelDef[];
@@ -112,68 +179,20 @@ export function buildGeometryBatches(input: {
     for (let p = 0; p < facetPanels.length; p++) {
       const frame = panelFrames[p]?.[index];
       if (frame === undefined) continue;
-      const placement = placements[p]!;
-      const projector = coordProjectors[p];
-      const joint = projector?.joint === true;
-      const pathLike = joint || pathLikeGeom(frame);
-      const needsPolarScaleRemap =
-        projector !== undefined &&
-        (projector.joint ||
-          !projector.expand ||
-          projector.thetaLimits !== undefined ||
-          projector.rLimits !== undefined);
-      const panelScalesForGeom =
-        projector !== undefined && needsPolarScaleRemap
-          ? scalesForCoordExpand(panelScales[p]!, projector.expand, {
-              ...(projector.polarTheta !== undefined && { theta: projector.polarTheta }),
-              ...(projector.thetaLimits !== undefined && { thetaLimits: projector.thetaLimits }),
-              ...(projector.rLimits !== undefined && { rLimits: projector.rLimits }),
-            })
-          : panelScales[p]!;
-      const built = buildBatch(
-        frame,
-        // Path topology must retain coordinate-invalid authored/stat vertices
-        // until the post-stat projector can split finite runs without bridging.
-        // Polar is always joint: never early-project through separable axes.
-        geometryPanelFrame(
-          placement,
-          panelScalesForGeom,
+      batches.push(
+        ...buildPanelGeometryBatches({
+          frame,
+          placement: placements[p]!,
+          panelScale: panelScales[p]!,
+          color,
+          fill,
+          styles,
           flip,
-          pathLike || joint ? undefined : projector,
-        ),
-        color,
-        fill,
-        styles,
-        warnings,
-      );
-      const tessellationBudget = createCoordTessellationBudget(built);
-      let panelBatches: GeometryBatch[] = [];
-      for (const batch of built) {
-        if (flip) flipBatchInPlace(batch, placement.width, placement.height);
-        if (projector !== undefined) {
-          projectGeometryBatch(
-            batch,
-            projector,
-            placement.width,
-            placement.height,
-            warnings,
-            tessellationBudget,
-          );
-        }
-        batch.panelIndex = p;
-        panelBatches.push(batch);
-      }
-      if (projector?.polar !== undefined) {
-        panelBatches = projectPolarGeometryBatches(
-          panelBatches,
-          projector,
-          placement.width,
-          placement.height,
+          projector: coordProjectors[p],
           warnings,
-          tessellationBudget,
-        );
-      }
-      batches.push(...panelBatches);
+          panelIndex: p,
+        }),
+      );
     }
   }
   return batches;

--- a/packages/core/src/pipeline/assemble-scene-panels.ts
+++ b/packages/core/src/pipeline/assemble-scene-panels.ts
@@ -95,6 +95,169 @@ function gridPositionsByKind(ticks: readonly SceneTick[]): {
   return { major, minor };
 }
 
+function buildScenePanel(
+  input: {
+    placements: readonly PanelPlacement[];
+    facetPanels: readonly FacetPanelDef[];
+    displayScales: (p: number) => { h: PositionScale; v: PositionScale };
+    coordProjectors: readonly PanelCoordProjector[];
+    axisTextSize: number;
+    strip?: import("./facets-types.js").FacetStripConfig;
+    stripBand?: number;
+    measureText?: TextMeasurer | undefined;
+    stripSize?: number;
+    hAxisTextSize?: number;
+    vAxisTextSize?: number;
+    tickChromePx?: number;
+    yTickChromePx?: number;
+    yLabelsVisible?: boolean;
+    hMinorBreaks?: readonly number[] | undefined;
+    vMinorBreaks?: readonly number[] | undefined;
+    degraded?: boolean;
+  },
+  p: number,
+  measurer: TextMeasurer,
+  stripSize: number,
+): ScenePanel {
+  const placement = input.placements[p]!;
+  const { h, v } = input.displayScales(p);
+  const majorBottom = axisTicks(h, placement.ticksH, placement.width, false);
+  const majorLeft = axisTicks(v, placement.ticksV, placement.height, true);
+  const projector = input.coordProjectors[p];
+  const projectBottom = (tick: SceneTick): SceneTick => ({
+    ...tick,
+    pos:
+      projector === undefined
+        ? tick.pos
+        : projector.x.projectFraction(tick.pos / placement.width) * placement.width,
+  });
+  const projectLeft = (tick: SceneTick): SceneTick => ({
+    ...tick,
+    pos:
+      projector === undefined
+        ? tick.pos
+        : (1 - projector.y.projectFraction(1 - tick.pos / placement.height)) * placement.height,
+  });
+  const projectedBottom = [
+    ...majorBottom,
+    ...numericMinorTicks(h, input.hMinorBreaks, majorBottom, placement.width, false),
+  ]
+    .map((tick) => projectBottom(tick))
+    .filter((tick) => Number.isFinite(tick.pos) && tick.pos >= 0 && tick.pos <= placement.width);
+  const projectedLeft = [
+    ...majorLeft,
+    ...numericMinorTicks(v, input.vMinorBreaks, majorLeft, placement.height, true),
+  ]
+    .map((tick) => projectLeft(tick))
+    .filter((tick) => Number.isFinite(tick.pos) && tick.pos >= 0 && tick.pos <= placement.height);
+  const bottom =
+    projector?.x.active === true
+      ? suppressProjectedLabelOverlap(
+          projectedBottom,
+          "horizontal",
+          measurer,
+          input.hAxisTextSize ?? input.axisTextSize,
+        )
+      : projectedBottom;
+  const left =
+    projector?.y.active === true
+      ? suppressProjectedLabelOverlap(
+          projectedLeft,
+          "vertical",
+          measurer,
+          input.vAxisTextSize ?? input.axisTextSize,
+        )
+      : projectedLeft;
+  const xGrid = gridPositionsByKind(bottom);
+  const yGrid = gridPositionsByKind(left);
+  const label = input.facetPanels[p]!.label;
+  const hasStrip = label !== "";
+  const strip = input.strip!;
+  const stripLabel =
+    hasStrip && strip.show && isSideStrip(strip.position)
+      ? capSideStripLabel(label, placement.height, measurer, stripSize)
+      : label;
+  return {
+    identity: input.facetPanels[p]!.identity,
+    id: input.facetPanels[p]!.id,
+    x: placement.x,
+    y: placement.y,
+    width: placement.width,
+    height: placement.height,
+    strip: stripLabel,
+    ...(hasStrip && {
+      stripPosition: strip.position,
+      showStrip: strip.show,
+      stripBand: strip.show ? input.stripBand : 0,
+    }),
+    ...(placement.allocation !== undefined && { allocation: { ...placement.allocation } }),
+    clip: projector?.clip ?? true,
+    axisX: placement.showAxisX ? bottom : null,
+    axisY: placement.showAxisY ? left : null,
+    grid: {
+      x: xGrid.major,
+      y: yGrid.major,
+      minorX: input.degraded === true ? [] : xGrid.minor,
+      minorY: input.degraded === true ? [] : yGrid.minor,
+    },
+  };
+}
+
+function assembleSceneAxes(input: {
+  scenePanels: readonly ScenePanel[];
+  placements: readonly PanelPlacement[];
+  hTitle: string;
+  vTitle: string;
+  measurer: TextMeasurer;
+  tickChromePx: number;
+  yTickChromePx: number;
+  axisTextSize: number;
+  vAxisTextSize?: number;
+  yLabelsVisible?: boolean;
+}): { xAxis: SceneAxis; yAxis: SceneAxis } {
+  const firstX = input.scenePanels.find((p) => p.axisX !== null);
+  const firstY = input.scenePanels.find((p) => p.axisY !== null);
+  const gap = 10;
+  const bandTitleOffset = input.placements.reduce((max, placement) => {
+    const plan = placement.showAxisX ? placement.hGuidePlan : undefined;
+    if (
+      plan?.bandLabelMode === undefined ||
+      plan.bandLabelMode === "single-line" ||
+      plan.bandLabelBandHeight === undefined
+    ) {
+      return max;
+    }
+    return Math.max(max, input.tickChromePx + plan.bandLabelBandHeight + gap);
+  }, 0);
+  const yLabelsVisible = input.yLabelsVisible !== false;
+  let yLabelBandPx = 0;
+  if (input.vTitle !== "" && yLabelsVisible) {
+    const fontSize = input.vAxisTextSize ?? input.axisTextSize;
+    for (const tick of input.scenePanels.flatMap((panel) => panel.axisY ?? [])) {
+      if (tick.label === "" || tick.showLabel === false) continue;
+      const size = tick.labelSize ?? fontSize;
+      const fragments =
+        tick.lines !== undefined && tick.lines.length > 0 ? tick.lines : [tick.label];
+      for (const fragment of fragments) {
+        yLabelBandPx = Math.max(yLabelBandPx, input.measurer.measureWidth(fragment, size));
+      }
+    }
+  }
+  const yTitleClearance = yLabelBandPx > 0 ? input.yTickChromePx + yLabelBandPx + gap : 0;
+  return {
+    xAxis: {
+      ticks: firstX?.axisX ?? [],
+      title: input.hTitle,
+      ...(bandTitleOffset > 0 && { titleOffset: bandTitleOffset }),
+    },
+    yAxis: {
+      ticks: firstY?.axisY ?? [],
+      title: input.vTitle,
+      ...(yTitleClearance > 32 && { titleOffset: yTitleClearance }),
+    },
+  };
+}
+
 export function assembleScenePanels(input: {
   placements: readonly PanelPlacement[];
   facetPanels: readonly FacetPanelDef[];
@@ -128,151 +291,27 @@ export function assembleScenePanels(input: {
   xAxis: SceneAxis;
   yAxis: SceneAxis;
 } {
-  const { placements, facetPanels, displayScales, hTitle, vTitle, strip, stripBand } = input;
+  const { placements, hTitle, vTitle } = input;
   const measurer = input.measureText ?? new MetricsTableMeasurer(FONT_METRICS);
   const stripSize = input.stripSize ?? 12;
 
-  const scenePanels: ScenePanel[] = placements.map((placement, p) => {
-    const { h, v } = displayScales(p);
-    const majorBottom = axisTicks(h, placement.ticksH, placement.width, false);
-    const majorLeft = axisTicks(v, placement.ticksV, placement.height, true);
-    const projector = input.coordProjectors[p];
-    const projectBottom = (tick: SceneTick): SceneTick => ({
-      ...tick,
-      pos:
-        projector === undefined
-          ? tick.pos
-          : projector.x.projectFraction(tick.pos / placement.width) * placement.width,
-    });
-    const projectLeft = (tick: SceneTick): SceneTick => ({
-      ...tick,
-      pos:
-        projector === undefined
-          ? tick.pos
-          : (1 - projector.y.projectFraction(1 - tick.pos / placement.height)) * placement.height,
-    });
-    const projectedBottom = [
-      ...majorBottom,
-      ...numericMinorTicks(h, input.hMinorBreaks, majorBottom, placement.width, false),
-    ]
-      .map((tick) => projectBottom(tick))
-      .filter((tick) => Number.isFinite(tick.pos) && tick.pos >= 0 && tick.pos <= placement.width);
-    const projectedLeft = [
-      ...majorLeft,
-      ...numericMinorTicks(v, input.vMinorBreaks, majorLeft, placement.height, true),
-    ]
-      .map((tick) => projectLeft(tick))
-      .filter((tick) => Number.isFinite(tick.pos) && tick.pos >= 0 && tick.pos <= placement.height);
-    const bottom =
-      projector?.x.active === true
-        ? suppressProjectedLabelOverlap(
-            projectedBottom,
-            "horizontal",
-            measurer,
-            input.hAxisTextSize ?? input.axisTextSize,
-          )
-        : projectedBottom;
-    const left =
-      projector?.y.active === true
-        ? suppressProjectedLabelOverlap(
-            projectedLeft,
-            "vertical",
-            measurer,
-            input.vAxisTextSize ?? input.axisTextSize,
-          )
-        : projectedLeft;
-    const xGrid = gridPositionsByKind(bottom);
-    const yGrid = gridPositionsByKind(left);
-    const label = facetPanels[p]!.label;
-    const hasStrip = label !== "";
-    // Left/right strips rotate labels 90°: advance width becomes vertical
-    // extent. Cap to panel height so multi-row layouts cannot paint into
-    // neighboring panel content (#611).
-    const stripLabel =
-      hasStrip && strip.show && isSideStrip(strip.position)
-        ? capSideStripLabel(label, placement.height, measurer, stripSize)
-        : label;
-    return {
-      identity: facetPanels[p]!.identity,
-      id: facetPanels[p]!.id,
-      x: placement.x,
-      y: placement.y,
-      width: placement.width,
-      height: placement.height,
-      strip: stripLabel,
-      ...(hasStrip && {
-        stripPosition: strip.position,
-        showStrip: strip.show,
-        stripBand: strip.show ? stripBand : 0,
-      }),
-      ...(placement.allocation !== undefined && { allocation: { ...placement.allocation } }),
-      clip: projector?.clip ?? true,
-      axisX: placement.showAxisX ? bottom : null,
-      axisY: placement.showAxisY ? left : null,
-      grid: {
-        x: xGrid.major,
-        y: yGrid.major,
-        minorX: input.degraded === true ? [] : xGrid.minor,
-        minorY: input.degraded === true ? [] : yGrid.minor,
-      },
-    };
-  });
+  const scenePanels: ScenePanel[] = placements.map((_, p) =>
+    buildScenePanel(input, p, measurer, stripSize),
+  );
 
-  const firstX = scenePanels.find((p) => p.axisX !== null);
-  const firstY = scenePanels.find((p) => p.axisY !== null);
-  // Multi-line / rotated band labels need the x-axis title pushed below the whole
-  // measured label band (max band height across panels for free scales), instead
-  // of the renderer's fixed single-line offset.
-  // Tick chrome from the active theme (renderer-matched), not a fixed default, so
-  // a custom longer-tick theme still pushes the x title below the label band.
   const tickChromePx = input.tickChromePx ?? 9; // tickLength(6) + gap(3) defaults
   const yTickChromePx = input.yTickChromePx ?? tickChromePx;
-  const TITLE_GAP_PX = 10; // sits within the axis-title reserve band
-  // Renderer default title offset (x and y) when scene leaves titleOffset unset.
-  const DEFAULT_TITLE_OFFSET_PX = 32;
-  const bandTitleOffset = placements.reduce((max, placement) => {
-    const plan = placement.showAxisX ? placement.hGuidePlan : undefined;
-    if (
-      plan?.bandLabelMode === undefined ||
-      plan.bandLabelMode === "single-line" ||
-      plan.bandLabelBandHeight === undefined
-    ) {
-      return max;
-    }
-    return Math.max(max, tickChromePx + plan.bandLabelBandHeight + TITLE_GAP_PX);
-  }, 0);
-  const xAxis: SceneAxis = {
-    ticks: firstX?.axisX ?? [],
-    title: hTitle,
-    ...(bandTitleOffset > 0 && { titleOffset: bandTitleOffset }),
-  };
-
-  // Wide y tick labels need the y-axis title pushed left of the label band so
-  // gridLeft - titleOffset clears them (mirrors x band-titleOffset max-across
-  // panels; #1570). Measure every panel that draws a y axis — free_y facets can
-  // share one left margin while tick strings differ per row.
-  const yTicks = firstY?.axisY ?? [];
-  const yLabelsVisible = input.yLabelsVisible !== false;
-  let yLabelBandPx = 0;
-  if (vTitle !== "" && yLabelsVisible) {
-    const fontSize = input.vAxisTextSize ?? input.axisTextSize;
-    const yAxisTicks = scenePanels.flatMap((panel) => panel.axisY ?? []);
-    for (const tick of yAxisTicks) {
-      if (tick.label === "" || tick.showLabel === false) continue;
-      const size = tick.labelSize ?? fontSize;
-      const fragments =
-        tick.lines !== undefined && tick.lines.length > 0 ? tick.lines : [tick.label];
-      for (const fragment of fragments) {
-        yLabelBandPx = Math.max(yLabelBandPx, measurer.measureWidth(fragment, size));
-      }
-    }
-  }
-  const yTitleClearance = yLabelBandPx > 0 ? yTickChromePx + yLabelBandPx + TITLE_GAP_PX : 0;
-  const yAxis: SceneAxis = {
-    ticks: yTicks,
-    title: vTitle,
-    ...(yTitleClearance > DEFAULT_TITLE_OFFSET_PX && { titleOffset: yTitleClearance }),
-  };
-
+  const { xAxis, yAxis } = assembleSceneAxes({
+    scenePanels,
+    placements,
+    hTitle,
+    vTitle,
+    measurer,
+    tickChromePx,
+    yTickChromePx,
+    axisTextSize: input.axisTextSize,
+    ...(input.vAxisTextSize !== undefined && { vAxisTextSize: input.vAxisTextSize }),
+    ...(input.yLabelsVisible !== undefined && { yLabelsVisible: input.yLabelsVisible }),
+  });
   return { scenePanels, xAxis, yAxis };
 }

--- a/packages/core/src/pipeline/finalize-geometry-scene.ts
+++ b/packages/core/src/pipeline/finalize-geometry-scene.ts
@@ -15,6 +15,32 @@ import type { PreparedPanels } from "./prepare-panels.js";
 import type { TrainedPipelineScales } from "./train-pipeline-scales.js";
 import type { PipelineWarning, RunOptions } from "./types.js";
 
+function resolvedStyleScales(
+  styleResolutions: TrainedPipelineScales["styleResolutions"],
+): import("./geometry-style.js").ResolvedStyleScales {
+  return Object.fromEntries(
+    Object.entries(styleResolutions).map(([aesthetic, resolution]) => [
+      aesthetic,
+      resolution.resolved,
+    ]),
+  ) as import("./geometry-style.js").ResolvedStyleScales;
+}
+
+function minorBreakOptions(
+  normalized: PortableSpec,
+  flip: boolean,
+): {
+  hMinorBreaks?: readonly number[];
+  vMinorBreaks?: readonly number[];
+} {
+  const h = flip ? normalized.scales?.y?.minorBreaks : normalized.scales?.x?.minorBreaks;
+  const v = flip ? normalized.scales?.x?.minorBreaks : normalized.scales?.y?.minorBreaks;
+  return {
+    ...(h !== undefined && { hMinorBreaks: h }),
+    ...(v !== undefined && { vMinorBreaks: v }),
+  };
+}
+
 export function finalizeGeometryAndScene(input: {
   normalized: PortableSpec;
   options: RunOptions;
@@ -52,12 +78,7 @@ export function finalizeGeometryAndScene(input: {
     panelScales,
     color: colorResolution.resolved,
     fill: fillResolution.resolved,
-    styles: Object.fromEntries(
-      Object.entries(styleResolutions).map(([aesthetic, resolution]) => [
-        aesthetic,
-        resolution.resolved,
-      ]),
-    ) as import("./geometry-style.js").ResolvedStyleScales,
+    styles: resolvedStyleScales(styleResolutions),
     flip,
     coordProjectors,
     warnings,
@@ -82,14 +103,7 @@ export function finalizeGeometryAndScene(input: {
     coordProjectors,
     ...(options.measureText !== undefined && { measureText: options.measureText }),
     axisTextSize: theme.axisTextSize,
-    ...((flip ? normalized.scales?.y?.minorBreaks : normalized.scales?.x?.minorBreaks) !==
-      undefined && {
-      hMinorBreaks: flip ? normalized.scales?.y?.minorBreaks : normalized.scales?.x?.minorBreaks,
-    }),
-    ...((flip ? normalized.scales?.x?.minorBreaks : normalized.scales?.y?.minorBreaks) !==
-      undefined && {
-      vMinorBreaks: flip ? normalized.scales?.x?.minorBreaks : normalized.scales?.y?.minorBreaks,
-    }),
+    ...minorBreakOptions(normalized, flip),
     batches,
     legendBlock: panelLayout.legendBlock,
     topBand: panelLayout.topBand,

--- a/packages/core/src/pipeline/panel-layout-chrome.ts
+++ b/packages/core/src/pipeline/panel-layout-chrome.ts
@@ -149,6 +149,64 @@ function makeDisplayScalesFn(
   };
 }
 
+function temporalDisplayAxis(
+  aesthetic: "x" | "y",
+  scale: PositionScale,
+  kind: TemporalScaleKind | null,
+  config: NonNullable<PortableSpec["scales"]>["x"],
+  panelIndex: number,
+) {
+  return scale.type === "time" && kind !== null
+    ? {
+        aesthetic,
+        panelIndex,
+        kind,
+        config: config ?? {},
+        ...(config?.breaks !== undefined && { sourceBreaks: config.breaks }),
+      }
+    : undefined;
+}
+
+function makeDisplayTemporalFn(input: {
+  flip: boolean;
+  xScale: PositionScale;
+  yScale: PositionScale;
+  scalesConfig: NonNullable<PortableSpec["scales"]>;
+  xTemporalKind: TemporalScaleKind | null;
+  yTemporalKind: TemporalScaleKind | null;
+}): DisplayTemporalFn {
+  return (panelIndex: number) => {
+    const xKind = input.xTemporalKind ?? input.scalesConfig.x?.temporalKind ?? null;
+    const yKind = input.yTemporalKind ?? input.scalesConfig.y?.temporalKind ?? null;
+    const x = temporalDisplayAxis("x", input.xScale, xKind, input.scalesConfig.x, panelIndex);
+    const y = temporalDisplayAxis("y", input.yScale, yKind, input.scalesConfig.y, panelIndex);
+    return input.flip
+      ? { ...(y !== undefined && { h: y }), ...(x !== undefined && { v: x }) }
+      : { ...(x !== undefined && { h: x }), ...(y !== undefined && { v: y }) };
+  };
+}
+
+function makeDisplayBandFn(
+  flip: boolean,
+  xScale: PositionScale,
+  yScale: PositionScale,
+  scalesConfig: NonNullable<PortableSpec["scales"]>,
+): DisplayBandFn {
+  return (panelIndex: number) => {
+    const x =
+      xScale.type === "band"
+        ? { aesthetic: "x" as const, panelIndex, config: scalesConfig.x ?? {} }
+        : undefined;
+    const y =
+      yScale.type === "band"
+        ? { aesthetic: "y" as const, panelIndex, config: scalesConfig.y ?? {} }
+        : undefined;
+    return flip
+      ? { ...(y !== undefined && { h: y }), ...(x !== undefined && { v: x }) }
+      : { ...(x !== undefined && { h: x }), ...(y !== undefined && { v: y }) };
+  };
+}
+
 function resolvePanelLayoutLabs(input: {
   allFrames: readonly LayerFrame[];
   labs: NonNullable<PortableSpec["labs"]>;
@@ -260,50 +318,8 @@ function resolvePanelLayoutDisplay(input: {
   const { hBreaks, vBreaks } = flipDisplayBreaks(flip, convertedBreaks("x"), convertedBreaks("y"));
   const { freeH, freeV } = flipDisplayFreeFlags(flip, freeX, freeY);
   const displayScales = makeDisplayScalesFn(flip, panelScales);
-  const displayTemporal = (panelIndex: number) => {
-    const xKind = input.xTemporalKind ?? scalesConfig.x?.temporalKind ?? null;
-    const yKind = input.yTemporalKind ?? scalesConfig.y?.temporalKind ?? null;
-    const x =
-      xScale.type === "time" && xKind !== null
-        ? {
-            aesthetic: "x" as const,
-            panelIndex,
-            kind: xKind,
-            config: scalesConfig.x ?? {},
-            ...(scalesConfig.x?.breaks !== undefined && {
-              sourceBreaks: scalesConfig.x.breaks,
-            }),
-          }
-        : undefined;
-    const y =
-      yScale.type === "time" && yKind !== null
-        ? {
-            aesthetic: "y" as const,
-            panelIndex,
-            kind: yKind,
-            config: scalesConfig.y ?? {},
-            ...(scalesConfig.y?.breaks !== undefined && {
-              sourceBreaks: scalesConfig.y.breaks,
-            }),
-          }
-        : undefined;
-    return flip
-      ? { ...(y !== undefined && { h: y }), ...(x !== undefined && { v: x }) }
-      : { ...(x !== undefined && { h: x }), ...(y !== undefined && { v: y }) };
-  };
-  const displayBand = (panelIndex: number) => {
-    const x =
-      xScale.type === "band"
-        ? { aesthetic: "x" as const, panelIndex, config: scalesConfig.x ?? {} }
-        : undefined;
-    const y =
-      yScale.type === "band"
-        ? { aesthetic: "y" as const, panelIndex, config: scalesConfig.y ?? {} }
-        : undefined;
-    return flip
-      ? { ...(y !== undefined && { h: y }), ...(x !== undefined && { v: x }) }
-      : { ...(x !== undefined && { h: x }), ...(y !== undefined && { v: y }) };
-  };
+  const displayTemporal = makeDisplayTemporalFn(input);
+  const displayBand = makeDisplayBandFn(flip, xScale, yScale, scalesConfig);
 
   return {
     hTitle,

--- a/packages/core/src/pipeline/train-pipeline-scales.ts
+++ b/packages/core/src/pipeline/train-pipeline-scales.ts
@@ -58,49 +58,27 @@ export interface TrainPipelineScalesInput {
   advisories: Advisory[];
 }
 
-export function trainPipelineScales(input: TrainPipelineScalesInput): TrainedPipelineScales {
-  const {
-    normalized,
-    options,
-    table,
-    sourceTable,
-    bindings,
-    facetPanels,
-    panelFrames,
-    freeX,
-    freeY,
-    xConversion,
-    yConversion,
-    editionDefaults,
-    warnings,
-    advisories,
-  } = input;
+function withResolvedParser(
+  config: NonNullable<PortableSpec["scales"]>["x"],
+  conversion: PositionConversionContext,
+): NonNullable<PortableSpec["scales"]>["x"] {
+  if (
+    config === undefined ||
+    config.parse !== undefined ||
+    conversion.parser === "auto" ||
+    config.type === "band" ||
+    config.type === "linear" ||
+    config.type === "log"
+  ) {
+    return config;
+  }
+  return { ...config, parse: conversion.parser };
+}
 
-  const sourceScalesConfig = normalized.scales ?? {};
-  const withResolvedParser = (
-    axis: "x" | "y",
-    conversion: typeof xConversion,
-  ): (typeof sourceScalesConfig)["x"] => {
-    const config = sourceScalesConfig[axis];
-    if (
-      config === undefined ||
-      config.parse !== undefined ||
-      conversion.parser === "auto" ||
-      config.type === "band" ||
-      config.type === "linear" ||
-      config.type === "log"
-    ) {
-      return config;
-    }
-    // This is an internal effective config only: the canonical PortableSpec
-    // remains untouched while domains/breaks reuse the source-column decision.
-    return { ...config, parse: conversion.parser };
-  };
-  const scalesConfig: NonNullable<typeof normalized.scales> = { ...sourceScalesConfig };
-  const resolvedX = withResolvedParser("x", xConversion);
-  const resolvedY = withResolvedParser("y", yConversion);
-  if (resolvedX !== undefined) scalesConfig.x = resolvedX;
-  if (resolvedY !== undefined) scalesConfig.y = resolvedY;
+function applyGuideOverrides(
+  scalesConfig: NonNullable<PortableSpec["scales"]>,
+  guides: PortableSpec["guides"],
+): void {
   for (const aesthetic of [
     "x",
     "y",
@@ -112,7 +90,7 @@ export function trainPipelineScales(input: TrainPipelineScalesInput): TrainedPip
     "shape",
     "linetype",
   ] as const) {
-    const top = normalized.guides?.[aesthetic];
+    const top = guides?.[aesthetic];
     if (top === undefined) continue;
     const scale = (scalesConfig[aesthetic] ?? {}) as { guide?: unknown };
     const local = scale.guide;
@@ -145,6 +123,42 @@ export function trainPipelineScales(input: TrainPipelineScalesInput): TrainedPip
         : top;
     Object.assign(scalesConfig, { [aesthetic]: { ...scale, guide } });
   }
+}
+
+function resolveTrainingScalesConfig(input: {
+  normalized: PortableSpec;
+  xConversion: PositionConversionContext;
+  yConversion: PositionConversionContext;
+}): NonNullable<PortableSpec["scales"]> {
+  const sourceScalesConfig = input.normalized.scales ?? {};
+  const scalesConfig: NonNullable<typeof sourceScalesConfig> = { ...sourceScalesConfig };
+  const resolvedX = withResolvedParser(sourceScalesConfig.x, input.xConversion);
+  const resolvedY = withResolvedParser(sourceScalesConfig.y, input.yConversion);
+  if (resolvedX !== undefined) scalesConfig.x = resolvedX;
+  if (resolvedY !== undefined) scalesConfig.y = resolvedY;
+  applyGuideOverrides(scalesConfig, input.normalized.guides);
+  return scalesConfig;
+}
+
+export function trainPipelineScales(input: TrainPipelineScalesInput): TrainedPipelineScales {
+  const {
+    normalized,
+    options,
+    table,
+    sourceTable,
+    bindings,
+    facetPanels,
+    panelFrames,
+    freeX,
+    freeY,
+    xConversion,
+    yConversion,
+    editionDefaults,
+    warnings,
+    advisories,
+  } = input;
+
+  const scalesConfig = resolveTrainingScalesConfig({ normalized, xConversion, yConversion });
   const position = trainPipelinePositionScales({
     scalesConfig,
     facetPanels,


### PR DESCRIPTION
Reduce complexity in six core pipeline and legend helpers while preserving behavior.

Validation:
- oxlint eslint/complexity max 20 on all touched files
- bunx tsc -b packages/spec packages/core packages/cli
- bun test packages/core (2464 passed)
- benchmark baseline/current captured in /tmp/core-small-pipeline-{baseline,current}.json; no coherent regression after rerun