### PR TITLE
refactor(core): reduce candidate index complexity

### DIFF
--- a/packages/core/src/candidate-store-index-build.ts
+++ b/packages/core/src/candidate-store-index-build.ts
@@ -1,0 +1,256 @@
+import { AUTO_MODE_CODE } from "./candidate-store-indexes.js";
+import {
+  candidatePrimitiveCount,
+  defaultAutoMode,
+  isCandidatePrimitive,
+  localAnchor,
+  primitiveCount,
+} from "./candidate-geometry.js";
+import type { CandidateStoreOptions, CandidateStyleColumn } from "./candidate-store-types.js";
+import type { Scene } from "./scene.js";
+import type { CellValue } from "./table.js";
+
+const NO_ROW = 0xffffffff;
+
+export type CandidateBufferState = {
+  n: number;
+  anyNonFiniteAnchor: boolean;
+  batchIds: Uint32Array;
+  primitiveIds: Uint32Array;
+  panelIds: Uint32Array;
+  rows: Uint32Array;
+  series: Uint32Array;
+  ranks: Uint32Array;
+  sources: Uint32Array;
+  lineages: Uint32Array;
+  autoModes: Uint8Array;
+  xs: Float32Array;
+  ys: Float32Array;
+  xTokenIds: Int32Array;
+  yTokenIds: Int32Array;
+  xDates: Uint8Array;
+  yDates: Uint8Array;
+  invalidX: Map<number, CellValue>;
+  invalidY: Map<number, CellValue>;
+  sizeValues: CellValue[];
+  linewidthValues: CellValue[];
+  alphaValues: CellValue[];
+  shapeValues: CellValue[];
+  linetypeValues: CellValue[];
+  remember: (value: CellValue) => number;
+};
+
+type EligiblePrimitives = {
+  primitiveIds: Uint32Array;
+  semanticIds: Uint32Array;
+  rowIds: Uint32Array;
+};
+
+function backfillStyle(arr: CellValue[], upto: number): void {
+  for (let i = arr.length; i < upto; i++) arr.push(null);
+}
+
+function writeCandidatePosition(
+  batch: Scene["batches"][number],
+  panel: NonNullable<Scene["panels"][number]>,
+  batchIndex: number,
+  primitiveIndex: number,
+  rowId: number,
+  lx: number,
+  ly: number,
+  state: CandidateBufferState,
+): void {
+  const candidateIndex = state.n;
+  state.batchIds[candidateIndex] = batchIndex;
+  state.primitiveIds[candidateIndex] = primitiveIndex;
+  state.panelIds[candidateIndex] = batch.panelIndex;
+  state.rows[candidateIndex] = rowId;
+  state.xs[candidateIndex] = panel.x + lx;
+  state.ys[candidateIndex] = panel.y + ly;
+  if (!Number.isFinite(state.xs[candidateIndex]!) || !Number.isFinite(state.ys[candidateIndex]!))
+    state.anyNonFiniteAnchor = true;
+}
+
+function writeCandidateAxisValues(
+  candidateIndex: number,
+  xValue: CellValue,
+  yValue: CellValue,
+  state: CandidateBufferState,
+): void {
+  const xToken = state.remember(xValue);
+  const yToken = state.remember(yValue);
+  state.xTokenIds[candidateIndex] = xToken;
+  state.yTokenIds[candidateIndex] = yToken;
+  state.xDates[candidateIndex] = xValue instanceof Date ? 1 : 0;
+  state.yDates[candidateIndex] = yValue instanceof Date ? 1 : 0;
+  if (xToken === -1 && xValue !== null) state.invalidX.set(candidateIndex, xValue);
+  if (yToken === -1 && yValue !== null) state.invalidY.set(candidateIndex, yValue);
+}
+
+function eligiblePrimitives(batch: Scene["batches"][number]): EligiblePrimitives {
+  const primitiveIds = new Uint32Array(candidatePrimitiveCount(batch));
+  const semanticIds = new Uint32Array(primitiveIds.length);
+  const rowIds = new Uint32Array(primitiveIds.length);
+  let eligible = 0;
+  for (let primitiveIndex = 0; primitiveIndex < primitiveCount(batch); primitiveIndex++) {
+    if (!isCandidatePrimitive(batch, primitiveIndex)) continue;
+    primitiveIds[eligible] = primitiveIndex;
+    semanticIds[eligible] =
+      batch.kind === "paths"
+        ? (batch.semanticIndex?.[primitiveIndex] ?? primitiveIndex)
+        : primitiveIndex;
+    rowIds[eligible] = batch.rowIndex[primitiveIndex] ?? NO_ROW;
+    eligible++;
+  }
+  return { primitiveIds, semanticIds, rowIds };
+}
+
+function writeStyleColumn(
+  target: CellValue[],
+  column: CandidateStyleColumn,
+  batchStart: number,
+  count: number,
+): void {
+  if (column === null) return;
+  backfillStyle(target, batchStart);
+  if (column.kind === "constant") {
+    for (let i = 0; i < count; i++) target.push(column.value);
+    return;
+  }
+  const offset = column.offset ?? 0;
+  for (let i = 0; i < count; i++) target.push(column.values[offset + i] ?? null);
+}
+
+function writeColumnarBatch(
+  batch: Scene["batches"][number],
+  panel: NonNullable<Scene["panels"][number]>,
+  batchIndex: number,
+  batchStart: number,
+  eligible: EligiblePrimitives,
+  columns: NonNullable<ReturnType<NonNullable<CandidateStoreOptions["datumColumns"]>>>,
+  state: CandidateBufferState,
+): void {
+  const count = eligible.primitiveIds.length;
+  writeStyleColumn(state.sizeValues, columns.sizeValue, batchStart, count);
+  writeStyleColumn(state.linewidthValues, columns.linewidthValue, batchStart, count);
+  writeStyleColumn(state.alphaValues, columns.alphaValue, batchStart, count);
+  writeStyleColumn(state.shapeValues, columns.shapeValue, batchStart, count);
+  writeStyleColumn(state.linetypeValues, columns.linetypeValue, batchStart, count);
+  for (let i = 0; i < count; i++) {
+    const primitiveIndex = eligible.primitiveIds[i]!;
+    const rowId = eligible.rowIds[i]!;
+    const [lx, ly] = localAnchor(batch, primitiveIndex);
+    const candidateIndex = state.n;
+    writeCandidatePosition(batch, panel, batchIndex, primitiveIndex, rowId, lx, ly, state);
+    const xValue = columns.xValue === null ? null : (columns.xValue[i] ?? null);
+    const yValue = columns.yValue === null ? null : (columns.yValue[i] ?? null);
+    writeCandidateAxisValues(candidateIndex, xValue, yValue, state);
+    const series = columns.seriesId === null ? 0 : (columns.seriesId[i] ?? 0);
+    state.series[candidateIndex] = series;
+    state.ranks[candidateIndex] =
+      columns.seriesRank === null ? series : (columns.seriesRank[i] ?? series);
+    const rowIndex = rowId === NO_ROW ? null : rowId;
+    state.sources[candidateIndex] =
+      columns.sourceOrder === null
+        ? (rowIndex ?? primitiveIndex)
+        : (columns.sourceOrder[i] ?? rowIndex ?? primitiveIndex);
+    state.lineages[candidateIndex] = columns.lineage === null ? 0 : (columns.lineage[i] ?? 0);
+    const defaultMode = AUTO_MODE_CODE[defaultAutoMode(batch, primitiveIndex)];
+    state.autoModes[candidateIndex] =
+      columns.autoMode === null ? defaultMode : (columns.autoMode[i] ?? defaultMode);
+    state.n++;
+  }
+}
+
+function flushStyle(target: CellValue[], values: CellValue[], batchStart: number): void {
+  if (values.every((value) => value === null)) return;
+  backfillStyle(target, batchStart);
+  for (const value of values) target.push(value);
+}
+
+function writeCallbackBatch(
+  batch: Scene["batches"][number],
+  panel: NonNullable<Scene["panels"][number]>,
+  batchIndex: number,
+  eligible: EligiblePrimitives,
+  batchStart: number,
+  options: CandidateStoreOptions,
+  state: CandidateBufferState,
+): void {
+  const sizeValues: CellValue[] = [];
+  const linewidthValues: CellValue[] = [];
+  const alphaValues: CellValue[] = [];
+  const shapeValues: CellValue[] = [];
+  const linetypeValues: CellValue[] = [];
+  for (let i = 0; i < eligible.primitiveIds.length; i++) {
+    const primitiveIndex = eligible.primitiveIds[i]!;
+    const rowId = eligible.rowIds[i]!;
+    const rowIndex = rowId === NO_ROW ? null : rowId;
+    const [lx, ly] = localAnchor(batch, primitiveIndex);
+    const candidateIndex = state.n;
+    const datum =
+      options.datum?.({
+        candidateIndex,
+        batchIndex,
+        primitiveIndex: eligible.semanticIds[i]!,
+        layerIndex: batch.layerIndex,
+        panelIndex: batch.panelIndex,
+        rowIndex,
+        kind: batch.kind,
+        x: panel.x + lx,
+        y: panel.y + ly,
+      }) ?? {};
+    sizeValues.push(datum.sizeValue ?? null);
+    linewidthValues.push(datum.linewidthValue ?? null);
+    alphaValues.push(datum.alphaValue ?? null);
+    shapeValues.push(datum.shapeValue ?? null);
+    linetypeValues.push(datum.linetypeValue ?? null);
+    writeCandidatePosition(batch, panel, batchIndex, primitiveIndex, rowId, lx, ly, state);
+    const xValue = datum.xValue ?? null;
+    const yValue = datum.yValue ?? null;
+    writeCandidateAxisValues(candidateIndex, xValue, yValue, state);
+    const series = datum.seriesId ?? 0;
+    state.series[candidateIndex] = series;
+    state.ranks[candidateIndex] = datum.seriesRank ?? series;
+    state.sources[candidateIndex] = datum.sourceOrder ?? rowIndex ?? primitiveIndex;
+    state.lineages[candidateIndex] = datum.lineage ?? 0;
+    state.autoModes[candidateIndex] =
+      AUTO_MODE_CODE[datum.autoMode ?? defaultAutoMode(batch, primitiveIndex)];
+    state.n++;
+  }
+  flushStyle(state.sizeValues, sizeValues, batchStart);
+  flushStyle(state.linewidthValues, linewidthValues, batchStart);
+  flushStyle(state.alphaValues, alphaValues, batchStart);
+  flushStyle(state.shapeValues, shapeValues, batchStart);
+  flushStyle(state.linetypeValues, linetypeValues, batchStart);
+}
+
+export function populateCandidateBuffers(
+  scene: Scene,
+  options: CandidateStoreOptions,
+  uninspectable: ReadonlySet<number> | undefined,
+  state: CandidateBufferState,
+): number {
+  for (let batchIndex = 0; batchIndex < scene.batches.length; batchIndex++) {
+    const batch = scene.batches[batchIndex]!;
+    const panel = scene.panels[batch.panelIndex];
+    if (panel === undefined || uninspectable?.has(batch.layerIndex) === true) continue;
+    const eligible = eligiblePrimitives(batch);
+    const batchStart = state.n;
+    const columns =
+      options.datumColumns?.({
+        batchIndex,
+        layerIndex: batch.layerIndex,
+        panelIndex: batch.panelIndex,
+        primitiveIds: eligible.primitiveIds,
+        semanticIds: eligible.semanticIds,
+        rowIds: eligible.rowIds,
+      }) ?? null;
+    if (columns !== null) {
+      writeColumnarBatch(batch, panel, batchIndex, batchStart, eligible, columns, state);
+      continue;
+    }
+    writeCallbackBatch(batch, panel, batchIndex, eligible, batchStart, options, state);
+  }
+  return state.n;
+}

--- a/packages/core/src/candidate-store-index-build.ts
+++ b/packages/core/src/candidate-store-index-build.ts
@@ -67,7 +67,7 @@ function writeCandidatePosition(
   state.rows[candidateIndex] = rowId;
   state.xs[candidateIndex] = panel.x + lx;
   state.ys[candidateIndex] = panel.y + ly;
-  if (!Number.isFinite(state.xs[candidateIndex]!) || !Number.isFinite(state.ys[candidateIndex]!))
+  if (!Number.isFinite(state.xs[candidateIndex]) || !Number.isFinite(state.ys[candidateIndex]))
     state.anyNonFiniteAnchor = true;
 }
 

--- a/packages/core/src/candidate-store-indexes.ts
+++ b/packages/core/src/candidate-store-indexes.ts
@@ -1,19 +1,15 @@
 import type { CanonicalAxisToken } from "./candidate-axis-token.js";
 import { buildCandidateCoincidence } from "./candidate-store-coincidence.js";
 import { createLazyCandidateAxisGroups } from "./candidate-store-axis-groups.js";
-import type { CandidateStoreIndexes } from "./candidate-store-index-types.js";
 import {
-  defaultAutoMode,
-  candidatePrimitiveCount,
-  isCandidatePrimitive,
-  localAnchor,
-  primitiveCount,
-} from "./candidate-geometry.js";
+  populateCandidateBuffers,
+  type CandidateBufferState,
+} from "./candidate-store-index-build.js";
+import type { CandidateStoreIndexes } from "./candidate-store-index-types.js";
+import { candidatePrimitiveCount } from "./candidate-geometry.js";
 import type {
-  CandidateBuildFacts,
   CandidateFacts,
   CandidateStoreOptions,
-  CandidateStyleColumn,
   ResolvedCandidateInspectMode,
 } from "./candidate-store-types.js";
 import type { Scene } from "./scene.js";
@@ -42,11 +38,6 @@ export const AUTO_MODES = [
  * group() bucket permutations. Growable construction buffers are cleared at
  * the end of this function (retained-memory budget boundary).
  */
-
-/** Pad a lazily materialized style array with nulls up to candidate `upto`. */
-function backfillStyle(arr: CellValue[], upto: number): void {
-  for (let i = arr.length; i < upto; i++) arr.push(null);
-}
 
 export function buildCandidateStoreIndexes(
   scene: Scene,
@@ -148,188 +139,35 @@ export function buildCandidateStoreIndexes(
     return -1;
   };
 
-  // Style-value arrays are append-only and lazily materialized: a batch
-  // whose style column resolves to null writes NOTHING (dense identity
-  // layers carry no style mappings, so unconditional null pushes were five
-  // growable-array writes per candidate). Before the first real write at
-  // candidate n, nulls are backfilled so `fact()` reads stay index-aligned;
-  // untouched columns read `undefined ?? null`.
-  let n = 0;
-  for (let batchIndex = 0; batchIndex < scene.batches.length; batchIndex++) {
-    const batch = scene.batches[batchIndex]!;
-    const panel = scene.panels[batch.panelIndex];
-    if (panel === undefined) continue;
-    // Layer opted out of inspection (#1065) — paint it, never target it.
-    if (uninspectable?.has(batch.layerIndex) === true) continue;
-
-    // Eligibility, shared by both datum paths: candidate-bearing primitives
-    // in candidate order, their datum-facing (semantic) indexes, and rows.
-    const primIds = new Uint32Array(candidatePrimitiveCount(batch));
-    const semIds = new Uint32Array(primIds.length);
-    const rowIds = new Uint32Array(primIds.length);
-    {
-      let e = 0;
-      for (let p = 0; p < primitiveCount(batch); p++) {
-        if (!isCandidatePrimitive(batch, p)) continue;
-        primIds[e] = p;
-        semIds[e] = batch.kind === "paths" ? (batch.semanticIndex?.[p] ?? p) : p;
-        rowIds[e] = batch.rowIndex[p] ?? NO_ROW;
-        e++;
-      }
-    }
-    const batchStart = n;
-    const columns =
-      options.datumColumns?.({
-        batchIndex,
-        layerIndex: batch.layerIndex,
-        panelIndex: batch.panelIndex,
-        primitiveIds: primIds,
-        semanticIds: semIds,
-        rowIds,
-      }) ?? null;
-
-    if (columns !== null) {
-      // Columnar path: zero per-candidate objects. Value semantics mirror the
-      // per-candidate loop exactly (`?? null` reads, `?? series` ranks,
-      // `rowIndex ?? primitiveIndex` source order, geometry-default autoMode).
-      const count = primIds.length;
-      const writeStyle = (target: CellValue[], column: CandidateStyleColumn): void => {
-        if (column === null) return;
-        backfillStyle(target, batchStart);
-        if (column.kind === "constant") {
-          for (let i = 0; i < count; i++) target.push(column.value);
-        } else {
-          const offset = column.offset ?? 0;
-          for (let i = 0; i < count; i++) target.push(column.values[offset + i] ?? null);
-        }
-      };
-      writeStyle(sizeValues, columns.sizeValue);
-      writeStyle(linewidthValues, columns.linewidthValue);
-      writeStyle(alphaValues, columns.alphaValue);
-      writeStyle(shapeValues, columns.shapeValue);
-      writeStyle(linetypeValues, columns.linetypeValue);
-      const xValues = columns.xValue;
-      const yValues = columns.yValue;
-      const seriesCol = columns.seriesId;
-      const rankCol = columns.seriesRank;
-      const sourceOrderCol = columns.sourceOrder;
-      const lineageCol = columns.lineage;
-      const autoModeCol = columns.autoMode;
-      for (let i = 0; i < count; i++) {
-        const primitiveIndex = primIds[i]!;
-        const rowId = rowIds[i]!;
-        const rowIndex = rowId === NO_ROW ? null : rowId;
-        const [lx, ly] = localAnchor(batch, primitiveIndex);
-        batchIdsBuf[n] = batchIndex;
-        primitiveIdsBuf[n] = primitiveIndex;
-        panelIdsBuf[n] = batch.panelIndex;
-        rowsBuf[n] = rowId;
-        const ax = panel.x + lx;
-        const ay = panel.y + ly;
-        xsBuf[n] = ax;
-        ysBuf[n] = ay;
-        // Read the NARROWED f32 values back (see the per-candidate path).
-        if (!Number.isFinite(xsBuf[n]!) || !Number.isFinite(ysBuf[n]!)) anyNonFiniteAnchor = true;
-        const xValue = xValues === null ? null : (xValues[i] ?? null);
-        const yValue = yValues === null ? null : (yValues[i] ?? null);
-        const xToken = remember(xValue);
-        const yToken = remember(yValue);
-        xTokenIdsBuf[n] = xToken;
-        yTokenIdsBuf[n] = yToken;
-        xDatesBuf[n] = xValue instanceof Date ? 1 : 0;
-        yDatesBuf[n] = yValue instanceof Date ? 1 : 0;
-        if (xToken === -1 && xValue !== null) invalidX.set(n, xValue);
-        if (yToken === -1 && yValue !== null) invalidY.set(n, yValue);
-        const series = seriesCol === null ? 0 : (seriesCol[i] ?? 0);
-        seriesBuf[n] = series;
-        ranksBuf[n] = rankCol === null ? series : (rankCol[i] ?? series);
-        sourcesBuf[n] =
-          sourceOrderCol === null
-            ? (rowIndex ?? primitiveIndex)
-            : (sourceOrderCol[i] ?? rowIndex ?? primitiveIndex);
-        lineagesBuf[n] = lineageCol === null ? 0 : (lineageCol[i] ?? 0);
-        autoModesBuf[n] =
-          autoModeCol === null
-            ? AUTO_MODE_CODE[defaultAutoMode(batch, primitiveIndex)]
-            : (autoModeCol[i] ?? AUTO_MODE_CODE[defaultAutoMode(batch, primitiveIndex)]);
-        n++;
-      }
-      continue;
-    }
-
-    // Per-callback path (identity-indexed strategy, and batches the columnar
-    // resolver declined). Style values land in batch-local scratch first so a
-    // null-only style never touches the shared arrays (see backfillStyle).
-    const batchSize: CellValue[] = [];
-    const batchLinewidth: CellValue[] = [];
-    const batchAlpha: CellValue[] = [];
-    const batchShape: CellValue[] = [];
-    const batchLinetype: CellValue[] = [];
-    for (let e = 0; e < primIds.length; e++) {
-      const primitiveIndex = primIds[e]!;
-      const candidateIndex = n;
-      const raw = rowIds[e]!;
-      const rowIndex = raw === NO_ROW ? null : raw;
-      const [lx, ly] = localAnchor(batch, primitiveIndex);
-      const buildFacts: CandidateBuildFacts = {
-        candidateIndex,
-        batchIndex,
-        primitiveIndex: semIds[e]!,
-        layerIndex: batch.layerIndex,
-        panelIndex: batch.panelIndex,
-        rowIndex,
-        kind: batch.kind,
-        x: panel.x + lx,
-        y: panel.y + ly,
-      };
-      const datum = options.datum?.(buildFacts) ?? {};
-      const xValue = datum.xValue ?? null;
-      const yValue = datum.yValue ?? null;
-      batchSize.push(datum.sizeValue ?? null);
-      batchLinewidth.push(datum.linewidthValue ?? null);
-      batchAlpha.push(datum.alphaValue ?? null);
-      batchShape.push(datum.shapeValue ?? null);
-      batchLinetype.push(datum.linetypeValue ?? null);
-      batchIdsBuf[n] = batchIndex;
-      primitiveIdsBuf[n] = primitiveIndex;
-      panelIdsBuf[n] = batch.panelIndex;
-      rowsBuf[n] = rowIndex ?? NO_ROW;
-      const ax = panel.x + lx;
-      const ay = panel.y + ly;
-      xsBuf[n] = ax;
-      ysBuf[n] = ay;
-      // Read the NARROWED f32 values back: a finite double that overflows
-      // float32 (e.g. 1e39) is stored as ±Infinity, and the fast paths below
-      // must see the same (non-)finiteness the stored columns carry.
-      if (!Number.isFinite(xsBuf[n]!) || !Number.isFinite(ysBuf[n]!)) anyNonFiniteAnchor = true;
-      const xToken = remember(xValue);
-      const yToken = remember(yValue);
-      xTokenIdsBuf[n] = xToken;
-      yTokenIdsBuf[n] = yToken;
-      xDatesBuf[n] = xValue instanceof Date ? 1 : 0;
-      yDatesBuf[n] = yValue instanceof Date ? 1 : 0;
-      if (xToken === -1 && xValue !== null) invalidX.set(candidateIndex, xValue);
-      if (yToken === -1 && yValue !== null) invalidY.set(candidateIndex, yValue);
-      const series = datum.seriesId ?? 0;
-      seriesBuf[n] = series;
-      ranksBuf[n] = datum.seriesRank ?? series;
-      sourcesBuf[n] = datum.sourceOrder ?? rowIndex ?? primitiveIndex;
-      lineagesBuf[n] = datum.lineage ?? 0;
-      autoModesBuf[n] = AUTO_MODE_CODE[datum.autoMode ?? defaultAutoMode(batch, primitiveIndex)]!;
-      n++;
-    }
-    // Flush style scratch, skipping null-only columns entirely.
-    const flushStyle = (target: CellValue[], values: CellValue[]): void => {
-      if (values.every((v) => v === null)) return;
-      backfillStyle(target, batchStart);
-      for (const v of values) target.push(v);
-    };
-    flushStyle(sizeValues, batchSize);
-    flushStyle(linewidthValues, batchLinewidth);
-    flushStyle(alphaValues, batchAlpha);
-    flushStyle(shapeValues, batchShape);
-    flushStyle(linetypeValues, batchLinetype);
-  }
+  const buildState: CandidateBufferState = {
+    n: 0,
+    anyNonFiniteAnchor: false,
+    batchIds: batchIdsBuf,
+    primitiveIds: primitiveIdsBuf,
+    panelIds: panelIdsBuf,
+    rows: rowsBuf,
+    series: seriesBuf,
+    ranks: ranksBuf,
+    sources: sourcesBuf,
+    lineages: lineagesBuf,
+    autoModes: autoModesBuf,
+    xs: xsBuf,
+    ys: ysBuf,
+    xTokenIds: xTokenIdsBuf,
+    yTokenIds: yTokenIdsBuf,
+    xDates: xDatesBuf,
+    yDates: yDatesBuf,
+    invalidX,
+    invalidY,
+    sizeValues,
+    linewidthValues,
+    alphaValues,
+    shapeValues,
+    linetypeValues,
+    remember,
+  };
+  const n = populateCandidateBuffers(scene, options, uninspectable, buildState);
+  anyNonFiniteAnchor = buildState.anyNonFiniteAnchor;
 
   // Exact-count trim: when eligibility skipped primitives the capacity was
   // an upper bound, so slice the tails off (a view when exact — the common


### PR DESCRIPTION
## Summary\n- split candidate eligibility and buffer population helpers from candidate-store-indexes\n- preserve columnar and callback candidate construction semantics\n- keep strict oxlint complexity max 20 clean\n\n## Validation\n- bunx oxlint -c /tmp/oxlintrc-core-max20.json packages/core/src/candidate-store-indexes.ts packages/core/src/candidate-store-index-build.ts\n- bunx tsc -b packages/spec packages/core packages/cli\n- bun test packages/core/tests (2464 pass)\n- bun run bench:json (baseline and two post-change runs; no coherent regression)\n