### PR TITLE
fix(docs): update framework copy and default homepage code to Svelte

### DIFF
--- a/apps/docs/src/lib/home-code-path.ts
+++ b/apps/docs/src/lib/home-code-path.ts
@@ -120,8 +120,8 @@ export const HOME_CODE_PATH_TABS: {
   code: string;
   language: string;
 }[] = [
-  { label: "React", code: HOME_CODE_PATH_REACT, language: "tsx" },
   { label: "Svelte", code: HOME_CODE_PATH_SVELTE, language: "svelte" },
+  { label: "React", code: HOME_CODE_PATH_REACT, language: "tsx" },
   {
     label: "Spec (JSON)",
     code: HOME_CODE_PATH_SPEC_JSON,

--- a/apps/docs/src/routes/+page.svelte
+++ b/apps/docs/src/routes/+page.svelte
@@ -67,11 +67,11 @@
   </div>
   <div class="code-path-copy">
     <h2 id="code-path-heading">
-      Svelte for builders, JSON for embedded agents.
+      Frameworks for builders, JSON for embedded agents.
     </h2>
     <p>
-      Human-agent pairs get Svelte components for clarity. Embedded agents can
-      use JSON specs for interactive charts on demand.
+      Frameworks for when humans need them. CLI validation for when embedded
+      agents need to write JSON specs.
     </p>
   </div>
   <div class="code-path-tabs">

--- a/tests/visual/docs-home-gallery.spec.ts
+++ b/tests/visual/docs-home-gallery.spec.ts
@@ -85,7 +85,7 @@ test("homepage code-path section SSRs heading and a static chart shell", async (
   const response = await request.get("/");
   const html = await response.text();
   // Section chrome is not gated on the dynamic plot import.
-  expect(html).toContain("Svelte for builders, JSON for embedded agents.");
+  expect(html).toContain("Frameworks for builders, JSON for embedded agents.");
   expect(html).toContain('id="code-path-heading"');
   // Static shell ships before live GGPlot hydrates.
   expect(html).toContain("grammar-static");
@@ -99,7 +99,7 @@ test("homepage grammar chart upgrades to full interactive layers on intent", asy
   await page.goto("/");
   // Code-path chrome is SSR'd immediately — not blocked on the plot chunk.
   await expect(
-    page.getByRole("heading", { name: "Svelte for builders, JSON for embedded agents." }),
+    page.getByRole("heading", { name: "Frameworks for builders, JSON for embedded agents." }),
   ).toBeVisible();
   const output = page.locator(".grammar-output");
   const plot = output.locator(".gg-plot-root");
@@ -173,7 +173,12 @@ test("code tabs share the manual-copy fallback", async ({ page }) => {
   await page.goto("/");
   const codePath = page.locator(".code-path");
   const tabs = codePath.getByRole("tablist", { name: "Code representations" }).getByRole("tab");
-  await expect(tabs).toHaveText(["React", "Svelte", "Spec (JSON)"]);
+  await expect(codePath.locator(".code-path-copy p")).toHaveText(
+    "Frameworks for when humans need them. CLI validation for when embedded agents need to write JSON specs.",
+  );
+  await expect(tabs).toHaveText(["Svelte", "React", "Spec (JSON)"]);
+  await expect(tabs.first()).toHaveAttribute("aria-selected", "true");
+  await expect(codePath.getByRole("tabpanel")).toContainText("@ggts-sh/svelte");
   await codePath.getByRole("button", { name: "Copy code" }).click();
   await expect(page.locator(".code-path [role=status]")).toHaveText(
     "Clipboard unavailable. Code selected for manual copy.",


### PR DESCRIPTION
## Summary

Use the requested homepage heading and subtitle:

> Frameworks for builders, JSON for embedded agents.

> Frameworks for when humans need them. CLI validation for when embedded agents need to write JSON specs.

Put Svelte first and selected by default in the homepage code tabs, followed by React and Spec (JSON). No changes to other pages or shared tab behavior.

## Verification

- 19 homepage/gallery Playwright journeys passed, including exact copy, tab order, selected Svelte tab, and Svelte code content.
- Docs and scripts type checks passed; Svelte reported zero errors/warnings.
- Production build, generated-artifact freshness, metadata/CSP checks, Svelte autofixer, and pre-commit hooks passed.

Docs-only change; no package changeset needed.
