### PR TITLE
refactor(core): reduce frame and guide complexity

### DIFF
--- a/packages/core/src/pipeline/frame-group-columns.ts
+++ b/packages/core/src/pipeline/frame-group-columns.ts
@@ -2,13 +2,18 @@
  * Layer grouping and carried discrete columns for stats/identity frames.
  */
 import { deriveGroups, type ChannelGroupingOverrides } from "../grouping.js";
-import { cellToNumber, type CellValue, type Discreteness } from "../table.js";
+import {
+  cellToNumber,
+  type CellValue,
+  type Discreteness,
+  type ParsedColumnOptions,
+} from "../table.js";
 import type { ColumnTable } from "../table.js";
 import { getTemporalRuntime } from "../temporal-runtime.js";
 
 import { styleBinIndex } from "./style-bin-index.js";
 import { positionDiscreteness } from "./temporal-position.js";
-import type { LayerBinding } from "./types.js";
+import type { LayerBinding, StyleBinding } from "./types.js";
 
 /**
  * Global semantic [low, high] for a binned style field, computed from the
@@ -52,50 +57,27 @@ function binnedStyleColumn(
       disambiguation: binding.binDisambiguation,
     }),
   };
-  const parsed = table.parsed(binding.field, parser, options);
-  const numeric = parsed.semantic;
-  const semanticOf = (value: CellValue): number | undefined => {
-    if (binding.binTemporal === true) {
-      const runtime = getTemporalRuntime();
-      if (runtime !== null) {
-        const result = runtime.parseColumn([value], binding.binParse ?? "auto", options);
-        return result.valid[0] === 1 ? result.semantic[0] : undefined;
-      }
-      // Lean path: ISO via cellToNumber (polyfill-free).
-      const number = cellToNumber(value);
-      return Number.isFinite(number) ? number : undefined;
-    }
-    const number = cellToNumber(value);
-    return Number.isFinite(number) ? number : undefined;
-  };
-  let inferredLow = Number.POSITIVE_INFINITY;
-  let inferredHigh = Number.NEGATIVE_INFINITY;
-  for (const value of numeric) {
-    if (!Number.isFinite(value)) continue;
-    inferredLow = Math.min(inferredLow, value);
-    inferredHigh = Math.max(inferredHigh, value);
-  }
-  if (!Number.isFinite(inferredLow)) return Array.from({ length: numeric.length }, () => null);
+  const numeric = table.parsed(binding.field, parser, options).semantic;
+  const semanticOf = semanticValue(binding, options);
+  const inferred = numericExtent(numeric);
+  if (inferred === undefined) return Array.from({ length: numeric.length }, () => null);
   const domainNumbers = binding.binDomain
-    ?.map(semanticOf)
-    .filter((value): value is number => value !== undefined);
+    ?.map((value) => semanticOf(value))
+    .filter((value) => isNumber(value));
   // The style-scale trainer normalizes an authored domain with Math.min/max
   // before deriving default breaks (scale-style.ts). A reversed authored domain
   // like [10, 0] would otherwise produce descending breaks here and treat every
   // in-domain value as out-of-bounds, so grouping bins would diverge from the
   // rendered scale. Normalize the bounds to match the trainer.
-  const rawLow = domainNumbers?.[0] ?? binding.binExtent?.[0] ?? inferredLow;
-  const rawHigh = domainNumbers?.at(-1) ?? binding.binExtent?.[1] ?? inferredHigh;
+  const rawLow = domainNumbers?.[0] ?? binding.binExtent?.[0] ?? inferred[0];
+  const rawHigh = domainNumbers?.at(-1) ?? binding.binExtent?.[1] ?? inferred[1];
   const low = Math.min(rawLow, rawHigh);
   const high = Math.max(rawLow, rawHigh);
   const binCount = binding.binCount ?? 5;
   const configuredBreaks = binding.binBreaks
-    ?.map(semanticOf)
-    .filter((value): value is number => value !== undefined);
-  const breaks =
-    configuredBreaks !== undefined && configuredBreaks.length >= 2
-      ? configuredBreaks
-      : Array.from({ length: binCount + 1 }, (_, index) => low + ((high - low) * index) / binCount);
+    ?.map((value) => semanticOf(value))
+    .filter((value) => isNumber(value));
+  const breaks = resolveBinBreaks(configuredBreaks, binCount, low, high);
   return Array.from(numeric, (value) => {
     if (!Number.isFinite(value)) return null;
     let bounded = value;
@@ -107,6 +89,49 @@ function binnedStyleColumn(
   });
 }
 
+function resolveBinBreaks(
+  configured: readonly number[] | undefined,
+  binCount: number,
+  low: number,
+  high: number,
+): readonly number[] {
+  return configured !== undefined && configured.length >= 2
+    ? configured
+    : Array.from({ length: binCount + 1 }, (_, index) => low + ((high - low) * index) / binCount);
+}
+
+function isNumber(value: number | undefined): value is number {
+  return value !== undefined;
+}
+
+function semanticValue(
+  binding: LayerBinding["size"],
+  options: ParsedColumnOptions,
+): (value: CellValue) => number | undefined {
+  return (value) => {
+    if (binding.binTemporal === true) {
+      const runtime = getTemporalRuntime();
+      if (runtime !== null) {
+        const result = runtime.parseColumn([value], binding.binParse ?? "auto", options);
+        return result.valid[0] === 1 ? result.semantic[0] : undefined;
+      }
+    }
+    const number = cellToNumber(value);
+    return Number.isFinite(number) ? number : undefined;
+  };
+}
+
+function numericExtent(values: Iterable<number>): readonly [number, number] | undefined {
+  let low = Number.POSITIVE_INFINITY;
+  let high = Number.NEGATIVE_INFINITY;
+  for (const value of values) {
+    if (!Number.isFinite(value)) continue;
+    low = Math.min(low, value);
+    high = Math.max(high, value);
+  }
+  return Number.isFinite(low) ? [low, high] : undefined;
+}
+
 export function deriveLayerGroups(binding: LayerBinding, table: ColumnTable): number[] {
   const aes = binding.layer.aes ?? {};
   // Explicit aes.group wins outright in deriveGroups — skip per-channel
@@ -115,60 +140,88 @@ export function deriveLayerGroups(binding: LayerBinding, table: ColumnTable): nu
   if (groupChannel !== undefined && groupChannel !== null && !("stat" in groupChannel)) {
     return deriveGroups(table.columns(), { group: groupChannel }).groups as number[];
   }
+  const { declared, overrides } = groupingInputs(binding, table, aes);
+  return deriveGroups(table.columns(), aes, declared, overrides).groups as number[];
+}
+
+function groupingInputs(
+  binding: LayerBinding,
+  table: ColumnTable,
+  aes: NonNullable<LayerBinding["layer"]["aes"]>,
+): {
+  declared: Record<string, Discreteness>;
+  overrides: Record<string, ChannelGroupingOverrides[string]>;
+} {
   const declared: Record<string, Discreteness> = {};
   const overrides: Record<string, ChannelGroupingOverrides[string]> = {};
   for (const [channel, mapping] of Object.entries(aes)) {
-    if (
-      mapping !== null &&
-      mapping !== undefined &&
-      "field" in mapping &&
-      table.has(mapping.field)
-    ) {
-      const conversion =
-        mapping.field === binding.xField ||
-        mapping.field === binding.xminField ||
-        mapping.field === binding.xmaxField
-          ? binding.xConversion
-          : mapping.field === binding.yField ||
-              mapping.field === binding.yminField ||
-              mapping.field === binding.ymaxField
-            ? binding.yConversion
-            : mapping.field === binding.xminField || mapping.field === binding.xmaxField
-              ? binding.xConversion
-              : undefined;
-      const forcedDiscrete =
-        (channel === "color" && binding.color.forcedDiscrete === true) ||
-        (channel === "fill" && binding.fill.forcedDiscrete === true) ||
-        (channel === "size" && binding.size.forcedDiscrete === true) ||
-        (channel === "linewidth" && binding.linewidth.forcedDiscrete === true) ||
-        (channel === "alpha" && binding.alpha.forcedDiscrete === true) ||
-        (channel === "shape" && binding.shape.forcedDiscrete === true) ||
-        (channel === "linetype" && binding.linetype.forcedDiscrete === true);
-      const style =
-        channel === "size" ||
-        channel === "linewidth" ||
-        channel === "alpha" ||
-        channel === "shape" ||
-        channel === "linetype"
-          ? binding[channel]
-          : undefined;
-      const discreteness = forcedDiscrete
-        ? "discrete"
-        : style?.forcedContinuous === true
-          ? "continuous"
-          : conversion === undefined
-            ? table.discreteness(mapping.field)
-            : positionDiscreteness(table, mapping.field, conversion);
-      declared[mapping.field] = discreteness;
-      const binned = style === undefined ? undefined : binnedStyleColumn(style, table);
-      overrides[channel] = {
-        discreteness,
-        ...(binned !== undefined && { column: binned }),
-      };
-    }
+    const entry = groupingInput(binding, table, channel, mapping);
+    if (entry === undefined) continue;
+    declared[entry.field] = entry.discreteness;
+    overrides[channel] = entry.override;
   }
-  // deriveGroups already returns a fresh number[]; do not spread-copy 30k ids.
-  return deriveGroups(table.columns(), aes, declared, overrides).groups as number[];
+  return { declared, overrides };
+}
+
+function groupingInput(
+  binding: LayerBinding,
+  table: ColumnTable,
+  channel: string,
+  mapping: unknown,
+):
+  | { field: string; discreteness: Discreteness; override: ChannelGroupingOverrides[string] }
+  | undefined {
+  if (
+    mapping === null ||
+    mapping === undefined ||
+    typeof mapping !== "object" ||
+    !("field" in mapping)
+  )
+    return undefined;
+  const field = mapping.field;
+  if (typeof field !== "string" || !table.has(field)) return undefined;
+  const conversion = positionConversion(binding, field);
+  const style = styleBinding(binding, channel);
+  const discreteness = isForcedDiscrete(binding, channel)
+    ? "discrete"
+    : style?.forcedContinuous === true
+      ? "continuous"
+      : conversion === null
+        ? table.discreteness(field)
+        : positionDiscreteness(table, field, conversion);
+  const binned = style === null ? undefined : binnedStyleColumn(style, table);
+  return {
+    field,
+    discreteness,
+    override: { discreteness, ...(binned !== undefined && { column: binned }) },
+  };
+}
+
+function positionConversion(binding: LayerBinding, field: string) {
+  if (field === binding.xField || field === binding.xminField || field === binding.xmaxField)
+    return binding.xConversion;
+  if (field === binding.yField || field === binding.yminField || field === binding.ymaxField)
+    return binding.yConversion;
+  return null;
+}
+
+function isForcedDiscrete(binding: LayerBinding, channel: string): boolean {
+  if (channel === "color") return binding.color.forcedDiscrete === true;
+  if (channel === "fill") return binding.fill.forcedDiscrete === true;
+  return styleBinding(binding, channel)?.forcedDiscrete === true;
+}
+
+function styleBinding(binding: LayerBinding, channel: string): StyleBinding | null {
+  if (
+    channel === "size" ||
+    channel === "linewidth" ||
+    channel === "alpha" ||
+    channel === "shape" ||
+    channel === "linetype"
+  ) {
+    return binding[channel];
+  }
+  return null;
 }
 
 /** Carried mapped columns for stats (styles/label, minus the x field). */

--- a/packages/core/src/pipeline/guide-config.ts
+++ b/packages/core/src/pipeline/guide-config.ts
@@ -42,26 +42,39 @@ export function resolveAxisGuide(
 ): AxisGuideAppearance {
   const local = typedGuide(scales[aesthetic]?.guide);
   const top = guides?.[aesthetic];
-  if (top?.type === "none" || (top === undefined && local?.type === "none")) {
+  if (axisHidden(local, top)) {
     return { visible: false, showTicks: false, showLabels: false, collision: "auto" };
   }
-  const localAxis = local?.type === "axis" ? local : undefined;
-  const chosen =
-    top?.type === "axis"
-      ? { ...localAxis, ...top, theme: { ...localAxis?.theme, ...top.theme } }
-      : top === undefined
-        ? localAxis
-        : undefined;
-  const themeAllowsLabels =
-    theme === undefined || (aesthetic === "x" ? theme.labelsX : theme.labelsY);
+  const chosen = chooseAxisGuide(local, top);
   return {
     visible: true,
     ...(chosen?.title !== undefined && { title: chosen.title }),
     showTicks: chosen?.showTicks ?? true,
-    showLabels: (chosen?.showLabels ?? true) && themeAllowsLabels,
+    showLabels: (chosen?.showLabels ?? true) && axisThemeAllowsLabels(aesthetic, theme),
     collision: chosen?.collision ?? "auto",
     ...(chosen?.theme !== undefined && { theme: chosen.theme }),
   };
+}
+
+function axisHidden(local: GuideSpec | undefined, top: GuideSpec | undefined): boolean {
+  return top?.type === "none" || (top === undefined && local?.type === "none");
+}
+
+function chooseAxisGuide(
+  local: GuideSpec | undefined,
+  top: GuideSpec | undefined,
+): Extract<GuideSpec, { type: "axis" }> | undefined {
+  const localAxis = local?.type === "axis" ? local : undefined;
+  if (top?.type === "axis")
+    return { ...localAxis, ...top, theme: { ...localAxis?.theme, ...top.theme } };
+  return top === undefined ? localAxis : undefined;
+}
+
+function axisThemeAllowsLabels(
+  aesthetic: "x" | "y",
+  theme: Pick<ThemeTokens, "labelsX" | "labelsY"> | undefined,
+): boolean {
+  return theme === undefined || (aesthetic === "x" ? theme.labelsX : theme.labelsY);
 }
 
 export interface LegendResolutionItem {
@@ -236,69 +249,83 @@ export function prepareLegendInputs(input: {
   scales: Scales;
   guides: GuidesSpec | undefined;
 }): LegendInput[] {
-  const prepared: Array<{
-    input: LegendInput;
-    plan: Exclude<GuidePlan, { type: "axis" }>;
-    identity: string;
-  }> = [];
-  for (const item of input.items) {
-    if (item.input === null || item.plan === null) continue;
-    const aesthetic = item.input.scale;
-    const defaultType =
-      item.input.kind === "ramp"
-        ? "colorbar"
-        : item.input.kind === "steps"
-          ? "colorsteps"
-          : "legend";
-    const guide = effectiveGuide(aesthetic, defaultType, input.scales, input.guides);
-    if (guide.type === "none") continue;
-    const appearance = appearanceOf(guide, item.input.title);
-    const expected = defaultType;
-    if (appearance.type !== expected) {
-      throw new PipelineError(
-        "guide-aesthetic-incompatible",
-        input.guides?.[aesthetic] === undefined
-          ? `/scales/${aesthetic}/guide`
-          : `/guides/${aesthetic}`,
-        `The ${appearance.type} guide is incompatible with the trained ${expected} guide for ${aesthetic}. Use ${expected}, none, or choose a matching explicit scale family.`,
-      );
-    }
-    if (
-      item.plan.type === "discrete" &&
-      (item.plan.scaleType === "manual" || item.plan.scaleType === "identity") &&
-      item.plan.entries.length < 2 &&
-      appearance.force !== true
-    ) {
-      continue;
-    }
-    const decorated = {
-      ...item.input,
-      title: appearance.title,
-      aesthetics: Object.freeze([item.input.scale]),
-      appearance,
-    } as LegendInput;
-    // Point-family layers carry shape as a mark constant (param or default
-    // circle). Fold those into color/fill keys so the legend matches the plot
-    // (cross vs point), not anonymous colored squares.
-    const withMarkKeys =
-      decorated.kind === "discrete" && isPaintLegend(decorated)
-        ? enrichPaintLegendKeys(decorated, input.bindings)
-        : decorated;
-    prepared.push({
-      input: withMarkKeys,
-      plan: item.plan,
-      identity:
-        withMarkKeys.kind === "discrete"
-          ? mergeIdentity(
-              withMarkKeys,
-              item.plan,
-              sourceIdentity(aesthetic, input.bindings),
-              appearance,
-            )
-          : `unique:${item.plan.id}`,
-    });
-  }
+  const prepared = input.items
+    .map((item) => prepareLegendItem(item, input))
+    .filter((item): item is PreparedLegend => item !== undefined);
+  return mergePreparedLegends(prepared);
+}
 
+type PreparedLegend = {
+  input: LegendInput;
+  plan: Exclude<GuidePlan, { type: "axis" }>;
+  identity: string;
+};
+
+function prepareLegendItem(
+  item: LegendResolutionItem,
+  input: Parameters<typeof prepareLegendInputs>[0],
+): PreparedLegend | undefined {
+  if (item.input === null || item.plan === null) return undefined;
+  const aesthetic = item.input.scale;
+  const defaultType =
+    item.input.kind === "ramp" ? "colorbar" : item.input.kind === "steps" ? "colorsteps" : "legend";
+  const guide = effectiveGuide(aesthetic, defaultType, input.scales, input.guides);
+  if (guide.type === "none") return undefined;
+  const appearance = appearanceOf(guide, item.input.title);
+  if (appearance.type !== defaultType)
+    throwGuideCompatibilityError(input, aesthetic, appearance.type, defaultType);
+  if (singleManualLegend(item.plan, appearance)) return undefined;
+  const decorated = {
+    ...item.input,
+    title: appearance.title,
+    aesthetics: Object.freeze([item.input.scale]),
+    appearance,
+  } as LegendInput;
+  const withMarkKeys =
+    decorated.kind === "discrete" && isPaintLegend(decorated)
+      ? enrichPaintLegendKeys(decorated, input.bindings)
+      : decorated;
+  return {
+    input: withMarkKeys,
+    plan: item.plan,
+    identity:
+      withMarkKeys.kind === "discrete"
+        ? mergeIdentity(
+            withMarkKeys,
+            item.plan,
+            sourceIdentity(aesthetic, input.bindings),
+            appearance,
+          )
+        : `unique:${item.plan.id}`,
+  };
+}
+
+function throwGuideCompatibilityError(
+  input: Parameters<typeof prepareLegendInputs>[0],
+  aesthetic: GuideAesthetic,
+  actual: string,
+  expected: string,
+): never {
+  throw new PipelineError(
+    "guide-aesthetic-incompatible",
+    input.guides?.[aesthetic] === undefined ? `/scales/${aesthetic}/guide` : `/guides/${aesthetic}`,
+    `The ${actual} guide is incompatible with the trained ${expected} guide for ${aesthetic}. Use ${expected}, none, or choose a matching explicit scale family.`,
+  );
+}
+
+function singleManualLegend(
+  plan: Exclude<GuidePlan, { type: "axis" }>,
+  appearance: ResolvedLegendAppearance,
+): boolean {
+  return (
+    plan.type === "discrete" &&
+    (plan.scaleType === "manual" || plan.scaleType === "identity") &&
+    plan.entries.length < 2 &&
+    appearance.force !== true
+  );
+}
+
+function mergePreparedLegends(prepared: readonly PreparedLegend[]): LegendInput[] {
   const out: LegendInput[] = [];
   const merged = new Set<number>();
   for (let index = 0; index < prepared.length; index++) {


### PR DESCRIPTION
## Summary
- split frame grouping and binned-column helpers into focused functions
- simplify axis-guide resolution and legend preparation
- keep behavior and warning/error precedence unchanged

## Verification
- bunx tsc -b packages/spec packages/core packages/cli
- bun test packages/core/tests (2464 pass)
- strict core complexity lint for touched files passes
- benchmark baseline/current captured; current run was faster across workloads with no coherent regression