### PR TITLE
refactor(core): split frame edge and feature geometry paths

### DIFF
--- a/packages/core/src/pipeline/frame-edge-expand.ts
+++ b/packages/core/src/pipeline/frame-edge-expand.ts
@@ -63,6 +63,17 @@ export function expandEdgeFrame(frame: LayerFrame, warnings: PipelineWarning[]):
   if (geom !== "tile" && geom !== "raster") return;
   if (frame.xNumeric === null || frame.yNumeric === null) return;
 
+  if (geom === "tile") {
+    expandTileFrame(frame);
+    return;
+  }
+  expandRasterFrame(frame, warnings);
+}
+
+function expandTileFrame(frame: LayerFrame): void {
+  const xNumeric = frame.xNumeric;
+  const yNumeric = frame.yNumeric;
+  if (xNumeric === null || yNumeric === null) return;
   const xType =
     frame.binding.xField === null
       ? "quantitative"
@@ -76,63 +87,61 @@ export function expandEdgeFrame(frame: LayerFrame, warnings: PipelineWarning[]):
   // (mixed band+continuous tiles keep continuous-axis domain expansion).
   // Clear inactive edge arrays so inherited plot-level ymin/ymax (or xmin/xmax)
   // meant for rect/ribbon cannot train continuous edge evidence on a band axis.
-  if (geom === "tile") {
-    if (xType === "nominal") {
-      frame.xmin = null;
-      frame.xmax = null;
-    }
-    if (yType === "nominal") {
-      frame.ymin = null;
-      frame.ymax = null;
-    }
-    if (xType === "nominal" && yType === "nominal") return;
-    const params = frame.binding.layer.params ?? {};
-    const defW = defaultResolution(frame.xNumeric);
-    const defH = defaultResolution(frame.yNumeric);
-    // Resolve size columns once — field names are invariant for the frame.
-    const widthCol =
-      frame.binding.widthField === null ? null : frame.table.column(frame.binding.widthField);
-    const heightCol =
-      frame.binding.heightField === null ? null : frame.table.column(frame.binding.heightField);
-    if (xType !== "nominal") {
-      const left = new Float64Array(frame.n);
-      const right = new Float64Array(frame.n);
-      for (let row = 0; row < frame.n; row++) {
-        const cx = frame.xNumeric[row]!;
-        const w = sizeAt(widthCol, params.width, defW, row);
-        if (!Number.isFinite(cx) || !(w > 0) || !Number.isFinite(w)) {
-          left[row] = NaN;
-          right[row] = NaN;
-          continue;
-        }
-        left[row] = cx - w / 2;
-        right[row] = cx + w / 2;
-      }
-      frame.xmin = left;
-      frame.xmax = right;
-    }
-    if (yType !== "nominal") {
-      const bottom = new Float64Array(frame.n);
-      const top = new Float64Array(frame.n);
-      for (let row = 0; row < frame.n; row++) {
-        const cy = frame.yNumeric[row]!;
-        const h = sizeAt(heightCol, params.height, defH, row);
-        if (!Number.isFinite(cy) || !(h > 0) || !Number.isFinite(h)) {
-          bottom[row] = NaN;
-          top[row] = NaN;
-          continue;
-        }
-        bottom[row] = cy - h / 2;
-        top[row] = cy + h / 2;
-      }
-      frame.ymin = bottom;
-      frame.ymax = top;
-    }
-    return;
+  if (xType === "nominal") {
+    frame.xmin = null;
+    frame.xmax = null;
   }
+  if (yType === "nominal") {
+    frame.ymin = null;
+    frame.ymax = null;
+  }
+  if (xType === "nominal" && yType === "nominal") return;
+  const params = (frame.binding.layer.params ?? {}) as { width?: number; height?: number };
+  const defW = defaultResolution(xNumeric);
+  const defH = defaultResolution(yNumeric);
+  const widthCol =
+    frame.binding.widthField === null ? null : frame.table.column(frame.binding.widthField);
+  const heightCol =
+    frame.binding.heightField === null ? null : frame.table.column(frame.binding.heightField);
+  if (xType !== "nominal") {
+    [frame.xmin, frame.xmax] = expandTileAxis(xNumeric, widthCol, params.width, defW);
+  }
+  if (yType !== "nominal") {
+    [frame.ymin, frame.ymax] = expandTileAxis(yNumeric, heightCol, params.height, defH);
+  }
+}
 
-  // raster
-  const params = frame.binding.layer.params ?? {};
+function expandTileAxis(
+  values: Float64Array,
+  sizeColumn: readonly CellValue[] | null,
+  param: number | undefined,
+  fallback: number,
+): readonly [Float64Array, Float64Array] {
+  const low = new Float64Array(values.length);
+  const high = new Float64Array(values.length);
+  for (let row = 0; row < values.length; row++) {
+    const center = values[row]!;
+    const size = sizeAt(sizeColumn, param, fallback, row);
+    if (!Number.isFinite(center) || !(size > 0) || !Number.isFinite(size)) {
+      low[row] = NaN;
+      high[row] = NaN;
+      continue;
+    }
+    low[row] = center - size / 2;
+    high[row] = center + size / 2;
+  }
+  return [low, high];
+}
+
+function expandRasterFrame(frame: LayerFrame, warnings: PipelineWarning[]): void {
+  const xNumeric = frame.xNumeric;
+  const yNumeric = frame.yNumeric;
+  if (xNumeric === null || yNumeric === null) return;
+  const params = (frame.binding.layer.params ?? {}) as {
+    interpolate?: unknown;
+    hjust?: number;
+    vjust?: number;
+  };
   // Schema only admits false; reject any non-false truthy at runtime too.
   if ((params as { interpolate?: unknown }).interpolate === true) {
     throw new PipelineError(
@@ -145,8 +154,8 @@ export function expandEdgeFrame(frame: LayerFrame, warnings: PipelineWarning[]):
   const vjust = params.vjust ?? 0.5;
   const seen = new Map<string, number>();
   for (let row = 0; row < frame.n; row++) {
-    const x = frame.xNumeric[row]!;
-    const y = frame.yNumeric[row]!;
+    const x = xNumeric[row]!;
+    const y = yNumeric[row]!;
     if (!Number.isFinite(x) || !Number.isFinite(y)) continue;
     const key = `${x}\0${y}`;
     if (seen.has(key)) {
@@ -158,8 +167,8 @@ export function expandEdgeFrame(frame: LayerFrame, warnings: PipelineWarning[]):
     }
     seen.set(key, row);
   }
-  const xSpace = spacingOf(uniqueSorted(frame.xNumeric));
-  const ySpace = spacingOf(uniqueSorted(frame.yNumeric));
+  const xSpace = spacingOf(uniqueSorted(xNumeric));
+  const ySpace = spacingOf(uniqueSorted(yNumeric));
   if (xSpace.irregular || ySpace.irregular) {
     warnings.push({
       code: "raster-irregular-spacing",
@@ -171,8 +180,8 @@ export function expandEdgeFrame(frame: LayerFrame, warnings: PipelineWarning[]):
   const bottom = new Float64Array(frame.n);
   const top = new Float64Array(frame.n);
   for (let row = 0; row < frame.n; row++) {
-    const x = frame.xNumeric[row]!;
-    const y = frame.yNumeric[row]!;
+    const x = xNumeric[row]!;
+    const y = yNumeric[row]!;
     if (!Number.isFinite(x) || !Number.isFinite(y)) {
       left[row] = NaN;
       right[row] = NaN;

--- a/packages/core/src/pipeline/sf-geometry.ts
+++ b/packages/core/src/pipeline/sf-geometry.ts
@@ -226,44 +226,54 @@ function polygonCentroid(ring: unknown): SfPosition | null {
  * Degenerate / empty parts are skipped.
  */
 export function representativePoints(type: string, coordinates: unknown): readonly SfPosition[] {
-  if (type === "Point") return isFinitePair(coordinates) ? [coordinates] : [];
-  if (type === "MultiPoint") {
-    if (!Array.isArray(coordinates)) return [];
-    const pts: SfPosition[] = [];
-    for (const c of coordinates) {
-      if (isFinitePair(c)) pts.push(c);
-    }
-    return pts;
-  }
-  if (type === "LineString") {
-    const m = meanPosition(ringPositions(coordinates));
-    return m === null ? [] : [m];
-  }
-  if (type === "MultiLineString") {
-    if (!Array.isArray(coordinates)) return [];
-    const out: SfPosition[] = [];
-    for (const line of coordinates) {
-      const m = meanPosition(ringPositions(line));
-      if (m !== null) out.push(m);
-    }
-    return out;
-  }
-  if (type === "Polygon") {
-    if (!Array.isArray(coordinates) || coordinates.length === 0) return [];
-    const c = polygonCentroid(coordinates[0]);
-    return c === null ? [] : [c];
-  }
-  if (type === "MultiPolygon") {
-    if (!Array.isArray(coordinates)) return [];
-    const out: SfPosition[] = [];
-    for (const poly of coordinates) {
-      if (!Array.isArray(poly) || poly.length === 0) continue;
-      const c = polygonCentroid(poly[0]);
-      if (c !== null) out.push(c);
-    }
-    return out;
-  }
+  if (type === "Point") return finitePoint(coordinates);
+  if (type === "MultiPoint") return finitePoints(coordinates);
+  if (type === "LineString") return linePoint(coordinates);
+  if (type === "MultiLineString") return linePoints(coordinates);
+  if (type === "Polygon") return polygonPoint(coordinates);
+  if (type === "MultiPolygon") return polygonPoints(coordinates);
   return [];
+}
+
+function finitePoint(coordinates: unknown): readonly SfPosition[] {
+  return isFinitePair(coordinates) ? [coordinates] : [];
+}
+
+function finitePoints(coordinates: unknown): readonly SfPosition[] {
+  if (!Array.isArray(coordinates)) return [];
+  return coordinates.filter((value): value is SfPosition => isFinitePair(value));
+}
+
+function linePoint(coordinates: unknown): readonly SfPosition[] {
+  const point = meanPosition(ringPositions(coordinates));
+  return point === null ? [] : [point];
+}
+
+function linePoints(coordinates: unknown): readonly SfPosition[] {
+  if (!Array.isArray(coordinates)) return [];
+  const out: SfPosition[] = [];
+  for (const line of coordinates) {
+    const point = meanPosition(ringPositions(line));
+    if (point !== null) out.push(point);
+  }
+  return out;
+}
+
+function polygonPoint(coordinates: unknown): readonly SfPosition[] {
+  if (!Array.isArray(coordinates) || coordinates.length === 0) return [];
+  const point = polygonCentroid(coordinates[0]);
+  return point === null ? [] : [point];
+}
+
+function polygonPoints(coordinates: unknown): readonly SfPosition[] {
+  if (!Array.isArray(coordinates)) return [];
+  const out: SfPosition[] = [];
+  for (const poly of coordinates) {
+    if (!Array.isArray(poly) || poly.length === 0) continue;
+    const point = polygonCentroid(poly[0]);
+    if (point !== null) out.push(point);
+  }
+  return out;
 }
 
 export function geometryFieldName(params: { geometry?: string } | undefined): string {


### PR DESCRIPTION
Split tile/raster expansion and simple-feature representative point paths into focused helpers. Verification: tsc, targeted geometry tests, strict touched-file complexity lint, and benchmark A/B runs with no coherent regression.