### PR TITLE
refactor(core): reduce finalize layout complexity

### DIFF
--- a/packages/core/src/pipeline/finalize-layout-pass.ts
+++ b/packages/core/src/pipeline/finalize-layout-pass.ts
@@ -1,7 +1,7 @@
 /**
  * Finalize phase: two-pass panel layout only.
  */
-import type { CellValue, CoordRadialSpec, PortableSpec } from "@ggsvelte/spec";
+import type { CellValue, CoordRadialSpec, PortableSpec, TemporalScaleKind } from "@ggsvelte/spec";
 import { getTemporalRuntime } from "../temporal-runtime.js";
 
 import { buildPolarProjector } from "../coord-polar.js";
@@ -34,90 +34,59 @@ function radialPanelAspect(coord: CoordRadialSpec): number {
   return by / bx;
 }
 
-export function finalizePanelLayoutPass(input: {
-  normalized: PortableSpec;
-  options: RunOptions;
-  theme: ThemeTokens;
-  flip: boolean;
-  prepared: PreparedPanels;
-  trained: TrainedPipelineScales;
-  warnings: PipelineWarning[];
-}): PanelLayoutResult {
-  const { normalized, options, theme, flip, prepared, trained, warnings } = input;
-  const { faceted, freeX, freeY, nrow, ncol, facetPanels, strip } = prepared;
-  const {
-    xTraining,
-    yTraining,
-    panelScales,
-    colorResolution,
-    fillResolution,
-    styleResolutions,
-    scalesConfig,
-    allFrames,
-  } = trained;
+function temporalDecisionKind(
+  values: readonly CellValue[] | undefined,
+  conversion: PreparedPanels["xConversion"],
+): TemporalScaleKind | null {
+  if (!conversion.requestedTime || values === undefined || values.length === 0) return null;
+  const runtime = getTemporalRuntime();
+  if (runtime === null) return null;
+  const decision = runtime.parseColumn(values, conversion.parser, conversion.options).decision;
+  return decision.kind ?? null;
+}
 
-  const temporalKind = (axis: "x" | "y") => {
-    const conversion = axis === "x" ? prepared.xConversion : prepared.yConversion;
-    if (conversion.requestedKind !== undefined) return conversion.requestedKind;
-    const kinds = prepared.scaleDecisions
-      .filter((decision) => decision.aesthetic === axis && decision.status === "temporal")
-      .map((decision) => decision.kind)
-      .filter((kind): kind is "date" | "datetime" | "time" => kind !== null);
-    if (kinds.length > 0) return kinds.includes("datetime") ? "datetime" : kinds[0]!;
+function scalarInterceptValues(normalized: PortableSpec, axis: "x" | "y"): CellValue[] {
+  const values: CellValue[] = [];
+  for (const layer of normalized.layers) {
+    const params = layer.params as
+      | { xintercept?: CellValue | CellValue[]; yintercept?: CellValue | CellValue[] }
+      | undefined;
+    const value = axis === "x" ? params?.xintercept : params?.yintercept;
+    if (value !== undefined) values.push(...(Array.isArray(value) ? value : [value]));
+  }
+  return values;
+}
 
-    const scalarValues: CellValue[] = [];
-    for (const layer of normalized.layers) {
-      const params = layer.params as
-        | { xintercept?: CellValue | CellValue[]; yintercept?: CellValue | CellValue[] }
-        | undefined;
-      const value = axis === "x" ? params?.xintercept : params?.yintercept;
-      if (value !== undefined) scalarValues.push(...(Array.isArray(value) ? value : [value]));
-    }
-    if (scalarValues.length > 0 && conversion.requestedTime) {
-      const runtime = getTemporalRuntime();
-      if (runtime !== null) {
-        const decision = runtime.parseColumn(
-          scalarValues,
-          conversion.parser,
-          conversion.options,
-        ).decision;
-        if (decision.kind !== null) return decision.kind;
-      }
-    }
+function resolveTemporalKind(
+  normalized: PortableSpec,
+  prepared: PreparedPanels,
+  xTraining: TrainedPipelineScales["xTraining"],
+  yTraining: TrainedPipelineScales["yTraining"],
+  axis: "x" | "y",
+): TemporalScaleKind | null {
+  const conversion = axis === "x" ? prepared.xConversion : prepared.yConversion;
+  if (conversion.requestedKind !== undefined) return conversion.requestedKind;
+  const kinds = prepared.scaleDecisions
+    .filter((decision) => decision.aesthetic === axis && decision.status === "temporal")
+    .map((decision) => decision.kind)
+    .filter((kind): kind is "date" | "datetime" | "time" => kind !== null);
+  if (kinds.length > 0) return kinds.includes("datetime") ? "datetime" : kinds[0]!;
+  const scalarKind = temporalDecisionKind(scalarInterceptValues(normalized, axis), conversion);
+  if (scalarKind !== null) return scalarKind;
+  const config = normalized.scales?.[axis];
+  for (const values of [config?.domain, config?.breaks]) {
+    const configuredKind = temporalDecisionKind(values, conversion);
+    if (configuredKind !== null) return configuredKind;
+  }
+  const scale = axis === "x" ? xTraining.scale : yTraining.scale;
+  return scale.type === "time" && conversion.requestedTime ? "datetime" : null;
+}
 
-    const config = normalized.scales?.[axis];
-    if (conversion.requestedTime) {
-      const runtime = getTemporalRuntime();
-      if (runtime !== null) {
-        for (const values of [config?.domain, config?.breaks]) {
-          if (values === undefined || values.length === 0) continue;
-          const decision = runtime.parseColumn(
-            values,
-            conversion.parser,
-            conversion.options,
-          ).decision;
-          if (decision.kind !== null) return decision.kind;
-        }
-      }
-    }
-
-    const scale = axis === "x" ? xTraining.scale : yTraining.scale;
-    return scale.type === "time" && conversion.requestedTime ? "datetime" : null;
-  };
-
-  /** Shared column precision for axisFormatters defaults; mixed precisions → null. */
-  const temporalPrecision = (axis: "x" | "y") => {
-    const precisions = prepared.scaleDecisions
-      .filter((decision) => decision.aesthetic === axis && decision.status === "temporal")
-      .map((decision) => decision.precision)
-      .filter((value): value is NonNullable<typeof value> => value !== null);
-    if (precisions.length === 0) return null;
-    const first = precisions[0]!;
-    return precisions.every((value) => value === first) ? first : null;
-  };
-
-  const xGuide = resolveAxisGuide("x", scalesConfig, normalized.guides, theme);
-  const yGuide = resolveAxisGuide("y", scalesConfig, normalized.guides, theme);
+function guideLabels(
+  normalized: PortableSpec,
+  xGuide: ReturnType<typeof resolveAxisGuide>,
+  yGuide: ReturnType<typeof resolveAxisGuide>,
+): NonNullable<PortableSpec["labs"]> {
   const labs = { ...normalized.labs };
   if (xGuide.visible) {
     if (xGuide.title !== undefined) labs.x = xGuide.title;
@@ -125,91 +94,53 @@ export function finalizePanelLayoutPass(input: {
   if (yGuide.visible) {
     if (yGuide.title !== undefined) labs.y = yGuide.title;
   } else labs.y = "";
-  const legendInputs = prepareLegendInputs({
+  return labs;
+}
+
+function scalesForLayout(
+  normalized: PortableSpec,
+  panelScales: TrainedPipelineScales["panelScales"],
+): TrainedPipelineScales["panelScales"] {
+  const radialCoord = normalized.coord?.type === "radial" ? normalized.coord : undefined;
+  if (radialCoord === undefined) return panelScales;
+  return panelScales.map((scales) =>
+    scalesForCoordExpand(scales, radialCoord.expand !== false, {
+      theta: radialCoord.theta === "y" ? "y" : "x",
+      ...(radialCoord.thetaLimits !== undefined &&
+        radialCoord.thetaLimits.length === 2 && {
+          thetaLimits: [radialCoord.thetaLimits[0]!, radialCoord.thetaLimits[1]!] as const,
+        }),
+      ...(radialCoord.rLimits !== undefined &&
+        radialCoord.rLimits.length === 2 && {
+          rLimits: [radialCoord.rLimits[0]!, radialCoord.rLimits[1]!] as const,
+        }),
+    }),
+  );
+}
+
+function legendInputsForLayout(
+  trained: TrainedPipelineScales,
+  prepared: PreparedPanels,
+  normalized: PortableSpec,
+) {
+  return prepareLegendInputs({
     items: [
-      { input: colorResolution.legendInput, plan: colorResolution.guidePlan },
-      { input: fillResolution.legendInput, plan: fillResolution.guidePlan },
-      ...Object.values(styleResolutions).map((resolution) => ({
+      { input: trained.colorResolution.legendInput, plan: trained.colorResolution.guidePlan },
+      { input: trained.fillResolution.legendInput, plan: trained.fillResolution.guidePlan },
+      ...Object.values(trained.styleResolutions).map((resolution) => ({
         input: resolution.legendInput,
         plan: resolution.guidePlan,
       })),
     ],
     bindings: prepared.bindings,
-    scales: scalesConfig,
+    scales: trained.scalesConfig,
     guides: normalized.guides,
   });
+}
 
-  // Radial expand:false / theta·r limits remaps geometry via scalesForCoordExpand
-  // (assemble-geometry-batches). Layout ticks and displayScales must use the same
-  // remapped domains so cartesian chrome describes the arc that sectors fill
-  // (#1514). Polar-aware guide_axis_theta remains deferred v1 work.
-  const radialCoord = normalized.coord?.type === "radial" ? normalized.coord : undefined;
-  const panelScalesForLayout =
-    radialCoord === undefined
-      ? panelScales
-      : panelScales.map((scales) =>
-          scalesForCoordExpand(scales, radialCoord.expand !== false, {
-            theta: radialCoord.theta === "y" ? "y" : "x",
-            ...(radialCoord.thetaLimits !== undefined &&
-              radialCoord.thetaLimits.length === 2 && {
-                thetaLimits: [radialCoord.thetaLimits[0]!, radialCoord.thetaLimits[1]!] as const,
-              }),
-            ...(radialCoord.rLimits !== undefined &&
-              radialCoord.rLimits.length === 2 && {
-                rLimits: [radialCoord.rLimits[0]!, radialCoord.rLimits[1]!] as const,
-              }),
-          }),
-        );
-
-  perfMark("ggsvelte:layout:start");
-  let panelLayout: PanelLayoutResult;
+function runLayoutPanels(input: Parameters<typeof layoutPanels>[0]): PanelLayoutResult {
   try {
-    panelLayout = layoutPanels({
-      flip,
-      faceted,
-      freedom: { freeX, freeY },
-      ...((normalized.coord?.type === "fixed" || normalized.coord?.type === "sf") && {
-        coordFixed: normalized.coord,
-      }),
-      // Polar panel aspect = polar_bbox height/width (1 for a full circle).
-      ...(normalized.coord?.type === "radial" && {
-        coordFixed: {
-          type: "radial" as const,
-          aspect: radialPanelAspect(normalized.coord),
-        },
-      }),
-      nrow,
-      ncol,
-      facetPanels,
-      strip,
-      panelScales: panelScalesForLayout,
-      allFrames,
-      hGuide: flip ? yGuide : xGuide,
-      vGuide: flip ? xGuide : yGuide,
-      labs,
-      scalesConfig,
-      xScale: xTraining.scale,
-      yScale: yTraining.scale,
-      xTemporalKind: temporalKind("x"),
-      yTemporalKind: temporalKind("y"),
-      xTemporalPrecision: temporalPrecision("x"),
-      yTemporalPrecision: temporalPrecision("y"),
-      legendInputs,
-      legendOrder: normalized.legend?.order ?? "stable-domain",
-      theme,
-      layoutAxisTitleSize: Math.max(
-        theme.axisTitleSize,
-        xGuide.theme?.titleSize ?? 0,
-        yGuide.theme?.titleSize ?? 0,
-      ),
-      layoutAxisTextSize: Math.max(
-        theme.axisTextSize,
-        xGuide.theme?.labelSize ?? 0,
-        yGuide.theme?.labelSize ?? 0,
-      ),
-      options,
-      warnings,
-    });
+    return layoutPanels(input);
   } catch (error) {
     if (!(error instanceof TemporalGuideIntervalError)) throw error;
     const intervalError = error.cause;
@@ -230,6 +161,93 @@ export function finalizePanelLayoutPass(input: {
       documentationUrl: "/guide/temporal-scales#explicit-intervals",
     });
   }
+}
+
+export function finalizePanelLayoutPass(input: {
+  normalized: PortableSpec;
+  options: RunOptions;
+  theme: ThemeTokens;
+  flip: boolean;
+  prepared: PreparedPanels;
+  trained: TrainedPipelineScales;
+  warnings: PipelineWarning[];
+}): PanelLayoutResult {
+  const { normalized, options, theme, flip, prepared, trained, warnings } = input;
+  const { faceted, freeX, freeY, nrow, ncol, facetPanels, strip } = prepared;
+  const { xTraining, yTraining, panelScales, scalesConfig, allFrames } = trained;
+
+  const temporalKind = (axis: "x" | "y") =>
+    resolveTemporalKind(normalized, prepared, xTraining, yTraining, axis);
+
+  /** Shared column precision for axisFormatters defaults; mixed precisions → null. */
+  const temporalPrecision = (axis: "x" | "y") => {
+    const precisions = prepared.scaleDecisions
+      .filter((decision) => decision.aesthetic === axis && decision.status === "temporal")
+      .map((decision) => decision.precision)
+      .filter((value): value is NonNullable<typeof value> => value !== null);
+    if (precisions.length === 0) return null;
+    const first = precisions[0]!;
+    return precisions.every((value) => value === first) ? first : null;
+  };
+
+  const xGuide = resolveAxisGuide("x", scalesConfig, normalized.guides, theme);
+  const yGuide = resolveAxisGuide("y", scalesConfig, normalized.guides, theme);
+  const labs = guideLabels(normalized, xGuide, yGuide);
+  const legendInputs = legendInputsForLayout(trained, prepared, normalized);
+
+  // Radial expand:false / theta·r limits remaps geometry via scalesForCoordExpand
+  // (assemble-geometry-batches). Layout ticks and displayScales must use the same
+  // remapped domains so cartesian chrome describes the arc that sectors fill
+  // (#1514). Polar-aware guide_axis_theta remains deferred v1 work.
+  const panelScalesForLayout = scalesForLayout(normalized, panelScales);
+
+  perfMark("ggsvelte:layout:start");
+  const panelLayout = runLayoutPanels({
+    flip,
+    faceted,
+    freedom: { freeX, freeY },
+    ...((normalized.coord?.type === "fixed" || normalized.coord?.type === "sf") && {
+      coordFixed: normalized.coord,
+    }),
+    // Polar panel aspect = polar_bbox height/width (1 for a full circle).
+    ...(normalized.coord?.type === "radial" && {
+      coordFixed: {
+        type: "radial" as const,
+        aspect: radialPanelAspect(normalized.coord),
+      },
+    }),
+    nrow,
+    ncol,
+    facetPanels,
+    strip,
+    panelScales: panelScalesForLayout,
+    allFrames,
+    hGuide: flip ? yGuide : xGuide,
+    vGuide: flip ? xGuide : yGuide,
+    labs,
+    scalesConfig,
+    xScale: xTraining.scale,
+    yScale: yTraining.scale,
+    xTemporalKind: temporalKind("x"),
+    yTemporalKind: temporalKind("y"),
+    xTemporalPrecision: temporalPrecision("x"),
+    yTemporalPrecision: temporalPrecision("y"),
+    legendInputs,
+    legendOrder: normalized.legend?.order ?? "stable-domain",
+    theme,
+    layoutAxisTitleSize: Math.max(
+      theme.axisTitleSize,
+      xGuide.theme?.titleSize ?? 0,
+      yGuide.theme?.titleSize ?? 0,
+    ),
+    layoutAxisTextSize: Math.max(
+      theme.axisTextSize,
+      xGuide.theme?.labelSize ?? 0,
+      yGuide.theme?.labelSize ?? 0,
+    ),
+    options,
+    warnings,
+  });
   perfMark("ggsvelte:layout:end");
   perfMeasure("ggsvelte:layout", "ggsvelte:layout:start", "ggsvelte:layout:end");
   return panelLayout;


### PR DESCRIPTION
## Summary
- extract temporal-kind resolution and guide-label helpers
- isolate radial scale preparation and layout error translation
- preserve panel layout behavior while satisfying max-20 complexity

## Validation
- bunx oxlint -c /tmp/oxlintrc-core-max20.json packages/core/src/pipeline/finalize-layout-pass.ts
- bunx tsc -b packages/spec packages/core packages/cli
- bun test packages/core/tests/pipeline-finalize.test.ts packages/core/tests/pipeline-scale-breaks.test.ts packages/core/tests/pipeline-coord-fixed.test.ts packages/core/tests/pipeline-temporal/guides.test.ts packages/core/tests/pipeline-temporal/scales-inference.test.ts
- benchmark: /tmp/core-finalize-layout-baseline.txt vs /tmp/core-finalize-layout-current.txt (no coherent regression)