### PR TITLE
refactor(core): split render and interaction helpers

### DIFF
--- a/packages/core/src/interaction-mask.ts
+++ b/packages/core/src/interaction-mask.ts
@@ -102,20 +102,7 @@ export function buildInteractionMasks<Key extends PropertyKey>(
 
   const focused = new Map<number, Uint8Array>();
   for (const candidate of candidates) {
-    if (candidate.keys.length === 0) continue;
-    const batch = batches[candidate.batchIndex];
-    if (batch === undefined) continue;
-    const primitiveIndex = rendererPrimitive(batch, candidate.primitiveIndex);
-    if (primitiveIndex === null) continue;
-
-    // Allocate the batch mask whenever a candidate is addressable so
-    // non-matching emphasis still yields focusedCount 0 (not a null mask).
-    let values = focused.get(candidate.batchIndex);
-    if (values === undefined) {
-      values = new Uint8Array(renderPrimitiveCount(batch));
-      focused.set(candidate.batchIndex, values);
-    }
-    if (candidate.keys.some((key) => emphasis.has(key))) values[primitiveIndex] = 1;
+    markFocusedCandidate(focused, batches, candidate, emphasis);
   }
 
   // Mirror fill-batch focus onto presentation-only path batches on the same
@@ -144,35 +131,55 @@ export function buildInteractionMasks<Key extends PropertyKey>(
         });
       }
     }
-    const peer = peerByLayer.get(batch.layerIndex);
-    if (peer === undefined) continue;
-    const source = peer.values;
-    const sourceCount = peer.count;
-    const outlineCount = renderPrimitiveCount(batch);
-    const mirrored = new Uint8Array(outlineCount);
-    if (outlineCount === sourceCount) {
-      mirrored.set(source);
-    } else if (sourceCount > 0 && outlineCount === sourceCount * 2) {
-      // outline: "both" — two open subpaths per closed fill run
-      for (let path = 0; path < sourceCount; path++) {
-        const bit = source[path]!;
-        mirrored[path * 2] = bit;
-        mirrored[path * 2 + 1] = bit;
-      }
-    } else if (sourceCount > 0) {
-      // Length mismatch: mute all outline primitives under any active emphasis.
-      // (zeros = not focused → canvas draws at mutedAlpha)
-    }
-    focused.set(index, mirrored);
-    if (index < peer.batchIndex)
-      peerByLayer.set(batch.layerIndex, {
-        batchIndex: index,
-        values: mirrored,
-        count: outlineCount,
-      });
+    const peer = peerByLayer?.get(batch.layerIndex);
+    mirrorPeerMask(focused, peerByLayer, batch, index, peer);
   }
 
   return freezeMasks(batches, focused);
+}
+
+function markFocusedCandidate<Key extends PropertyKey>(
+  focused: Map<number, Uint8Array>,
+  batches: readonly GeometryBatch[],
+  candidate: SemanticCandidateKeys<Key>,
+  emphasis: ReadonlySet<Key>,
+): void {
+  if (candidate.keys.length === 0) return;
+  const batch = batches[candidate.batchIndex];
+  if (batch === undefined) return;
+  const primitiveIndex = rendererPrimitive(batch, candidate.primitiveIndex);
+  if (primitiveIndex === null) return;
+  let values = focused.get(candidate.batchIndex);
+  if (values === undefined) {
+    values = new Uint8Array(renderPrimitiveCount(batch));
+    focused.set(candidate.batchIndex, values);
+  }
+  if (candidate.keys.some((key) => emphasis.has(key))) values[primitiveIndex] = 1;
+}
+
+function mirrorPeerMask(
+  focused: Map<number, Uint8Array>,
+  peerByLayer: Map<number, { batchIndex: number; values: Uint8Array; count: number }> | null,
+  batch: GeometryBatch,
+  index: number,
+  peer: { batchIndex: number; values: Uint8Array; count: number } | undefined,
+): void {
+  if (peer === undefined || peerByLayer === null) return;
+  const source = peer.values;
+  const sourceCount = peer.count;
+  const outlineCount = renderPrimitiveCount(batch);
+  const mirrored = new Uint8Array(outlineCount);
+  if (outlineCount === sourceCount) mirrored.set(source);
+  else if (sourceCount > 0 && outlineCount === sourceCount * 2) {
+    for (let path = 0; path < sourceCount; path++) {
+      const bit = source[path]!;
+      mirrored[path * 2] = bit;
+      mirrored[path * 2 + 1] = bit;
+    }
+  }
+  focused.set(index, mirrored);
+  if (index < peer.batchIndex)
+    peerByLayer.set(batch.layerIndex, { batchIndex: index, values: mirrored, count: outlineCount });
 }
 
 /**

--- a/packages/core/src/render-svg-marks.ts
+++ b/packages/core/src/render-svg-marks.ts
@@ -335,26 +335,45 @@ function renderGlyphs(batch: GlyphsBatch, theme: ThemeTokens): string {
       batch.boxStroke !== undefined ||
       batch.boxStrokes !== undefined);
   for (let j = 0; j < n; j++) {
-    const mark = resolveGlyphMark(batch, j, themeInk);
-    const size = batch.sizes === undefined ? undefined : mark.size;
-    const alpha = batch.alphas === undefined ? undefined : mark.alpha;
-    const tx = batch.positions[j * 2]!;
-    const ty = batch.positions[j * 2 + 1]!;
-    if (hasBox) {
-      const bw = batch.boxWidths![j]!;
-      const bh = batch.boxHeights![j]!;
-      const pad = batch.boxPadding ?? 0;
-      const origin = labelBoxOrigin(tx, ty, bw, bh, batch.anchor, pad);
-      const boxFill = batch.boxFills?.[j] ?? batch.boxFill ?? themePaper;
-      const boxStroke = batch.boxStrokes?.[j] ?? batch.boxStroke ?? themeInk;
-      const sw = batch.boxStrokeWidth ?? 0.5;
-      const rx = batch.boxRadius ?? 0;
-      out += `<rect x="${px(origin.x)}" y="${px(origin.y)}" width="${px(bw)}" height="${px(bh)}" rx="${px(rx)}" ry="${px(rx)}" fill="${boxFill}" stroke="${boxStroke}" stroke-width="${px(sw)}"${alpha === undefined ? "" : alphaAttr(alpha)}/>`;
-    }
-    out += `<text x="${px(tx)}" y="${px(ty)}" dy="0.32em" fill="${mark.fill}"${size === undefined ? "" : ` font-size="${px(size)}"`}${alpha === undefined ? "" : alphaAttr(alpha)}>${escapeXML(batch.texts[j]!)}</text>`;
+    out += renderGlyph(batch, j, themeInk, themePaper, hasBox);
   }
   out += "</g>";
   return out;
+}
+
+function renderGlyph(
+  batch: GlyphsBatch,
+  index: number,
+  themeInk: string,
+  themePaper: string,
+  hasBox: boolean,
+): string {
+  const mark = resolveGlyphMark(batch, index, themeInk);
+  const size = batch.sizes === undefined ? undefined : mark.size;
+  const alpha = batch.alphas === undefined ? undefined : mark.alpha;
+  const tx = batch.positions[index * 2]!;
+  const ty = batch.positions[index * 2 + 1]!;
+  const box = hasBox ? renderGlyphBox(batch, index, tx, ty, alpha, themeInk, themePaper) : "";
+  return `${box}<text x="${px(tx)}" y="${px(ty)}" dy="0.32em" fill="${mark.fill}"${size === undefined ? "" : ` font-size="${px(size)}"`}${alpha === undefined ? "" : alphaAttr(alpha)}>${escapeXML(batch.texts[index]!)}</text>`;
+}
+
+function renderGlyphBox(
+  batch: GlyphsBatch,
+  index: number,
+  tx: number,
+  ty: number,
+  alpha: number | undefined,
+  themeInk: string,
+  themePaper: string,
+): string {
+  const bw = batch.boxWidths![index]!;
+  const bh = batch.boxHeights![index]!;
+  const origin = labelBoxOrigin(tx, ty, bw, bh, batch.anchor, batch.boxPadding ?? 0);
+  const boxFill = batch.boxFills?.[index] ?? batch.boxFill ?? themePaper;
+  const boxStroke = batch.boxStrokes?.[index] ?? batch.boxStroke ?? themeInk;
+  const sw = batch.boxStrokeWidth ?? 0.5;
+  const rx = batch.boxRadius ?? 0;
+  return `<rect x="${px(origin.x)}" y="${px(origin.y)}" width="${px(bw)}" height="${px(bh)}" rx="${px(rx)}" ry="${px(rx)}" fill="${boxFill}" stroke="${boxStroke}" stroke-width="${px(sw)}"${alpha === undefined ? "" : alphaAttr(alpha)}/>`;
 }
 
 /** Dispatch one geometry batch to its emitter (internal to the pure renderer). */


### PR DESCRIPTION
Split SVG glyph rendering and interaction-mask candidate/mirroring helpers to keep complexity under 20 while preserving output and focus semantics. Verified with tsc, interaction-mask tests, strict touched-file lint, and benchmark A/B runs with no coherent regression.