### PR TITLE
refactor(core): split scale and rendering helpers

### DIFF
--- a/packages/core/src/iso-epoch.ts
+++ b/packages/core/src/iso-epoch.ts
@@ -16,16 +16,7 @@ export function isoHasClock(value: string): boolean {
   return /[T ]\d{2}:\d{2}/.test(value);
 }
 
-/** Parse common ISO date/datetime strings to UTC epoch ms, or undefined. */
-export function isoEpochMs(value: string): number | undefined {
-  // Cheap reject before the full regex: YYYY-MM-DD is 10 chars, and the year
-  // must start with a digit. Series labels ("s0") and other short strings hit
-  // this path on every cell during column coercion.
-  if (value.length < 10) return undefined;
-  const c0 = value.codePointAt(0);
-  if (c0 === undefined || c0 < 48 /* 0 */ || c0 > 57 /* 9 */) return undefined;
-  const match = ISO_LIKE.exec(value);
-  if (match === null) return undefined;
+function parseIsoCalendar(match: RegExpExecArray): number | undefined {
   const year = Number(match[1]);
   const month = Number(match[2]);
   const day = Number(match[3]);
@@ -33,11 +24,9 @@ export function isoEpochMs(value: string): number | undefined {
   const hour = match[4] === undefined ? 0 : Number(match[4]);
   const minute = match[5] === undefined ? 0 : Number(match[5]);
   const second = match[6] === undefined ? 0 : Number(match[6]);
-  // Truncate fractional seconds to milliseconds (up to 9 digits accepted).
   const fractionRaw = match[7] ?? "0";
   const fraction = Number(fractionRaw.padEnd(3, "0").slice(0, 3));
   if (hour > 23 || minute > 59 || second > 59) return undefined;
-  // Date.UTC maps years 0–99 to 1900+; use setUTCFullYear for full range.
   const date = new Date(0);
   date.setUTCFullYear(year, month - 1, day);
   date.setUTCHours(hour, minute, second, fraction);
@@ -48,13 +37,28 @@ export function isoEpochMs(value: string): number | undefined {
   ) {
     return undefined;
   }
-  let epoch = date.getTime();
-  if (match[8] !== undefined) {
-    const sign = match[8] === "+" ? 1 : -1;
-    const offH = Number(match[9]);
-    const offM = Number(match[10]);
-    if (offH > 23 || offM > 59) return undefined;
-    epoch -= sign * (offH * 60 + offM) * 60_000;
-  }
-  return epoch;
+  return date.getTime();
+}
+
+function applyIsoOffset(epoch: number, match: RegExpExecArray): number | undefined {
+  if (match[8] === undefined) return epoch;
+  const sign = match[8] === "+" ? 1 : -1;
+  const offH = Number(match[9]);
+  const offM = Number(match[10]);
+  if (offH > 23 || offM > 59) return undefined;
+  return epoch - sign * (offH * 60 + offM) * 60_000;
+}
+
+/** Parse common ISO date/datetime strings to UTC epoch ms, or undefined. */
+export function isoEpochMs(value: string): number | undefined {
+  // Cheap reject before the full regex: YYYY-MM-DD is 10 chars, and the year
+  // must start with a digit. Series labels ("s0") and other short strings hit
+  // this path on every cell during column coercion.
+  if (value.length < 10) return undefined;
+  const c0 = value.codePointAt(0);
+  if (c0 === undefined || c0 < 48 /* 0 */ || c0 > 57 /* 9 */) return undefined;
+  const match = ISO_LIKE.exec(value);
+  if (match === null) return undefined;
+  const epoch = parseIsoCalendar(match);
+  return epoch === undefined ? undefined : applyIsoOffset(epoch, match);
 }

--- a/packages/core/src/legend-build-discrete.ts
+++ b/packages/core/src/legend-build-discrete.ts
@@ -12,7 +12,7 @@ import {
   presentedDiscreteLabel,
   settings,
 } from "./legend-build-shared.js";
-import type { DiscreteLegendInput, LegendOrder } from "./legend-build-types.js";
+import type { DiscreteLegendInput, LegendKeyStyle, LegendOrder } from "./legend-build-types.js";
 
 const UNKNOWN_COLOR = DEFAULT_MISSING_COLOR;
 
@@ -37,6 +37,150 @@ function orderedValues(input: DiscreteLegendInput, order: LegendOrder): unknown[
   }
 }
 
+function discreteEntry(input: {
+  value: unknown;
+  fullLabel: string;
+  presented: ReturnType<typeof presentedDiscreteLabel>;
+  key: LegendKeyStyle;
+  paint: string | undefined;
+  x: number;
+  y: number;
+  height: number;
+}): SceneLegendEntry {
+  const { value, fullLabel, presented, key, paint, x, y, height } = input;
+  return {
+    value,
+    label: presented.label,
+    fullLabel,
+    ...(presented.lines !== undefined && {
+      lines: presented.lines,
+      lineHeight: presented.lineHeight,
+    }),
+    ...key,
+    color: paint ?? key.color ?? UNKNOWN_COLOR,
+    ...((paint !== undefined || key.color !== undefined) && { hasPaint: true }),
+    x,
+    y,
+    ...(height !== LEGEND_ROW_HEIGHT && { height }),
+  };
+}
+
+function buildVerticalDiscrete(input: {
+  source: DiscreteLegendInput;
+  values: unknown[];
+  fullLabels: string[];
+  keys: LegendKeyStyle[];
+  style: ReturnType<typeof settings>;
+  measurer: TextMeasurer;
+  maxWidth: number;
+  titleHeight: number;
+  keySize: number;
+}): { entries: SceneLegendEntry[]; width: number; height: number } {
+  const { source, values, fullLabels, keys, style, measurer, maxWidth, titleHeight, keySize } =
+    input;
+  const maxLabelWidth = Math.max(1, maxWidth - PADDING * 2 - keySize - style.keyGap);
+  const entries: SceneLegendEntry[] = [];
+  let labelWidth = 0;
+  let cursorY = titleHeight;
+  for (let index = 0; index < values.length; index++) {
+    const fullLabel = fullLabels[index]!;
+    const presented = presentedDiscreteLabel(
+      fullLabel,
+      maxLabelWidth,
+      measurer,
+      style.labelSize,
+      style.appearance,
+      source.scale,
+    );
+    const rowHeight = Math.max(LEGEND_ROW_HEIGHT, keySize, presented.height);
+    labelWidth = Math.max(labelWidth, presented.width);
+    entries.push(
+      discreteEntry({
+        value: values[index],
+        fullLabel,
+        presented,
+        key: keys[index]!,
+        paint: source.colorOf?.(values[index]),
+        x: 0,
+        y: cursorY,
+        height: rowHeight,
+      }),
+    );
+    cursorY += rowHeight + (index + 1 < values.length ? style.rowGap : 0);
+  }
+  const titleWidth = measurer.measureWidth(style.title, style.titleSize);
+  return {
+    entries,
+    width: Math.min(
+      maxWidth,
+      PADDING * 2 + Math.max(keySize + style.keyGap + Math.ceil(labelWidth), Math.ceil(titleWidth)),
+    ),
+    height: cursorY + PADDING,
+  };
+}
+
+function buildHorizontalDiscrete(input: {
+  source: DiscreteLegendInput;
+  values: unknown[];
+  fullLabels: string[];
+  keys: LegendKeyStyle[];
+  style: ReturnType<typeof settings>;
+  measurer: TextMeasurer;
+  maxWidth: number;
+  titleHeight: number;
+  keySize: number;
+}): { entries: SceneLegendEntry[]; width: number; height: number } {
+  const { source, values, fullLabels, keys, style, measurer, maxWidth, titleHeight, keySize } =
+    input;
+  const entries: SceneLegendEntry[] = [];
+  let cursorX = PADDING;
+  let cursorY = titleHeight;
+  let rowHeight = 0;
+  let rowWidth = 0;
+  for (let index = 0; index < values.length; index++) {
+    const fullLabel = fullLabels[index]!;
+    const maxLabelWidth = Math.max(1, maxWidth - PADDING * 2 - keySize - style.keyGap);
+    const presented = presentedDiscreteLabel(
+      fullLabel,
+      maxLabelWidth,
+      measurer,
+      style.labelSize,
+      style.appearance,
+      source.scale,
+    );
+    const entryHeight = Math.max(LEGEND_ROW_HEIGHT, keySize, presented.height);
+    const itemWidth = keySize + style.keyGap + presented.width + PADDING * 2;
+    if (cursorX > PADDING && cursorX + itemWidth > maxWidth) {
+      cursorX = PADDING;
+      cursorY += rowHeight + style.rowGap;
+      rowHeight = 0;
+    }
+    entries.push(
+      discreteEntry({
+        value: values[index],
+        fullLabel,
+        presented,
+        key: keys[index]!,
+        paint: source.colorOf?.(values[index]),
+        x: cursorX - PADDING,
+        y: cursorY,
+        height: entryHeight,
+      }),
+    );
+    cursorX += itemWidth;
+    rowHeight = Math.max(rowHeight, entryHeight);
+    rowWidth = Math.max(rowWidth, cursorX);
+  }
+  return {
+    entries,
+    width: Math.min(
+      maxWidth,
+      Math.max(rowWidth, measurer.measureWidth(style.title, style.titleSize) + PADDING * 2),
+    ),
+    height: cursorY + (values.length === 0 ? 0 : rowHeight) + PADDING,
+  };
+}
+
 export function buildDiscrete(
   input: DiscreteLegendInput,
   order: LegendOrder,
@@ -56,100 +200,19 @@ export function buildDiscrete(
   // mapped size keys remain visually distinct instead of collapsing at that cap.
   const maxKeyRadius = keys.reduce((max, key) => Math.max(max, key.size ?? 0), 0);
   const keySize = Math.max(style.keySize, Math.ceil(maxKeyRadius * 2));
-  const entries: SceneLegendEntry[] = [];
-  let width = 0;
-  let height = titleHeight + PADDING;
-  if (style.direction === "vertical") {
-    const maxLabelWidth = Math.max(1, maxWidth - PADDING * 2 - keySize - style.keyGap);
-    let labelWidth = 0;
-    let cursorY = titleHeight;
-    for (let index = 0; index < values.length; index++) {
-      const fullLabel = fullLabels[index]!;
-      const presented = presentedDiscreteLabel(
-        fullLabel,
-        maxLabelWidth,
-        measurer,
-        style.labelSize,
-        style.appearance,
-        input.scale,
-      );
-      const rowHeight = Math.max(LEGEND_ROW_HEIGHT, keySize, presented.height);
-      labelWidth = Math.max(labelWidth, presented.width);
-      const key = keys[index]!;
-      const paint = input.colorOf?.(values[index]);
-      entries.push({
-        value: values[index],
-        label: presented.label,
-        fullLabel,
-        ...(presented.lines !== undefined && {
-          lines: presented.lines,
-          lineHeight: presented.lineHeight,
-        }),
-        ...key,
-        color: paint ?? key.color ?? UNKNOWN_COLOR,
-        ...((paint !== undefined || key.color !== undefined) && { hasPaint: true }),
-        x: 0,
-        y: cursorY,
-        ...(rowHeight !== LEGEND_ROW_HEIGHT && { height: rowHeight }),
-      });
-      cursorY += rowHeight + (index + 1 < values.length ? style.rowGap : 0);
-    }
-    const titleWidth = measurer.measureWidth(style.title, style.titleSize);
-    width = Math.min(
+  const layout = (style.direction === "vertical" ? buildVerticalDiscrete : buildHorizontalDiscrete)(
+    {
+      source: input,
+      values,
+      fullLabels,
+      keys,
+      style,
+      measurer,
       maxWidth,
-      PADDING * 2 + Math.max(keySize + style.keyGap + Math.ceil(labelWidth), Math.ceil(titleWidth)),
-    );
-    height = cursorY + PADDING;
-  } else {
-    let cursorX = PADDING;
-    let cursorY = titleHeight;
-    let rowHeight = 0;
-    let rowWidth = 0;
-    for (let index = 0; index < values.length; index++) {
-      const fullLabel = fullLabels[index]!;
-      const maxLabelWidth = Math.max(1, maxWidth - PADDING * 2 - keySize - style.keyGap);
-      const presented = presentedDiscreteLabel(
-        fullLabel,
-        maxLabelWidth,
-        measurer,
-        style.labelSize,
-        style.appearance,
-        input.scale,
-      );
-      const entryHeight = Math.max(LEGEND_ROW_HEIGHT, keySize, presented.height);
-      const itemWidth = keySize + style.keyGap + presented.width + PADDING * 2;
-      const key = keys[index]!;
-      const paint = input.colorOf?.(values[index]);
-      if (cursorX > PADDING && cursorX + itemWidth > maxWidth) {
-        cursorX = PADDING;
-        cursorY += rowHeight + style.rowGap;
-        rowHeight = 0;
-      }
-      entries.push({
-        value: values[index],
-        label: presented.label,
-        fullLabel,
-        ...(presented.lines !== undefined && {
-          lines: presented.lines,
-          lineHeight: presented.lineHeight,
-        }),
-        ...key,
-        color: paint ?? key.color ?? UNKNOWN_COLOR,
-        ...((paint !== undefined || key.color !== undefined) && { hasPaint: true }),
-        x: cursorX - PADDING,
-        y: cursorY,
-        ...(entryHeight !== LEGEND_ROW_HEIGHT && { height: entryHeight }),
-      });
-      cursorX += itemWidth;
-      rowHeight = Math.max(rowHeight, entryHeight);
-      rowWidth = Math.max(rowWidth, cursorX);
-    }
-    width = Math.min(
-      maxWidth,
-      Math.max(rowWidth, measurer.measureWidth(style.title, style.titleSize) + PADDING * 2),
-    );
-    height = cursorY + (values.length === 0 ? 0 : rowHeight) + PADDING;
-  }
+      titleHeight,
+      keySize,
+    },
+  );
   return {
     type: "discrete",
     scale: input.scale,
@@ -164,9 +227,9 @@ export function buildDiscrete(
     keyGap: style.keyGap,
     x: 0,
     y: 0,
-    width,
-    height,
-    entries,
+    width: layout.width,
+    height: layout.height,
+    entries: layout.entries,
     swatchSize: keySize,
   };
 }

--- a/packages/core/src/legend-build-types.ts
+++ b/packages/core/src/legend-build-types.ts
@@ -22,7 +22,7 @@ export interface ResolvedLegendAppearance {
   theme?: GuideThemeSpec;
 }
 
-interface LegendKeyStyle {
+export interface LegendKeyStyle {
   color?: string;
   size?: number;
   linewidth?: number;

--- a/packages/core/src/pipeline/scale-axis-collect-x-mapped.ts
+++ b/packages/core/src/pipeline/scale-axis-collect-x-mapped.ts
@@ -7,6 +7,29 @@ import type { AxisCollectAcc } from "./scale-axis-collect-acc.js";
 import { positionFieldType, xConversionOf } from "./temporal-position.js";
 import type { Advisory, LayerFrame } from "./types.js";
 
+function collectMappedXEndEvidence(
+  frame: LayerFrame,
+  conversion: ReturnType<typeof xConversionOf>,
+  acc: AxisCollectAcc,
+): void {
+  if (frame.xend === null || frame.xend === undefined) return;
+  acc.numeric.push(frame.xend);
+  if (frame.xendValues !== null && frame.xendValues !== undefined) {
+    acc.columns.push(frame.xendValues);
+  }
+  const endField = frame.binding.xendField;
+  if (endField !== null && frame.table.has(endField)) {
+    const endType = positionFieldType(frame.table, endField, conversion);
+    acc.typeParts.add(endType);
+    if (endType === "nominal") acc.anyDiscrete = true;
+    if (endType !== "temporal") acc.allTemporal = false;
+  } else {
+    acc.typeParts.add("quantitative");
+    acc.allTemporal = false;
+  }
+  acc.sawContinuousEvidence = true;
+}
+
 export function collectMappedXEvidence(
   frame: LayerFrame,
   configType: PositionScaleSpec["type"] | undefined,
@@ -42,23 +65,5 @@ export function collectMappedXEvidence(
   if (fieldType !== "temporal") acc.allTemporal = false;
   acc.sawContinuousEvidence = true;
 
-  // Segment end x: same dual evidence as mapped x (numeric + discrete categories).
-  // Guard undefined partial fixtures (not only null).
-  if (frame.xend !== null && frame.xend !== undefined) {
-    acc.numeric.push(frame.xend);
-    if (frame.xendValues !== null && frame.xendValues !== undefined) {
-      acc.columns.push(frame.xendValues);
-    }
-    const endField = binding.xendField;
-    if (endField !== null && frame.table.has(endField)) {
-      const endType = positionFieldType(frame.table, endField, conversion);
-      acc.typeParts.add(endType);
-      if (endType === "nominal") acc.anyDiscrete = true;
-      if (endType !== "temporal") acc.allTemporal = false;
-    } else {
-      acc.typeParts.add("quantitative");
-      acc.allTemporal = false;
-    }
-    acc.sawContinuousEvidence = true;
-  }
+  collectMappedXEndEvidence(frame, conversion, acc);
 }

--- a/packages/core/src/pipeline/scale-style-numeric.ts
+++ b/packages/core/src/pipeline/scale-style-numeric.ts
@@ -97,7 +97,22 @@ function numericIdentityResolution(input: {
   };
 }
 
-export function resolveNumericStyleScale(input: {
+function numericStyleRange(
+  aesthetic: NumericStyleAesthetic,
+  config: NumericStyleConfig | undefined,
+): number[] {
+  const defaultRange = NUMERIC_DEFAULT_RANGE[aesthetic];
+  const range = [
+    ...(config?.range ??
+      Array.from({ length: 5 }, (_, index) =>
+        numericMappedValue(aesthetic, index / 4, defaultRange, config?.sizeUnit),
+      )),
+  ];
+  if (config?.reverse === true) range.reverse();
+  return range;
+}
+
+function resolveNonIdentityNumericStyleScale(input: {
   aesthetic: NumericStyleAesthetic;
   values: readonly CellValue[];
   catalog: readonly CellValue[];
@@ -122,39 +137,11 @@ export function resolveNumericStyleScale(input: {
     warnings,
   } = input;
   const type = config?.type ?? (anyDiscrete ? "ordinal" : "sequential");
-  if (type === "identity") {
-    return numericIdentityResolution({
-      aesthetic,
-      values,
-      config,
-      title,
-      warnings,
-    });
-  }
-  if (type === "sequential" || type === "binned") {
-    return numericSequentialResolution({
-      aesthetic,
-      kind: type,
-      values,
-      config,
-      title,
-      warnings,
-    });
-  }
-  const defaultRange = NUMERIC_DEFAULT_RANGE[aesthetic];
-  const range = [
-    ...(config?.range ??
-      Array.from({ length: 5 }, (_, index) =>
-        numericMappedValue(aesthetic, index / 4, defaultRange, config?.sizeUnit),
-      )),
-  ];
-  if (config?.reverse === true) range.reverse();
+  const range = numericStyleRange(aesthetic, config);
   const fallback = numericFallback(aesthetic, config);
   return discreteStyleResolution({
     aesthetic,
-    kind: type,
-    // Stat columns never reach the source catalog, so fall back to the observed
-    // (post-stat) values when no catalog/explicit domain exists — matching color.
+    kind: type === "manual" ? "manual" : "ordinal",
     values:
       type === "manual"
         ? (config?.domain ?? (catalog.length > 0 ? catalog : values))
@@ -174,4 +161,40 @@ export function resolveNumericStyleScale(input: {
     title,
     warnings,
   });
+}
+
+export function resolveNumericStyleScale(input: {
+  aesthetic: NumericStyleAesthetic;
+  values: readonly CellValue[];
+  catalog: readonly CellValue[];
+  anyDiscrete: boolean;
+  anyIndexable: boolean;
+  nonInteractiveValues?: readonly CellValue[];
+  config: NumericStyleConfig | undefined;
+  prevState: ScaleState | null;
+  title: string;
+  warnings: PipelineWarning[];
+}): StyleResolution {
+  const { aesthetic, values, anyDiscrete, config, title, warnings } = input;
+  const type = config?.type ?? (anyDiscrete ? "ordinal" : "sequential");
+  if (type === "identity") {
+    return numericIdentityResolution({
+      aesthetic,
+      values,
+      config,
+      title,
+      warnings,
+    });
+  }
+  if (type === "sequential" || type === "binned") {
+    return numericSequentialResolution({
+      aesthetic,
+      kind: type,
+      values,
+      config,
+      title,
+      warnings,
+    });
+  }
+  return resolveNonIdentityNumericStyleScale(input);
 }

--- a/packages/core/src/render-svg-scene.ts
+++ b/packages/core/src/render-svg-scene.ts
@@ -70,6 +70,35 @@ export interface SceneSVGOptions {
   paintMode?: PaintRenderMode;
 }
 
+function renderScenePanels(
+  scene: Scene,
+  theme: Scene["theme"],
+  paintMode: PaintRenderMode,
+): string[] {
+  const parts: string[] = [];
+  const { byPanel } = groupBatchesByPanel(scene.panels.length, scene.batches, false);
+  for (let i = 0; i < scene.panels.length; i++) {
+    const p = scene.panels[i]!;
+    parts.push(
+      `<g class="gg-panel" data-panel="${i}" transform="translate(${px(p.x)},${px(p.y)})">`,
+      theme.panel === "none"
+        ? ""
+        : `<rect class="gg-panel-background" width="${px(p.width)}" height="${px(p.height)}" fill="${themeVar("panel", theme)}"/>`,
+      renderGrid(p, theme),
+      `<g class="gg-marks"${p.clip === false ? "" : ` clip-path="url(#gg-clip-${i})"`}>`,
+    );
+    for (const batch of byPanel[i]!) parts.push(renderBatch(batch, theme, paintMode));
+    parts.push("</g>");
+    if (theme.showPanelBorder) {
+      parts.push(
+        `<rect class="gg-panel-border" width="${px(p.width)}" height="${px(p.height)}" fill="none" stroke="${themeVar("panelBorder", theme)}" stroke-width="${px(theme.panelBorderWidth)}" vector-effect="non-scaling-stroke"/>`,
+      );
+    }
+    parts.push("</g>", renderStrip(p, scene, i), renderPanelAxes(p, theme));
+  }
+  return parts;
+}
+
 /** Serialize a computed Scene to a standalone SVG string. */
 export function sceneToSVGString(scene: Scene, options: SceneSVGOptions = {}): string {
   const paintMode = options.paintMode ?? "full";
@@ -126,30 +155,7 @@ export function sceneToSVGString(scene: Scene, options: SceneSVGOptions = {}): s
       );
     }
   }
-  // One O(P+B) panel→batch index (issue #185) instead of re-scanning all
-  // batches per panel (O(P·B)). Bucket order preserves original batch list
-  // order within each panel.
-  const { byPanel } = groupBatchesByPanel(scene.panels.length, scene.batches, false);
-  for (let i = 0; i < scene.panels.length; i++) {
-    const p = scene.panels[i]!;
-    parts.push(
-      `<g class="gg-panel" data-panel="${i}" transform="translate(${px(p.x)},${px(p.y)})">`,
-      theme.panel === "none"
-        ? ""
-        : `<rect class="gg-panel-background" width="${px(p.width)}" height="${px(p.height)}" fill="${themeVar("panel", theme)}"/>`,
-      renderGrid(p, theme),
-      `<g class="gg-marks"${p.clip === false ? "" : ` clip-path="url(#gg-clip-${i})"`}>`,
-    );
-    for (const batch of byPanel[i]!) parts.push(renderBatch(batch, theme, paintMode));
-    parts.push("</g>");
-    if (theme.showPanelBorder) {
-      parts.push(
-        `<rect class="gg-panel-border" width="${px(p.width)}" height="${px(p.height)}" fill="none" stroke="${themeVar("panelBorder", theme)}" stroke-width="${px(theme.panelBorderWidth)}" vector-effect="non-scaling-stroke"/>`,
-      );
-    }
-    parts.push("</g>", renderStrip(p, scene, i), renderPanelAxes(p, theme));
-  }
-  parts.push(renderAxisTitles(scene));
+  parts.push(...renderScenePanels(scene, theme, paintMode), renderAxisTitles(scene));
   for (const legend of scene.legends) {
     // Deterministic gradient ids (byte-determinism wins over cross-plot id
     // uniqueness; documented caveat when inlining several plots in one page —


### PR DESCRIPTION
Reduce cyclomatic complexity in scale collection/resolution, discrete legends, ISO parsing, and SVG scene assembly.

Validation:
- oxlint eslint/complexity max 20 on touched scopes
- bunx tsc -b packages/spec packages/core packages/cli
- focused table/style/legend/ISO tests pass
- benchmark baseline/current captured in /tmp/core-small-scales-{baseline,current}.json; no coherent regression