### PR TITLE
refactor(core): split coordinate projector validation

### DIFF
--- a/packages/core/src/coord-projector.ts
+++ b/packages/core/src/coord-projector.ts
@@ -3,7 +3,7 @@ import type { CoordRadialSpec, CoordTransformAxisSpec } from "@ggsvelte/spec";
 import { buildPolarProjector, type PolarProjector } from "./coord-polar.js";
 import type { PipelineErrorCode } from "./diagnostics-error-catalog.js";
 import { PipelineError } from "./pipeline/types.js";
-import type { PositionScale } from "./scales/train.js";
+import type { ContinuousScale, PositionScale } from "./scales/train.js";
 import { scaleTransform } from "./scales/transform.js";
 
 export interface CoordAxisProjector {
@@ -50,63 +50,45 @@ function identityProjector(axis: "x" | "y", reverse: boolean): CoordAxisProjecto
   };
 }
 
-/**
- * Build one post-stat coordinate projector over an already-trained position
- * scale. The input fraction is the scale's affine output; reconstruction of
- * scale space means coordinate transforms never forward semantic values twice.
- */
-export function buildCoordAxisProjector(
+function buildBandAxisProjector(
   axis: "x" | "y",
-  scale: PositionScale,
-  config: CoordTransformAxisSpec | undefined,
+  transformName: CoordTransformAxisSpec["transform"],
+  reverse: boolean,
+  hasLimits: boolean,
 ): CoordAxisProjector {
-  const transformName = config?.transform ?? "identity";
-  const reverse = config?.reverse === true;
-  const hasLimits = config?.limits !== undefined;
-
-  if (scale.type === "band") {
-    if (transformName !== "identity") {
-      failure(
-        "coord-transform-continuous",
-        axis,
-        `The ${axis} coordinate transform requires a continuous scale.`,
-        `The ${axis} scale is discrete/banded, so ${transformName} has no quantitative coordinate domain.`,
-        [
-          { description: `Use transform: "identity" for the ${axis} coordinate.` },
-          { description: `Use a continuous or binned quantitative ${axis} scale.` },
-        ],
-      );
-    }
-    if (hasLimits) {
-      failure(
-        "coord-transform-continuous",
-        axis,
-        `Numeric coordinate limits require a continuous ${axis} scale.`,
-        `The ${axis} scale is discrete/banded, so numeric limits cannot identify category boundaries.`,
-        [{ description: `Remove coord ${axis}.limits or configure a continuous scale.` }],
-      );
-    }
-    return identityProjector(axis, reverse);
-  }
-
-  if (scale.type === "time" && transformName !== "identity") {
+  if (transformName !== "identity") {
     failure(
-      "coord-transform-temporal",
+      "coord-transform-continuous",
       axis,
-      `Temporal ${axis} coordinates permit only the identity transform.`,
-      `Applying ${transformName} to epoch magnitudes would destroy calendar meaning.`,
+      `The ${axis} coordinate transform requires a continuous scale.`,
+      `The ${axis} scale is discrete/banded, so ${transformName} has no quantitative coordinate domain.`,
       [
-        { description: `Remove the ${axis} coordinate transform.` },
-        { description: `Use identity coordinate limits/reverse for a temporal viewport.` },
+        { description: `Use transform: "identity" for the ${axis} coordinate.` },
+        { description: `Use a continuous or binned quantitative ${axis} scale.` },
       ],
     );
   }
+  if (hasLimits) {
+    failure(
+      "coord-transform-continuous",
+      axis,
+      `Numeric coordinate limits require a continuous ${axis} scale.`,
+      `The ${axis} scale is discrete/banded, so numeric limits cannot identify category boundaries.`,
+      [{ description: `Remove coord ${axis}.limits or configure a continuous scale.` }],
+    );
+  }
+  return identityProjector(axis, reverse);
+}
 
-  const scaleTx = scaleTransform(scale.transform);
-  const coordTx = scaleTransform(transformName);
-  const scaleDomain = scale.transformedDomain;
-  let scaleLo = scaleDomain[0];
-  let scaleHi = scaleDomain[1];
+function resolveScaleDomain(
+  axis: "x" | "y",
+  scale: ContinuousScale,
+  config: CoordTransformAxisSpec | undefined,
+  scaleTx: ReturnType<typeof scaleTransform>,
+  coordTx: ReturnType<typeof scaleTransform>,
+  transformName: CoordTransformAxisSpec["transform"],
+): readonly [number, number] {
+  let [scaleLo, scaleHi] = scale.transformedDomain;
   if (config?.limits !== undefined) {
     const lo = config.limits[0]!;
     const hi = config.limits[1]!;
@@ -128,15 +110,12 @@ export function buildCoordAxisProjector(
     scaleLo = scaleTx.forward(lo);
     scaleHi = scaleTx.forward(hi);
   }
-
-  if (!hasLimits && (!coordTx.valid(scaleLo) || !coordTx.valid(scaleHi))) {
+  if (config?.limits === undefined && (!coordTx.valid(scaleLo) || !coordTx.valid(scaleHi))) {
     // Scale nice/expansion may cross a coordinate transform's boundary even
-    // when every trained value is valid (for example positive data expanded
-    // below zero before coord log10). Fall back to the raw finite evidence;
-    // coordinate projection owns its own post-stat display domain.
+    // when every trained value is valid. Coordinate projection owns its raw
+    // finite evidence domain in this case.
     [scaleLo, scaleHi] = scale.evidenceTransformedDomain;
   }
-
   if (!coordTx.valid(scaleLo) || !coordTx.valid(scaleHi)) {
     failure(
       "coord-transform-domain",
@@ -149,13 +128,20 @@ export function buildCoordAxisProjector(
       ],
     );
   }
+  return [scaleLo, scaleHi];
+}
 
+function resolveCoordinateDomain(
+  axis: "x" | "y",
+  scaleLo: number,
+  scaleHi: number,
+  config: CoordTransformAxisSpec | undefined,
+  coordTx: ReturnType<typeof scaleTransform>,
+  transformName: CoordTransformAxisSpec["transform"],
+): readonly [number, number] {
   let coordLo = coordTx.forward(scaleLo);
   let coordHi = coordTx.forward(scaleHi);
-  if (!hasLimits && scaleLo === scaleHi && Number.isFinite(coordLo)) {
-    // Raw evidence can be a valid singleton after scale nice/expansion crossed
-    // the coordinate transform boundary. Pad in coordinate space so the
-    // singleton stays centered without inventing invalid scale-space values.
+  if (config?.limits === undefined && scaleLo === scaleHi && Number.isFinite(coordLo)) {
     coordLo -= 0.5;
     coordHi += 0.5;
     if (transformName === "sqrt") coordLo = Math.max(0, coordLo);
@@ -169,8 +155,7 @@ export function buildCoordAxisProjector(
       [{ description: `Choose distinct limits or a different coordinate transform.` }],
     );
   }
-
-  if (hasLimits && config?.expand !== false) {
+  if (config?.limits !== undefined && config.expand !== false) {
     const padding = (coordHi - coordLo) * 0.05;
     coordLo -= padding;
     coordHi += padding;
@@ -179,6 +164,59 @@ export function buildCoordAxisProjector(
       coordHi = Math.max(0, coordHi);
     }
   }
+  return [coordLo, coordHi];
+}
+
+/**
+ * Build one post-stat coordinate projector over an already-trained position
+ * scale. The input fraction is the scale's affine output; reconstruction of
+ * scale space means coordinate transforms never forward semantic values twice.
+ */
+export function buildCoordAxisProjector(
+  axis: "x" | "y",
+  scale: PositionScale,
+  config: CoordTransformAxisSpec | undefined,
+): CoordAxisProjector {
+  const transformName = config?.transform ?? "identity";
+  const reverse = config?.reverse === true;
+  const hasLimits = config?.limits !== undefined;
+
+  if (scale.type === "band") {
+    return buildBandAxisProjector(axis, transformName, reverse, hasLimits);
+  }
+
+  if (scale.type === "time" && transformName !== "identity") {
+    failure(
+      "coord-transform-temporal",
+      axis,
+      `Temporal ${axis} coordinates permit only the identity transform.`,
+      `Applying ${transformName} to epoch magnitudes would destroy calendar meaning.`,
+      [
+        { description: `Remove the ${axis} coordinate transform.` },
+        { description: `Use identity coordinate limits/reverse for a temporal viewport.` },
+      ],
+    );
+  }
+
+  const scaleTx = scaleTransform(scale.transform);
+  const coordTx = scaleTransform(transformName);
+  const scaleDomain = scale.transformedDomain;
+  const [scaleLo, scaleHi] = resolveScaleDomain(
+    axis,
+    scale,
+    config,
+    scaleTx,
+    coordTx,
+    transformName,
+  );
+  const [coordLo, coordHi] = resolveCoordinateDomain(
+    axis,
+    scaleLo,
+    scaleHi,
+    config,
+    coordTx,
+    transformName,
+  );
 
   const coordSpan = coordHi - coordLo;
   const scaleSpan = scaleDomain[1] - scaleDomain[0];


### PR DESCRIPTION
## Summary\n- extract band validation, scale-domain resolution, and coordinate-domain resolution from buildCoordAxisProjector\n- preserve coordinate transform errors, limits, expansion, reversal, and singleton-domain behavior\n\n## Validation\n- strict oxlint complexity lint for changed file\n- bunx tsc -b packages/spec packages/core packages/cli\n- bun test packages/core/tests (2464 pass)\n- focused coord-transform and pipeline-finalize tests\n- bench:json before/after twice; no clear regression\n\nNo changeset: internal refactor.