### PR TITLE
fix(docs): enable chart controls after hydration

### DIFF
--- a/apps/docs/src/lib/components/ExampleLiveFrame.svelte
+++ b/apps/docs/src/lib/components/ExampleLiveFrame.svelte
@@ -57,6 +57,7 @@
   let Live = $state<Component | null>(null);
   let liveReady = $state(false);
   let shellVisible = $state(true);
+  let mounted = $state(false);
   /** True when the user tabbed into the shell; hand focus to .gg-capture on ready. */
   let restoreKeyboardFocus = $state(false);
   let loadStarted = false;
@@ -127,6 +128,7 @@
   }
 
   onMount(() => {
+    mounted = true;
     cancelled = false;
     if (Live !== null || loadStarted) {
       return () => {
@@ -253,7 +255,8 @@
       type="button"
       class="load-interactive"
       onclick={startLoad}
-      aria-disabled={Live !== null}
+      disabled={!mounted}
+      aria-disabled={!mounted || Live !== null}
       aria-busy={Live !== null}
     >
       {Live === null ? "Load interactive chart" : "Loading…"}

--- a/apps/docs/src/lib/components/GrammarDemo.svelte
+++ b/apps/docs/src/lib/components/GrammarDemo.svelte
@@ -29,6 +29,7 @@
   let loadStarted = $state(false);
   let liveReady = $state(false);
   let shellVisible = $state(true);
+  let mounted = $state(false);
   /** True when the user tabbed into the shell; hand focus to .gg-capture on ready. */
   let restoreKeyboardFocus = $state(false);
 
@@ -87,6 +88,7 @@
   }
 
   onMount(() => {
+    mounted = true;
     const el = host;
     if (el === null) return;
     return observeUserIntent(el, ensureLive);
@@ -196,7 +198,8 @@
       type="button"
       class="load-interactive"
       onclick={ensureLive}
-      aria-disabled={loadStarted}
+      disabled={!mounted}
+      aria-disabled={!mounted || loadStarted}
       aria-busy={loadStarted}
     >
       {loadStarted ? "Loading…" : "Load interactive chart"}

--- a/tests/visual/docs-home-gallery.spec.ts
+++ b/tests/visual/docs-home-gallery.spec.ts
@@ -11,6 +11,31 @@ async function expectNoOverflow(page: import("@playwright/test").Page): Promise<
   );
 }
 
+for (const route of ["/", "/examples/interactions/inspection"]) {
+  test(`${route} chart load waits for page hydration`, async ({ page }) => {
+    let releaseBootstrap!: () => void;
+    const bootstrap = new Promise<void>((resolve) => {
+      releaseBootstrap = resolve;
+    });
+    await page.route("**/_app/immutable/entry/*.js", async (request) => {
+      await bootstrap;
+      await request.continue();
+    });
+    await page.goto(route, { waitUntil: "commit" });
+    const button = page.getByRole("button", { name: "Load interactive chart" });
+    try {
+      await expect(button).toBeDisabled();
+    } finally {
+      releaseBootstrap();
+    }
+    await expect(button).toBeEnabled();
+    await button.click();
+    await expect(page.locator('.gg-plot-root[data-gg-ready="true"]')).toHaveCount(1, {
+      timeout: 60_000,
+    });
+  });
+}
+
 test("homepage leads with the agent sandbox and links to both framework quickstarts", async ({
   page,
 }) => {


### PR DESCRIPTION
A visitor can click “Load interactive chart” before the page JavaScript has attached its handlers, losing the first click. Keep the homepage and example chart buttons disabled until their components mount; loading a chart afterward keeps the existing focus behavior.

Verified both failures against production with bootstrap scripts held back, then passed the new regressions and all 69 browser journeys against the fix. Docs build, type checks, and Svelte analysis pass; no published package changes.
