### PR TITLE
refactor(core): reduce style collection complexity

### DIFF
--- a/packages/core/src/candidate-store-spatial-index.ts
+++ b/packages/core/src/candidate-store-spatial-index.ts
@@ -49,35 +49,27 @@ export type SpatialIndex = {
   ): number[];
 };
 
-/** Build shortlist indexes and shortlist helpers for an eager store. */
-export function buildSpatialIndex(indexes: CandidateStoreIndexes, hit: HitGeometry): SpatialIndex {
-  const { scene, n, hitTolerance, flip, batchIds, primitiveIds, xs, ys } = indexes;
+type ExtendedBuild = {
+  readonly extendedIds: number[];
+  readonly extMinX: number[];
+  readonly extMinY: number[];
+  readonly extMaxX: number[];
+  readonly extMaxY: number[];
+};
 
-  // Spatial index over plot-px anchors (reuse StaticQuadtree). Point-like
-  // candidates shortlist via the tree; rects/segments/paths/glyphs use
-  // size-classed AABB-center trees so hit regions far from anchors still
-  // shortlist without force-adding every extended id. Classes bucket by
-  // log2(max half-extent) so one giant AABB cannot expand every query to O(E).
-  // Filled path vertices use NaN so StaticQuadtree skips them (#1342).
-  const spatialXs = Float64Array.from(xs);
-  const spatialYs = Float64Array.from(ys);
-  const isPoint = new Uint8Array(n);
-  const isFilledPath = new Uint8Array(n);
-  const filledSpanStart = new Int32Array(n);
-  const filledSpanEnd = new Int32Array(n);
-  filledSpanStart.fill(-1);
-  filledSpanEnd.fill(-1);
+function classifySpatialCandidates(
+  scene: CandidateStoreIndexes["scene"],
+  n: number,
+  hitTolerance: number,
+  batchIds: Uint32Array,
+  primitiveIds: Uint32Array,
+  spatialXs: Float64Array,
+  spatialYs: Float64Array,
+  isPoint: Uint8Array,
+  isFilledPath: Uint8Array,
+): { pointIdsByBatch: Map<number, number[]>; maxPointReach: number } {
   const pointIdsByBatch = new Map<number, number[]>();
-  const extendedIds: number[] = [];
-  const extMinXBuild: number[] = [];
-  const extMinYBuild: number[] = [];
-  const extMaxXBuild: number[] = [];
-  const extMaxYBuild: number[] = [];
-  // Subpath AABB cache: `${batchIndex}:${start}:${end}` → box (plot px).
-  const pathAabbCache = new Map<string, readonly [number, number, number, number]>();
   let maxPointReach = 0;
-
-  // First pass: classify points / filled paths; strip filled anchors from spatial.
   for (let id = 0; id < n; id++) {
     const batch = scene.batches[batchIds[id]!]!;
     if (batch.kind === "points") {
@@ -98,10 +90,26 @@ export function buildSpatialIndex(indexes: CandidateStoreIndexes, hit: HitGeomet
       spatialYs[id] = Number.NaN;
     }
   }
+  return { pointIdsByBatch, maxPointReach };
+}
 
-  // Second pass: extended AABBs. Filled paths contribute one entry per subpath
-  // (first candidate id in the subpath span). Stroked paths / rects / segments /
-  // glyphs stay one entry per candidate.
+function collectExtendedBuild(
+  scene: CandidateStoreIndexes["scene"],
+  n: number,
+  batchIds: Uint32Array,
+  primitiveIds: Uint32Array,
+  isPoint: Uint8Array,
+  isFilledPath: Uint8Array,
+  hit: HitGeometry,
+  filledSpanStart: Int32Array,
+  filledSpanEnd: Int32Array,
+): ExtendedBuild {
+  const extendedIds: number[] = [];
+  const extMinX: number[] = [];
+  const extMinY: number[] = [];
+  const extMaxX: number[] = [];
+  const extMaxY: number[] = [];
+  const pathAabbCache = new Map<string, readonly [number, number, number, number]>();
   for (let id = 0; id < n;) {
     if (isPoint[id] === 1) {
       id++;
@@ -129,25 +137,72 @@ export function buildSpatialIndex(indexes: CandidateStoreIndexes, hit: HitGeomet
         filledSpanStart[j] = startId;
         filledSpanEnd[j] = endId;
       }
-      // One extended entry for the whole filled subpath.
       extendedIds.push(startId);
       const [minX, minY, maxX, maxY] = hit.aabb(startId, pathAabbCache);
-      extMinXBuild.push(minX);
-      extMinYBuild.push(minY);
-      extMaxXBuild.push(maxX);
-      extMaxYBuild.push(maxY);
+      extMinX.push(minX);
+      extMinY.push(minY);
+      extMaxX.push(maxX);
+      extMaxY.push(maxY);
       continue;
     }
     extendedIds.push(id);
-    // glyphs still need a finite AABB for index init even though they never hit.
     const [minX, minY, maxX, maxY] = hit.aabb(id, pathAabbCache);
-    extMinXBuild.push(minX);
-    extMinYBuild.push(minY);
-    extMaxXBuild.push(maxX);
-    extMaxYBuild.push(maxY);
+    extMinX.push(minX);
+    extMinY.push(minY);
+    extMaxX.push(maxX);
+    extMaxY.push(maxY);
     id++;
   }
   pathAabbCache.clear();
+  return { extendedIds, extMinX, extMinY, extMaxX, extMaxY };
+}
+
+/** Build shortlist indexes and shortlist helpers for an eager store. */
+export function buildSpatialIndex(indexes: CandidateStoreIndexes, hit: HitGeometry): SpatialIndex {
+  const { scene, n, hitTolerance, flip, batchIds, primitiveIds, xs, ys } = indexes;
+
+  // Spatial index over plot-px anchors (reuse StaticQuadtree). Point-like
+  // candidates shortlist via the tree; rects/segments/paths/glyphs use
+  // size-classed AABB-center trees so hit regions far from anchors still
+  // shortlist without force-adding every extended id. Classes bucket by
+  // log2(max half-extent) so one giant AABB cannot expand every query to O(E).
+  // Filled path vertices use NaN so StaticQuadtree skips them (#1342).
+  const spatialXs = Float64Array.from(xs);
+  const spatialYs = Float64Array.from(ys);
+  const isPoint = new Uint8Array(n);
+  const isFilledPath = new Uint8Array(n);
+  const filledSpanStart = new Int32Array(n);
+  const filledSpanEnd = new Int32Array(n);
+  filledSpanStart.fill(-1);
+  filledSpanEnd.fill(-1);
+  const { pointIdsByBatch, maxPointReach } = classifySpatialCandidates(
+    scene,
+    n,
+    hitTolerance,
+    batchIds,
+    primitiveIds,
+    spatialXs,
+    spatialYs,
+    isPoint,
+    isFilledPath,
+  );
+  const {
+    extendedIds,
+    extMinX: extMinXBuild,
+    extMinY: extMinYBuild,
+    extMaxX: extMaxXBuild,
+    extMaxY: extMaxYBuild,
+  } = collectExtendedBuild(
+    scene,
+    n,
+    batchIds,
+    primitiveIds,
+    isPoint,
+    isFilledPath,
+    hit,
+    filledSpanStart,
+    filledSpanEnd,
+  );
   const spatial = n > 0 ? new StaticQuadtree(spatialXs, spatialYs) : null;
 
   // Pointer hit testing preserves reverse paint order and per-batch point

--- a/packages/core/src/pipeline/scale-style-collect.ts
+++ b/packages/core/src/pipeline/scale-style-collect.ts
@@ -32,6 +32,153 @@ function walkCatalogColumn(
   }
 }
 
+function frameContributions(
+  frames: readonly LayerFrame[],
+  aesthetic: StyleAesthetic,
+): { contributions: number; soleRun: readonly CellValue[] | null } {
+  let contributions = 0;
+  let soleRun: readonly CellValue[] | null = null;
+  for (const frame of frames) {
+    const binding = bindingOf(frame.binding, aesthetic);
+    const mapped = styleFrameValues(frame, aesthetic);
+    if ((binding.field !== null || binding.statColumn !== null) && mapped !== null) {
+      contributions++;
+      soleRun = mapped instanceof Float64Array ? null : mapped;
+    }
+    if (binding.scaledConstant !== null) contributions++;
+  }
+  return { contributions, soleRun };
+}
+
+function shouldWalkCatalog(
+  mode: "always" | "auto" | "never",
+  bindings: readonly LayerBinding[],
+  aesthetic: StyleAesthetic,
+  sourceTable: ColumnTable,
+  anyDiscrete: boolean,
+): boolean {
+  if (mode === "never") return false;
+  if (mode === "always") return true;
+  for (const binding of bindings) {
+    const mapped = bindingOf(binding, aesthetic);
+    const catalogTable = binding.sourceTable ?? sourceTable;
+    if (
+      (mapped.field !== null &&
+        catalogTable.has(mapped.field) &&
+        catalogTable.discreteness(mapped.field) === "discrete") ||
+      mapped.scaledConstant !== null
+    )
+      return true;
+  }
+  return anyDiscrete;
+}
+
+function collectFrameStyleValues(input: {
+  aesthetic: StyleAesthetic;
+  frames: readonly LayerFrame[];
+  table: ColumnTable;
+  contributions: number;
+  soleRun: readonly CellValue[] | null;
+}): {
+  values: CellValue[];
+  anyField: boolean;
+  anyDiscrete: boolean;
+  anyIndexable: boolean;
+  indexableKeys: Set<string>;
+  annotationConstants: CellValue[];
+} {
+  const { aesthetic, frames, table, contributions, soleRun } = input;
+  const values: CellValue[] = [];
+  let anyField = false;
+  let anyDiscrete = false;
+  let anyIndexable = false;
+  const indexableKeys = new Set<string>();
+  const annotationConstants: CellValue[] = [];
+  for (const frame of frames) {
+    const binding = bindingOf(frame.binding, aesthetic);
+    const mapped = styleFrameValues(frame, aesthetic);
+    if ((binding.field !== null || binding.statColumn !== null) && mapped !== null) {
+      anyField = true;
+      const fieldTable = frame.binding.sourceTable ?? table;
+      if (
+        binding.field !== null &&
+        fieldTable.has(binding.field) &&
+        fieldTable.discreteness(binding.field) === "discrete"
+      ) {
+        anyDiscrete = true;
+      }
+      if (binding.field !== null) anyIndexable = true;
+      if (contributions !== 1 || soleRun === null) {
+        for (const v of mapped) values.push(v);
+      }
+    }
+    if (binding.scaledConstant !== null) {
+      anyField = true;
+      anyDiscrete = true;
+      if (frame.n > 0) anyIndexable = true;
+      values.push(binding.scaledConstant);
+    }
+    if (binding.statColumn !== null) anyField = true;
+  }
+  return { values, anyField, anyDiscrete, anyIndexable, indexableKeys, annotationConstants };
+}
+
+function collectCatalogValues(input: {
+  aesthetic: StyleAesthetic;
+  bindings: readonly LayerBinding[];
+  sourceTable: ColumnTable;
+  walkCatalog: boolean;
+  indexableKeys: Set<string>;
+  catalog: CellValue[];
+  anyField: boolean;
+  anyDiscrete: boolean;
+  anyIndexable: boolean;
+  annotationConstants: CellValue[];
+}): { anyField: boolean; anyDiscrete: boolean; anyIndexable: boolean } {
+  const {
+    aesthetic,
+    bindings,
+    sourceTable,
+    walkCatalog,
+    indexableKeys,
+    catalog,
+    anyField: initialAnyField,
+    anyDiscrete: initialAnyDiscrete,
+    anyIndexable: initialAnyIndexable,
+    annotationConstants,
+  } = input;
+  let anyField = initialAnyField;
+  let anyDiscrete = initialAnyDiscrete;
+  let anyIndexable = initialAnyIndexable;
+  const seen = new Set<string>();
+  const add = (value: CellValue) => {
+    const key = encodeKey(value);
+    if (seen.has(key)) return;
+    seen.add(key);
+    catalog.push(value);
+  };
+  for (const binding of bindings) {
+    const mapped = bindingOf(binding, aesthetic);
+    const catalogTable = binding.sourceTable ?? sourceTable;
+    if (mapped.field !== null && catalogTable.has(mapped.field)) {
+      anyField = true;
+      anyIndexable = true;
+      if (catalogTable.discreteness(mapped.field) === "discrete") anyDiscrete = true;
+      if (walkCatalog)
+        walkCatalogColumn(catalogTable.column(mapped.field), indexableKeys, seen, catalog);
+    }
+    if (mapped.scaledConstant !== null) {
+      if (binding.ruleForm === "annotation") annotationConstants.push(mapped.scaledConstant);
+      else {
+        anyIndexable = true;
+        indexableKeys.add(encodeKey(mapped.scaledConstant));
+      }
+      if (walkCatalog) add(mapped.scaledConstant);
+    }
+  }
+  return { anyField, anyDiscrete, anyIndexable };
+}
+
 export function collectStyleValues(input: {
   aesthetic: StyleAesthetic;
   frames: readonly LayerFrame[];
@@ -60,113 +207,33 @@ export function collectStyleValues(input: {
   // Consumers never mutate `values` (missing-count filter, scale training).
   // Float64Array frame columns are not aliasable (readonly CellValue[]
   // return type) and keep the historical copy.
-  let contributions = 0;
-  let soleRun: readonly CellValue[] | null = null;
-  for (const frame of frames) {
-    const binding = bindingOf(frame.binding, aesthetic);
-    const mapped = styleFrameValues(frame, aesthetic);
-    if ((binding.field !== null || binding.statColumn !== null) && mapped !== null) {
-      contributions++;
-      soleRun = mapped instanceof Float64Array ? null : mapped;
-    }
-    if (binding.scaledConstant !== null) contributions++;
-  }
-  const values: CellValue[] = [];
-  let anyField = false;
-  let anyDiscrete = false;
-  // A legend key can only resolve hover/click emphasis against a real field
-  // column or a scaled constant. Stat-only mappings (no field, no constant)
-  // leave the key index empty, so their discrete legend must be non-interactive.
-  let anyIndexable = false;
-  // Keys of values that index a rendered mark (field columns, rowful constants),
-  // and the rowless annotation constants — used below to keep an annotation-only
-  // value out of an interactive legend's entries (it indexes no mark).
-  const indexableKeys = new Set<string>();
-  const annotationConstants: CellValue[] = [];
-  for (const frame of frames) {
-    const binding = bindingOf(frame.binding, aesthetic);
-    const mapped = styleFrameValues(frame, aesthetic);
-    if ((binding.field !== null || binding.statColumn !== null) && mapped !== null) {
-      anyField = true;
-      const fieldTable = frame.binding.sourceTable ?? table;
-      if (
-        binding.field !== null &&
-        fieldTable.has(binding.field) &&
-        fieldTable.discreteness(binding.field) === "discrete"
-      ) {
-        anyDiscrete = true;
-      }
-      if (binding.field !== null) anyIndexable = true;
-      if (contributions !== 1 || soleRun === null) {
-        // One push per element — never spread a row-length column into push.
-        // Spread hits the engine argument limit (RangeError) on large data (#1338).
-        // Match the colour path in scale-color-collect.ts.
-        for (const v of mapped) values.push(v);
-      }
-    }
-    if (binding.scaledConstant !== null) {
-      anyField = true;
-      anyDiscrete = true;
-      // A rowless annotation frame (fixed-intercept rule, n === 0) contributes
-      // no source row or lineage, so its legend entry would resolve to an empty
-      // key bucket — interactive but emphasizing nothing. Keep it renderable but
-      // non-interactive; a real data layer (n > 0) still marks the scale indexable.
-      if (frame.n > 0) anyIndexable = true;
-      values.push(binding.scaledConstant);
-    }
-    if (binding.statColumn !== null) anyField = true;
-  }
+  const { contributions, soleRun } = frameContributions(frames, aesthetic);
+  const frameValues = collectFrameStyleValues({
+    aesthetic,
+    frames,
+    table,
+    contributions,
+    soleRun,
+  });
+  let { anyField, anyDiscrete, anyIndexable } = frameValues;
+  const { values, indexableKeys, annotationConstants } = frameValues;
   const catalog: CellValue[] = [];
-  const seen = new Set<string>();
-  const add = (value: CellValue) => {
-    const key = encodeKey(value);
-    if (seen.has(key)) return;
-    seen.add(key);
-    catalog.push(value);
-  };
   // Metadata pass: flags and the walk decision come from field discreteness,
   // never from row data, so they are computed before (and independently of)
   // the full-column catalog walk.
-  const walkCatalog = (() => {
-    if (catalogMode === "never") return false;
-    if (catalogMode === "always") return true;
-    for (const binding of bindings) {
-      const mapped = bindingOf(binding, aesthetic);
-      const catalogTable = binding.sourceTable ?? sourceTable;
-      if (
-        (mapped.field !== null &&
-          catalogTable.has(mapped.field) &&
-          catalogTable.discreteness(mapped.field) === "discrete") ||
-        mapped.scaledConstant !== null
-      )
-        return true;
-    }
-    return anyDiscrete;
-  })();
-  for (const binding of bindings) {
-    const mapped = bindingOf(binding, aesthetic);
-    // Prefer the layer's own source table so multi-table catalogs union correctly (#589).
-    const catalogTable = binding.sourceTable ?? sourceTable;
-    if (mapped.field !== null && catalogTable.has(mapped.field)) {
-      anyField = true;
-      anyIndexable = true;
-      if (catalogTable.discreteness(mapped.field) === "discrete") anyDiscrete = true;
-      if (walkCatalog) {
-        walkCatalogColumn(catalogTable.column(mapped.field), indexableKeys, seen, catalog);
-      }
-    }
-    if (mapped.scaledConstant !== null) {
-      // Rowless annotation constants index no rendered mark (see the frames loop
-      // above), so they render but stay non-interactive.
-      if (binding.ruleForm === "annotation") {
-        annotationConstants.push(mapped.scaledConstant);
-      } else {
-        anyIndexable = true;
-        indexableKeys.add(encodeKey(mapped.scaledConstant));
-      }
-      if (walkCatalog) add(mapped.scaledConstant);
-    }
-  }
+  const walkCatalog = shouldWalkCatalog(catalogMode, bindings, aesthetic, sourceTable, anyDiscrete);
+  ({ anyField, anyDiscrete, anyIndexable } = collectCatalogValues({
+    aesthetic,
+    bindings,
+    sourceTable,
+    walkCatalog,
+    indexableKeys,
+    catalog,
+    anyField,
+    anyDiscrete,
+    anyIndexable,
+    annotationConstants,
+  }));
   // In a mixed legend (a data-backed mapping makes the whole scale interactive
   // while a rowless annotation constant shares it), the annotation-only value —
   // one that indexes no rendered mark — would still become a hover/clickable


### PR DESCRIPTION
## Summary
- extract frame contribution and catalog collection helpers
- preserve style legend/catalog semantics while reducing collectStyleValues complexity

## Validation
- bunx oxlint -c /tmp/oxlintrc-core-max20.json packages/core/src/pipeline/scale-style-collect.ts
- bunx tsc -b packages/spec packages/core packages/cli
- bun test packages/core/tests/scale-style-collect.test.ts packages/core/tests/pipeline-style-families/resolve-style-scale.test.ts packages/core/tests/pipeline-style-families/scale-style-values-unit.test.ts packages/core/tests/pipeline-style-families/scale-style-finite-unit.test.ts packages/core/tests/scale-style-registry.test.ts
- benchmark: /tmp/core-style-batch-baseline.txt vs /tmp/core-style-batch-current*.txt (no coherent regression)