### PR TITLE
deps-dev: bump vitest-browser-svelte from 3.0.0 to 3.1.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -118,7 +118,7 @@
     },
     "packages/cli": {
       "name": "@ggts-sh/cli",
-      "version": "0.42.0",
+      "version": "0.43.0",
       "bin": {
         "ggsvelte-render": "bin/ggsvelte-render.js",
       },
@@ -128,7 +128,7 @@
     },
     "packages/compose": {
       "name": "@ggts-sh/compose",
-      "version": "0.42.0",
+      "version": "0.43.0",
       "dependencies": {
         "@ggts-sh/spec": "^0.42.0",
       },
@@ -138,7 +138,7 @@
     },
     "packages/core": {
       "name": "@ggts-sh/core",
-      "version": "0.42.0",
+      "version": "0.43.0",
       "dependencies": {
         "@ggts-sh/spec": "^0.42.0",
       },
@@ -148,7 +148,7 @@
     },
     "packages/react": {
       "name": "@ggts-sh/react",
-      "version": "0.42.0",
+      "version": "0.43.0",
       "dependencies": {
         "@ggts-sh/compose": "^0.42.0",
         "@ggts-sh/core": "^0.42.0",
@@ -174,11 +174,11 @@
     },
     "packages/skill": {
       "name": "@ggts-sh/skill",
-      "version": "0.42.0",
+      "version": "0.43.0",
     },
     "packages/spec": {
       "name": "@ggts-sh/spec",
-      "version": "0.42.0",
+      "version": "0.43.0",
       "dependencies": {
         "@js-temporal/polyfill": "^0.5.1",
         "typebox": "^1.3.8",
@@ -190,7 +190,7 @@
     },
     "packages/svelte": {
       "name": "@ggts-sh/svelte",
-      "version": "0.42.0",
+      "version": "0.43.0",
       "bin": {
         "ggts-codemod": "bin/ggts-codemod.js",
       },
@@ -229,7 +229,7 @@
         "typescript": "^6.0.3",
         "vite": "^8.2.0",
         "vitest": "^4.1.11",
-        "vitest-browser-svelte": "^3.0.0",
+        "vitest-browser-svelte": "^3.1.0",
       },
     },
     "spikes/pure": {
@@ -1730,7 +1730,7 @@
 
     "vitest": ["vitest@4.1.11", "", { "dependencies": { "@vitest/expect": "4.1.11", "@vitest/mocker": "4.1.11", "@vitest/pretty-format": "4.1.11", "@vitest/runner": "4.1.11", "@vitest/snapshot": "4.1.11", "@vitest/spy": "4.1.11", "@vitest/utils": "4.1.11", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.11", "@vitest/browser-preview": "4.1.11", "@vitest/browser-webdriverio": "4.1.11", "@vitest/coverage-istanbul": "4.1.11", "@vitest/coverage-v8": "4.1.11", "@vitest/ui": "4.1.11", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw=="],
 
-    "vitest-browser-svelte": ["vitest-browser-svelte@3.0.0", "", { "dependencies": { "@testing-library/svelte-core": "^1.1.3" }, "peerDependencies": { "svelte": "^3 || ^4 || ^5 || ^5.0.0-next.0", "vitest": "^4.0.0" } }, "sha512-BKM9iBGNsEQzigWuSZFAiw6AJDqQqMttApoD8gM8LTI6vxfd423rDMN8GqUHJyGbhH3XcOo9N9u/4hu47Nxhsw=="],
+    "vitest-browser-svelte": ["vitest-browser-svelte@3.1.0", "", { "dependencies": { "@testing-library/svelte-core": "^1.1.3" }, "peerDependencies": { "svelte": "^3 || ^4 || ^5 || ^5.0.0-next.0", "vitest": "^4.0.0 || ^5.0.0" } }, "sha512-+EBXSed6NArmzOC2DY4v9sI5n9TMIyfkMnewbXNQ7sR5IckQTCx7g1BbLdkH7kzm/tkgG/eEbRYlMWSbVfBtWA=="],
 
     "vt-pbf": ["vt-pbf@3.1.3", "", { "dependencies": { "@mapbox/point-geometry": "0.1.0", "@mapbox/vector-tile": "^1.3.1", "pbf": "^3.2.1" } }, "sha512-2LzDFzt0mZKZ9IpVF2r69G9bXaP2Q2sArJCmcCgvfTdCCZzSyz4aCLoQyUilu37Ll56tCblIZrXFIjNUpGIlmA=="],
 

--- a/spikes/browser/package.json
+++ b/spikes/browser/package.json
@@ -17,6 +17,6 @@
     "typescript": "^6.0.3",
     "vite": "^8.2.0",
     "vitest": "^4.1.11",
-    "vitest-browser-svelte": "^3.0.0"
+    "vitest-browser-svelte": "^3.1.0"
   }
 }


### PR DESCRIPTION
## Why

Dependabot opened #1765 for vitest-browser-svelte ^3.0.0 → ^3.1.0 in spikes/browser. That PR is two commits behind current `main`.

This replacement starts from current `main` and applies the same patch. This is a spike test helper, not a production runtime.

Replaces #1765.