### PR TITLE
fix(react): synchronize readiness tests with native resize

### DIFF
--- a/.github/workflows/ci-component-svelte.yml
+++ b/.github/workflows/ci-component-svelte.yml
@@ -135,10 +135,10 @@ jobs:
 
   # Merge the shards' blob reports into one coverage report, enforce the
   # thresholds the shards skipped, and upload the combined lcov. Also runs the
-  # SSR lane, which is ~15s and needs no browser — cheaper here than paying for
-  # it on a shard. Owns the content-hash marker for the whole execution.
+  # Svelte/React SSR lanes and React browser tests. Owns the content-hash marker
+  # for the whole execution; every test and coverage threshold must pass first.
   component-svelte-coverage:
-    name: component-svelte (coverage merge + ssr)
+    name: React browsers + Svelte/React SSR + Svelte coverage merge
     needs: component-svelte
     runs-on: ubuntu-latest
     timeout-minutes: 25

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,7 +256,7 @@ jobs:
       pr_labels: ${{ join(github.event.pull_request.labels.*.name, ',') }}
 
   component-svelte:
-    name: component-svelte (packages/svelte chromium + coverage + ssr)
+    name: component (Svelte chromium + React browsers + SSR + coverage)
     needs: [detect-changes, packages-dist]
     if: >-
       needs.detect-changes.outputs.component == 'true' &&

--- a/packages/react/tests/parity.test.tsx
+++ b/packages/react/tests/parity.test.tsx
@@ -1,7 +1,7 @@
 import { StrictMode, useState } from "react";
 import { renderToString } from "react-dom/server";
 import { hydrateRoot } from "react-dom/client";
-import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createPlotInteraction,
@@ -291,14 +291,31 @@ describe("React host parity", () => {
     const root = result.container.querySelector<HTMLElement>(".gg-plot-root");
     if (root === null) throw new Error("missing plot root");
     expect(root.dataset["ggReady"]).toBe("false");
-    result.rerender(chart(true));
-    await waitFor(() => {
-      expect(root.dataset["ggReady"]).toBe("true");
+    let onResize: ((width: number) => void) | undefined;
+    const observer = new ResizeObserver(([entry]) => {
+      if (entry !== undefined) onResize?.(entry.contentRect.width);
     });
-    expect(root.getBoundingClientRect().width).toBe(640);
-    result.rerender(chart(false));
-    await waitFor(() => {
-      expect(root.dataset["ggReady"]).toBe("false");
-    });
+    observer.observe(root);
+    const expectVisibility = async (visible: boolean) => {
+      const expectedWidth = visible ? 640 : 0;
+      const resized = new Promise<void>((resolve) => {
+        onResize = (width) => {
+          if (width === expectedWidth) resolve();
+        };
+      });
+      result.rerender(chart(visible));
+      // WebKit can deliver resize after waitFor's deadline under CI contention.
+      // Await the native event, then flush React before checking the public signal.
+      await act(async () => {
+        await resized;
+      });
+      expect(root.dataset["ggReady"]).toBe(visible ? "true" : "false");
+      expect(root.getBoundingClientRect().width).toBe(expectedWidth);
+    };
+    try {
+      for (const visible of [true, false, true, false]) await expectVisibility(visible);
+    } finally {
+      observer.disconnect();
+    }
   });
 });

--- a/scripts/release-wiring/ci.test.ts
+++ b/scripts/release-wiring/ci.test.ts
@@ -324,7 +324,17 @@ describe("R0 release wiring — CI lanes", () => {
     const svelteCollect = ciJob(ci, "component-svelte-coverage");
     expect(svelteCollect.length).toBeGreaterThan(0);
     expect(svelteCollect).toContain("needs: component-svelte");
-    expect(svelteCollect).toContain("--merge-reports");
+    expect(svelteCollect).toContain(
+      "name: React browsers + Svelte/React SSR + Svelte coverage merge",
+    );
+    expect(svelteCollect).toContain("working-directory: packages/react");
+    expect(svelteCollect).toContain("bun run --bun test && bun run --bun test:ssr");
+    expect(svelteCollect).toContain("bunx --bun vitest run --config vitest.ssr.config.ts");
+    expect(svelteCollect).toContain(
+      "bunx --bun vitest --merge-reports --project chromium --coverage",
+    );
+    expect(svelteCollect).not.toContain("--coverage.thresholds.");
+    expect(svelteCollect).not.toContain("continue-on-error:");
     expect(svelteCollect).toContain("uses: ./.github/actions/ci-content-hash-write");
     expect(svelteCollect).toContain("execution: component_svelte");
 


### PR DESCRIPTION
## Summary

Closes #1771.

- Await native resize delivery inside React `act` before asserting `data-gg-ready` and container width. Exercise hide → show → hide twice, with the test observer disconnected on completion.
- Rename the combined job and caller to expose React browser tests, Svelte/React SSR, and Svelte coverage aggregation. Keep job IDs, routing, and cache identities unchanged.
- Extend the CI wiring check to preserve browser/SSR commands and coverage enforcement. No runtime, timeout, retry, or coverage-threshold changes.

## Root cause and reproduction

Test scheduling, not a lost application update. In `ghcr.io/ggts-sh/ggts/ci-runner:v1.61.1-noble`, CPU contention delayed WebKit's first native resize notification past Testing Library's default deadline:

```text
At 1009 ms: observations=[], actual width=640, ggReady=false (waitFor timed out)
At 1303 ms: native ResizeObserver reported width=640
At 2201 ms: ggReady=true, without changing the component
```

The original test failed the first WebKit cycle under a one-CPU full-suite run; the next 49 passed. A half-CPU, three-browser parity run reproduced the failure with the timing probe above. This explains the visible wrapper plus fallback-width SVG in the original CI failure.

Container command used for the three-browser stress run:

```sh
docker run --rm --ipc=host --cpus=0.5 -e CI=true \
  -v "$PWD:/repo" -v "$(which bun):/usr/local/bin/bun:ro" \
  -w /repo/packages/react \
  ghcr.io/ggts-sh/ggts/ci-runner:v1.61.1-noble \
  bash -lc 'bun x --bun vitest run tests/parity.test.tsx'
```

For stress testing, expanded the visibility case to 50 fresh `it.each` instances; removed that expansion and the timing probes before commit. With the fix, all 180 parity tests passed across Chromium, Firefox, and WebKit: 100 hide/show/hide cycles per engine. The committed test keeps two cycles without adding stress overhead to each CI run.

## Verification

- Mutation check: replacing the component's resize update with `setContainerWidth(0)` makes the revised test fail at the readiness assertion. Restored the component before commit.
- Pinned-container React browser suite: **183 passed**.
- Pinned-container React SSR: **1 passed**; Svelte SSR: **132 passed**.
- `bun run test`: **5117 passed, 7 skipped, 0 failed**.
- `bun test scripts/release-wiring/ci.test.ts`: **10 passed**; the new job-name check failed before the rename.
- `bun run check`, `bun run lint:actions`, scoped lint, formatting, and commit hooks passed.
- Pre-PR Standards and Spec reviews: no blocking findings. Retained existing string-based CI-test conventions.
- Required ruleset contexts remain `ci-gate (required aggregator)`, `detect-changes (path routing)`, and `vr-gate (required pixel aggregator)`. Browser/SSR commands and the shard coverage merge are unchanged.

No changeset: tests and CI only. No deferred fixes.
