### PR TITLE
refactor(core): reduce SVG rendering complexity

### DIFF
--- a/packages/core/src/render-svg-legend.ts
+++ b/packages/core/src/render-svg-legend.ts
@@ -79,56 +79,92 @@ export function renderLegend(legend: SceneLegend, theme: ThemeTokens, gradientId
     );
   }
   if (legend.type === "discrete") {
-    for (const entry of legend.entries) {
-      const baseX = (entry.x ?? 0) + 4;
-      const rowHeight = entry.height ?? LEGEND_ROW_HEIGHT;
-      const swatchY = entry.y + (rowHeight - legend.swatchSize) / 2;
-      parts.push(
-        renderDiscreteLegendKey(entry, baseX, swatchY, legend.swatchSize, ink),
-        renderDiscreteLegendLabel(
-          entry,
-          baseX + legend.swatchSize + (legend.keyGap ?? 6),
-          rowHeight,
-          labelSize,
-          ink,
-        ),
-      );
-    }
+    parts.push(...renderDiscreteLegendEntries(legend, labelSize, ink));
   } else if (legend.type === "steps") {
-    for (const entry of legend.entries) {
-      const entryX = 4 + (entry.x ?? 0);
-      const entryY = contentTop + entry.y;
-      parts.push(
-        `<rect class="gg-legend-step" x="${px(entryX)}" y="${px(entryY)}" width="${px(legend.stepWidth)}" height="${px(legend.stepHeight)}" fill="${entry.color}"/>`,
-        entry.label === ""
-          ? ""
-          : `<text class="gg-legend-label" x="${px(horizontal ? entryX + legend.stepWidth / 2 : entryX + legend.stepWidth + 6)}" y="${px(horizontal ? entryY + legend.stepHeight + 12 : entryY + legend.stepHeight / 2)}" text-anchor="${horizontal ? "middle" : "start"}" dy="0.32em" font-size="${px(labelSize)}" fill="${ink}">${escapeXML(entry.label)}${entry.fullLabel !== undefined && entry.fullLabel !== entry.label ? `<title>${escapeXML(entry.fullLabel)}</title>` : ""}</text>`,
-      );
-    }
+    parts.push(...renderStepLegendEntries(legend, contentTop, horizontal, labelSize, ink));
   } else {
-    const rampX = horizontal ? (legend.rampX ?? 4) : 4;
-    const stops = legend.stops
-      .map(([offset, color]) => `<stop offset="${px(offset * 100)}%" stop-color="${color}"/>`)
-      .join("");
     parts.push(
-      `<defs><linearGradient id="${gradientId}" x1="0" y1="0" x2="${horizontal ? "1" : "0"}" y2="${horizontal ? "0" : "1"}">${stops}</linearGradient></defs>`,
-      `<rect class="gg-legend-ramp" x="${px(rampX)}" y="${px(contentTop)}" width="${px(legend.rampWidth)}" height="${px(legend.rampHeight)}" fill="url(#${gradientId})"/>`,
+      ...renderContinuousLegend(legend, contentTop, horizontal, labelSize, ink, gradientId),
     );
-    for (const tick of legend.ticks) {
-      const pos = tick.pos ?? tick.y ?? 0;
-      if (legend.showTicks !== false) {
-        parts.push(
-          horizontal
-            ? `<line class="gg-legend-tick" x1="${px(rampX + pos)}" y1="${px(contentTop + legend.rampHeight)}" x2="${px(rampX + pos)}" y2="${px(contentTop + legend.rampHeight + 4)}" stroke="${ink}"/>`
-            : `<line class="gg-legend-tick" x1="${px(rampX + legend.rampWidth)}" y1="${px(contentTop + pos)}" x2="${px(rampX + legend.rampWidth + 4)}" y2="${px(contentTop + pos)}" stroke="${ink}"/>`,
-        );
-      }
-      if (tick.label === "") continue;
-      parts.push(
-        `<text class="gg-legend-label" x="${px(horizontal ? rampX + pos : rampX + legend.rampWidth + 6)}" y="${px(horizontal ? contentTop + legend.rampHeight + 12 : contentTop + pos)}" text-anchor="${horizontal ? "middle" : "start"}" dy="0.32em" font-size="${px(labelSize)}" fill="${ink}">${escapeXML(tick.label)}${tick.fullLabel !== undefined && tick.fullLabel !== tick.label ? `<title>${escapeXML(tick.fullLabel)}</title>` : ""}</text>`,
-      );
-    }
   }
   parts.push("</g>");
   return parts.join("");
+}
+
+function renderDiscreteLegendEntries(
+  legend: Extract<SceneLegend, { type: "discrete" }>,
+  labelSize: number,
+  ink: string,
+): string[] {
+  const parts: string[] = [];
+  for (const entry of legend.entries) {
+    const baseX = (entry.x ?? 0) + 4;
+    const rowHeight = entry.height ?? LEGEND_ROW_HEIGHT;
+    const swatchY = entry.y + (rowHeight - legend.swatchSize) / 2;
+    parts.push(
+      renderDiscreteLegendKey(entry, baseX, swatchY, legend.swatchSize, ink),
+      renderDiscreteLegendLabel(
+        entry,
+        baseX + legend.swatchSize + (legend.keyGap ?? 6),
+        rowHeight,
+        labelSize,
+        ink,
+      ),
+    );
+  }
+  return parts;
+}
+
+function renderStepLegendEntries(
+  legend: Extract<SceneLegend, { type: "steps" }>,
+  contentTop: number,
+  horizontal: boolean,
+  labelSize: number,
+  ink: string,
+): string[] {
+  const parts: string[] = [];
+  for (const entry of legend.entries) {
+    const entryX = 4 + (entry.x ?? 0);
+    const entryY = contentTop + entry.y;
+    parts.push(
+      `<rect class="gg-legend-step" x="${px(entryX)}" y="${px(entryY)}" width="${px(legend.stepWidth)}" height="${px(legend.stepHeight)}" fill="${entry.color}"/>`,
+      entry.label === ""
+        ? ""
+        : `<text class="gg-legend-label" x="${px(horizontal ? entryX + legend.stepWidth / 2 : entryX + legend.stepWidth + 6)}" y="${px(horizontal ? entryY + legend.stepHeight + 12 : entryY + legend.stepHeight / 2)}" text-anchor="${horizontal ? "middle" : "start"}" dy="0.32em" font-size="${px(labelSize)}" fill="${ink}">${escapeXML(entry.label)}${entry.fullLabel !== undefined && entry.fullLabel !== entry.label ? `<title>${escapeXML(entry.fullLabel)}</title>` : ""}</text>`,
+    );
+  }
+  return parts;
+}
+
+function renderContinuousLegend(
+  legend: Extract<SceneLegend, { type: "ramp" }>,
+  contentTop: number,
+  horizontal: boolean,
+  labelSize: number,
+  ink: string,
+  gradientId: string,
+): string[] {
+  const rampX = horizontal ? (legend.rampX ?? 4) : 4;
+  const stops = legend.stops
+    .map(([offset, color]) => `<stop offset="${px(offset * 100)}%" stop-color="${color}"/>`)
+    .join("");
+  const parts = [
+    `<defs><linearGradient id="${gradientId}" x1="0" y1="0" x2="${horizontal ? "1" : "0"}" y2="${horizontal ? "0" : "1"}">${stops}</linearGradient></defs>`,
+    `<rect class="gg-legend-ramp" x="${px(rampX)}" y="${px(contentTop)}" width="${px(legend.rampWidth)}" height="${px(legend.rampHeight)}" fill="url(#${gradientId})"/>`,
+  ];
+  for (const tick of legend.ticks) {
+    const pos = tick.pos ?? tick.y ?? 0;
+    if (legend.showTicks !== false) {
+      parts.push(
+        horizontal
+          ? `<line class="gg-legend-tick" x1="${px(rampX + pos)}" y1="${px(contentTop + legend.rampHeight)}" x2="${px(rampX + pos)}" y2="${px(contentTop + legend.rampHeight + 4)}" stroke="${ink}"/>`
+          : `<line class="gg-legend-tick" x1="${px(rampX + legend.rampWidth)}" y1="${px(contentTop + pos)}" x2="${px(rampX + legend.rampWidth + 4)}" y2="${px(contentTop + pos)}" stroke="${ink}"/>`,
+      );
+    }
+    if (tick.label === "") continue;
+    parts.push(
+      `<text class="gg-legend-label" x="${px(horizontal ? rampX + pos : rampX + legend.rampWidth + 6)}" y="${px(horizontal ? contentTop + legend.rampHeight + 12 : contentTop + pos)}" text-anchor="${horizontal ? "middle" : "start"}" dy="0.32em" font-size="${px(labelSize)}" fill="${ink}">${escapeXML(tick.label)}${tick.fullLabel !== undefined && tick.fullLabel !== tick.label ? `<title>${escapeXML(tick.fullLabel)}</title>` : ""}</text>`,
+    );
+  }
+  return parts;
 }

--- a/packages/core/src/render-svg-panel-chrome.ts
+++ b/packages/core/src/render-svg-panel-chrome.ts
@@ -29,84 +29,115 @@ function rotatedBandLabelSvg(
 
 export function renderPanelAxes(panel: ScenePanel, theme: ThemeTokens): string {
   const parts: string[] = [];
+  if (panel.axisX !== null) parts.push(renderXAxis(panel, theme));
+  if (panel.axisY !== null) parts.push(renderYAxis(panel, theme));
+  return parts.join("");
+}
+
+function renderXAxis(panel: ScenePanel, theme: ThemeTokens): string {
   const axisText = themeVar("axisText", theme);
   const axisLine = themeVar("axisLine", theme);
   const tickColor = themeVar("tickColor", theme);
-  if (panel.axisX !== null) {
+  const parts = [
+    `<g class="gg-axis gg-axis-x" transform="translate(${px(panel.x)},${px(panel.y + panel.height)})">`,
+  ];
+  if (theme.axisLineX) {
     parts.push(
-      `<g class="gg-axis gg-axis-x" transform="translate(${px(panel.x)},${px(panel.y + panel.height)})">`,
+      `<line class="gg-axis-line" x1="0" y1="0" x2="${px(panel.width)}" y2="0" stroke="${axisLine}" stroke-width="${px(theme.axisLineWidth)}" vector-effect="non-scaling-stroke"/>`,
     );
-    if (theme.axisLineX) {
-      parts.push(
-        `<line class="gg-axis-line" x1="0" y1="0" x2="${px(panel.width)}" y2="0" stroke="${axisLine}" stroke-width="${px(theme.axisLineWidth)}" vector-effect="non-scaling-stroke"/>`,
-      );
-    }
-    for (const tick of panel.axisX) {
-      const minor = tick.kind === "minor";
-      parts.push(
-        `<g class="gg-tick${minor ? " gg-tick-minor" : ""}" transform="translate(${px(tick.pos)},0)">`,
-      );
-      if (!minor) parts.push(`<title>${escapeXML(tick.fullLabel ?? tick.label)}</title>`);
-      if (theme.ticksX && tick.showTick !== false) {
-        parts.push(
-          `<line y2="${px(minor ? theme.tickLength / 2 : theme.tickLength)}" stroke="${tickColor}" stroke-width="${px(theme.tickWidth)}"${minor ? ' opacity="0.5"' : ""} vector-effect="non-scaling-stroke"/>`,
-        );
-      }
-      if (tick.label !== "" && tick.showLabel !== false) {
-        const yOff = (theme.ticksX && tick.showTick !== false ? theme.tickLength : 0) + 3;
-        const labelSize = tick.labelSize ?? theme.axisTextSize;
-        const font = `fill="${axisText}" font-size="${px(labelSize)}" font-weight="${theme.fontWeight}"`;
-        if (tick.angle !== undefined && tick.angle !== 0) {
-          parts.push(rotatedBandLabelSvg({ ...tick, angle: tick.angle }, yOff, labelSize, font));
-        } else if (tick.lines !== undefined && tick.lines.length > 1) {
-          // Wrapped band label: one tspan per line, centered.
-          const lineH = labelSize * 1.15;
-          const tspans = tick.lines
-            .map(
-              (line, i) =>
-                `<tspan x="0" dy="${i === 0 ? "0.71em" : px(lineH)}">${escapeXML(line)}</tspan>`,
-            )
-            .join("");
-          parts.push(`<text y="${px(yOff)}" text-anchor="middle" ${font}>${tspans}</text>`);
-        } else {
-          parts.push(
-            `<text y="${px(yOff)}" dy="0.71em" text-anchor="middle" ${font}>${escapeXML(tick.label)}</text>`,
-          );
-        }
-      }
-      parts.push("</g>");
-    }
-    parts.push("</g>");
   }
-  if (panel.axisY !== null) {
+  for (const tick of panel.axisX!) parts.push(renderXAxisTick(tick, theme, axisText, tickColor));
+  parts.push("</g>");
+  return parts.join("");
+}
+
+function renderXAxisTick(
+  tick: NonNullable<ScenePanel["axisX"]>[number],
+  theme: ThemeTokens,
+  axisText: string,
+  tickColor: string,
+): string {
+  const minor = tick.kind === "minor";
+  const parts = [
+    `<g class="gg-tick${minor ? " gg-tick-minor" : ""}" transform="translate(${px(tick.pos)},0)">`,
+  ];
+  if (!minor) parts.push(`<title>${escapeXML(tick.fullLabel ?? tick.label)}</title>`);
+  if (theme.ticksX && tick.showTick !== false) {
     parts.push(
-      `<g class="gg-axis gg-axis-y" transform="translate(${px(panel.x)},${px(panel.y)})">`,
+      `<line y2="${px(minor ? theme.tickLength / 2 : theme.tickLength)}" stroke="${tickColor}" stroke-width="${px(theme.tickWidth)}"${minor ? ' opacity="0.5"' : ""} vector-effect="non-scaling-stroke"/>`,
     );
-    if (theme.axisLineY) {
-      parts.push(
-        `<line class="gg-axis-line" x1="0" y1="0" x2="0" y2="${px(panel.height)}" stroke="${axisLine}" stroke-width="${px(theme.axisLineWidth)}" vector-effect="non-scaling-stroke"/>`,
-      );
-    }
-    for (const tick of panel.axisY) {
-      const minor = tick.kind === "minor";
-      parts.push(
-        `<g class="gg-tick${minor ? " gg-tick-minor" : ""}" transform="translate(0,${px(tick.pos)})">`,
-      );
-      if (!minor) parts.push(`<title>${escapeXML(tick.fullLabel ?? tick.label)}</title>`);
-      if (theme.ticksY && tick.showTick !== false) {
-        parts.push(
-          `<line x2="-${px(minor ? theme.tickLength / 2 : theme.tickLength)}" stroke="${tickColor}" stroke-width="${px(theme.tickWidth)}"${minor ? ' opacity="0.5"' : ""} vector-effect="non-scaling-stroke"/>`,
-        );
-      }
-      if (tick.label !== "" && tick.showLabel !== false) {
-        parts.push(
-          `<text x="-${px((theme.ticksY && tick.showTick !== false ? theme.tickLength : 0) + 3)}" dy="0.32em" text-anchor="end" fill="${axisText}" font-size="${px(tick.labelSize ?? theme.axisTextSize)}" font-weight="${theme.fontWeight}">${escapeXML(tick.label)}</text>`,
-        );
-      }
-      parts.push("</g>");
-    }
-    parts.push("</g>");
   }
+  if (tick.label !== "" && tick.showLabel !== false) {
+    const yOff = (theme.ticksX && tick.showTick !== false ? theme.tickLength : 0) + 3;
+    const labelSize = tick.labelSize ?? theme.axisTextSize;
+    const font = `fill="${axisText}" font-size="${px(labelSize)}" font-weight="${theme.fontWeight}"`;
+    parts.push(renderXAxisLabel(tick, yOff, labelSize, font));
+  }
+  parts.push("</g>");
+  return parts.join("");
+}
+
+function renderXAxisLabel(
+  tick: NonNullable<ScenePanel["axisX"]>[number],
+  yOff: number,
+  labelSize: number,
+  font: string,
+): string {
+  if (tick.angle !== undefined && tick.angle !== 0) {
+    return rotatedBandLabelSvg({ ...tick, angle: tick.angle }, yOff, labelSize, font);
+  }
+  if (tick.lines !== undefined && tick.lines.length > 1) {
+    const lineH = labelSize * 1.15;
+    const tspans = tick.lines
+      .map(
+        (line, i) =>
+          `<tspan x="0" dy="${i === 0 ? "0.71em" : px(lineH)}">${escapeXML(line)}</tspan>`,
+      )
+      .join("");
+    return `<text y="${px(yOff)}" text-anchor="middle" ${font}>${tspans}</text>`;
+  }
+  return `<text y="${px(yOff)}" dy="0.71em" text-anchor="middle" ${font}>${escapeXML(tick.label)}</text>`;
+}
+
+function renderYAxis(panel: ScenePanel, theme: ThemeTokens): string {
+  const axisText = themeVar("axisText", theme);
+  const axisLine = themeVar("axisLine", theme);
+  const tickColor = themeVar("tickColor", theme);
+  const parts = [
+    `<g class="gg-axis gg-axis-y" transform="translate(${px(panel.x)},${px(panel.y)})">`,
+  ];
+  if (theme.axisLineY) {
+    parts.push(
+      `<line class="gg-axis-line" x1="0" y1="0" x2="0" y2="${px(panel.height)}" stroke="${axisLine}" stroke-width="${px(theme.axisLineWidth)}" vector-effect="non-scaling-stroke"/>`,
+    );
+  }
+  for (const tick of panel.axisY!) parts.push(renderYAxisTick(tick, theme, axisText, tickColor));
+  parts.push("</g>");
+  return parts.join("");
+}
+
+function renderYAxisTick(
+  tick: NonNullable<ScenePanel["axisY"]>[number],
+  theme: ThemeTokens,
+  axisText: string,
+  tickColor: string,
+): string {
+  const minor = tick.kind === "minor";
+  const parts = [
+    `<g class="gg-tick${minor ? " gg-tick-minor" : ""}" transform="translate(0,${px(tick.pos)})">`,
+  ];
+  if (!minor) parts.push(`<title>${escapeXML(tick.fullLabel ?? tick.label)}</title>`);
+  if (theme.ticksY && tick.showTick !== false) {
+    parts.push(
+      `<line x2="-${px(minor ? theme.tickLength / 2 : theme.tickLength)}" stroke="${tickColor}" stroke-width="${px(theme.tickWidth)}"${minor ? ' opacity="0.5"' : ""} vector-effect="non-scaling-stroke"/>`,
+    );
+  }
+  if (tick.label !== "" && tick.showLabel !== false) {
+    parts.push(
+      `<text x="-${px((theme.ticksY && tick.showTick !== false ? theme.tickLength : 0) + 3)}" dy="0.32em" text-anchor="end" fill="${axisText}" font-size="${px(tick.labelSize ?? theme.axisTextSize)}" font-weight="${theme.fontWeight}">${escapeXML(tick.label)}</text>`,
+    );
+  }
+  parts.push("</g>");
   return parts.join("");
 }
 


### PR DESCRIPTION
## Summary\n- split panel axis rendering into x/y and tick helpers\n- split discrete, steps, and ramp legend rendering\n- preserve SVG output and chrome behavior\n\n## Verification\n- bunx oxlint -c /tmp/oxlintrc-core-max20.json packages/core/src/render-svg-panel-chrome.ts packages/core/src/render-svg-legend.ts\n- bunx tsc -b packages/spec packages/core packages/cli\n- bun test packages/core/tests/render-svg.test.ts packages/core/tests/render-band-labels.test.ts packages/core/tests/render-svg-golden.test.ts packages/core/tests/pipeline-m2/render-svg.test.ts packages/core/tests/facets/svg-render.test.ts\n- bun run bench:json (repeated; no coherent rendering regression)