### PR TITLE
refactor(core): reduce binned scale complexity

### DIFF
--- a/packages/core/src/pipeline/resolve-binned-axis.ts
+++ b/packages/core/src/pipeline/resolve-binned-axis.ts
@@ -5,7 +5,11 @@
 import type { PositionScaleSpec } from "@ggsvelte/spec";
 
 import type { ColumnTable } from "../table.js";
-import { getScaleTransform, type ColumnTransformConfig } from "../scales/transform.js";
+import {
+  getScaleTransform,
+  type ColumnTransformConfig,
+  type ScaleTransform,
+} from "../scales/transform.js";
 
 import {
   resolveBinnedBoundaries,
@@ -31,22 +35,40 @@ export function resolveBinnedAxis(
 ): BinnedBoundaries | undefined {
   if (config?.type !== "binned") return undefined;
   const scaleTransform = transform?.transform ?? getScaleTransform("identity");
-  const authoredBreaks = config.breaks;
+  const explicitEdges = resolveExplicitEdges(axis, config.breaks, scaleTransform);
+  const measuredExtent = collectBinnedExtent(
+    axis,
+    bindings,
+    tables,
+    conversion,
+    transform,
+    explicitEdges !== null,
+  );
+  const extent = explicitEdges === null ? measuredExtent : null;
+  return resolveBinnedBoundaries(extent, explicitEdges, axis) ?? undefined;
+}
+
+function resolveExplicitEdges(
+  axis: "x" | "y",
+  authoredBreaks: PositionScaleSpec["breaks"],
+  transform: ScaleTransform,
+): readonly number[] | null {
   if (
     authoredBreaks !== undefined &&
     authoredBreaks.some(
-      (value) =>
-        typeof value !== "number" || !Number.isFinite(value) || !scaleTransform.valid(value),
+      (value) => typeof value !== "number" || !Number.isFinite(value) || !transform.valid(value),
     )
   ) {
     throw new PipelineError(
       "invalid-scale-breaks",
       `/scales/${axis}/breaks`,
-      `A type: "binned" scale requires finite numeric boundaries inside the ${scaleTransform.key} transform domain.`,
+      `A type: "binned" scale requires finite numeric boundaries inside the ${transform.key} transform domain.`,
     );
   }
-  const numericBreaks = authoredBreaks as readonly number[] | undefined;
-  const explicitEdges = transformExplicitBreaks(numericBreaks, scaleTransform);
+  const explicitEdges = transformExplicitBreaks(
+    authoredBreaks as readonly number[] | undefined,
+    transform,
+  );
   if (explicitEdges !== null && new Set(explicitEdges).size < 2) {
     throw new PipelineError(
       "invalid-scale-breaks",
@@ -54,17 +76,24 @@ export function resolveBinnedAxis(
       `A type: "binned" scale requires at least two distinct usable boundaries.`,
     );
   }
+  return explicitEdges;
+}
 
+function collectBinnedExtent(
+  axis: "x" | "y",
+  bindings: readonly LayerBinding[],
+  tables: readonly ColumnTable[],
+  conversion: PositionConversionContext,
+  transform: ColumnTransformConfig | undefined,
+  hasExplicitEdges: boolean,
+): [number, number] | null {
   let lo = Number.POSITIVE_INFINITY;
   let hi = Number.NEGATIVE_INFINITY;
-  // Keyed by sourceId+field so same name on different tables both contribute.
   const seen = new Set<string>();
   for (let index = 0; index < bindings.length; index++) {
     const binding = bindings[index]!;
     const table = tables[index] ?? tables[0];
     if (table === undefined) continue;
-    // Segment endpoints train the same axis — only when this binding is a segment
-    // (plot-level aes can leave xend/yend on non-segment layers that ignore them).
     const isSegment = binding.layer.geom === "segment";
     const fields =
       axis === "x"
@@ -76,28 +105,35 @@ export function resolveBinnedAxis(
       if (seen.has(seenKey)) continue;
       seen.add(seenKey);
       if (!table.has(field)) continue;
-      const fieldType = positionFieldType(table, field, conversion);
-      if (fieldType !== "quantitative") {
-        throw new PipelineError(
-          "binned-scale-requires-continuous",
-          `/scales/${axis}`,
-          `A type: "binned" scale on ${axis} is bound to field "${field}" (${fieldType}), which is not quantitative.`,
-        );
-      }
-      if (explicitEdges !== null) continue;
+      assertQuantitativeBinnedField(axis, field, table, conversion);
+      if (hasExplicitEdges) continue;
       const values =
         transform === undefined
           ? table.numeric(field, conversion.sourceParser, conversion.options)
           : table.transformed(field, conversion.sourceParser, conversion.options, transform)
               .transformed;
-      for (let i = 0; i < values.length; i++) {
-        const value = values[i]!;
+      for (const value of values) {
         if (!Number.isFinite(value)) continue;
-        if (value < lo) lo = value;
-        if (value > hi) hi = value;
+        lo = Math.min(lo, value);
+        hi = Math.max(hi, value);
       }
     }
   }
-  const extent: [number, number] | null = explicitEdges === null && lo <= hi ? [lo, hi] : null;
-  return resolveBinnedBoundaries(extent, explicitEdges, axis) ?? undefined;
+  return lo <= hi ? [lo, hi] : null;
+}
+
+function assertQuantitativeBinnedField(
+  axis: "x" | "y",
+  field: string,
+  table: ColumnTable,
+  conversion: PositionConversionContext,
+): void {
+  const fieldType = positionFieldType(table, field, conversion);
+  if (fieldType !== "quantitative") {
+    throw new PipelineError(
+      "binned-scale-requires-continuous",
+      `/scales/${axis}`,
+      `A type: "binned" scale on ${axis} is bound to field "${field}" (${fieldType}), which is not quantitative.`,
+    );
+  }
 }

--- a/packages/core/src/pipeline/scale-color-binned.ts
+++ b/packages/core/src/pipeline/scale-color-binned.ts
@@ -27,12 +27,105 @@ export function resolveBinnedColorScale(input: {
 }): ColorResolution {
   const { name, values, config, legendTitle, warnings, editionDefaults } = input;
   const view = resolveColorValueView({ name, values, config, warnings });
-  const transformName = config.transform ?? "identity";
-  const transform = scaleTransform(transformName);
-  const valid = Float64Array.from(view.semantic, (value) =>
-    transform.valid(value) ? value : Number.NaN,
+  const { transformName, transform, domain, breaks, transformedBreaks } = prepareBinnedDomain(
+    name,
+    config,
+    view,
   );
-  const extent = finiteExtent([valid]);
+  const binCount = breaks.length - 1;
+  const configuredRange = resolveSequentialRange(config, editionDefaults) ?? VIRIDIS_RAMP_10;
+  const normalizedRange = configuredRange.map((color) => normalizeColor(color));
+  const colors = resolveBinnedColors(normalizedRange, binCount, config.reverse === true);
+  const { naValue, unknownValue } = fallbackColors(config);
+  const sourceLower = domain[0];
+  const sourceUpper = domain[1];
+  const transformedOf = (semantic: number): number | undefined => {
+    let bounded = semantic;
+    if (bounded < sourceLower || bounded > sourceUpper) {
+      if (config.oob !== "squish") return undefined;
+      bounded = Math.min(sourceUpper, Math.max(sourceLower, bounded));
+    }
+    const transformed = transform.forward(bounded);
+    return Number.isFinite(transformed) ? transformed : undefined;
+  };
+  const semanticColorOf = (semantic: number): string =>
+    binnedColorOf(semantic, transformedBreaks, colors, binCount, transformedOf, unknownValue);
+  const scale: BinnedColorScale = Object.freeze({
+    type: "binned" as const,
+    domain,
+    transformedDomain: [transformedBreaks[0]!, transformedBreaks.at(-1)!] as [number, number],
+    transform: transformName,
+    reverse: config.reverse === true,
+    breaks: Object.freeze([...breaks]),
+    transformedBreaks: Object.freeze(transformedBreaks),
+    colors: Object.freeze(colors),
+    naValue,
+    unknownValue,
+    ...(view.temporalKind !== null &&
+      view.temporalKind !== "time" && { temporalKind: view.temporalKind }),
+    colorOf(value: unknown): string | undefined {
+      if (value === null || value === undefined) return naValue;
+      const semantic = view.semanticOf(value);
+      return semantic === undefined ? unknownValue : semanticColorOf(semantic);
+    },
+  });
+  // Index the batch semantic array (same alignment as sequential-train). Do not
+  // re-derive rows via semanticOf — that re-pays encodeKey/Map lookup or a
+  // single-row parseColumn on temporal misses the batch already recorded.
+  warnUnknownColors(name, countUnknownBinnedValues(values, view.semantic, transformedOf), warnings);
+  const formatStep = minAdjacentWidth(breaks);
+  const formatter = resolveBinnedLegendFormat({
+    domain,
+    temporalKind: view.temporalKind,
+    config,
+    name,
+    warnings,
+    ...(formatStep !== undefined && { formatStep }),
+  });
+  const steps = breaks.slice(0, -1).map((lower, index) =>
+    Object.freeze({
+      lower,
+      upper: breaks[index + 1]!,
+      lowerInclusive: true as const,
+      upperInclusive: index === binCount - 1,
+      label: `${formatter.label(lower)}–${formatter.label(breaks[index + 1]!)}`,
+      color: colors[index]!,
+    }),
+  );
+  return {
+    resolved: { kind: "binned", scale },
+    legendInput: {
+      kind: "steps",
+      scale: name,
+      title: legendTitle,
+      entries: steps.map(({ label, color }) => ({ label, color })),
+    },
+    guidePlan: Object.freeze({
+      type: "colorsteps" as const,
+      id: `guide:${name}`,
+      aesthetic: name,
+      title: legendTitle,
+      domain: Object.freeze([...domain] as [number, number]),
+      transformedDomain: Object.freeze([...scale.transformedDomain] as [number, number]),
+      transform: transformName,
+      temporalKind: view.temporalKind,
+      direction: config.reverse === true ? ("descending" as const) : ("ascending" as const),
+      steps: Object.freeze(steps),
+      naValue,
+      unknownValue,
+    }),
+    state: null,
+  };
+}
+
+type BinnedValueView = ReturnType<typeof resolveColorValueView>;
+
+function configuredBinnedDomain(
+  name: "color" | "fill",
+  config: ColorScaleSpec,
+  view: BinnedValueView,
+  extent: [number, number] | null,
+): [number, number] | null {
   const configuredDomain = config.domain;
   const mappedDomain =
     configuredDomain?.length === 2
@@ -48,11 +141,18 @@ export function resolveBinnedColorScale(input: {
       `The ${name} binned domain must contain exactly two finite semantic values.`,
     );
   }
-  let domain: [number, number] | null =
-    mappedDomain?.[0] !== undefined && mappedDomain[1] !== undefined
-      ? [mappedDomain[0], mappedDomain[1]]
-      : extent;
-  let breaks =
+  return mappedDomain?.[0] !== undefined && mappedDomain[1] !== undefined
+    ? [mappedDomain[0], mappedDomain[1]]
+    : extent;
+}
+
+function parsedBinnedBreaks(
+  name: "color" | "fill",
+  config: ColorScaleSpec,
+  view: BinnedValueView,
+  domain: [number, number] | null,
+): number[] {
+  const breaks =
     config.breaks?.map((value) => view.semanticOf(value)).filter((value) => value !== undefined) ??
     [];
   if (config.breaks !== undefined && breaks.length !== config.breaks.length) {
@@ -62,20 +162,57 @@ export function resolveBinnedColorScale(input: {
       `Every ${name} colorstep boundary must parse as a finite semantic value.`,
     );
   }
-  if (breaks.length >= 2) {
-    if (
-      domain !== null &&
-      configuredDomain !== undefined &&
-      (domain[0] !== breaks[0] || domain[1] !== breaks.at(-1))
-    ) {
-      throw new PipelineError(
-        "color-binned-domain",
-        `/scales/${name}/domain`,
-        `The ${name} binned domain must match the first and last explicit colorstep boundaries.`,
-      );
-    }
-    domain = [breaks[0]!, breaks.at(-1)!];
+  if (
+    breaks.length >= 2 &&
+    domain !== null &&
+    config.domain !== undefined &&
+    (domain[0] !== breaks[0] || domain[1] !== breaks.at(-1))
+  ) {
+    throw new PipelineError(
+      "color-binned-domain",
+      `/scales/${name}/domain`,
+      `The ${name} binned domain must match the first and last explicit colorstep boundaries.`,
+    );
   }
+  return breaks;
+}
+
+function binnedBreakDomain(
+  name: "color" | "fill",
+  config: ColorScaleSpec,
+  domain: [number, number] | null,
+  breaks: readonly number[],
+): [number, number] {
+  if (domain === null) {
+    throw new PipelineError(
+      "color-binned-empty",
+      `/scales/${name}`,
+      `No ${name} values are valid for the ${config.transform ?? "identity"} binned scale.`,
+    );
+  }
+  return [breaks[0]!, breaks.at(-1)!];
+}
+
+function prepareBinnedDomain(
+  name: "color" | "fill",
+  config: ColorScaleSpec,
+  view: BinnedValueView,
+): {
+  transformName: ReturnType<typeof scaleTransform>["key"];
+  transform: ReturnType<typeof scaleTransform>;
+  domain: [number, number];
+  breaks: number[];
+  transformedBreaks: number[];
+} {
+  const transformName = config.transform ?? "identity";
+  const transform = scaleTransform(transformName);
+  const valid = Float64Array.from(view.semantic, (value) =>
+    transform.valid(value) ? value : Number.NaN,
+  );
+  const extent = finiteExtent([valid]);
+  let domain = configuredBinnedDomain(name, config, view, extent);
+  let breaks = parsedBinnedBreaks(name, config, view, domain);
+  if (breaks.length >= 2) domain = binnedBreakDomain(name, config, domain, breaks);
   if (domain === null) {
     throw new PipelineError(
       "color-binned-empty",
@@ -108,117 +245,61 @@ export function resolveBinnedColorScale(input: {
       `The ${name} colorstep boundaries must be distinct and strictly increasing in ${transformName} space.`,
     );
   }
-  domain = [breaks[0]!, breaks.at(-1)!];
-  const binCount = breaks.length - 1;
-  const configuredRange = resolveSequentialRange(config, editionDefaults) ?? VIRIDIS_RAMP_10;
-  const normalizedRange = configuredRange.map((color) => normalizeColor(color));
-  let colors =
-    normalizedRange.length === binCount
-      ? [...normalizedRange]
-      : Array.from({ length: binCount }, (_, index) =>
-          rampColor(normalizedRange, (index + 0.5) / binCount),
-        );
-  if (config.reverse === true) colors = colors.toReversed();
-  const { naValue, unknownValue } = fallbackColors(config);
-  const sourceLower = domain[0];
-  const sourceUpper = domain[1];
-  const transformedOf = (semantic: number): number | undefined => {
-    let bounded = semantic;
-    if (bounded < sourceLower || bounded > sourceUpper) {
-      if (config.oob !== "squish") return undefined;
-      bounded = Math.min(sourceUpper, Math.max(sourceLower, bounded));
-    }
-    const transformed = transform.forward(bounded);
-    return Number.isFinite(transformed) ? transformed : undefined;
+  return {
+    transformName,
+    transform,
+    domain: [breaks[0]!, breaks.at(-1)!],
+    breaks,
+    transformedBreaks,
   };
-  const semanticColorOf = (semantic: number): string => {
-    const transformed = transformedOf(semantic);
-    if (transformed === undefined) return unknownValue;
-    // Upper-bound search makes exact internal boundaries start the next bin;
-    // the final boundary remains in the final closed interval.
-    let low = 0;
-    let high = transformedBreaks.length;
-    while (low < high) {
-      const middle = (low + high) >>> 1;
-      if (transformed < transformedBreaks[middle]!) high = middle;
-      else low = middle + 1;
-    }
-    const index = Math.min(binCount - 1, low - 1);
-    return index < 0 ? unknownValue : colors[index]!;
-  };
-  const scale: BinnedColorScale = Object.freeze({
-    type: "binned" as const,
-    domain,
-    transformedDomain: [transformedBreaks[0]!, transformedBreaks.at(-1)!] as [number, number],
-    transform: transformName,
-    reverse: config.reverse === true,
-    breaks: Object.freeze([...breaks]),
-    transformedBreaks: Object.freeze(transformedBreaks),
-    colors: Object.freeze(colors),
-    naValue,
-    unknownValue,
-    ...(view.temporalKind !== null &&
-      view.temporalKind !== "time" && { temporalKind: view.temporalKind }),
-    colorOf(value: unknown): string | undefined {
-      if (value === null || value === undefined) return naValue;
-      const semantic = view.semanticOf(value);
-      return semantic === undefined ? unknownValue : semanticColorOf(semantic);
-    },
-  });
-  // Index the batch semantic array (same alignment as sequential-train). Do not
-  // re-derive rows via semanticOf — that re-pays encodeKey/Map lookup or a
-  // single-row parseColumn on temporal misses the batch already recorded.
+}
+
+function resolveBinnedColors(
+  range: readonly string[],
+  binCount: number,
+  reverse: boolean,
+): string[] {
+  const colors =
+    range.length === binCount
+      ? [...range]
+      : Array.from({ length: binCount }, (_, index) => rampColor(range, (index + 0.5) / binCount));
+  return reverse ? colors.toReversed() : colors;
+}
+
+function binnedColorOf(
+  semantic: number,
+  transformedBreaks: readonly number[],
+  colors: readonly string[],
+  binCount: number,
+  transformedOf: (value: number) => number | undefined,
+  unknownValue: string,
+): string {
+  const transformed = transformedOf(semantic);
+  if (transformed === undefined) return unknownValue;
+  let low = 0;
+  let high = transformedBreaks.length;
+  while (low < high) {
+    const middle = (low + high) >>> 1;
+    if (transformed < transformedBreaks[middle]!) high = middle;
+    else low = middle + 1;
+  }
+  const index = Math.min(binCount - 1, low - 1);
+  return index < 0 ? unknownValue : colors[index]!;
+}
+
+function countUnknownBinnedValues(
+  values: readonly CellValue[],
+  semantic: ArrayLike<number>,
+  transformedOf: (value: number) => number | undefined,
+): number {
   let unknownCount = 0;
   for (let index = 0; index < values.length; index++) {
-    if (values[index] === null) continue;
-    const semantic = view.semantic[index]!;
-    if (!Number.isFinite(semantic) || transformedOf(semantic) === undefined) {
+    if (
+      values[index] !== null &&
+      (!Number.isFinite(semantic[index]!) || transformedOf(semantic[index]!) === undefined)
+    ) {
       unknownCount++;
     }
   }
-  warnUnknownColors(name, unknownCount, warnings);
-  const formatStep = minAdjacentWidth(breaks);
-  const formatter = resolveBinnedLegendFormat({
-    domain,
-    temporalKind: view.temporalKind,
-    config,
-    name,
-    warnings,
-    ...(formatStep !== undefined && { formatStep }),
-  });
-  const steps = breaks.slice(0, -1).map((lower, index) => {
-    const upper = breaks[index + 1]!;
-    return Object.freeze({
-      lower,
-      upper,
-      lowerInclusive: true as const,
-      upperInclusive: index === binCount - 1,
-      label: `${formatter.label(lower)}–${formatter.label(upper)}`,
-      color: colors[index]!,
-    });
-  });
-  return {
-    resolved: { kind: "binned", scale },
-    legendInput: {
-      kind: "steps",
-      scale: name,
-      title: legendTitle,
-      entries: steps.map(({ label, color }) => ({ label, color })),
-    },
-    guidePlan: Object.freeze({
-      type: "colorsteps" as const,
-      id: `guide:${name}`,
-      aesthetic: name,
-      title: legendTitle,
-      domain: Object.freeze([...domain] as [number, number]),
-      transformedDomain: Object.freeze([...scale.transformedDomain] as [number, number]),
-      transform: transformName,
-      temporalKind: view.temporalKind,
-      direction: config.reverse === true ? ("descending" as const) : ("ascending" as const),
-      steps: Object.freeze(steps),
-      naValue,
-      unknownValue,
-    }),
-    state: null,
-  };
+  return unknownCount;
 }


### PR DESCRIPTION
## Summary\n- extract binned axis boundary validation and extent collection\n- extract binned color domain, color assignment, and diagnostics helpers\n- preserve binned scale behavior and errors\n\n## Verification\n- bunx oxlint -c /tmp/oxlintrc-core-max20.json packages/core/src/pipeline/resolve-binned-axis.ts packages/core/src/pipeline/scale-color-binned.ts\n- bunx tsc -b packages/spec packages/core packages/cli\n- bun test packages/core/tests/pipeline-position-binned.test.ts packages/core/tests/pipeline-color-scales/binned.test.ts\n- bun run bench:json (repeated; unrelated workloads showed host-wide contention, no localized coherent regression)